### PR TITLE
Drop local/remote compatibility override constructors

### DIFF
--- a/src/net/config/ConfigAddress.h
+++ b/src/net/config/ConfigAddress.h
@@ -67,6 +67,9 @@ namespace net::config {
     protected:
         ConfigAddress(ConfigInstance* instance, const std::string& addressOptionName, const std::string& addressOptionDescription);
 
+        template <typename ConfigAddressSectionT>
+        ConfigAddress(ConfigInstance* instance, ConfigAddressSectionT*);
+
         ~ConfigAddress() override;
 
         virtual void configurable(bool configurable) = 0;

--- a/src/net/config/ConfigAddress.hpp
+++ b/src/net/config/ConfigAddress.hpp
@@ -58,6 +58,12 @@ namespace net::config {
     }
 
     template <typename SocketAddress>
+    template <typename ConfigAddressSectionT>
+    ConfigAddress<SocketAddress>::ConfigAddress(ConfigInstance* instance, ConfigAddressSectionT*)
+        : Super(instance, static_cast<ConfigAddressSectionT*>(nullptr)) {
+    }
+
+    template <typename SocketAddress>
     ConfigAddress<SocketAddress>::~ConfigAddress() {
         delete socketAddress;
     }

--- a/src/net/config/ConfigAddressBase.h
+++ b/src/net/config/ConfigAddressBase.h
@@ -64,6 +64,9 @@ namespace net::config {
                                    const std::string& addressOptionName = "",
                                    const std::string& addressOptionDescription = "");
 
+        template <typename ConfigAddressSectionT>
+        explicit ConfigAddressBase(ConfigInstance* instance, ConfigAddressSectionT*);
+
         virtual ~ConfigAddressBase() = default;
 
     public:

--- a/src/net/config/ConfigAddressBase.hpp
+++ b/src/net/config/ConfigAddressBase.hpp
@@ -56,6 +56,13 @@ namespace net::config {
     }
 
     template <typename SocketAddress>
+    template <typename ConfigAddressSectionT>
+    ConfigAddressBase<SocketAddress>::ConfigAddressBase(ConfigInstance* instance, ConfigAddressSectionT*)
+        : net::config::ConfigSection(instance,
+                                     net::config::Section(ConfigAddressSectionT::name, ConfigAddressSectionT::description, this)) {
+    }
+
+    template <typename SocketAddress>
     SocketAddress ConfigAddressBase<SocketAddress>::getSocketAddress(const typename SocketAddress::SockAddr& sockAddr,
                                                                      typename SocketAddress::SockLen sockAddrLen) {
         return SocketAddress(sockAddr, sockAddrLen);

--- a/src/net/config/ConfigAddressLocal.h
+++ b/src/net/config/ConfigAddressLocal.h
@@ -56,7 +56,11 @@ namespace net::config {
         using Super = net::config::ConfigAddress<SocketAddressT>;
 
     protected:
-        using Super::Super;
+        explicit ConfigAddressLocal(ConfigInstance* instance);
+
+    public:
+        constexpr static std::string name{"local"};
+        constexpr static std::string description{"Local side of connection"};
     };
 
 } // namespace net::config

--- a/src/net/config/ConfigAddressLocal.h
+++ b/src/net/config/ConfigAddressLocal.h
@@ -59,8 +59,8 @@ namespace net::config {
         explicit ConfigAddressLocal(ConfigInstance* instance);
 
     public:
-        constexpr static std::string name{"local"};
-        constexpr static std::string description{"Local side of connection"};
+        constexpr static const char* name{"local"};
+        constexpr static const char* description{"Local side of connection"};
     };
 
 } // namespace net::config

--- a/src/net/config/ConfigAddressLocal.hpp
+++ b/src/net/config/ConfigAddressLocal.hpp
@@ -46,6 +46,12 @@
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
-namespace net::config {} // namespace net::config
+namespace net::config {
 
-// "local", "Local side of connection for instance '" + instance->getInstanceName() + "'"
+    template <typename SocketAddress>
+    ConfigAddressLocal<SocketAddress>::ConfigAddressLocal(ConfigInstance* instance)
+        : Super(instance, static_cast<ConfigAddressLocal<SocketAddress>*>(nullptr)) {
+    }
+
+
+} // namespace net::config

--- a/src/net/config/ConfigAddressRemote.h
+++ b/src/net/config/ConfigAddressRemote.h
@@ -59,8 +59,8 @@ namespace net::config {
         explicit ConfigAddressRemote(ConfigInstance* instance);
 
     public:
-        constexpr static std::string name{"remote"};
-        constexpr static std::string description{"Remote side of connection"};
+        constexpr static const char* name{"remote"};
+        constexpr static const char* description{"Remote side of connection"};
     };
 
 } // namespace net::config

--- a/src/net/config/ConfigAddressRemote.h
+++ b/src/net/config/ConfigAddressRemote.h
@@ -56,7 +56,11 @@ namespace net::config {
         using Super = net::config::ConfigAddress<SocketAddressT>;
 
     protected:
-        using Super::Super;
+        explicit ConfigAddressRemote(ConfigInstance* instance);
+
+    public:
+        constexpr static std::string name{"remote"};
+        constexpr static std::string description{"Remote side of connection"};
     };
 
 } // namespace net::config

--- a/src/net/config/ConfigAddressRemote.hpp
+++ b/src/net/config/ConfigAddressRemote.hpp
@@ -46,6 +46,12 @@
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
-namespace net::config {} // namespace net::config
+namespace net::config {
 
-// "remote", "Remote side of connection for instance '" + instance->getInstanceName() + "'"
+    template <typename SocketAddress>
+    ConfigAddressRemote<SocketAddress>::ConfigAddressRemote(ConfigInstance* instance)
+        : Super(instance, static_cast<ConfigAddressRemote<SocketAddress>*>(nullptr)) {
+    }
+
+
+} // namespace net::config

--- a/src/net/config/stream/ConfigSocketClient.hpp
+++ b/src/net/config/stream/ConfigSocketClient.hpp
@@ -50,8 +50,8 @@ namespace net::config::stream {
     template <template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressLocal,
               template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressRemote>
     ConfigSocketClient<ConfigAddressLocal, ConfigAddressRemote>::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : ConfigAddressRemote<net::config::ConfigAddressRemote>(instance, "remote", "Remote side of connection")
-        , ConfigAddressLocal<net::config::ConfigAddressLocal>(instance, "local", "Local side of connection")
+        : ConfigAddressRemote<net::config::ConfigAddressRemote>(instance)
+        , ConfigAddressLocal<net::config::ConfigAddressLocal>(instance)
         , net::config::ConfigConnection(instance)
         , net::config::ConfigPhysicalSocketClient(instance) {
     }

--- a/src/net/config/stream/ConfigSocketServer.hpp
+++ b/src/net/config/stream/ConfigSocketServer.hpp
@@ -50,8 +50,8 @@ namespace net::config::stream {
     template <template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressLocal,
               template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressRemote>
     ConfigSocketServer<ConfigAddressLocal, ConfigAddressRemote>::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : ConfigAddressLocal<net::config::ConfigAddressLocal>(instance, "local", "Local side of connection")
-        , ConfigAddressRemote<net::config::ConfigAddressReverse>(instance, "remote", "Remote side of connection")
+        : ConfigAddressLocal<net::config::ConfigAddressLocal>(instance)
+        , ConfigAddressRemote<net::config::ConfigAddressReverse>(instance)
         , net::config::ConfigConnection(instance)
         , net::config::ConfigPhysicalSocketServer(instance) {
     }

--- a/src/net/in/config/ConfigAddress.cpp
+++ b/src/net/in/config/ConfigAddress.cpp
@@ -62,10 +62,8 @@
 namespace net::in::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                                                  const std::string& addressOptionName,
-                                                                  const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance)
+        : Super(instance, "remote", "Remote side of connection") {
         numericReverseOpt = Super::addFlag( //
             "--numeric-reverse{true}",
             "Suppress reverse host name lookup",
@@ -106,10 +104,8 @@ namespace net::in::config {
     }
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance)
+        : Super(instance) {
         hostOpt = Super::addOption( //
             "--host",
             "Host name or IPv4 address",

--- a/src/net/in/config/ConfigAddress.h
+++ b/src/net/in/config/ConfigAddress.h
@@ -70,9 +70,7 @@ namespace net::in::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        explicit ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                      const std::string& addressOptionName,
-                                      const std::string& addressOptionDescription);
+        explicit ConfigAddressReverse(net::config::ConfigInstance* instance);
 
     public:
         SocketAddress getSocketAddress(const SocketAddress::SockAddr& sockAddr, SocketAddress::SockLen sockAddrLen);
@@ -90,9 +88,7 @@ namespace net::in::config {
         using Super = ConfigAddressTypeT<net::in::SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        explicit ConfigAddress(net::config::ConfigInstance* instance);
 
     private:
         SocketAddress* init() final;

--- a/src/net/in6/config/ConfigAddress.cpp
+++ b/src/net/in6/config/ConfigAddress.cpp
@@ -62,10 +62,8 @@
 namespace net::in6::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                                                  const std::string& addressOptionName,
-                                                                  const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance)
+        : Super(instance, "remote", "Remote side of connection") {
         numericReverseOpt = Super::addFlag( //
             "--numeric-reverse",
             "Suppress reverse host name lookup",
@@ -106,10 +104,8 @@ namespace net::in6::config {
     }
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance)
+        : Super(instance) {
         hostOpt = Super::addOption( //
             "--host",
             "Host name or IPv6 address",

--- a/src/net/in6/config/ConfigAddress.h
+++ b/src/net/in6/config/ConfigAddress.h
@@ -72,9 +72,7 @@ namespace net::in6::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        explicit ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                      const std::string& addressOptionName,
-                                      const std::string& addressOptionDescription);
+        explicit ConfigAddressReverse(net::config::ConfigInstance* instance);
 
     public:
         SocketAddress getSocketAddress(const SocketAddress::SockAddr& sockAddr, SocketAddress::SockLen sockAddrLen);
@@ -92,9 +90,7 @@ namespace net::in6::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        explicit ConfigAddress(net::config::ConfigInstance* instance);
 
     private:
         SocketAddress* init() final;

--- a/src/net/l2/config/ConfigAddress.cpp
+++ b/src/net/l2/config/ConfigAddress.cpp
@@ -56,10 +56,13 @@
 namespace net::l2::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance)
+        : Super(instance, "remote", "Remote side of connection") {
+    }
+
+    template <template <typename SocketAddress> typename ConfigAddressType>
+    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance)
+        : Super(instance) {
         btAddressOpt = Super::addOption( //
             "--host",
             "Bluetooth address",

--- a/src/net/l2/config/ConfigAddress.h
+++ b/src/net/l2/config/ConfigAddress.h
@@ -70,7 +70,7 @@ namespace net::l2::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        using Super::Super;
+        explicit ConfigAddressReverse(net::config::ConfigInstance* instance);
     };
 
     template <template <typename SocketAddressT> typename ConfigAddressTypeT>
@@ -79,9 +79,7 @@ namespace net::l2::config {
         using Super = ConfigAddressTypeT<net::l2::SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        explicit ConfigAddress(net::config::ConfigInstance* instance);
 
     private:
         SocketAddress* init() final;

--- a/src/net/rc/config/ConfigAddress.cpp
+++ b/src/net/rc/config/ConfigAddress.cpp
@@ -56,10 +56,13 @@
 namespace net::rc::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance)
+        : Super(instance, "remote", "Remote side of connection") {
+    }
+
+    template <template <typename SocketAddress> typename ConfigAddressType>
+    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance)
+        : Super(instance) {
         btAddressOpt = Super::addOption( //
             "--host",
             "Bluetooth address",

--- a/src/net/rc/config/ConfigAddress.h
+++ b/src/net/rc/config/ConfigAddress.h
@@ -70,7 +70,7 @@ namespace net::rc::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        using Super::Super;
+        explicit ConfigAddressReverse(net::config::ConfigInstance* instance);
     };
 
     template <template <typename SocketAddressT> typename ConfigAddressTypeT>
@@ -79,9 +79,7 @@ namespace net::rc::config {
         using Super = ConfigAddressTypeT<net::rc::SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        explicit ConfigAddress(net::config::ConfigInstance* instance);
 
     private:
         SocketAddress* init() final;

--- a/src/net/un/config/ConfigAddress.cpp
+++ b/src/net/un/config/ConfigAddress.cpp
@@ -59,10 +59,13 @@
 namespace net::un::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance)
+        : Super(instance, "remote", "Remote side of connection") {
+    }
+
+    template <template <typename SocketAddress> typename ConfigAddressType>
+    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance)
+        : Super(instance) {
         sunPathOpt = Super::addOption( //
             "--sun-path",
             "Unix domain bind path",

--- a/src/net/un/config/ConfigAddress.h
+++ b/src/net/un/config/ConfigAddress.h
@@ -69,7 +69,7 @@ namespace net::un::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        using Super::Super;
+        explicit ConfigAddressReverse(net::config::ConfigInstance* instance);
     };
 
     template <template <typename SocketAddressT> typename ConfigAddressTypeT>
@@ -78,9 +78,7 @@ namespace net::un::config {
         using Super = ConfigAddressTypeT<net::un::SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        explicit ConfigAddress(net::config::ConfigInstance* instance);
 
     private:
         SocketAddress* init() final;


### PR DESCRIPTION
### Motivation
- Enforce that local/remote section identity comes from the concrete section types rather than ad-hoc string overrides, simplifying the API and avoiding duplicated metadata paths.

### Description
- Removed the compatibility constructors that accepted explicit `(addressOptionName, addressOptionDescription)` from `ConfigAddressLocal` and `ConfigAddressRemote` so each only exposes an `instance`-only constructor and section metadata via the concrete section type.
- Updated stream config initializers in `ConfigSocketClient` and `ConfigSocketServer` to call the instance-only local/remote constructors (removed call-site string overrides).
- Kept and used the typed `ConfigAddressBase` constructor that consumes `ConfigAddressSectionT::name` and `::description` as the canonical metadata path.
- Key files changed: `src/net/config/ConfigAddressBase.h/.hpp`, `src/net/config/ConfigAddressLocal.h/.hpp`, `src/net/config/ConfigAddressRemote.h/.hpp`, `src/net/config/stream/ConfigSocketClient.hpp`, and `src/net/config/stream/ConfigSocketServer.hpp`.

### Testing
- Ran `cmake -S . -B build` to validate configuration and header changes, and configuration failed due to a missing dependency `EASYLOGGINGPP_INCLUDE_DIR` (Doxygen and iwyu are only warnings). No unit tests were executed in this environment due to the configure dependency failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f693e9ef4832c92c0ea7092e144fc)