### PR TITLE
express: scope params per layer and stop query-based route matching

### DIFF
--- a/src/express/dispatcher/ApplicationDispatcher.cpp
+++ b/src/express/dispatcher/ApplicationDispatcher.cpp
@@ -98,6 +98,7 @@ namespace express::dispatcher {
 
                 // Express-style mount path stripping is only applied for use()
                 const ScopedPathStrip pathStrip(req, match.requestPath, match.isPrefix, match.consumedLength);
+                const ScopedParams scopedParams(req, match.params, false);
 
                 // NOTE: do not run legacy setParams() here; it can overwrite regex-extracted params
                 lambda(controller.getRequest(), controller.getResponse());

--- a/src/express/dispatcher/MiddlewareDispatcher.cpp
+++ b/src/express/dispatcher/MiddlewareDispatcher.cpp
@@ -96,6 +96,7 @@ namespace express::dispatcher {
 
                 // Express-style mount path stripping is only applied for use()
                 const ScopedPathStrip pathStrip(req, match.requestPath, match.isPrefix, match.consumedLength);
+                const ScopedParams scopedParams(req, match.params, false);
 
                 // NOTE: do not run legacy setParams() here; it can overwrite regex-extracted params
                 Next next(controller);

--- a/src/express/dispatcher/RouterDispatcher.cpp
+++ b/src/express/dispatcher/RouterDispatcher.cpp
@@ -118,6 +118,7 @@ namespace express::dispatcher {
 
                 // Express-style mount path stripping is only applied for use()
                 const ScopedPathStrip pathStrip(req, match.requestPath, match.isPrefix, match.consumedLength);
+                const ScopedParams scopedParams(req, match.params, false);
 
                 const bool oldStrictRouting = controller.setStrictRouting(strictRouting);
                 const bool oldCaseInsensitiveRouting = controller.setCaseInsensitiveRouting(caseInsensitiveRouting);

--- a/src/express/dispatcher/regex_utils.h
+++ b/src/express/dispatcher/regex_utils.h
@@ -52,6 +52,7 @@ namespace express {
 
 #include <cctype>
 #include <cstddef>
+#include <map>
 #include <regex>
 #include <string>
 #include <string_view>
@@ -78,6 +79,7 @@ namespace express::dispatcher {
         bool isPrefix{false};
         std::size_t consumedLength{0};
         std::string_view requestPath;
+        std::map<std::string, std::string> params;
         std::unordered_map<std::string, std::string> requestQueryPairs;
     };
 
@@ -104,6 +106,21 @@ namespace express::dispatcher {
         express::Request* req_{nullptr};
         std::string backup_;
         bool enabled_{false};
+    };
+
+    class ScopedParams {
+    public:
+        ScopedParams(express::Request& req, const std::map<std::string, std::string>& params, bool mergeWithParent);
+        ~ScopedParams();
+
+        ScopedParams(const ScopedParams&) = delete;
+        ScopedParams& operator=(const ScopedParams&) = delete;
+        ScopedParams(ScopedParams&&) = delete;
+        ScopedParams& operator=(ScopedParams&&) = delete;
+
+    private:
+        express::Request* req_{nullptr};
+        std::map<std::string, std::string> backup_;
     };
 
 } // namespace express::dispatcher


### PR DESCRIPTION
### Motivation
- Bring routing behavior closer to Express semantics by making routing path-only and not gate routing on mount-point query-string constraints.
- Ensure captured route parameters (named and unnamed splats) are decoded the same way a browser `decodeURIComponent` would and are made available per dispatch layer without leaking between layers.
- Avoid mutating `req.params` during low-level regex matching so each middleware/router can snapshot and restore a layer-local view of params.

### Description
- Removed mount-path query-string constraint matching so route decisions are made from the path only and mount path query parsing is treated as data (see changes in `regex_utils.cpp`).
- Plumbed captured params out of the matcher into `MountMatchResult` by adding `params` to that struct and changed `matchAndFillParamsAndConsume` to fill a `std::map<std::string,std::string>` instead of writing directly to `Request` (see `regex_utils.h` / `regex_utils.cpp`).
- Added `decodeURIComponent`-style percent-decoding for captured param values (hex `%xx` decoding without `+`→space) and apply it when storing captures; unnamed wildcards (`*`) keep numeric param keys (`"0"`, `"1"`, ...).
- Introduced `ScopedParams` RAII helper that snapshots/restores `req.params` for each dispatch layer and wired it into `ApplicationDispatcher`, `MiddlewareDispatcher`, and `RouterDispatcher` so `req.params` is layer-scoped (merge behavior exposed via a `mergeWithParent` flag, currently passed `false`).

### Testing
- Ran a focused static compile of the modified matcher with `g++ -std=c++20 -fsyntax-only -I./src src/express/dispatcher/regex_utils.cpp`, which succeeded.
- Attempted a broader syntax-only compile of dispatcher units with `g++ -std=c++20 -fsyntax-only -I./src src/express/dispatcher/regex_utils.cpp src/express/dispatcher/ApplicationDispatcher.cpp src/express/dispatcher/MiddlewareDispatcher.cpp src/express/dispatcher/RouterDispatcher.cpp`, which failed due to missing headers in this container (`nlohmann/json_fwd.hpp`).
- Attempted full project configure with `cmake -S . -B build`, which failed because required dependency `EASYLOGGINGPP` is not available in the build environment.
- Performed a quick scan of the external `MQTTSuite` reference repo to review ecosystem layout (no code changes were made there).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698791de3620832c8959f63f8851484d)