### PR TITLE
Refactor SubCommand required/disabled handling and update ConfigInstance to use forceUnrequired

### DIFF
--- a/src/net/config/ConfigInstance.cpp
+++ b/src/net/config/ConfigInstance.cpp
@@ -70,11 +70,7 @@ namespace net::config {
         , disableOpt(setConfigurable(addFlagFunction(
                                          "--disabled{true}",
                                          [this]() {
-                                             if (getParent() != nullptr) {
-                                                 getParent()->disabled(this, disableOpt->as<bool>());
-                                             }
-
-                                             //                                             required(disableOpt->as<bool>(), true);
+                                             forceUnrequired(disableOpt->as<bool>());
                                          },
                                          "Disable this instance",
                                          "bool",
@@ -109,11 +105,7 @@ namespace net::config {
     ConfigInstance* ConfigInstance::setDisabled(bool disabled) {
         setDefaultValue(disableOpt, disabled ? "true" : "false");
 
-        if (getParent() != nullptr) {
-            getParent()->disabled(this, disabled);
-        }
-
-        //        required(disabled, true);
+        this->forceUnrequired(disabled);
 
         return this;
     }

--- a/src/utils/SubCommand.cpp
+++ b/src/utils/SubCommand.cpp
@@ -201,6 +201,24 @@ namespace utils {
         return this;
     }
 
+    SubCommand* SubCommand::forceUnrequired(bool unrequired) {
+        const bool previouslyRequired = subCommandApp->get_required();
+        const bool countedRequired = subCommandApp->get_ignore_case();
+
+        requiredForced = unrequired;
+
+        const bool effectiveRequired = requiredForced ? false : countedRequired;
+        if (previouslyRequired != effectiveRequired) {
+            subCommandApp->required(effectiveRequired);
+
+            if (hasParent()) {
+                getParent()->needs(this, effectiveRequired);
+            }
+        }
+
+        return this;
+    }
+
     CLI::App* SubCommand::getCommandlineTriggerApp() {
         return commandlineTriggerApp;
     }
@@ -213,22 +231,27 @@ namespace utils {
         return helpTriggerApp;
     }
 
-    SubCommand* SubCommand::required(bool required, bool force) {
+    SubCommand* SubCommand::required(bool required) {
+        const bool previousCountedRequired = subCommandApp->get_ignore_case();
+        const bool previousEffectiveRequired = subCommandApp->get_required();
+
         requiredCount += required ? 1 : -1;
+        const bool countedRequired = requiredCount > 0;
+        const bool effectiveRequired = requiredForced ? false : countedRequired;
 
-        required = force ? required : requiredCount > 0;
+        subCommandApp->ignore_case(countedRequired);
+        if (subCommandApp->get_required() != effectiveRequired) {
+            subCommandApp->required(effectiveRequired);
+        }
 
-        if (subCommandApp->get_required() != required) {
-            subCommandApp->required(required);
-            subCommandApp->ignore_case(required);
+        if (hasParent()) {
+            SubCommand* parent = getParent();
 
-            if (hasParent()) {
-                SubCommand* parent = getParent();
-
-                parent->needs(this, required);
-                if (!force) {
-                    parent->required(required, false);
-                }
+            if (previousEffectiveRequired != effectiveRequired) {
+                parent->needs(this, effectiveRequired);
+            }
+            if (previousCountedRequired != countedRequired) {
+                parent->required(countedRequired);
             }
         }
 
@@ -246,7 +269,7 @@ namespace utils {
                 subCommandApp->remove_needs(option);
             }
 
-            this->required(required, false);
+            this->required(required);
         }
 
         return this;
@@ -258,14 +281,6 @@ namespace utils {
         } else {
             subCommandApp->remove_needs(subCommand->subCommandApp);
         }
-
-        return this;
-    }
-
-    SubCommand* SubCommand::disabled(SubCommand* subCommand, bool disabled) {
-        needs(subCommand, disabled ? !subCommand->subCommandApp->get_ignore_case() : subCommand->subCommandApp->get_ignore_case());
-
-        subCommand->subCommandApp->required(disabled ? false : subCommand->subCommandApp->get_ignore_case());
 
         return this;
     }

--- a/src/utils/SubCommand.h
+++ b/src/utils/SubCommand.h
@@ -131,7 +131,8 @@ namespace utils {
 
         SubCommand* allowExtras(bool allow = true);
 
-        SubCommand* required(bool required = true, bool force = true);
+        SubCommand* forceUnrequired(bool unrequired = true);
+        SubCommand* required(bool required = true);
         SubCommand* required(CLI::Option* option, bool required = true);
 
         bool getRequired() const {
@@ -139,7 +140,6 @@ namespace utils {
         }
 
         SubCommand* needs(SubCommand* subCommand, bool needs = true);
-        SubCommand* disabled(SubCommand* subCommand, bool disabled = true);
 
         SubCommand* setRequireCallback(const std::function<void(void)>& callback);
         SubCommand* finalCallback(const std::function<void()>& finalCallback);
@@ -264,6 +264,7 @@ namespace utils {
         CLI::Option* commandlineOpt = nullptr;
 
         int requiredCount = 0;
+        bool requiredForced = false;
     };
 
     template <typename ConcretSubCommand>


### PR DESCRIPTION
### Motivation
- Decouple explicit "unrequired" (forced disabled) state from the counted required logic to avoid incorrect parent/needs bookkeeping when an instance is disabled. 
- Replace the old `disabled` handling with a clearer API that explicitly forces a subcommand to be unrequired while preserving counted requirements.

### Description
- Add `SubCommand::forceUnrequired(bool)` and a `requiredForced` flag to track an externally forced unrequired state and compute the effective `required` value accordingly. 
- Rewrite `SubCommand::required(bool)` to use `requiredCount` to derive `countedRequired`, update `ignore_case` to reflect counted requirements, and set `required` based on `requiredForced` and `countedRequired`, while minimizing parent notifications to only when effective values change. 
- Remove the `disabled(SubCommand*, bool)` API and update `ConfigInstance` to call `forceUnrequired` inside the `--disabled` handler and in `setDisabled`. 
- Update `SubCommand.h` signatures to expose `forceUnrequired` and adjust `required` declaration to the new signature.

### Testing
- Built the project locally with the changes using the standard build (`make`) and verified the code compiles successfully. 
- Ran the test suite (`ctest`) and confirmed automated tests passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4546766c4832cb305a18dae29249e)