### PR TITLE
Defer net config initialization: add `lateConstruct` and remove non-default constructors

### DIFF
--- a/src/net/config/ConfigAddress.h
+++ b/src/net/config/ConfigAddress.h
@@ -65,7 +65,13 @@ namespace net::config {
         using SocketAddress = SocketAddressT;
 
     protected:
-        ConfigAddress(ConfigInstance* instance, const std::string& addressOptionName, const std::string& addressOptionDescription);
+        using Super::lateConstruct;
+
+        ConfigAddress() = default;
+
+        virtual void lateConstruct(ConfigInstance* instance,
+                                   const std::string& addressOptionName,
+                                   const std::string& addressOptionDescription);
 
         ~ConfigAddress() override;
 

--- a/src/net/config/ConfigAddress.hpp
+++ b/src/net/config/ConfigAddress.hpp
@@ -51,10 +51,10 @@
 namespace net::config {
 
     template <typename SocketAddress>
-    ConfigAddress<SocketAddress>::ConfigAddress(ConfigInstance* instance,
-                                                const std::string& addressOptionName,
-                                                const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddress<SocketAddress>::lateConstruct(ConfigInstance* instance,
+                                                     const std::string& addressOptionName,
+                                                     const std::string& addressOptionDescription) {
+        Super::lateConstruct(instance, addressOptionName, addressOptionDescription);
     }
 
     template <typename SocketAddress>

--- a/src/net/config/ConfigAddressBase.h
+++ b/src/net/config/ConfigAddressBase.h
@@ -60,9 +60,14 @@ namespace net::config {
         using Super = ConfigSection;
 
     protected:
-        explicit ConfigAddressBase(ConfigInstance* instance,
-                                   const std::string& addressOptionName = "",
-                                   const std::string& addressOptionDescription = "");
+        using Super::lateConstruct;
+
+    protected:
+        ConfigAddressBase() = default;
+
+        void lateConstruct(ConfigInstance* instance,
+                           const std::string& addressOptionName = "",
+                           const std::string& addressOptionDescription = "");
 
     public:
         SocketAddressT getSocketAddress(const typename SocketAddressT::SockAddr& sockAddr, typename SocketAddressT::SockLen sockAddrLen);

--- a/src/net/config/ConfigAddressBase.hpp
+++ b/src/net/config/ConfigAddressBase.hpp
@@ -49,10 +49,10 @@
 namespace net::config {
 
     template <typename SocketAddress>
-    ConfigAddressBase<SocketAddress>::ConfigAddressBase(ConfigInstance* instance,
-                                                        const std::string& addressOptionName,
-                                                        const std::string& addressOptionDescription)
-        : net::config::ConfigSection(instance, net::config::Section(addressOptionName, addressOptionDescription, this)) {
+    void ConfigAddressBase<SocketAddress>::lateConstruct(ConfigInstance* instance,
+                                                         const std::string& addressOptionName,
+                                                         const std::string& addressOptionDescription) {
+        net::config::ConfigSection::lateConstruct(instance, net::config::Section(addressOptionName, addressOptionDescription, this));
     }
 
     template <typename SocketAddress>

--- a/src/net/config/ConfigConnection.cpp
+++ b/src/net/config/ConfigConnection.cpp
@@ -49,9 +49,9 @@
 
 namespace net::config {
 
-    ConfigConnection::ConfigConnection(ConfigInstance* instance)
-        : net::config::ConfigSection(instance,
-                                     net::config::Section(ConfigConnection::name, "Configuration of established connections", this)) {
+    void ConfigConnection::lateConstruct(ConfigInstance* instance) {
+        net::config::ConfigSection::lateConstruct(instance,
+                                                  net::config::Section(ConfigConnection::name, "Configuration of established connections", this));
         readTimeoutOpt = addOption( //
             "--read-timeout",
             "Read timeout in seconds",

--- a/src/net/config/ConfigConnection.h
+++ b/src/net/config/ConfigConnection.h
@@ -66,7 +66,12 @@ namespace net::config {
         using Connection = ConfigConnection;
 
     protected:
-        explicit ConfigConnection(ConfigInstance* instance);
+        using ConfigSection::lateConstruct;
+
+    protected:
+        ConfigConnection() = default;
+
+        void lateConstruct(ConfigInstance* instance);
 
     public:
         constexpr static std::string name{"connection"};

--- a/src/net/config/ConfigLegacy.cpp
+++ b/src/net/config/ConfigLegacy.cpp
@@ -49,8 +49,8 @@
 
 namespace net::config {
 
-    ConfigLegacy::ConfigLegacy(ConfigInstance* instance)
-        : net::config::ConfigSection(instance, net::config::Section(ConfigLegacy::name, "Configuration of legacy behavior", this)) {
+    void ConfigLegacy::lateConstruct(ConfigInstance* instance) {
+        net::config::ConfigSection::lateConstruct(instance, net::config::Section(ConfigLegacy::name, "Configuration of legacy behavior", this));
     }
 
 } // namespace net::config

--- a/src/net/config/ConfigLegacy.h
+++ b/src/net/config/ConfigLegacy.h
@@ -61,7 +61,9 @@ namespace net::config {
         using Legacy = ConfigLegacy;
 
     protected:
-        explicit ConfigLegacy(ConfigInstance* instance);
+        ConfigLegacy() = default;
+
+        void lateConstruct(ConfigInstance* instance);
     };
 
 } // namespace net::config

--- a/src/net/config/ConfigPhysicalSocket.cpp
+++ b/src/net/config/ConfigPhysicalSocket.cpp
@@ -56,8 +56,8 @@
 
 namespace net::config {
 
-    ConfigPhysicalSocket::ConfigPhysicalSocket(ConfigInstance* instance)
-        : ConfigSection(instance, net::config::Section(ConfigPhysicalSocket::name, "Configuration of socket behavior", this)) {
+    void ConfigPhysicalSocket::lateConstruct(ConfigInstance* instance) {
+        ConfigSection::lateConstruct(instance, net::config::Section(ConfigPhysicalSocket::name, "Configuration of socket behavior", this));
         retryOpt = addFlag( //
             "--retry{true}",
             "Automatically retry listen|connect",

--- a/src/net/config/ConfigPhysicalSocket.h
+++ b/src/net/config/ConfigPhysicalSocket.h
@@ -65,7 +65,12 @@ namespace net::config {
 
     class ConfigPhysicalSocket : protected ConfigSection {
     protected:
-        explicit ConfigPhysicalSocket(ConfigInstance* instance);
+        using ConfigSection::lateConstruct;
+
+    protected:
+        ConfigPhysicalSocket() = default;
+
+        virtual void lateConstruct(ConfigInstance* instance);
 
     public:
         constexpr static std::string name{"socket"};

--- a/src/net/config/ConfigPhysicalSocketClient.cpp
+++ b/src/net/config/ConfigPhysicalSocketClient.cpp
@@ -56,8 +56,8 @@
 
 namespace net::config {
 
-    ConfigPhysicalSocketClient::ConfigPhysicalSocketClient(ConfigInstance* instance)
-        : Super(instance) {
+    void ConfigPhysicalSocketClient::lateConstruct(ConfigInstance* instance) {
+        Super::lateConstruct(instance);
         reconnectOpt = addFlagFunction( //
             "--reconnect{true}",
             [this]() {

--- a/src/net/config/ConfigPhysicalSocketClient.h
+++ b/src/net/config/ConfigPhysicalSocketClient.h
@@ -67,7 +67,9 @@ namespace net::config {
         using Socket = ConfigPhysicalSocketClient;
 
     protected:
-        explicit ConfigPhysicalSocketClient(ConfigInstance* instance);
+        ConfigPhysicalSocketClient() = default;
+
+        void lateConstruct(ConfigInstance* instance) override;
 
     public:
         ConfigPhysicalSocketClient& setReconnect(bool reconnect = true);

--- a/src/net/config/ConfigPhysicalSocketServer.cpp
+++ b/src/net/config/ConfigPhysicalSocketServer.cpp
@@ -51,8 +51,8 @@
 
 namespace net::config {
 
-    ConfigPhysicalSocketServer::ConfigPhysicalSocketServer(ConfigInstance* instance)
-        : Super(instance) {
+    void ConfigPhysicalSocketServer::lateConstruct(ConfigInstance* instance) {
+        Super::lateConstruct(instance);
         backlogOpt = addOption( //
             "--backlog",
             "Listen backlog",

--- a/src/net/config/ConfigPhysicalSocketServer.h
+++ b/src/net/config/ConfigPhysicalSocketServer.h
@@ -67,7 +67,9 @@ namespace net::config {
         using Socket = ConfigPhysicalSocketServer;
 
     protected:
-        explicit ConfigPhysicalSocketServer(ConfigInstance* instance);
+        ConfigPhysicalSocketServer() = default;
+
+        void lateConstruct(ConfigInstance* instance) override;
 
     public:
         ConfigPhysicalSocketServer& setBacklog(int newBacklog);

--- a/src/net/config/ConfigSection.cpp
+++ b/src/net/config/ConfigSection.cpp
@@ -75,8 +75,8 @@
 
 namespace net::config {
 
-    ConfigSection::ConfigSection(ConfigInstance* instanceSc, std::shared_ptr<CLI::App> sectionApp, const std::string& group)
-        : instanceSc(instanceSc) {
+    void ConfigSection::lateConstruct(ConfigInstance* instanceSc, std::shared_ptr<CLI::App> sectionApp, const std::string& group) {
+        this->instanceSc = instanceSc;
         sectionSc = instanceSc->newSection(sectionApp, group);
         sectionSc->description(sectionSc->get_description() + " for instance '" + instanceSc->getInstanceName() + "'");
     }

--- a/src/net/config/ConfigSection.h
+++ b/src/net/config/ConfigSection.h
@@ -65,7 +65,11 @@ namespace net::config {
 
     class ConfigSection {
     public:
-        ConfigSection(ConfigInstance* instanceSc, std::shared_ptr<CLI::App> sectionApp, const std::string& group = "Sections");
+        ConfigSection() = default;
+
+        virtual void lateConstruct(ConfigInstance* instanceSc,
+                                   std::shared_ptr<CLI::App> sectionApp,
+                                   const std::string& group = "Sections");
 
         virtual ~ConfigSection() = default;
 

--- a/src/net/config/ConfigTls.cpp
+++ b/src/net/config/ConfigTls.cpp
@@ -49,8 +49,8 @@
 
 namespace net::config {
 
-    ConfigTls::ConfigTls(ConfigInstance* instance)
-        : ConfigSection(instance, net::config::Section(ConfigTls::name, "Configuration of SSL/TLS behavior", this)) {
+    void ConfigTls::lateConstruct(ConfigInstance* instance) {
+        ConfigSection::lateConstruct(instance, net::config::Section(ConfigTls::name, "Configuration of SSL/TLS behavior", this));
         certOpt = addOption( //
             "--cert",
             "Certificate chain file",

--- a/src/net/config/ConfigTls.h
+++ b/src/net/config/ConfigTls.h
@@ -64,7 +64,12 @@ namespace net::config {
 
     class ConfigTls : protected ConfigSection {
     protected:
-        explicit ConfigTls(ConfigInstance* instance);
+        using ConfigSection::lateConstruct;
+
+    protected:
+        ConfigTls() = default;
+
+        virtual void lateConstruct(ConfigInstance* instance);
 
     public:
         constexpr static std::string name{"tls"};

--- a/src/net/config/ConfigTlsClient.cpp
+++ b/src/net/config/ConfigTlsClient.cpp
@@ -49,8 +49,8 @@
 
 namespace net::config {
 
-    ConfigTlsClient::ConfigTlsClient(ConfigInstance* instance)
-        : Super(instance) {
+    void ConfigTlsClient::lateConstruct(ConfigInstance* instance) {
+        Super::lateConstruct(instance);
         sniOpt = addOption( //
             "--sni",
             "Server Name Indication",

--- a/src/net/config/ConfigTlsClient.h
+++ b/src/net/config/ConfigTlsClient.h
@@ -68,7 +68,9 @@ namespace net::config {
         using Tls = ConfigTlsClient;
 
     protected:
-        explicit ConfigTlsClient(ConfigInstance* instance);
+        ConfigTlsClient() = default;
+
+        void lateConstruct(ConfigInstance* instance) override;
 
     public:
         ConfigTlsClient& setSni(const std::string& sni);

--- a/src/net/config/ConfigTlsServer.cpp
+++ b/src/net/config/ConfigTlsServer.cpp
@@ -52,8 +52,8 @@
 
 namespace net::config {
 
-    ConfigTlsServer::ConfigTlsServer(ConfigInstance* instance)
-        : Super(instance) {
+    void ConfigTlsServer::lateConstruct(ConfigInstance* instance) {
+        Super::lateConstruct(instance);
         sniCertsOpt = sectionSc //
                           ->add_option("--sni-cert",
                                        configuredSniCerts,

--- a/src/net/config/ConfigTlsServer.h
+++ b/src/net/config/ConfigTlsServer.h
@@ -70,7 +70,9 @@ namespace net::config {
         using Tls = ConfigTlsServer;
 
     protected:
-        explicit ConfigTlsServer(ConfigInstance* instance);
+        ConfigTlsServer() = default;
+
+        void lateConstruct(ConfigInstance* instance) override;
 
     public:
         ConfigTlsServer& setForceSni(bool forceSni = true);

--- a/src/net/config/stream/ConfigSocketClient.h
+++ b/src/net/config/stream/ConfigSocketClient.h
@@ -65,7 +65,9 @@ namespace net::config::stream {
         using Local = ConfigAddressLocalT<net::config::ConfigAddressLocal>;
 
     protected:
-        explicit ConfigSocketClient(net::config::ConfigInstance* instance);
+        ConfigSocketClient() = default;
+
+        void lateConstruct(net::config::ConfigInstance* instance);
     };
 
 } // namespace net::config::stream

--- a/src/net/config/stream/ConfigSocketClient.hpp
+++ b/src/net/config/stream/ConfigSocketClient.hpp
@@ -49,11 +49,11 @@ namespace net::config::stream {
 
     template <template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressLocal,
               template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressRemote>
-    ConfigSocketClient<ConfigAddressLocal, ConfigAddressRemote>::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : ConfigAddressRemote<net::config::ConfigAddressRemote>(instance, "remote", "Remote side of connection")
-        , ConfigAddressLocal<net::config::ConfigAddressLocal>(instance, "local", "Local side of connection")
-        , net::config::ConfigConnection(instance)
-        , net::config::ConfigPhysicalSocketClient(instance) {
+    void ConfigSocketClient<ConfigAddressLocal, ConfigAddressRemote>::lateConstruct(net::config::ConfigInstance* instance) {
+        ConfigAddressRemote<net::config::ConfigAddressRemote>::lateConstruct(instance, "remote", "Remote side of connection");
+        ConfigAddressLocal<net::config::ConfigAddressLocal>::lateConstruct(instance, "local", "Local side of connection");
+        net::config::ConfigConnection::lateConstruct(instance);
+        net::config::ConfigPhysicalSocketClient::lateConstruct(instance);
     }
 
 } // namespace net::config::stream

--- a/src/net/config/stream/ConfigSocketServer.h
+++ b/src/net/config/stream/ConfigSocketServer.h
@@ -65,7 +65,9 @@ namespace net::config::stream {
         using Remote = ConfigAddressRemoteT<net::config::ConfigAddressReverse>;
 
     protected:
-        explicit ConfigSocketServer(net::config::ConfigInstance* instance);
+        ConfigSocketServer() = default;
+
+        void lateConstruct(net::config::ConfigInstance* instance);
     };
 
 } // namespace net::config::stream

--- a/src/net/config/stream/ConfigSocketServer.hpp
+++ b/src/net/config/stream/ConfigSocketServer.hpp
@@ -49,11 +49,11 @@ namespace net::config::stream {
 
     template <template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressLocal,
               template <template <typename SocketAddress> typename ConfigAddressType> typename ConfigAddressRemote>
-    ConfigSocketServer<ConfigAddressLocal, ConfigAddressRemote>::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : ConfigAddressLocal<net::config::ConfigAddressLocal>(instance, "local", "Local side of connection")
-        , ConfigAddressRemote<net::config::ConfigAddressReverse>(instance, "remote", "Remote side of connection")
-        , net::config::ConfigConnection(instance)
-        , net::config::ConfigPhysicalSocketServer(instance) {
+    void ConfigSocketServer<ConfigAddressLocal, ConfigAddressRemote>::lateConstruct(net::config::ConfigInstance* instance) {
+        ConfigAddressLocal<net::config::ConfigAddressLocal>::lateConstruct(instance, "local", "Local side of connection");
+        ConfigAddressRemote<net::config::ConfigAddressReverse>::lateConstruct(instance, "remote", "Remote side of connection");
+        net::config::ConfigConnection::lateConstruct(instance);
+        net::config::ConfigPhysicalSocketServer::lateConstruct(instance);
     }
 
 } // namespace net::config::stream

--- a/src/net/in/config/ConfigAddress.cpp
+++ b/src/net/in/config/ConfigAddress.cpp
@@ -62,10 +62,11 @@
 namespace net::in::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                                                  const std::string& addressOptionName,
-                                                                  const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddressReverse<ConfigAddressType>::lateConstruct(net::config::ConfigInstance* instance,
+                                                                 const std::string& addressOptionName,
+                                                                 const std::string& addressOptionDescription) {
+        Super::lateConstruct(instance, addressOptionName, addressOptionDescription);
+
         numericReverseOpt = Super::addFlag( //
             "--numeric-reverse{true}",
             "Suppress reverse host name lookup",
@@ -106,10 +107,11 @@ namespace net::in::config {
     }
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddress<ConfigAddressType>::lateConstruct(net::config::ConfigInstance* instance,
+                                                           const std::string& addressOptionName,
+                                                           const std::string& addressOptionDescription) {
+        Super::lateConstruct(instance, addressOptionName, addressOptionDescription);
+
         hostOpt = Super::addOption( //
             "--host",
             "Host name or IPv4 address",

--- a/src/net/in/config/ConfigAddress.h
+++ b/src/net/in/config/ConfigAddress.h
@@ -70,9 +70,13 @@ namespace net::in::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        ConfigAddressReverse(net::config::ConfigInstance* instance,
-                             const std::string& addressOptionName,
-                             const std::string& addressOptionDescription);
+        using Super::lateConstruct;
+
+        ConfigAddressReverse() = default;
+
+        void lateConstruct(net::config::ConfigInstance* instance,
+                           const std::string& addressOptionName,
+                           const std::string& addressOptionDescription);
 
     public:
         SocketAddress getSocketAddress(const SocketAddress::SockAddr& sockAddr, SocketAddress::SockLen sockAddrLen);
@@ -90,12 +94,16 @@ namespace net::in::config {
         using Super = ConfigAddressTypeT<net::in::SocketAddress>;
 
     protected:
-        explicit ConfigAddress(net::config::ConfigInstance* instance,
-                               const std::string& addressOptionName,
-                               const std::string& addressOptionDescription);
+        using Super::lateConstruct;
+
+        ConfigAddress() = default;
+
+        void lateConstruct(net::config::ConfigInstance* instance,
+                           const std::string& addressOptionName,
+                           const std::string& addressOptionDescription) override;
 
     private:
-        SocketAddress* init() final;
+        SocketAddress* init() override final;
 
     public:
         using Super::getSocketAddress;
@@ -115,7 +123,7 @@ namespace net::in::config {
         ConfigAddress& setNumericReverse(bool numeric = true);
         bool getNumericReverse() const;
 
-        void configurable(bool configurable = true) final;
+        void configurable(bool configurable = true) override;
 
     protected:
         ConfigAddress& setAiFlags(int aiFlags);

--- a/src/net/in/stream/config/ConfigSocketClient.cpp
+++ b/src/net/in/stream/config/ConfigSocketClient.cpp
@@ -82,7 +82,8 @@
 namespace net::in::stream::config {
 
     ConfigSocketClient::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketClient<net::in::config::ConfigAddress>(instance) {
+        {
+        net::config::stream::ConfigSocketClient<net::in::config::ConfigAddress>::lateConstruct(instance);
         net::in::config::ConfigAddress<net::config::ConfigAddressRemote>::setHostRequired();
         net::in::config::ConfigAddress<net::config::ConfigAddressRemote>::setPortRequired();
         net::in::config::ConfigAddress<net::config::ConfigAddressRemote>::setAiSockType(SOCK_STREAM);

--- a/src/net/in/stream/config/ConfigSocketServer.cpp
+++ b/src/net/in/stream/config/ConfigSocketServer.cpp
@@ -82,7 +82,8 @@
 namespace net::in::stream::config {
 
     ConfigSocketServer::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketServer<net::in::config::ConfigAddress, net::in::config::ConfigAddressReverse>(instance) {
+        {
+        net::config::stream::ConfigSocketServer<net::in::config::ConfigAddress, net::in::config::ConfigAddressReverse>::lateConstruct(instance);
         net::in::config::ConfigAddress<net::config::ConfigAddressLocal>::setPortRequired();
         net::in::config::ConfigAddress<net::config::ConfigAddressLocal>::setAiFlags(AI_PASSIVE);
         net::in::config::ConfigAddress<net::config::ConfigAddressLocal>::setAiSockType(SOCK_STREAM);

--- a/src/net/in6/config/ConfigAddress.cpp
+++ b/src/net/in6/config/ConfigAddress.cpp
@@ -62,10 +62,11 @@
 namespace net::in6::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddressReverse<ConfigAddressType>::ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                                                  const std::string& addressOptionName,
-                                                                  const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddressReverse<ConfigAddressType>::lateConstruct(net::config::ConfigInstance* instance,
+                                                                 const std::string& addressOptionName,
+                                                                 const std::string& addressOptionDescription) {
+        Super::lateConstruct(instance, addressOptionName, addressOptionDescription);
+
         numericReverseOpt = Super::addFlag( //
             "--numeric-reverse",
             "Suppress reverse host name lookup",
@@ -106,10 +107,11 @@ namespace net::in6::config {
     }
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddress<ConfigAddressType>::lateConstruct(net::config::ConfigInstance* instance,
+                                                           const std::string& addressOptionName,
+                                                           const std::string& addressOptionDescription) {
+        Super::lateConstruct(instance, addressOptionName, addressOptionDescription);
+
         hostOpt = Super::addOption( //
             "--host",
             "Host name or IPv6 address",

--- a/src/net/in6/config/ConfigAddress.h
+++ b/src/net/in6/config/ConfigAddress.h
@@ -72,9 +72,13 @@ namespace net::in6::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        explicit ConfigAddressReverse(net::config::ConfigInstance* instance,
-                                      const std::string& addressOptionName,
-                                      const std::string& addressOptionDescription);
+        using Super::lateConstruct;
+
+        ConfigAddressReverse() = default;
+
+        void lateConstruct(net::config::ConfigInstance* instance,
+                           const std::string& addressOptionName,
+                           const std::string& addressOptionDescription);
 
     public:
         SocketAddress getSocketAddress(const SocketAddress::SockAddr& sockAddr, SocketAddress::SockLen sockAddrLen);
@@ -92,12 +96,16 @@ namespace net::in6::config {
         using Super = ConfigAddressTypeT<SocketAddress>;
 
     protected:
-        ConfigAddress(net::config::ConfigInstance* instance,
-                      const std::string& addressOptionName,
-                      const std::string& addressOptionDescription);
+        using Super::lateConstruct;
+
+        ConfigAddress() = default;
+
+        void lateConstruct(net::config::ConfigInstance* instance,
+                           const std::string& addressOptionName,
+                           const std::string& addressOptionDescription) override;
 
     private:
-        SocketAddress* init() final;
+        SocketAddress* init() override final;
 
     public:
         using Super::getSocketAddress;
@@ -117,7 +125,7 @@ namespace net::in6::config {
         ConfigAddress& setNumericReverse(bool numeric = true);
         bool getNumericReverse() const;
 
-        void configurable(bool configurable = true) final;
+        void configurable(bool configurable = true) override;
 
     protected:
         ConfigAddress& setIpv4Mapped(bool ipv4Mapped = true);

--- a/src/net/in6/stream/config/ConfigSocketClient.cpp
+++ b/src/net/in6/stream/config/ConfigSocketClient.cpp
@@ -82,7 +82,8 @@
 namespace net::in6::stream::config {
 
     ConfigSocketClient::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketClient<net::in6::config::ConfigAddress>(instance) {
+        {
+        net::config::stream::ConfigSocketClient<net::in6::config::ConfigAddress>::lateConstruct(instance);
         net::in6::config::ConfigAddress<net::config::ConfigAddressRemote>::setHostRequired();
         net::in6::config::ConfigAddress<net::config::ConfigAddressRemote>::setPortRequired();
 

--- a/src/net/in6/stream/config/ConfigSocketServer.cpp
+++ b/src/net/in6/stream/config/ConfigSocketServer.cpp
@@ -82,7 +82,8 @@
 namespace net::in6::stream::config {
 
     ConfigSocketServer::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketServer<net::in6::config::ConfigAddress, net::in6::config::ConfigAddressReverse>(instance) {
+        {
+        net::config::stream::ConfigSocketServer<net::in6::config::ConfigAddress, net::in6::config::ConfigAddressReverse>::lateConstruct(instance);
         net::in6::config::ConfigAddress<net::config::ConfigAddressLocal>::setPortRequired();
 
         net::in6::config::ConfigAddress<net::config::ConfigAddressLocal>::setAiFlags(AI_PASSIVE);

--- a/src/net/l2/config/ConfigAddress.cpp
+++ b/src/net/l2/config/ConfigAddress.cpp
@@ -56,10 +56,11 @@
 namespace net::l2::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddress<ConfigAddressType>::lateConstruct(net::config::ConfigInstance* instance,
+                                                           const std::string& addressOptionName,
+                                                           const std::string& addressOptionDescription) {
+        Super::lateConstruct(instance, addressOptionName, addressOptionDescription);
+
         btAddressOpt = Super::addOption( //
             "--host",
             "Bluetooth address",

--- a/src/net/l2/config/ConfigAddress.h
+++ b/src/net/l2/config/ConfigAddress.h
@@ -79,12 +79,16 @@ namespace net::l2::config {
         using Super = ConfigAddressTypeT<net::l2::SocketAddress>;
 
     protected:
-        ConfigAddress(net::config::ConfigInstance* instance,
-                      const std::string& addressOptionName,
-                      const std::string& addressOptionDescription);
+        using Super::lateConstruct;
+
+        ConfigAddress() = default;
+
+        void lateConstruct(net::config::ConfigInstance* instance,
+                           const std::string& addressOptionName,
+                           const std::string& addressOptionDescription) override;
 
     private:
-        SocketAddress* init() final;
+        SocketAddress* init() override final;
 
     public:
         ConfigAddress& setSocketAddress(const SocketAddress& socketAddress);
@@ -95,7 +99,7 @@ namespace net::l2::config {
         ConfigAddress& setPsm(uint16_t psm);
         uint16_t getPsm() const;
 
-        void configurable(bool configurable = true) final;
+        void configurable(bool configurable = true) override;
 
     protected:
         ConfigAddress& setBtAddressRequired(bool required = true);

--- a/src/net/l2/stream/config/ConfigSocketClient.cpp
+++ b/src/net/l2/stream/config/ConfigSocketClient.cpp
@@ -76,7 +76,8 @@
 namespace net::l2::stream::config {
 
     ConfigSocketClient::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketClient<net::l2::config::ConfigAddress>(instance) {
+        {
+        net::config::stream::ConfigSocketClient<net::l2::config::ConfigAddress>::lateConstruct(instance);
         net::l2::config::ConfigAddress<net::config::ConfigAddressRemote>::setBtAddressRequired();
         net::l2::config::ConfigAddress<net::config::ConfigAddressRemote>::setPsmRequired();
 

--- a/src/net/l2/stream/config/ConfigSocketServer.cpp
+++ b/src/net/l2/stream/config/ConfigSocketServer.cpp
@@ -76,7 +76,8 @@
 namespace net::l2::stream::config {
 
     ConfigSocketServer::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketServer<net::l2::config::ConfigAddress, net::l2::config::ConfigAddressReverse>(instance) {
+        {
+        net::config::stream::ConfigSocketServer<net::l2::config::ConfigAddress, net::l2::config::ConfigAddressReverse>::lateConstruct(instance);
         net::l2::config::ConfigAddress<net::config::ConfigAddressLocal>::setPsmRequired();
 
         net::l2::config::ConfigAddress<net::config::ConfigAddressLocal>::psmOpt //

--- a/src/net/rc/config/ConfigAddress.cpp
+++ b/src/net/rc/config/ConfigAddress.cpp
@@ -56,10 +56,11 @@
 namespace net::rc::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddress<ConfigAddressType>::lateConstruct(net::config::ConfigInstance* instance,
+                                                           const std::string& addressOptionName,
+                                                           const std::string& addressOptionDescription) {
+        Super::lateConstruct(instance, addressOptionName, addressOptionDescription);
+
         btAddressOpt = Super::addOption( //
             "--host",
             "Bluetooth address",

--- a/src/net/rc/config/ConfigAddress.h
+++ b/src/net/rc/config/ConfigAddress.h
@@ -79,12 +79,16 @@ namespace net::rc::config {
         using Super = ConfigAddressTypeT<net::rc::SocketAddress>;
 
     protected:
-        ConfigAddress(net::config::ConfigInstance* instance,
-                      const std::string& addressOptionName,
-                      const std::string& addressOptionDescription);
+        using Super::lateConstruct;
+
+        ConfigAddress() = default;
+
+        void lateConstruct(net::config::ConfigInstance* instance,
+                           const std::string& addressOptionName,
+                           const std::string& addressOptionDescription) override;
 
     private:
-        SocketAddress* init() final;
+        SocketAddress* init() override final;
 
     public:
         ConfigAddress& setSocketAddress(const SocketAddress& socketAddress);
@@ -95,7 +99,7 @@ namespace net::rc::config {
         ConfigAddress& setChannel(uint8_t channel);
         uint8_t getChannel() const;
 
-        void configurable(bool configurable = true) final;
+        void configurable(bool configurable = true) override;
 
     protected:
         ConfigAddress& setBtAddressRequired(bool required = true);

--- a/src/net/rc/stream/config/ConfigSocketClient.cpp
+++ b/src/net/rc/stream/config/ConfigSocketClient.cpp
@@ -73,7 +73,8 @@
 namespace net::rc::stream::config {
 
     ConfigSocketClient::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketClient<net::rc::config::ConfigAddress>(instance) {
+        {
+        net::config::stream::ConfigSocketClient<net::rc::config::ConfigAddress>::lateConstruct(instance);
         net::rc::config::ConfigAddress<net::config::ConfigAddressRemote>::setBtAddressRequired();
         net::rc::config::ConfigAddress<net::config::ConfigAddressRemote>::setChannelRequired();
 

--- a/src/net/rc/stream/config/ConfigSocketServer.cpp
+++ b/src/net/rc/stream/config/ConfigSocketServer.cpp
@@ -77,7 +77,8 @@ namespace net::config {
 namespace net::rc::stream::config {
 
     ConfigSocketServer::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketServer<net::rc::config::ConfigAddress, net::rc::config::ConfigAddressReverse>(instance) {
+        {
+        net::config::stream::ConfigSocketServer<net::rc::config::ConfigAddress, net::rc::config::ConfigAddressReverse>::lateConstruct(instance);
         net::rc::config::ConfigAddress<net::config::ConfigAddressLocal>::setChannelRequired();
 
         net::rc::config::ConfigAddress<net::config::ConfigAddressLocal>::channelOpt //

--- a/src/net/un/config/ConfigAddress.cpp
+++ b/src/net/un/config/ConfigAddress.cpp
@@ -59,10 +59,11 @@
 namespace net::un::config {
 
     template <template <typename SocketAddress> typename ConfigAddressType>
-    ConfigAddress<ConfigAddressType>::ConfigAddress(net::config::ConfigInstance* instance,
-                                                    const std::string& addressOptionName,
-                                                    const std::string& addressOptionDescription)
-        : Super(instance, addressOptionName, addressOptionDescription) {
+    void ConfigAddress<ConfigAddressType>::lateConstruct(net::config::ConfigInstance* instance,
+                                                           const std::string& addressOptionName,
+                                                           const std::string& addressOptionDescription) {
+        Super::lateConstruct(instance, addressOptionName, addressOptionDescription);
+
         sunPathOpt = Super::addOption( //
             "--sun-path",
             "Unix domain bind path",

--- a/src/net/un/config/ConfigAddress.h
+++ b/src/net/un/config/ConfigAddress.h
@@ -78,12 +78,16 @@ namespace net::un::config {
         using Super = ConfigAddressTypeT<net::un::SocketAddress>;
 
     protected:
-        ConfigAddress(net::config::ConfigInstance* instance,
-                      const std::string& addressOptionName,
-                      const std::string& addressOptionDescription);
+        using Super::lateConstruct;
+
+        ConfigAddress() = default;
+
+        void lateConstruct(net::config::ConfigInstance* instance,
+                           const std::string& addressOptionName,
+                           const std::string& addressOptionDescription) override;
 
     private:
-        SocketAddress* init() final;
+        SocketAddress* init() override final;
 
     public:
         ConfigAddress& setSocketAddress(const SocketAddress& socketAddress);
@@ -91,7 +95,7 @@ namespace net::un::config {
         ConfigAddress& setSunPath(const std::string& sunPath);
         std::string getSunPath() const;
 
-        void configurable(bool configurable = true) final;
+        void configurable(bool configurable = true) override;
 
     protected:
         ConfigAddress& sunPathRequired(bool required = true);

--- a/src/net/un/stream/config/ConfigSocketClient.cpp
+++ b/src/net/un/stream/config/ConfigSocketClient.cpp
@@ -50,7 +50,8 @@
 namespace net::un::stream::config {
 
     ConfigSocketClient::ConfigSocketClient(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketClient<net::un::config::ConfigAddress>(instance) {
+        {
+        net::config::stream::ConfigSocketClient<net::un::config::ConfigAddress>::lateConstruct(instance);
         net::un::config::ConfigAddress<net::config::ConfigAddressRemote>::sunPathRequired();
     }
 

--- a/src/net/un/stream/config/ConfigSocketServer.cpp
+++ b/src/net/un/stream/config/ConfigSocketServer.cpp
@@ -50,7 +50,8 @@
 namespace net::un::stream::config {
 
     ConfigSocketServer::ConfigSocketServer(net::config::ConfigInstance* instance)
-        : net::config::stream::ConfigSocketServer<net::un::config::ConfigAddress, net::un::config::ConfigAddressReverse>(instance) {
+        {
+        net::config::stream::ConfigSocketServer<net::un::config::ConfigAddress, net::un::config::ConfigAddressReverse>::lateConstruct(instance);
         net::un::config::ConfigAddress<net::config::ConfigAddressLocal>::sunPathRequired();
     }
 


### PR DESCRIPTION
### Motivation

- Config section setup in `ConfigSection` (and derived `Config*`) was executed too early during construction, causing issues with multi-inheritance initialisation ordering (notably `ConfigAddress` and `ConfigPhysicalSocket` variants).  
- Initialization of address-specific options (e.g. IPv4 in `net/in/config/ConfigAddress`) must happen after the full inheritance chain is established.

### Description

- Introduced deferred initialization API: added `ConfigSection::lateConstruct(...)` and converted all config classes to default-constructible, moving the work previously in non-default constructors into `lateConstruct(...)` implementations.  
- Reworked many `Config*` classes to follow the new flow: `ConfigAddressBase`, `ConfigAddress`, `ConfigConnection`, `ConfigPhysicalSocket` (and client/server variants), `ConfigTls` (and client/server), `ConfigLegacy`, and the templated stream compositions `ConfigSocketClient`/`ConfigSocketServer` now call `lateConstruct(...)` recursively to wire-up sections and options after the whole object hierarchy exists.  
- Removed non-default constructors of the form `Config*(ConfigInstance* instance, ...)` and added `using Super::lateConstruct` / `lateConstruct` overrides where necessary to avoid overload hiding.  
- Added correct override annotations for overriding methods such as `init()` and `configurable()` (`override` / `override final` as appropriate).  
- Updated all protocol-specific modules to call the new deferred initialization (examples: `net/in`, `net/in6`, `net/un`, `net/l2`, `net/rc` stream config entry points now invoke `lateConstruct(instance)`).

### Testing

- Installed build deps with `apt-get install -y libeasyloggingpp-dev libssl-dev openssl nlohmann-json3-dev libbluetooth-dev libmagic-dev`. (Succeeded.)
- Configured the project with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` (Succeeded; dependencies discovered).
- Per-file syntax validation using `compile_commands.json` + `-fsyntax-only` for the modified net/config and net/*/config units (Succeeded for the representative set of changed files).
- Built a subset of targets and modules: `cmake --build build --target mqtt-types mqtt-fast-types mqtt-fast-packets` (Succeeded).  
- Full project build (`cmake --build build -j4`) is currently blocked by an unrelated upstream/system issue: a warning in the system `easylogging++` include (`/usr/include/easylogging++.cc`) is promoted to error by the project compile flags (`-Werror=stringop-overflow`), causing the final link/build to fail; this is external to the refactor and does not indicate problems in the changed `Config*` code.  

If you want I can: run a focused unit test or build CI-friendly fixes (e.g. relax Werror for system includes) to let the full build complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991eaae4938832ca300ffa362770bce)