### PR TITLE
Remove ConfigInstance constructors from net Config* hierarchy and switch to deferred init

### DIFF
--- a/src/net/config/ConfigAddress.h
+++ b/src/net/config/ConfigAddress.h
@@ -65,9 +65,11 @@ namespace net::config {
         using SocketAddress = SocketAddressT;
 
     protected:
-        ConfigAddress(ConfigInstance* instance, const std::string& addressOptionName, const std::string& addressOptionDescription);
+        ConfigAddress();
 
         ~ConfigAddress() override;
+
+        void init(ConfigInstance* instance, const std::string& addressOptionName, const std::string& addressOptionDescription) override;
 
         virtual void configurable(bool configurable) = 0;
 

--- a/src/net/config/ConfigAddress.hpp
+++ b/src/net/config/ConfigAddress.hpp
@@ -51,10 +51,13 @@
 namespace net::config {
 
     template <typename SocketAddress>
-    ConfigAddress<SocketAddress>::ConfigAddress(ConfigInstance* instance,
-                                                const std::string& addressOptionName,
-                                                const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    ConfigAddress<SocketAddress>::ConfigAddress() = default;
+
+    template <typename SocketAddress>
+    void ConfigAddress<SocketAddress>::init(ConfigInstance* instance,
+                                            const std::string& addressOptionName,
+                                            const std::string& addressOptionDescription) {
+        Super::init(instance, addressOptionName, addressOptionDescription);
     }
 
     template <typename SocketAddress>

--- a/src/net/config/ConfigAddressBase.h
+++ b/src/net/config/ConfigAddressBase.h
@@ -60,9 +60,11 @@ namespace net::config {
         using Super = ConfigSection;
 
     protected:
-        explicit ConfigAddressBase(ConfigInstance* instance,
-                                   const std::string& addressOptionName = "",
-                                   const std::string& addressOptionDescription = "");
+        ConfigAddressBase() = default;
+
+        virtual void init(ConfigInstance* instance,
+                          const std::string& addressOptionName = "",
+                          const std::string& addressOptionDescription = "");
 
     public:
         SocketAddressT getSocketAddress(const typename SocketAddressT::SockAddr& sockAddr, typename SocketAddressT::SockLen sockAddrLen);

--- a/src/net/config/ConfigAddressBase.hpp
+++ b/src/net/config/ConfigAddressBase.hpp
@@ -49,10 +49,10 @@
 namespace net::config {
 
     template <typename SocketAddress>
-    ConfigAddressBase<SocketAddress>::ConfigAddressBase(ConfigInstance* instance,
-                                                        const std::string& addressOptionName,
-                                                        const std::string& addressOptionDescription)
-        : net::config::ConfigSection(instance, net::config::Section(addressOptionName, addressOptionDescription, this)) {
+    void ConfigAddressBase<SocketAddress>::init(ConfigInstance* instance,
+                                                const std::string& addressOptionName,
+                                                const std::string& addressOptionDescription) {
+        net::config::ConfigSection::init(instance, net::config::Section(addressOptionName, addressOptionDescription, this));
     }
 
     template <typename SocketAddress>

--- a/src/net/config/ConfigConnection.cpp
+++ b/src/net/config/ConfigConnection.cpp
@@ -49,9 +49,9 @@
 
 namespace net::config {
 
-    ConfigConnection::ConfigConnection(ConfigInstance* instance)
-        : net::config::ConfigSection(instance,
-                                     net::config::Section(ConfigConnection::name, "Configuration of established connections", this)) {
+    void ConfigConnection::init(ConfigInstance* instance) {
+        net::config::ConfigSection::init(instance,
+                                         net::config::Section(ConfigConnection::name, "Configuration of established connections", this));
         readTimeoutOpt = addOption( //
             "--read-timeout",
             "Read timeout in seconds",

--- a/src/net/config/ConfigConnection.h
+++ b/src/net/config/ConfigConnection.h
@@ -66,7 +66,9 @@ namespace net::config {
         using Connection = ConfigConnection;
 
     protected:
-        explicit ConfigConnection(ConfigInstance* instance);
+        ConfigConnection() = default;
+
+        virtual void init(ConfigInstance* instance);
 
     public:
         constexpr static std::string name{"connection"};

--- a/src/net/config/ConfigLegacy.cpp
+++ b/src/net/config/ConfigLegacy.cpp
@@ -49,8 +49,8 @@
 
 namespace net::config {
 
-    ConfigLegacy::ConfigLegacy(ConfigInstance* instance)
-        : net::config::ConfigSection(instance, net::config::Section(ConfigLegacy::name, "Configuration of legacy behavior", this)) {
+    void ConfigLegacy::init(ConfigInstance* instance) {
+        net::config::ConfigSection::init(instance, net::config::Section(ConfigLegacy::name, "Configuration of legacy behavior", this));
     }
 
 } // namespace net::config

--- a/src/net/config/ConfigLegacy.h
+++ b/src/net/config/ConfigLegacy.h
@@ -61,7 +61,9 @@ namespace net::config {
         using Legacy = ConfigLegacy;
 
     protected:
-        explicit ConfigLegacy(ConfigInstance* instance);
+        ConfigLegacy() = default;
+
+        virtual void init(ConfigInstance* instance);
     };
 
 } // namespace net::config

--- a/src/net/config/ConfigPhysicalSocket.cpp
+++ b/src/net/config/ConfigPhysicalSocket.cpp
@@ -56,8 +56,9 @@
 
 namespace net::config {
 
-    ConfigPhysicalSocket::ConfigPhysicalSocket(ConfigInstance* instance)
-        : ConfigSection(instance, net::config::Section(ConfigPhysicalSocket::name, "Configuration of socket behavior", this)) {
+    void ConfigPhysicalSocket::init(ConfigInstance* instance) {
+        ConfigSection::init(instance, net::config::Section(ConfigPhysicalSocket::name, "Configuration of socket behavior", this));
+
         retryOpt = addFlag( //
             "--retry{true}",
             "Automatically retry listen|connect",

--- a/src/net/config/ConfigPhysicalSocket.h
+++ b/src/net/config/ConfigPhysicalSocket.h
@@ -65,7 +65,9 @@ namespace net::config {
 
     class ConfigPhysicalSocket : protected ConfigSection {
     protected:
-        explicit ConfigPhysicalSocket(ConfigInstance* instance);
+        ConfigPhysicalSocket() = default;
+
+        virtual void init(ConfigInstance* instance);
 
     public:
         constexpr static std::string name{"socket"};

--- a/src/net/config/ConfigPhysicalSocketClient.cpp
+++ b/src/net/config/ConfigPhysicalSocketClient.cpp
@@ -56,8 +56,9 @@
 
 namespace net::config {
 
-    ConfigPhysicalSocketClient::ConfigPhysicalSocketClient(ConfigInstance* instance)
-        : Super(instance) {
+    void ConfigPhysicalSocketClient::init(ConfigInstance* instance) {
+        Super::init(instance);
+
         reconnectOpt = addFlagFunction( //
             "--reconnect{true}",
             [this]() {

--- a/src/net/config/ConfigPhysicalSocketClient.h
+++ b/src/net/config/ConfigPhysicalSocketClient.h
@@ -67,7 +67,9 @@ namespace net::config {
         using Socket = ConfigPhysicalSocketClient;
 
     protected:
-        explicit ConfigPhysicalSocketClient(ConfigInstance* instance);
+        ConfigPhysicalSocketClient() = default;
+
+        void init(ConfigInstance* instance) override;
 
     public:
         ConfigPhysicalSocketClient& setReconnect(bool reconnect = true);

--- a/src/net/config/ConfigPhysicalSocketServer.cpp
+++ b/src/net/config/ConfigPhysicalSocketServer.cpp
@@ -51,8 +51,9 @@
 
 namespace net::config {
 
-    ConfigPhysicalSocketServer::ConfigPhysicalSocketServer(ConfigInstance* instance)
-        : Super(instance) {
+    void ConfigPhysicalSocketServer::init(ConfigInstance* instance) {
+        Super::init(instance);
+
         backlogOpt = addOption( //
             "--backlog",
             "Listen backlog",

--- a/src/net/config/ConfigPhysicalSocketServer.h
+++ b/src/net/config/ConfigPhysicalSocketServer.h
@@ -67,7 +67,9 @@ namespace net::config {
         using Socket = ConfigPhysicalSocketServer;
 
     protected:
-        explicit ConfigPhysicalSocketServer(ConfigInstance* instance);
+        ConfigPhysicalSocketServer() = default;
+
+        void init(ConfigInstance* instance) override;
 
     public:
         ConfigPhysicalSocketServer& setBacklog(int newBacklog);

--- a/src/net/config/ConfigSection.cpp
+++ b/src/net/config/ConfigSection.cpp
@@ -75,10 +75,19 @@
 
 namespace net::config {
 
-    ConfigSection::ConfigSection(ConfigInstance* instanceSc, std::shared_ptr<CLI::App> sectionApp, const std::string& group)
-        : instanceSc(instanceSc) {
+    ConfigSection::ConfigSection(ConfigInstance* instanceSc, std::shared_ptr<CLI::App> sectionApp, const std::string& group) {
+        init(instanceSc, sectionApp, group);
+    }
+
+    void ConfigSection::init(ConfigInstance* instanceSc, std::shared_ptr<CLI::App> sectionApp, const std::string& group) {
+        if (initialized) {
+            return;
+        }
+
+        this->instanceSc = instanceSc;
         sectionSc = instanceSc->newSection(sectionApp, group);
         sectionSc->description(sectionSc->get_description() + " for instance '" + instanceSc->getInstanceName() + "'");
+        initialized = true;
     }
 
     void ConfigSection::required(CLI::Option* opt, bool req) {

--- a/src/net/config/ConfigSection.h
+++ b/src/net/config/ConfigSection.h
@@ -65,6 +65,7 @@ namespace net::config {
 
     class ConfigSection {
     public:
+        ConfigSection() = default;
         ConfigSection(ConfigInstance* instanceSc, std::shared_ptr<CLI::App> sectionApp, const std::string& group = "Sections");
 
         virtual ~ConfigSection() = default;
@@ -139,6 +140,8 @@ namespace net::config {
         bool required() const;
 
     protected:
+        void init(ConfigInstance* instanceSc, std::shared_ptr<CLI::App> sectionApp, const std::string& group = "Sections");
+
         void setConfigurable(CLI::Option* option, bool configurable);
 
         CLI::App* sectionSc = nullptr;
@@ -147,6 +150,7 @@ namespace net::config {
         ConfigInstance* instanceSc = nullptr;
 
         uint8_t requiredCount = 0;
+        bool initialized = false;
     };
 
 } // namespace net::config

--- a/src/net/config/ConfigTls.cpp
+++ b/src/net/config/ConfigTls.cpp
@@ -49,8 +49,8 @@
 
 namespace net::config {
 
-    ConfigTls::ConfigTls(ConfigInstance* instance)
-        : ConfigSection(instance, net::config::Section(ConfigTls::name, "Configuration of SSL/TLS behavior", this)) {
+    void ConfigTls::init(ConfigInstance* instance) {
+        ConfigSection::init(instance, net::config::Section(ConfigTls::name, "Configuration of SSL/TLS behavior", this));
         certOpt = addOption( //
             "--cert",
             "Certificate chain file",

--- a/src/net/config/ConfigTls.h
+++ b/src/net/config/ConfigTls.h
@@ -64,7 +64,9 @@ namespace net::config {
 
     class ConfigTls : protected ConfigSection {
     protected:
-        explicit ConfigTls(ConfigInstance* instance);
+        ConfigTls() = default;
+
+        virtual void init(ConfigInstance* instance);
 
     public:
         constexpr static std::string name{"tls"};

--- a/src/net/config/ConfigTlsClient.cpp
+++ b/src/net/config/ConfigTlsClient.cpp
@@ -49,8 +49,8 @@
 
 namespace net::config {
 
-    ConfigTlsClient::ConfigTlsClient(ConfigInstance* instance)
-        : Super(instance) {
+    void ConfigTlsClient::init(ConfigInstance* instance) {
+        Super::init(instance);
         sniOpt = addOption( //
             "--sni",
             "Server Name Indication",

--- a/src/net/config/ConfigTlsClient.h
+++ b/src/net/config/ConfigTlsClient.h
@@ -68,7 +68,9 @@ namespace net::config {
         using Tls = ConfigTlsClient;
 
     protected:
-        explicit ConfigTlsClient(ConfigInstance* instance);
+        ConfigTlsClient() = default;
+
+        void init(ConfigInstance* instance) override;
 
     public:
         ConfigTlsClient& setSni(const std::string& sni);

--- a/src/net/config/ConfigTlsServer.cpp
+++ b/src/net/config/ConfigTlsServer.cpp
@@ -52,8 +52,8 @@
 
 namespace net::config {
 
-    ConfigTlsServer::ConfigTlsServer(ConfigInstance* instance)
-        : Super(instance) {
+    void ConfigTlsServer::init(ConfigInstance* instance) {
+        Super::init(instance);
         sniCertsOpt = sectionSc //
                           ->add_option("--sni-cert",
                                        configuredSniCerts,

--- a/src/net/config/ConfigTlsServer.h
+++ b/src/net/config/ConfigTlsServer.h
@@ -70,7 +70,9 @@ namespace net::config {
         using Tls = ConfigTlsServer;
 
     protected:
-        explicit ConfigTlsServer(ConfigInstance* instance);
+        ConfigTlsServer() = default;
+
+        void init(ConfigInstance* instance) override;
 
     public:
         ConfigTlsServer& setForceSni(bool forceSni = true);

--- a/src/net/config/stream/ConfigSocketClient.h
+++ b/src/net/config/stream/ConfigSocketClient.h
@@ -65,7 +65,9 @@ namespace net::config::stream {
         using Local = ConfigAddressLocalT<net::config::ConfigAddressLocal>;
 
     protected:
-        explicit ConfigSocketClient(net::config::ConfigInstance* instance);
+        ConfigSocketClient() = default;
+
+        void init(net::config::ConfigInstance* instance);
     };
 
 } // namespace net::config::stream

--- a/src/net/config/stream/ConfigSocketClient.hpp
+++ b/src/net/config/stream/ConfigSocketClient.hpp
@@ -49,11 +49,11 @@ namespace net::config::stream {
 
     template <template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressLocal,
               template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressRemote>
-    ConfigSocketClient<ConfigAddressLocal, ConfigAddressRemote>::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : ConfigAddressRemote<net::config::ConfigAddressRemote>(instance, "remote", "Remote side of connection")
-        , ConfigAddressLocal<net::config::ConfigAddressLocal>(instance, "local", "Local side of connection")
-        , net::config::ConfigConnection(instance)
-        , net::config::ConfigPhysicalSocketClient(instance) {
+    void ConfigSocketClient<ConfigAddressLocal, ConfigAddressRemote>::init(net::config::ConfigInstance* instance) {
+        ConfigAddressRemote<net::config::ConfigAddressRemote>::init(instance, "remote", "Remote side of connection");
+        ConfigAddressLocal<net::config::ConfigAddressLocal>::init(instance, "local", "Local side of connection");
+        net::config::ConfigConnection::init(instance);
+        net::config::ConfigPhysicalSocketClient::init(instance);
     }
 
 } // namespace net::config::stream

--- a/src/net/config/stream/ConfigSocketServer.h
+++ b/src/net/config/stream/ConfigSocketServer.h
@@ -65,7 +65,9 @@ namespace net::config::stream {
         using Remote = ConfigAddressRemoteT<net::config::ConfigAddressReverse>;
 
     protected:
-        explicit ConfigSocketServer(net::config::ConfigInstance* instance);
+        ConfigSocketServer() = default;
+
+        void init(net::config::ConfigInstance* instance);
     };
 
 } // namespace net::config::stream

--- a/src/net/config/stream/ConfigSocketServer.hpp
+++ b/src/net/config/stream/ConfigSocketServer.hpp
@@ -49,11 +49,11 @@ namespace net::config::stream {
 
     template <template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressLocal,
               template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressRemote>
-    ConfigSocketServer<ConfigAddressLocal, ConfigAddressRemote>::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : ConfigAddressLocal<net::config::ConfigAddressLocal>(instance, "local", "Local side of connection")
-        , ConfigAddressRemote<net::config::ConfigAddressReverse>(instance, "remote", "Remote side of connection")
-        , net::config::ConfigConnection(instance)
-        , net::config::ConfigPhysicalSocketServer(instance) {
+    void ConfigSocketServer<ConfigAddressLocal, ConfigAddressRemote>::init(net::config::ConfigInstance* instance) {
+        ConfigAddressLocal<net::config::ConfigAddressLocal>::init(instance, "local", "Local side of connection");
+        ConfigAddressRemote<net::config::ConfigAddressReverse>::init(instance, "remote", "Remote side of connection");
+        net::config::ConfigConnection::init(instance);
+        net::config::ConfigPhysicalSocketServer::init(instance);
     }
 
 } // namespace net::config::stream

--- a/src/net/config/stream/legacy/ConfigSocketClient.hpp
+++ b/src/net/config/stream/legacy/ConfigSocketClient.hpp
@@ -49,9 +49,9 @@ namespace net::config::stream::legacy {
 
     template <typename ConfigSocketClientBase>
     ConfigSocketClient<ConfigSocketClientBase>::ConfigSocketClient(const std::string& name)
-        : net::config::ConfigInstance(name, net::config::ConfigInstance::Role::CLIENT)
-        , ConfigSocketClientBase(this)
-        , net::config::ConfigLegacy(this) {
+        : net::config::ConfigInstance(name, net::config::ConfigInstance::Role::CLIENT) {
+        ConfigSocketClientBase::init(this);
+        net::config::ConfigLegacy::init(this);
     }
 
 } // namespace net::config::stream::legacy

--- a/src/net/config/stream/legacy/ConfigSocketServer.hpp
+++ b/src/net/config/stream/legacy/ConfigSocketServer.hpp
@@ -49,9 +49,9 @@ namespace net::config::stream::legacy {
 
     template <typename ConfigSocketServerBase>
     ConfigSocketServer<ConfigSocketServerBase>::ConfigSocketServer(const std::string& name)
-        : net::config::ConfigInstance(name, net::config::ConfigInstance::Role::SERVER)
-        , ConfigSocketServerBase(this)
-        , net::config::ConfigLegacy(this) {
+        : net::config::ConfigInstance(name, net::config::ConfigInstance::Role::SERVER) {
+        ConfigSocketServerBase::init(this);
+        net::config::ConfigLegacy::init(this);
     }
 
 } // namespace net::config::stream::legacy

--- a/src/net/config/stream/tls/ConfigSocketClient.hpp
+++ b/src/net/config/stream/tls/ConfigSocketClient.hpp
@@ -49,9 +49,9 @@ namespace net::config::stream::tls {
 
     template <typename ConfigSocketClientBase>
     ConfigSocketClient<ConfigSocketClientBase>::ConfigSocketClient(const std::string& name)
-        : net::config::ConfigInstance(name, net::config::ConfigInstance::Role::CLIENT)
-        , ConfigSocketClientBase(this)
-        , net::config::ConfigTlsClient(this) {
+        : net::config::ConfigInstance(name, net::config::ConfigInstance::Role::CLIENT) {
+        ConfigSocketClientBase::init(this);
+        net::config::ConfigTlsClient::init(this);
     }
 
     template <typename ConfigSocketClientBase>

--- a/src/net/config/stream/tls/ConfigSocketServer.hpp
+++ b/src/net/config/stream/tls/ConfigSocketServer.hpp
@@ -56,9 +56,9 @@ namespace net::config::stream::tls {
 
     template <typename ConfigSocketServerBase>
     ConfigSocketServer<ConfigSocketServerBase>::ConfigSocketServer(const std::string& name)
-        : net::config::ConfigInstance(name, net::config::ConfigInstance::Role::SERVER)
-        , ConfigSocketServerBase(this)
-        , net::config::ConfigTlsServer(this) {
+        : net::config::ConfigInstance(name, net::config::ConfigInstance::Role::SERVER) {
+        ConfigSocketServerBase::init(this);
+        net::config::ConfigTlsServer::init(this);
     }
 
     template <typename ConfigSocketServerBase>

--- a/src/net/in/config/ConfigAddress.cpp
+++ b/src/net/in/config/ConfigAddress.cpp
@@ -62,10 +62,11 @@
 namespace net::in::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                                                  const std::string& addressOptionName,
-                                                                  const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddressReverse<ConfigAddressType>::init(net::config::ConfigInstance* instance,
+                                                       const std::string& addressOptionName,
+                                                       const std::string& addressOptionDescription) {
+        Super::init(instance, addressOptionName, addressOptionDescription);
+
         numericReverseOpt = Super::addFlag( //
             "--numeric-reverse{true}",
             "Suppress reverse host name lookup",
@@ -106,10 +107,11 @@ namespace net::in::config {
     }
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddress<ConfigAddressType>::init(net::config::ConfigInstance* instance,
+                                                const std::string& addressOptionName,
+                                                const std::string& addressOptionDescription) {
+        Super::init(instance, addressOptionName, addressOptionDescription);
+
         hostOpt = Super::addOption( //
             "--host",
             "Host name or IPv4 address",

--- a/src/net/in/config/ConfigAddress.h
+++ b/src/net/in/config/ConfigAddress.h
@@ -70,9 +70,11 @@ namespace net::in::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        ConfigAddressReverse(net::config::ConfigInstance* instance,
-                             const std::string& addressOptionName,
-                             const std::string& addressOptionDescription);
+        ConfigAddressReverse() = default;
+
+        void init(net::config::ConfigInstance* instance,
+                  const std::string& addressOptionName,
+                  const std::string& addressOptionDescription) override;
 
     public:
         SocketAddress getSocketAddress(const SocketAddress::SockAddr& sockAddr, SocketAddress::SockLen sockAddrLen);
@@ -90,9 +92,11 @@ namespace net::in::config {
         using Super = ConfigAddressTypeT<net::in::SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        ConfigAddress() = default;
+
+        void init(net::config::ConfigInstance* instance,
+                  const std::string& addressOptionName,
+                  const std::string& addressOptionDescription) override;
 
     private:
         SocketAddress* init() final;

--- a/src/net/in/stream/config/ConfigSocketClient.cpp
+++ b/src/net/in/stream/config/ConfigSocketClient.cpp
@@ -81,8 +81,8 @@
 
 namespace net::in::stream::config {
 
-    ConfigSocketClient::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketClient<net::in::config::ConfigAddress>(instance) {
+    void ConfigSocketClient::init(net::config::ConfigInstance* instance) {
+        this->net::config::stream::ConfigSocketClient<net::in::config::ConfigAddress>::init(instance);
         net::in::config::ConfigAddress<net::config::ConfigAddressRemote>::setHostRequired();
         net::in::config::ConfigAddress<net::config::ConfigAddressRemote>::setPortRequired();
         net::in::config::ConfigAddress<net::config::ConfigAddressRemote>::setAiSockType(SOCK_STREAM);

--- a/src/net/in/stream/config/ConfigSocketClient.h
+++ b/src/net/in/stream/config/ConfigSocketClient.h
@@ -61,7 +61,9 @@ namespace net::in::stream::config {
 
     class ConfigSocketClient : public net::config::stream::ConfigSocketClient<net::in::config::ConfigAddress> {
     protected:
-        explicit ConfigSocketClient(net::config::ConfigInstance* instance);
+        ConfigSocketClient() = default;
+
+        void init(net::config::ConfigInstance* instance);
 
         ~ConfigSocketClient() override;
 

--- a/src/net/in/stream/config/ConfigSocketServer.cpp
+++ b/src/net/in/stream/config/ConfigSocketServer.cpp
@@ -81,8 +81,8 @@
 
 namespace net::in::stream::config {
 
-    ConfigSocketServer::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketServer<net::in::config::ConfigAddress, net::in::config::ConfigAddressReverse>(instance) {
+    void ConfigSocketServer::init(net::config::ConfigInstance* instance) {
+        this->net::config::stream::ConfigSocketServer<net::in::config::ConfigAddress, net::in::config::ConfigAddressReverse>::init(instance);
         net::in::config::ConfigAddress<net::config::ConfigAddressLocal>::setPortRequired();
         net::in::config::ConfigAddress<net::config::ConfigAddressLocal>::setAiFlags(AI_PASSIVE);
         net::in::config::ConfigAddress<net::config::ConfigAddressLocal>::setAiSockType(SOCK_STREAM);

--- a/src/net/in/stream/config/ConfigSocketServer.h
+++ b/src/net/in/stream/config/ConfigSocketServer.h
@@ -62,7 +62,9 @@ namespace net::in::stream::config {
     class ConfigSocketServer
         : public net::config::stream::ConfigSocketServer<net::in::config::ConfigAddress, net::in::config::ConfigAddressReverse> {
     protected:
-        explicit ConfigSocketServer(net::config::ConfigInstance* instance);
+        ConfigSocketServer() = default;
+
+        void init(net::config::ConfigInstance* instance);
 
         ~ConfigSocketServer() override;
 

--- a/src/net/in6/config/ConfigAddress.cpp
+++ b/src/net/in6/config/ConfigAddress.cpp
@@ -62,10 +62,11 @@
 namespace net::in6::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                                                  const std::string& addressOptionName,
-                                                                  const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddressReverse<ConfigAddressType>::init(net::config::ConfigInstance* instance,
+                                                       const std::string& addressOptionName,
+                                                       const std::string& addressOptionDescription) {
+        Super::init(instance, addressOptionName, addressOptionDescription);
+
         numericReverseOpt = Super::addFlag( //
             "--numeric-reverse",
             "Suppress reverse host name lookup",
@@ -106,10 +107,11 @@ namespace net::in6::config {
     }
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddress<ConfigAddressType>::init(net::config::ConfigInstance* instance,
+                                                const std::string& addressOptionName,
+                                                const std::string& addressOptionDescription) {
+        Super::init(instance, addressOptionName, addressOptionDescription);
+
         hostOpt = Super::addOption( //
             "--host",
             "Host name or IPv6 address",

--- a/src/net/in6/config/ConfigAddress.h
+++ b/src/net/in6/config/ConfigAddress.h
@@ -72,9 +72,11 @@ namespace net::in6::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        explicit ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                      const std::string& addressOptionName,
-                                      const std::string& addressOptionDescription);
+        ConfigAddressReverse() = default;
+
+        void init(net::config::ConfigInstance* instance,
+                  const std::string& addressOptionName,
+                  const std::string& addressOptionDescription) override;
 
     public:
         SocketAddress getSocketAddress(const SocketAddress::SockAddr& sockAddr, SocketAddress::SockLen sockAddrLen);
@@ -92,9 +94,11 @@ namespace net::in6::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        ConfigAddress(net::config::ConfigInstance* instance,
-                      const std::string& addressOptionName,
-                      const std::string& addressOptionDescription);
+        ConfigAddress() = default;
+
+        void init(net::config::ConfigInstance* instance,
+                  const std::string& addressOptionName,
+                  const std::string& addressOptionDescription) override;
 
     private:
         SocketAddress* init() final;

--- a/src/net/in6/stream/config/ConfigSocketClient.cpp
+++ b/src/net/in6/stream/config/ConfigSocketClient.cpp
@@ -81,8 +81,8 @@
 
 namespace net::in6::stream::config {
 
-    ConfigSocketClient::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketClient<net::in6::config::ConfigAddress>(instance) {
+    void ConfigSocketClient::init(net::config::ConfigInstance* instance) {
+        this->net::config::stream::ConfigSocketClient<net::in6::config::ConfigAddress>::init(instance);
         net::in6::config::ConfigAddress<net::config::ConfigAddressRemote>::setHostRequired();
         net::in6::config::ConfigAddress<net::config::ConfigAddressRemote>::setPortRequired();
 

--- a/src/net/in6/stream/config/ConfigSocketClient.h
+++ b/src/net/in6/stream/config/ConfigSocketClient.h
@@ -61,7 +61,9 @@ namespace net::in6::stream::config {
 
     class ConfigSocketClient : public net::config::stream::ConfigSocketClient<net::in6::config::ConfigAddress> {
     protected:
-        explicit ConfigSocketClient(net::config::ConfigInstance* instance);
+        ConfigSocketClient() = default;
+
+        void init(net::config::ConfigInstance* instance);
 
         ~ConfigSocketClient() override;
 

--- a/src/net/in6/stream/config/ConfigSocketServer.cpp
+++ b/src/net/in6/stream/config/ConfigSocketServer.cpp
@@ -81,8 +81,8 @@
 
 namespace net::in6::stream::config {
 
-    ConfigSocketServer::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketServer<net::in6::config::ConfigAddress, net::in6::config::ConfigAddressReverse>(instance) {
+    void ConfigSocketServer::init(net::config::ConfigInstance* instance) {
+        this->net::config::stream::ConfigSocketServer<net::in6::config::ConfigAddress, net::in6::config::ConfigAddressReverse>::init(instance);
         net::in6::config::ConfigAddress<net::config::ConfigAddressLocal>::setPortRequired();
 
         net::in6::config::ConfigAddress<net::config::ConfigAddressLocal>::setAiFlags(AI_PASSIVE);

--- a/src/net/in6/stream/config/ConfigSocketServer.h
+++ b/src/net/in6/stream/config/ConfigSocketServer.h
@@ -62,7 +62,9 @@ namespace net::in6::stream::config {
     class ConfigSocketServer
         : public net::config::stream::ConfigSocketServer<net::in6::config::ConfigAddress, net::in6::config::ConfigAddressReverse> {
     protected:
-        explicit ConfigSocketServer(net::config::ConfigInstance* instance);
+        ConfigSocketServer() = default;
+
+        void init(net::config::ConfigInstance* instance);
 
         ~ConfigSocketServer() override;
 

--- a/src/net/l2/config/ConfigAddress.cpp
+++ b/src/net/l2/config/ConfigAddress.cpp
@@ -56,10 +56,10 @@
 namespace net::l2::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddress<ConfigAddressType>::init(net::config::ConfigInstance* instance,
+                                                const std::string& addressOptionName,
+                                                const std::string& addressOptionDescription) {
+        Super::init(instance, addressOptionName, addressOptionDescription);
         btAddressOpt = Super::addOption( //
             "--host",
             "Bluetooth address",

--- a/src/net/l2/config/ConfigAddress.h
+++ b/src/net/l2/config/ConfigAddress.h
@@ -79,12 +79,14 @@ namespace net::l2::config {
         using Super = ConfigAddressTypeT<net::l2::SocketAddress>;
 
     protected:
-        ConfigAddress(net::config::ConfigInstance* instance,
-                      const std::string& addressOptionName,
-                      const std::string& addressOptionDescription);
+        ConfigAddress() = default;
+
+        void init(net::config::ConfigInstance* instance,
+                  const std::string& addressOptionName,
+                  const std::string& addressOptionDescription) override;
 
     private:
-        SocketAddress* init() final;
+        SocketAddress* init();
 
     public:
         ConfigAddress& setSocketAddress(const SocketAddress& socketAddress);
@@ -95,7 +97,7 @@ namespace net::l2::config {
         ConfigAddress& setPsm(uint16_t psm);
         uint16_t getPsm() const;
 
-        void configurable(bool configurable = true) final;
+        void configurable(bool configurable = true);
 
     protected:
         ConfigAddress& setBtAddressRequired(bool required = true);

--- a/src/net/l2/stream/config/ConfigSocketClient.cpp
+++ b/src/net/l2/stream/config/ConfigSocketClient.cpp
@@ -75,8 +75,8 @@
 
 namespace net::l2::stream::config {
 
-    ConfigSocketClient::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketClient<net::l2::config::ConfigAddress>(instance) {
+    void ConfigSocketClient::init(net::config::ConfigInstance* instance) {
+        this->net::config::stream::ConfigSocketClient<net::l2::config::ConfigAddress>::init(instance);
         net::l2::config::ConfigAddress<net::config::ConfigAddressRemote>::setBtAddressRequired();
         net::l2::config::ConfigAddress<net::config::ConfigAddressRemote>::setPsmRequired();
 

--- a/src/net/l2/stream/config/ConfigSocketClient.h
+++ b/src/net/l2/stream/config/ConfigSocketClient.h
@@ -57,7 +57,9 @@ namespace net::l2::stream::config {
 
     class ConfigSocketClient : public net::config::stream::ConfigSocketClient<net::l2::config::ConfigAddress> {
     protected:
-        explicit ConfigSocketClient(net::config::ConfigInstance* instance);
+        ConfigSocketClient() = default;
+
+        void init(net::config::ConfigInstance* instance);
 
         ~ConfigSocketClient() override;
     };

--- a/src/net/l2/stream/config/ConfigSocketServer.cpp
+++ b/src/net/l2/stream/config/ConfigSocketServer.cpp
@@ -75,8 +75,8 @@
 
 namespace net::l2::stream::config {
 
-    ConfigSocketServer::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketServer<net::l2::config::ConfigAddress, net::l2::config::ConfigAddressReverse>(instance) {
+    void ConfigSocketServer::init(net::config::ConfigInstance* instance) {
+        this->net::config::stream::ConfigSocketServer<net::l2::config::ConfigAddress, net::l2::config::ConfigAddressReverse>::init(instance);
         net::l2::config::ConfigAddress<net::config::ConfigAddressLocal>::setPsmRequired();
 
         net::l2::config::ConfigAddress<net::config::ConfigAddressLocal>::psmOpt //

--- a/src/net/l2/stream/config/ConfigSocketServer.h
+++ b/src/net/l2/stream/config/ConfigSocketServer.h
@@ -58,7 +58,9 @@ namespace net::l2::stream::config {
     class ConfigSocketServer
         : public net::config::stream::ConfigSocketServer<net::l2::config::ConfigAddress, net::l2::config::ConfigAddressReverse> {
     protected:
-        explicit ConfigSocketServer(net::config::ConfigInstance* instance);
+        ConfigSocketServer() = default;
+
+        void init(net::config::ConfigInstance* instance);
 
         ~ConfigSocketServer() override;
     };

--- a/src/net/rc/config/ConfigAddress.cpp
+++ b/src/net/rc/config/ConfigAddress.cpp
@@ -56,10 +56,10 @@
 namespace net::rc::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddress<ConfigAddressType>::init(net::config::ConfigInstance* instance,
+                                                const std::string& addressOptionName,
+                                                const std::string& addressOptionDescription) {
+        Super::init(instance, addressOptionName, addressOptionDescription);
         btAddressOpt = Super::addOption( //
             "--host",
             "Bluetooth address",

--- a/src/net/rc/config/ConfigAddress.h
+++ b/src/net/rc/config/ConfigAddress.h
@@ -79,12 +79,14 @@ namespace net::rc::config {
         using Super = ConfigAddressTypeT<net::rc::SocketAddress>;
 
     protected:
-        ConfigAddress(net::config::ConfigInstance* instance,
-                      const std::string& addressOptionName,
-                      const std::string& addressOptionDescription);
+        ConfigAddress() = default;
+
+        void init(net::config::ConfigInstance* instance,
+                  const std::string& addressOptionName,
+                  const std::string& addressOptionDescription) override;
 
     private:
-        SocketAddress* init() final;
+        SocketAddress* init();
 
     public:
         ConfigAddress& setSocketAddress(const SocketAddress& socketAddress);
@@ -95,7 +97,7 @@ namespace net::rc::config {
         ConfigAddress& setChannel(uint8_t channel);
         uint8_t getChannel() const;
 
-        void configurable(bool configurable = true) final;
+        void configurable(bool configurable = true);
 
     protected:
         ConfigAddress& setBtAddressRequired(bool required = true);

--- a/src/net/rc/stream/config/ConfigSocketClient.cpp
+++ b/src/net/rc/stream/config/ConfigSocketClient.cpp
@@ -72,8 +72,8 @@
 
 namespace net::rc::stream::config {
 
-    ConfigSocketClient::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketClient<net::rc::config::ConfigAddress>(instance) {
+    void ConfigSocketClient::init(net::config::ConfigInstance* instance) {
+        this->net::config::stream::ConfigSocketClient<net::rc::config::ConfigAddress>::init(instance);
         net::rc::config::ConfigAddress<net::config::ConfigAddressRemote>::setBtAddressRequired();
         net::rc::config::ConfigAddress<net::config::ConfigAddressRemote>::setChannelRequired();
 

--- a/src/net/rc/stream/config/ConfigSocketClient.h
+++ b/src/net/rc/stream/config/ConfigSocketClient.h
@@ -57,7 +57,9 @@ namespace net::rc::stream::config {
 
     class ConfigSocketClient : public net::config::stream::ConfigSocketClient<net::rc::config::ConfigAddress> {
     protected:
-        explicit ConfigSocketClient(net::config::ConfigInstance* instance);
+        ConfigSocketClient() = default;
+
+        void init(net::config::ConfigInstance* instance);
 
         ~ConfigSocketClient() override;
     };

--- a/src/net/rc/stream/config/ConfigSocketServer.cpp
+++ b/src/net/rc/stream/config/ConfigSocketServer.cpp
@@ -76,8 +76,8 @@ namespace net::config {
 
 namespace net::rc::stream::config {
 
-    ConfigSocketServer::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketServer<net::rc::config::ConfigAddress, net::rc::config::ConfigAddressReverse>(instance) {
+    void ConfigSocketServer::init(net::config::ConfigInstance* instance) {
+        this->net::config::stream::ConfigSocketServer<net::rc::config::ConfigAddress, net::rc::config::ConfigAddressReverse>::init(instance);
         net::rc::config::ConfigAddress<net::config::ConfigAddressLocal>::setChannelRequired();
 
         net::rc::config::ConfigAddress<net::config::ConfigAddressLocal>::channelOpt //

--- a/src/net/rc/stream/config/ConfigSocketServer.h
+++ b/src/net/rc/stream/config/ConfigSocketServer.h
@@ -58,7 +58,9 @@ namespace net::rc::stream::config {
     class ConfigSocketServer
         : public net::config::stream::ConfigSocketServer<net::rc::config::ConfigAddress, net::rc::config::ConfigAddressReverse> {
     protected:
-        explicit ConfigSocketServer(net::config::ConfigInstance* instance);
+        ConfigSocketServer() = default;
+
+        void init(net::config::ConfigInstance* instance);
 
         ~ConfigSocketServer() override;
     };

--- a/src/net/un/config/ConfigAddress.cpp
+++ b/src/net/un/config/ConfigAddress.cpp
@@ -59,10 +59,10 @@
 namespace net::un::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddress<ConfigAddressType>::init(net::config::ConfigInstance* instance,
+                                                const std::string& addressOptionName,
+                                                const std::string& addressOptionDescription) {
+        Super::init(instance, addressOptionName, addressOptionDescription);
         sunPathOpt = Super::addOption( //
             "--sun-path",
             "Unix domain bind path",

--- a/src/net/un/config/ConfigAddress.h
+++ b/src/net/un/config/ConfigAddress.h
@@ -78,12 +78,14 @@ namespace net::un::config {
         using Super = ConfigAddressTypeT<net::un::SocketAddress>;
 
     protected:
-        ConfigAddress(net::config::ConfigInstance* instance,
-                      const std::string& addressOptionName,
-                      const std::string& addressOptionDescription);
+        ConfigAddress() = default;
+
+        void init(net::config::ConfigInstance* instance,
+                  const std::string& addressOptionName,
+                  const std::string& addressOptionDescription) override;
 
     private:
-        SocketAddress* init() final;
+        SocketAddress* init();
 
     public:
         ConfigAddress& setSocketAddress(const SocketAddress& socketAddress);
@@ -91,7 +93,7 @@ namespace net::un::config {
         ConfigAddress& setSunPath(const std::string& sunPath);
         std::string getSunPath() const;
 
-        void configurable(bool configurable = true) final;
+        void configurable(bool configurable = true);
 
     protected:
         ConfigAddress& sunPathRequired(bool required = true);

--- a/src/net/un/stream/config/ConfigSocketClient.cpp
+++ b/src/net/un/stream/config/ConfigSocketClient.cpp
@@ -49,8 +49,8 @@
 
 namespace net::un::stream::config {
 
-    ConfigSocketClient::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketClient<net::un::config::ConfigAddress>(instance) {
+    void ConfigSocketClient::init(net::config::ConfigInstance* instance) {
+        this->net::config::stream::ConfigSocketClient<net::un::config::ConfigAddress>::init(instance);
         net::un::config::ConfigAddress<net::config::ConfigAddressRemote>::sunPathRequired();
     }
 

--- a/src/net/un/stream/config/ConfigSocketClient.h
+++ b/src/net/un/stream/config/ConfigSocketClient.h
@@ -57,7 +57,9 @@ namespace net::un::stream::config {
 
     class ConfigSocketClient : public net::config::stream::ConfigSocketClient<net::un::config::ConfigAddress> {
     protected:
-        explicit ConfigSocketClient(net::config::ConfigInstance* instance);
+        ConfigSocketClient() = default;
+
+        void init(net::config::ConfigInstance* instance);
 
         ~ConfigSocketClient() override;
     };

--- a/src/net/un/stream/config/ConfigSocketServer.cpp
+++ b/src/net/un/stream/config/ConfigSocketServer.cpp
@@ -49,8 +49,8 @@
 
 namespace net::un::stream::config {
 
-    ConfigSocketServer::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketServer<net::un::config::ConfigAddress, net::un::config::ConfigAddressReverse>(instance) {
+    void ConfigSocketServer::init(net::config::ConfigInstance* instance) {
+        this->net::config::stream::ConfigSocketServer<net::un::config::ConfigAddress, net::un::config::ConfigAddressReverse>::init(instance);
         net::un::config::ConfigAddress<net::config::ConfigAddressLocal>::sunPathRequired();
     }
 

--- a/src/net/un/stream/config/ConfigSocketServer.h
+++ b/src/net/un/stream/config/ConfigSocketServer.h
@@ -58,7 +58,9 @@ namespace net::un::stream::config {
     class ConfigSocketServer
         : public net::config::stream::ConfigSocketServer<net::un::config::ConfigAddress, net::un::config::ConfigAddressReverse> {
     protected:
-        explicit ConfigSocketServer(net::config::ConfigInstance* instance);
+        ConfigSocketServer() = default;
+
+        void init(net::config::ConfigInstance* instance);
 
         ~ConfigSocketServer() override;
     };


### PR DESCRIPTION
### Motivation
- Avoid early `ConfigSection` wiring during base/ intermediate construction by removing constructors that took `ConfigInstance*` and deferring registration until the concrete object is fully constructed.
- Ensure option wiring that needs concrete subclass state (addresses, socket roles, TLS context) runs after full object construction to prevent incorrect registration and ordering bugs.
- Provide a uniform, idempotent initialization pattern across the net config hierarchy without changing external configuration APIs.

### Description
- Removed non-default constructors of the form `Config*(ConfigInstance* ...)` across the net config tree and replaced them with defaulted constructors plus virtual `init(ConfigInstance* ...)` methods where appropriate.
- Moved section/option wiring out of constructors into `init(...)` implementations for `ConfigSection` subclasses including `ConfigAddressBase`/family, `ConfigPhysicalSocket*`, `ConfigTls*`, `ConfigConnection`, and `ConfigLegacy` and added guarding in `ConfigSection::init(...)` to be idempotent.
- Updated stream-level templates and concrete per-family stream classes (`in`, `in6`, `l2`, `rc`, `un`) and legacy/tls wrapper templates to call the recursive `init(...)` chain after full object construction (e.g. `Base::init(this)` / `Super::init(instance)`), preserving the previous registration semantics but deferring them.
- Fixed related virtual/final declarations and a few template-call-site issues so that `init(...)` calls resolve correctly across the inheritance and templated stacks.

### Testing
- Installed required build dependencies with `apt-get install -y libeasyloggingpp-dev nlohmann-json3-dev` and the installs succeeded.
- Configured the project with `cmake -S . -B build -G Ninja` and the configuration completed successfully.
- Built the full project with `cmake --build build -j4` and the build completed successfully without errors.
- Performed repository checks with `git diff --check` and local consistency checks, which reported no whitespace/diff issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c90e515c832cad0e449e758af7e7)