### PR TITLE
Refactor express dispatchers to share mount matching and add wildcard support

### DIFF
--- a/src/express/dispatcher/ApplicationDispatcher.cpp
+++ b/src/express/dispatcher/ApplicationDispatcher.cpp
@@ -57,7 +57,6 @@
 #include <cstddef>
 #include <list>
 #include <string_view>
-#include <tuple>
 #include <unordered_map>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -80,62 +79,13 @@ namespace express::dispatcher {
             const bool isPrefix = isUse; // Express: only app.use() is prefix-based
 
             if ((controller.getFlags() & Controller::NEXT) == 0) {
-                // Split mount & request into path + query
-                std::string_view mountPath;
-                std::string_view mountQueryString;
-                splitPathAndQuery(absoluteMountPath, mountPath, mountQueryString);
-                const auto requiredQueryPairs = parseQuery(mountQueryString);
-
-                std::string_view requestPath;
-                std::string_view requestQueryString;
-                splitPathAndQuery(controller.getRequest()->originalUrl, requestPath, requestQueryString);
-                const auto requestQueryPairs = parseQuery(requestQueryString);
-
-                // Normalize single trailing slash if not strict
-                if (!controller.getStrictRouting()) {
-                    mountPath = trimOneTrailingSlash(mountPath);
-                    requestPath = trimOneTrailingSlash(requestPath);
-                }
-                if (mountPath.empty()) {
-                    mountPath = "/";
-                }
-
-                // Matching is independent of callback arity:
-                //   - use() => prefix with boundary
-                //   - verbs/all() => end-anchored equality
-                bool pathMatches = false;
-                std::size_t consumedLength = 0;
-                if (mountPath.find(':') != std::string::npos) {
-                    // Param mount: compile once, match once, fill params, and record matched prefix length (use only)
-                    if (regex.mark_count() == 0) {
-                        LOG(TRACE) << "ApplicationDispatcher: precompiled regex";
-                        std::tie(regex, names) = compileParamRegex(mountPath,
-                                                                   /*isPrefix*/ isPrefix,
-                                                                   controller.getStrictRouting(),
-                                                                   controller.getCaseInsensitiveRouting());
-                    } else {
-                        LOG(TRACE) << "ApplicationDispatcher: using precompiled regex";
-                    }
-                    std::size_t matchLen = 0;
-                    pathMatches = matchAndFillParamsAndConsume(regex, names, requestPath, *controller.getRequest(), matchLen);
-                    if (pathMatches && isPrefix) {
-                        consumedLength = matchLen;
-                    }
-                } else {
-                    if (isPrefix) {
-                        // Literal boundary prefix
-                        pathMatches = boundaryPrefix(requestPath, mountPath, controller.getCaseInsensitiveRouting());
-                        if (pathMatches) {
-                            consumedLength = mountPath.size();
-                        }
-                    } else {
-                        // End-anchored equality
-                        pathMatches = equalPath(requestPath, mountPath, controller.getCaseInsensitiveRouting());
-                    }
-                }
-
-                const bool queryMatches = querySupersetMatches(requestQueryPairs, requiredQueryPairs);
-                requestMatched = (pathMatches && queryMatches);
+                const RouteMatchResult matchResult = matchMountPath(absoluteMountPath,
+                                                                    controller.getRequest()->originalUrl,
+                                                                    isPrefix,
+                                                                    controller.getStrictRouting(),
+                                                                    controller.getCaseInsensitiveRouting(),
+                                                                    *controller.getRequest());
+                requestMatched = matchResult.matched;
 
                 LOG(TRACE) << controller.getResponse()->getSocketContext()->getSocketConnection()->getConnectionName()
                            << " HTTP Express: application -> " << (requestMatched ? "MATCH" : "NO MATCH");
@@ -150,14 +100,14 @@ namespace express::dispatcher {
 
                 if (requestMatched) {
                     auto& req = *controller.getRequest();
-                    req.queries.insert(requestQueryPairs.begin(), requestQueryPairs.end());
+                    req.queries.insert(matchResult.requestQueryPairs.begin(), matchResult.requestQueryPairs.end());
 
                     // Express-style mount path stripping is only applied for use()
                     const std::string previousPathBackup = req.path;
                     if (isPrefix) {
                         std::string_view remainderPath{};
-                        if (requestPath.size() > consumedLength) {
-                            remainderPath = requestPath.substr(consumedLength);
+                        if (matchResult.requestPath.size() > matchResult.consumedLength) {
+                            remainderPath = matchResult.requestPath.substr(matchResult.consumedLength);
                             if (!remainderPath.empty() && remainderPath.front() == '/') {
                                 remainderPath.remove_prefix(1);
                             }

--- a/src/express/dispatcher/ApplicationDispatcher.h
+++ b/src/express/dispatcher/ApplicationDispatcher.h
@@ -53,9 +53,7 @@ namespace express {
 
 #include <functional>
 #include <memory>
-#include <regex>
 #include <string>
-#include <vector>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -72,9 +70,6 @@ namespace express::dispatcher {
         getRoutes(const std::string& parentMountPath, const MountPoint& mountPoint, bool strictRouting) const override;
 
         const std::function<void(const std::shared_ptr<Request>&, const std::shared_ptr<Response>&)> lambda;
-
-        std::regex regex;
-        std::vector<std::string> names;
     };
 
 } // namespace express::dispatcher

--- a/src/express/dispatcher/MiddlewareDispatcher.h
+++ b/src/express/dispatcher/MiddlewareDispatcher.h
@@ -54,9 +54,7 @@ namespace express {
 
 #include <functional>
 #include <memory>
-#include <regex>
 #include <string>
-#include <vector>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -73,9 +71,6 @@ namespace express::dispatcher {
         getRoutes(const std::string& parentMountPath, const MountPoint& mountPoint, bool strictRouting) const override;
 
         const std::function<void(const std::shared_ptr<Request>&, const std::shared_ptr<Response>&, express::Next&)> lambda;
-
-        std::regex regex;
-        std::vector<std::string> names;
     };
 
 } // namespace express::dispatcher

--- a/src/express/dispatcher/regex_utils.h
+++ b/src/express/dispatcher/regex_utils.h
@@ -63,6 +63,15 @@ namespace express {
 
 namespace express::dispatcher {
 
+    struct RouteMatchResult {
+        bool pathMatched = false;
+        bool queryMatched = false;
+        bool matched = false;
+        std::size_t consumedLength = 0;
+        std::unordered_map<std::string, std::string> requestQueryPairs;
+        std::string_view requestPath;
+    };
+
     std::vector<std::string> explode(const std::string& s, char delim);
 
     const std::regex& pathRegex();
@@ -103,6 +112,13 @@ namespace express::dispatcher {
                                                                       bool strictRouting,
                                                                       bool caseInsensitive);
 
+    RouteMatchResult matchMountPath(std::string_view absoluteMountPath,
+                                    std::string_view requestUrl,
+                                    bool isPrefix,
+                                    bool strictRouting,
+                                    bool caseInsensitive,
+                                    express::Request& req);
+
     template <typename RequestLike>
     inline bool
     matchAndFillParams(const std::regex& rx, const std::vector<std::string>& names, std::string_view reqPath, RequestLike& req) {
@@ -117,7 +133,6 @@ namespace express::dispatcher {
         }
         return true;
     }
-
 
     template <typename RequestLike>
     inline bool matchAndFillParamsAndConsume(const std::regex& rx,


### PR DESCRIPTION
### Motivation
- Eliminate duplicated and divergent route matching logic across the three dispatchers and provide identical semantics for path matching, param extraction and mount stripping.  
- Add Express v4-style wildcard (`*`) support in string mount paths so applications can use glob-style routes as expected.  
- Avoid stale per-dispatcher regex state and make matching fully driven by the mount path and request at dispatch time.  

### Description
- Introduced a shared matching helper `RouteMatchResult matchMountPath(...)` and `RouteMatchResult` in `src/express/dispatcher/regex_utils.*` to centralize path+query parsing, normalization, param/wildcard regex compilation and match-result reporting.  
- Refactored `ApplicationDispatcher`, `MiddlewareDispatcher` and `RouterDispatcher` to call `matchMountPath(...)` and removed the duplicated path/query matching branches from each dispatcher so they all follow exactly the same semantics (strict vs non-strict trailing slash, case-insensitive routing, prefix vs end-anchored, consumed length for `use(...)`).  
- Extended `compileParamRegex(...)` to support escaped characters and Express-style `*` wildcards, compiling `*` into capture groups and exposing those captures in `req.params` with numeric keys like `"0"`, `"1"`, etc., while retaining existing `:param` and `:param(...)` custom-regex behavior.  
- Removed the per-dispatcher cached `std::regex`/`names` members from the application and middleware dispatcher headers to avoid inconsistent reuse across different mount-paths/options.  

### Testing
- Ran formatter: `clang-format -i` on the modified dispatcher and regex utility files (succeeded).  
- Attempted full CMake configure with `cmake -S . -B build` to validate integration; configure failed in the environment due to a missing system dependency (`EASYLOGGINGPP` not found) and not because of dispatcher changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987390c0eb8832c9afa69b8e5c7e6bd)