### PR TITLE
Use typed section metadata for ConfigAddress and unify constructors

### DIFF
--- a/src/net/config/ConfigAddress.h
+++ b/src/net/config/ConfigAddress.h
@@ -65,7 +65,8 @@ namespace net::config {
         using SocketAddress = SocketAddressT;
 
     protected:
-        ConfigAddress(ConfigInstance* instance, const std::string& addressOptionName, const std::string& addressOptionDescription);
+        template <typename ConfigAddressSectionT>
+        ConfigAddress(ConfigInstance* instance, ConfigAddressSectionT*);
 
         ~ConfigAddress() override;
 

--- a/src/net/config/ConfigAddress.hpp
+++ b/src/net/config/ConfigAddress.hpp
@@ -51,10 +51,9 @@
 namespace net::config {
 
     template <typename SocketAddress>
-    ConfigAddress<SocketAddress>::ConfigAddress(ConfigInstance* instance,
-                                                const std::string& addressOptionName,
-                                                const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    template <typename ConfigAddressSectionT>
+    ConfigAddress<SocketAddress>::ConfigAddress(ConfigInstance* instance, ConfigAddressSectionT*)
+        : Super(instance, static_cast<ConfigAddressSectionT*>(nullptr)) {
     }
 
     template <typename SocketAddress>

--- a/src/net/config/ConfigAddressBase.h
+++ b/src/net/config/ConfigAddressBase.h
@@ -60,9 +60,8 @@ namespace net::config {
         using Super = ConfigSection;
 
     protected:
-        explicit ConfigAddressBase(ConfigInstance* instance,
-                                   const std::string& addressOptionName = "",
-                                   const std::string& addressOptionDescription = "");
+        template <typename ConfigAddressSectionT>
+        explicit ConfigAddressBase(ConfigInstance* instance, ConfigAddressSectionT*);
 
         virtual ~ConfigAddressBase() = default;
 

--- a/src/net/config/ConfigAddressBase.hpp
+++ b/src/net/config/ConfigAddressBase.hpp
@@ -49,10 +49,10 @@
 namespace net::config {
 
     template <typename SocketAddress>
-    ConfigAddressBase<SocketAddress>::ConfigAddressBase(ConfigInstance* instance,
-                                                        const std::string& addressOptionName,
-                                                        const std::string& addressOptionDescription)
-        : net::config::ConfigSection(instance, net::config::Section(addressOptionName, addressOptionDescription, this)) {
+    template <typename ConfigAddressSectionT>
+    ConfigAddressBase<SocketAddress>::ConfigAddressBase(ConfigInstance* instance, ConfigAddressSectionT*)
+        : net::config::ConfigSection(instance,
+                                     net::config::Section(ConfigAddressSectionT::name, ConfigAddressSectionT::description, this)) {
     }
 
     template <typename SocketAddress>

--- a/src/net/config/ConfigAddressLocal.h
+++ b/src/net/config/ConfigAddressLocal.h
@@ -56,7 +56,11 @@ namespace net::config {
         using Super = net::config::ConfigAddress<SocketAddressT>;
 
     protected:
-        using Super::Super;
+        explicit ConfigAddressLocal(ConfigInstance* instance);
+
+    public:
+        constexpr static const char* name{"local"};
+        constexpr static const char* description{"Local side of connection"};
     };
 
 } // namespace net::config

--- a/src/net/config/ConfigAddressLocal.hpp
+++ b/src/net/config/ConfigAddressLocal.hpp
@@ -46,6 +46,12 @@
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
-namespace net::config {} // namespace net::config
+namespace net::config {
 
-// "local", "Local side of connection for instance '" + instance->getInstanceName() + "'"
+    template <typename SocketAddress>
+    ConfigAddressLocal<SocketAddress>::ConfigAddressLocal(ConfigInstance* instance)
+        : Super(instance, static_cast<ConfigAddressLocal<SocketAddress>*>(nullptr)) {
+    }
+
+
+} // namespace net::config

--- a/src/net/config/ConfigAddressRemote.h
+++ b/src/net/config/ConfigAddressRemote.h
@@ -56,7 +56,11 @@ namespace net::config {
         using Super = net::config::ConfigAddress<SocketAddressT>;
 
     protected:
-        using Super::Super;
+        explicit ConfigAddressRemote(ConfigInstance* instance);
+
+    public:
+        constexpr static const char* name{"remote"};
+        constexpr static const char* description{"Remote side of connection"};
     };
 
 } // namespace net::config

--- a/src/net/config/ConfigAddressRemote.hpp
+++ b/src/net/config/ConfigAddressRemote.hpp
@@ -46,6 +46,12 @@
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
-namespace net::config {} // namespace net::config
+namespace net::config {
 
-// "remote", "Remote side of connection for instance '" + instance->getInstanceName() + "'"
+    template <typename SocketAddress>
+    ConfigAddressRemote<SocketAddress>::ConfigAddressRemote(ConfigInstance* instance)
+        : Super(instance, static_cast<ConfigAddressRemote<SocketAddress>*>(nullptr)) {
+    }
+
+
+} // namespace net::config

--- a/src/net/config/ConfigAddressReverse.h
+++ b/src/net/config/ConfigAddressReverse.h
@@ -44,6 +44,10 @@
 
 #include "net/config/ConfigAddressBase.h" // IWYU pragma: export
 
+namespace net::config {
+    class ConfigInstance;
+}
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
@@ -56,7 +60,11 @@ namespace net::config {
         using Super = net::config::ConfigAddressBase<SocketAddressT>;
 
     protected:
-        using Super::Super;
+        explicit ConfigAddressReverse(ConfigInstance* instance);
+
+    public:
+        constexpr static const char* name{"remote"};
+        constexpr static const char* description{"Remote side of connection"};
     };
 
 } // namespace net::config

--- a/src/net/config/ConfigAddressReverse.hpp
+++ b/src/net/config/ConfigAddressReverse.hpp
@@ -45,4 +45,11 @@
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
-namespace net::config {} // namespace net::config
+namespace net::config {
+
+    template <typename SocketAddress>
+    ConfigAddressReverse<SocketAddress>::ConfigAddressReverse(ConfigInstance* instance)
+        : Super(instance, static_cast<ConfigAddressReverse<SocketAddress>*>(nullptr)) {
+    }
+
+} // namespace net::config

--- a/src/net/config/stream/ConfigSocketClient.hpp
+++ b/src/net/config/stream/ConfigSocketClient.hpp
@@ -50,8 +50,8 @@ namespace net::config::stream {
     template <template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressLocal,
               template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressRemote>
     ConfigSocketClient<ConfigAddressLocal, ConfigAddressRemote>::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : ConfigAddressRemote<net::config::ConfigAddressRemote>(instance, "remote", "Remote side of connection")
-        , ConfigAddressLocal<net::config::ConfigAddressLocal>(instance, "local", "Local side of connection")
+        : ConfigAddressRemote<net::config::ConfigAddressRemote>(instance)
+        , ConfigAddressLocal<net::config::ConfigAddressLocal>(instance)
         , net::config::ConfigConnection(instance)
         , net::config::ConfigPhysicalSocketClient(instance) {
     }

--- a/src/net/config/stream/ConfigSocketServer.hpp
+++ b/src/net/config/stream/ConfigSocketServer.hpp
@@ -50,8 +50,8 @@ namespace net::config::stream {
     template <template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressLocal,
               template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressRemote>
     ConfigSocketServer<ConfigAddressLocal, ConfigAddressRemote>::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : ConfigAddressLocal<net::config::ConfigAddressLocal>(instance, "local", "Local side of connection")
-        , ConfigAddressRemote<net::config::ConfigAddressReverse>(instance, "remote", "Remote side of connection")
+        : ConfigAddressLocal<net::config::ConfigAddressLocal>(instance)
+        , ConfigAddressRemote<net::config::ConfigAddressReverse>(instance)
         , net::config::ConfigConnection(instance)
         , net::config::ConfigPhysicalSocketServer(instance) {
     }

--- a/src/net/in/config/ConfigAddress.cpp
+++ b/src/net/in/config/ConfigAddress.cpp
@@ -62,10 +62,8 @@
 namespace net::in::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                                                  const std::string& addressOptionName,
-                                                                  const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance)
+        : Super(instance) {
         numericReverseOpt = Super::addFlag( //
             "--numeric-reverse{true}",
             "Suppress reverse host name lookup",
@@ -106,10 +104,8 @@ namespace net::in::config {
     }
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance)
+        : Super(instance) {
         hostOpt = Super::addOption( //
             "--host",
             "Host name or IPv4 address",

--- a/src/net/in/config/ConfigAddress.h
+++ b/src/net/in/config/ConfigAddress.h
@@ -70,9 +70,7 @@ namespace net::in::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        explicit ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                      const std::string& addressOptionName,
-                                      const std::string& addressOptionDescription);
+        explicit ConfigAddressReverse(net::config::ConfigInstance* instance);
 
     public:
         SocketAddress getSocketAddress(const SocketAddress::SockAddr& sockAddr, SocketAddress::SockLen sockAddrLen);
@@ -90,9 +88,7 @@ namespace net::in::config {
         using Super = ConfigAddressTypeT<net::in::SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        explicit ConfigAddress(net::config::ConfigInstance* instance);
 
     private:
         SocketAddress* init() final;

--- a/src/net/in6/config/ConfigAddress.cpp
+++ b/src/net/in6/config/ConfigAddress.cpp
@@ -62,10 +62,8 @@
 namespace net::in6::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                                                  const std::string& addressOptionName,
-                                                                  const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance)
+        : Super(instance) {
         numericReverseOpt = Super::addFlag( //
             "--numeric-reverse",
             "Suppress reverse host name lookup",
@@ -106,10 +104,8 @@ namespace net::in6::config {
     }
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance)
+        : Super(instance) {
         hostOpt = Super::addOption( //
             "--host",
             "Host name or IPv6 address",

--- a/src/net/in6/config/ConfigAddress.h
+++ b/src/net/in6/config/ConfigAddress.h
@@ -72,9 +72,7 @@ namespace net::in6::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        explicit ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                      const std::string& addressOptionName,
-                                      const std::string& addressOptionDescription);
+        explicit ConfigAddressReverse(net::config::ConfigInstance* instance);
 
     public:
         SocketAddress getSocketAddress(const SocketAddress::SockAddr& sockAddr, SocketAddress::SockLen sockAddrLen);
@@ -92,9 +90,7 @@ namespace net::in6::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        explicit ConfigAddress(net::config::ConfigInstance* instance);
 
     private:
         SocketAddress* init() final;

--- a/src/net/l2/config/ConfigAddress.cpp
+++ b/src/net/l2/config/ConfigAddress.cpp
@@ -56,10 +56,13 @@
 namespace net::l2::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance)
+        : Super(instance) {
+    }
+
+    template <template <typename SocketAddress> typename ConfigAddressType>
+    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance)
+        : Super(instance) {
         btAddressOpt = Super::addOption( //
             "--host",
             "Bluetooth address",

--- a/src/net/l2/config/ConfigAddress.h
+++ b/src/net/l2/config/ConfigAddress.h
@@ -70,7 +70,7 @@ namespace net::l2::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        using Super::Super;
+        explicit ConfigAddressReverse(net::config::ConfigInstance* instance);
     };
 
     template <template <typename SocketAddressT> typename ConfigAddressTypeT>
@@ -79,9 +79,7 @@ namespace net::l2::config {
         using Super = ConfigAddressTypeT<net::l2::SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        explicit ConfigAddress(net::config::ConfigInstance* instance);
 
     private:
         SocketAddress* init() final;

--- a/src/net/rc/config/ConfigAddress.cpp
+++ b/src/net/rc/config/ConfigAddress.cpp
@@ -56,10 +56,13 @@
 namespace net::rc::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance)
+        : Super(instance) {
+    }
+
+    template <template <typename SocketAddress> typename ConfigAddressType>
+    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance)
+        : Super(instance) {
         btAddressOpt = Super::addOption( //
             "--host",
             "Bluetooth address",

--- a/src/net/rc/config/ConfigAddress.h
+++ b/src/net/rc/config/ConfigAddress.h
@@ -70,7 +70,7 @@ namespace net::rc::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        using Super::Super;
+        explicit ConfigAddressReverse(net::config::ConfigInstance* instance);
     };
 
     template <template <typename SocketAddressT> typename ConfigAddressTypeT>
@@ -79,9 +79,7 @@ namespace net::rc::config {
         using Super = ConfigAddressTypeT<net::rc::SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        explicit ConfigAddress(net::config::ConfigInstance* instance);
 
     private:
         SocketAddress* init() final;

--- a/src/net/un/config/ConfigAddress.cpp
+++ b/src/net/un/config/ConfigAddress.cpp
@@ -59,10 +59,13 @@
 namespace net::un::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance)
+        : Super(instance) {
+    }
+
+    template <template <typename SocketAddress> typename ConfigAddressType>
+    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance)
+        : Super(instance) {
         sunPathOpt = Super::addOption( //
             "--sun-path",
             "Unix domain bind path",

--- a/src/net/un/config/ConfigAddress.h
+++ b/src/net/un/config/ConfigAddress.h
@@ -69,7 +69,7 @@ namespace net::un::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        using Super::Super;
+        explicit ConfigAddressReverse(net::config::ConfigInstance* instance);
     };
 
     template <template <typename SocketAddressT> typename ConfigAddressTypeT>
@@ -78,9 +78,7 @@ namespace net::un::config {
         using Super = ConfigAddressTypeT<net::un::SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        explicit ConfigAddress(net::config::ConfigInstance* instance);
 
     private:
         SocketAddress* init() final;


### PR DESCRIPTION
### Motivation
- Align `ConfigAddress`/`ConfigAddressBase` with the same section identity scheme used by other config sections (e.g. `ConfigConnection`) so section names/descriptions are owned by concrete section types rather than passed as ad-hoc strings.
- Remove the dual constructor plumbing (`addressOptionName`/`addressOptionDescription`) that caused inconsistent initialization and template/instantiation friction across network-family specializations.

### Description
- Removed the string-based constructors from `ConfigAddressBase` and `ConfigAddress` and kept only the typed constructor path that consumes `ConfigAddressSectionT::name` / `ConfigAddressSectionT::description`. 
- Added explicit instance-only constructors and `constexpr static const char* name/description` metadata to address section types (`ConfigAddressLocal`, `ConfigAddressRemote`, `ConfigAddressReverse`) so final classes supply section identity. 
- Updated `ConfigAddressReverse` to provide its own `name`/`description` and a small instance constructor in the implementation. 
- Updated all network-family reverse/config address implementations (`net/in`, `net/in6`, `net/l2`, `net/rc`, `net/un`) and stream templates (`ConfigSocketClient` / `ConfigSocketServer`) to call the instance-only constructors (e.g. `Super(instance)`) and to use the typed metadata flow. 

### Testing
- Installed build deps via `apt-get install -y libeasyloggingpp-dev nlohmann-json3-dev` which completed successfully. 
- Configured the tree with `cmake -S . -B build` which completed successfully. 
- Built the repository with `cmake --build build -j4` and observed a full successful build to completion. 
- Ran a search for the prior string-based constructor patterns to confirm replacement and consistency (`rg`/repository diff); checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f693e9ef4832c92c0ea7092e144fc)