### PR TITLE
Centralize SubCommand disabled handling and update ConfigInstance

### DIFF
--- a/src/net/config/ConfigInstance.cpp
+++ b/src/net/config/ConfigInstance.cpp
@@ -70,11 +70,7 @@ namespace net::config {
         , disableOpt(setConfigurable(addFlagFunction(
                                          "--disabled{true}",
                                          [this]() {
-                                             if (getParent() != nullptr) {
-                                                 getParent()->disabled(this, disableOpt->as<bool>());
-                                             }
-
-                                             //                                             required(disableOpt->as<bool>(), true);
+                                             disabled(disableOpt->as<bool>());
                                          },
                                          "Disable this instance",
                                          "bool",
@@ -109,11 +105,7 @@ namespace net::config {
     ConfigInstance* ConfigInstance::setDisabled(bool disabled) {
         setDefaultValue(disableOpt, disabled ? "true" : "false");
 
-        if (getParent() != nullptr) {
-            getParent()->disabled(this, disabled);
-        }
-
-        //        required(disabled, true);
+        this->disabled(disabled);
 
         return this;
     }

--- a/src/net/config/ConfigInstance.cpp
+++ b/src/net/config/ConfigInstance.cpp
@@ -70,7 +70,7 @@ namespace net::config {
         , disableOpt(setConfigurable(addFlagFunction(
                                          "--disabled{true}",
                                          [this]() {
-                                             disabled(disableOpt->as<bool>());
+                                             forceRequired(!disableOpt->as<bool>());
                                          },
                                          "Disable this instance",
                                          "bool",
@@ -105,7 +105,7 @@ namespace net::config {
     ConfigInstance* ConfigInstance::setDisabled(bool disabled) {
         setDefaultValue(disableOpt, disabled ? "true" : "false");
 
-        this->disabled(disabled);
+        this->forceRequired(!disabled);
 
         return this;
     }

--- a/src/utils/SubCommand.cpp
+++ b/src/utils/SubCommand.cpp
@@ -201,18 +201,18 @@ namespace utils {
         return this;
     }
 
-    SubCommand* SubCommand::disabled(bool disabled) {
-        if (requiredDisabled != disabled) {
-            requiredDisabled = disabled;
-
+    SubCommand* SubCommand::forceRequired(bool required) {
+        if (requiredForced != true || requiredForcedValue != required) {
             const bool previouslyRequired = subCommandApp->get_required();
-            const bool currentlyRequired = requiredDisabled ? false : subCommandApp->get_ignore_case();
 
-            if (previouslyRequired != currentlyRequired) {
-                subCommandApp->required(currentlyRequired);
+            requiredForced = true;
+            requiredForcedValue = required;
+
+            if (previouslyRequired != requiredForcedValue) {
+                subCommandApp->required(requiredForcedValue);
 
                 if (hasParent()) {
-                    getParent()->needs(this, currentlyRequired);
+                    getParent()->needs(this, requiredForcedValue);
                 }
             }
         }
@@ -238,7 +238,7 @@ namespace utils {
 
         requiredCount += required ? 1 : -1;
         const bool countedRequired = requiredCount > 0;
-        const bool effectiveRequired = requiredDisabled ? false : countedRequired;
+        const bool effectiveRequired = requiredForced ? requiredForcedValue : countedRequired;
 
         subCommandApp->ignore_case(countedRequired);
         if (subCommandApp->get_required() != effectiveRequired) {

--- a/src/utils/SubCommand.cpp
+++ b/src/utils/SubCommand.cpp
@@ -201,6 +201,25 @@ namespace utils {
         return this;
     }
 
+    SubCommand* SubCommand::disabled(bool disabled) {
+        if (requiredDisabled != disabled) {
+            requiredDisabled = disabled;
+
+            const bool previouslyRequired = subCommandApp->get_required();
+            const bool currentlyRequired = requiredDisabled ? false : subCommandApp->get_ignore_case();
+
+            if (previouslyRequired != currentlyRequired) {
+                subCommandApp->required(currentlyRequired);
+
+                if (hasParent()) {
+                    getParent()->needs(this, currentlyRequired);
+                }
+            }
+        }
+
+        return this;
+    }
+
     CLI::App* SubCommand::getCommandlineTriggerApp() {
         return commandlineTriggerApp;
     }
@@ -213,22 +232,27 @@ namespace utils {
         return helpTriggerApp;
     }
 
-    SubCommand* SubCommand::required(bool required, bool force) {
+    SubCommand* SubCommand::required(bool required) {
+        const bool previousCountedRequired = subCommandApp->get_ignore_case();
+        const bool previousEffectiveRequired = subCommandApp->get_required();
+
         requiredCount += required ? 1 : -1;
+        const bool countedRequired = requiredCount > 0;
+        const bool effectiveRequired = requiredDisabled ? false : countedRequired;
 
-        required = force ? required : requiredCount > 0;
+        subCommandApp->ignore_case(countedRequired);
+        if (subCommandApp->get_required() != effectiveRequired) {
+            subCommandApp->required(effectiveRequired);
+        }
 
-        if (subCommandApp->get_required() != required) {
-            subCommandApp->required(required);
-            subCommandApp->ignore_case(required);
+        if (hasParent()) {
+            SubCommand* parent = getParent();
 
-            if (hasParent()) {
-                SubCommand* parent = getParent();
-
-                parent->needs(this, required);
-                if (!force) {
-                    parent->required(required, false);
-                }
+            if (previousEffectiveRequired != effectiveRequired) {
+                parent->needs(this, effectiveRequired);
+            }
+            if (previousCountedRequired != countedRequired) {
+                parent->required(countedRequired);
             }
         }
 
@@ -246,7 +270,7 @@ namespace utils {
                 subCommandApp->remove_needs(option);
             }
 
-            this->required(required, false);
+            this->required(required);
         }
 
         return this;
@@ -258,14 +282,6 @@ namespace utils {
         } else {
             subCommandApp->remove_needs(subCommand->subCommandApp);
         }
-
-        return this;
-    }
-
-    SubCommand* SubCommand::disabled(SubCommand* subCommand, bool disabled) {
-        needs(subCommand, disabled ? !subCommand->subCommandApp->get_ignore_case() : subCommand->subCommandApp->get_ignore_case());
-
-        subCommand->subCommandApp->required(disabled ? false : subCommand->subCommandApp->get_ignore_case());
 
         return this;
     }

--- a/src/utils/SubCommand.h
+++ b/src/utils/SubCommand.h
@@ -131,7 +131,8 @@ namespace utils {
 
         SubCommand* allowExtras(bool allow = true);
 
-        SubCommand* required(bool required = true, bool force = true);
+        SubCommand* disabled(bool disabled = true);
+        SubCommand* required(bool required = true);
         SubCommand* required(CLI::Option* option, bool required = true);
 
         bool getRequired() const {
@@ -139,7 +140,6 @@ namespace utils {
         }
 
         SubCommand* needs(SubCommand* subCommand, bool needs = true);
-        SubCommand* disabled(SubCommand* subCommand, bool disabled = true);
 
         SubCommand* setRequireCallback(const std::function<void(void)>& callback);
         SubCommand* finalCallback(const std::function<void()>& finalCallback);
@@ -264,6 +264,7 @@ namespace utils {
         CLI::Option* commandlineOpt = nullptr;
 
         int requiredCount = 0;
+        bool requiredDisabled = false;
     };
 
     template <typename ConcretSubCommand>

--- a/src/utils/SubCommand.h
+++ b/src/utils/SubCommand.h
@@ -131,7 +131,7 @@ namespace utils {
 
         SubCommand* allowExtras(bool allow = true);
 
-        SubCommand* disabled(bool disabled = true);
+        SubCommand* forceRequired(bool required = true);
         SubCommand* required(bool required = true);
         SubCommand* required(CLI::Option* option, bool required = true);
 
@@ -264,7 +264,8 @@ namespace utils {
         CLI::Option* commandlineOpt = nullptr;
 
         int requiredCount = 0;
-        bool requiredDisabled = false;
+        bool requiredForced = false;
+        bool requiredForcedValue = false;
     };
 
     template <typename ConcretSubCommand>


### PR DESCRIPTION
### Motivation

- Centralize and simplify how subcommand "disabled" state affects required/needs propagation instead of having parents toggle child state externally.
- Ensure the effective required state accounts for both counted requirements and whether a subcommand is disabled.
- Simplify `ConfigInstance` so it applies the disabled state to itself rather than calling parent notification logic.

### Description

- Add `SubCommand::disabled(bool)` and a `requiredDisabled` member to track when a subcommand is disabled and to update effective required state accordingly.
- Rework `SubCommand::required(bool)` to compute `countedRequired` and `effectiveRequired` (which is `false` when `requiredDisabled` is set), update `ignore_case` and `required` flags, and propagate changes to the parent via `needs` only when the effective state changes.
- Update `required(CLI::Option*, bool)` to call the new `required(bool)` path and remove the old external `disabled(SubCommand*, bool)` usage.
- Modify `ConfigInstance` to call `disabled(...)` on itself in the option callback and in `setDisabled`, removing direct calls to parent notification and centralizing behavior.

### Testing

- Project build was performed with the updated sources and completed successfully using the standard build pipeline (`cmake`/build). 
- Automated unit tests were executed (`ctest`) and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4546766c4832cb305a18dae29249e)