### PR TITLE
Add self-contained HTTP test app for express `next()` / `next("route")` / `next("router")` flows

### DIFF
--- a/src/apps/http/CMakeLists.txt
+++ b/src/apps/http/CMakeLists.txt
@@ -191,3 +191,16 @@ set_target_properties(
 install(TARGETS testbasicauthentication
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT apps
 )
+
+add_executable(testexpressnext testexpressnext.cpp)
+target_link_libraries(
+    testexpressnext PRIVATE http-server-express http-client
+                            net-in-stream-legacy
+)
+set_target_properties(
+    testexpressnext
+    PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${HTTP_INSTALL_RPATH}"
+)
+install(TARGETS testexpressnext RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                                COMPONENT apps
+)

--- a/src/apps/http/testexpressnext.cpp
+++ b/src/apps/http/testexpressnext.cpp
@@ -48,7 +48,6 @@
 #include <deque>
 #include <memory>
 #include <string>
-#include <vector>
 
 using express::Router;
 
@@ -70,7 +69,23 @@ class NextTester {
     }
 
     void run() {
-        dispatchNextRequest();
+        client = std::make_shared<Client>(
+            "testexpressnext-client",
+            [this](const std::shared_ptr<MasterRequest>& connectedRequest) {
+                masterRequest = connectedRequest;
+                dispatchNextRequest();
+            },
+            [](const std::shared_ptr<MasterRequest>&) {});
+
+        client->connect("localhost",
+                        18080,
+                        [this](const Client::SocketAddress&, const core::socket::State& state) {
+                            if (state != core::socket::State::OK) {
+                                ++failures;
+                                LOG(ERROR) << "FAIL: connect failed: " << state.what();
+                                core::timer::Timer::singleshotTimer([] { core::SNodeC::stop(); }, 1);
+                            }
+                        });
     }
 
     std::size_t getFailures() const {
@@ -86,6 +101,16 @@ class NextTester {
     void dispatchNextRequest() {
         if (testCases.empty()) {
             LOG(INFO) << "All express next() tests executed. failures=" << failures;
+            if (masterRequest && masterRequest->isConnected()) {
+                masterRequest->disconnect();
+            }
+            core::timer::Timer::singleshotTimer([] { core::SNodeC::stop(); }, 1);
+            return;
+        }
+
+        if (!masterRequest || !masterRequest->isConnected()) {
+            ++failures;
+            LOG(ERROR) << "FAIL: master request not connected";
             core::timer::Timer::singleshotTimer([] { core::SNodeC::stop(); }, 1);
             return;
         }
@@ -93,51 +118,39 @@ class NextTester {
         const TestCase current = testCases.front();
         testCases.pop_front();
 
-        auto client = std::make_shared<Client>(
-            "testexpressnext-client",
-            [this, current](const std::shared_ptr<MasterRequest>& req) {
-                req->method = "GET";
-                req->url = current.url;
-                req->set("Connection", "close");
-                req->end(
-                    [this, current](const std::shared_ptr<Request>&, const std::shared_ptr<Response>& res) {
-                        const std::string body(res->body.begin(), res->body.end());
-                        const bool statusOk = res->statusCode == current.expectedStatus;
-                        const bool bodyOk = body.find(current.expectedBody) != std::string::npos;
+        masterRequest->init();
+        masterRequest->method = "GET";
+        masterRequest->url = current.url;
+        masterRequest->set("Connection", "keep-alive");
+        masterRequest->end(
+            [this, current](const std::shared_ptr<Request>& req, const std::shared_ptr<Response>& res) {
+                const std::string body(res->body.begin(), res->body.end());
+                const bool statusOk = res->statusCode == current.expectedStatus;
+                const bool bodyOk = body.find(current.expectedBody) != std::string::npos;
 
-                        if (statusOk && bodyOk) {
-                            LOG(INFO) << "PASS: " << current.name << " status=" << res->statusCode << " body='" << body << "'";
-                        } else {
-                            ++failures;
-                            LOG(ERROR) << "FAIL: " << current.name << " expected status=" << current.expectedStatus
-                                       << " expected body fragment='" << current.expectedBody << "'"
-                                       << " got status=" << res->statusCode << " body='" << body << "'";
-                        }
+                if (statusOk && bodyOk) {
+                    LOG(INFO) << "PASS: " << current.name << " status=" << res->statusCode << " body='" << body << "'";
+                } else {
+                    ++failures;
+                    LOG(ERROR) << "FAIL: " << current.name << " expected status=" << current.expectedStatus
+                               << " expected body fragment='" << current.expectedBody << "'"
+                               << " got status=" << res->statusCode << " body='" << body << "'";
+                }
 
-                        dispatchNextRequest();
-                    },
-                    [this, current](const std::shared_ptr<Request>&, const std::string& reason) {
-                        ++failures;
-                        LOG(ERROR) << "FAIL: " << current.name << " parse-error: " << reason;
-                        dispatchNextRequest();
-                    });
+                masterRequest = req->getMasterRequest();
+                dispatchNextRequest();
+            },
+            [this, current](const std::shared_ptr<Request>& req, const std::string& reason) {
+                ++failures;
+                LOG(ERROR) << "FAIL: " << current.name << " parse-error: " << reason;
+                masterRequest = req->getMasterRequest();
+                dispatchNextRequest();
             });
-
-        activeClients.push_back(client);
-
-        client->connect("localhost",
-                        18080,
-                        [this, current](const Client::SocketAddress&, const core::socket::State& state) {
-                            if (state != core::socket::State::OK) {
-                                ++failures;
-                                LOG(ERROR) << "FAIL: " << current.name << " connect failed: " << state.what();
-                                dispatchNextRequest();
-                            }
-                        });
     }
 
     std::deque<TestCase> testCases;
-    std::vector<std::shared_ptr<Client>> activeClients;
+    std::shared_ptr<Client> client;
+    std::shared_ptr<MasterRequest> masterRequest;
     std::size_t failures = 0;
 };
 

--- a/src/apps/http/testexpressnext.cpp
+++ b/src/apps/http/testexpressnext.cpp
@@ -45,9 +45,8 @@
 #include "log/Logger.h"
 #include "web/http/legacy/in/Client.h"
 
+#include <cstddef>
 #include <deque>
-#include <memory>
-#include <string>
 
 using express::Router;
 
@@ -56,43 +55,50 @@ struct TestCase {
     std::string url;
     int expectedStatus;
     std::string expectedBody;
+    std::string connection;
 };
 
 class NextTester {
-  public:
+public:
     NextTester()
-        : testCases({{"next() middleware chain", "/next/basic", 200, "next() reached final handler"},
-                     {"next('route') fallback", "/next/route/0", 200, "next(route) fallback for id=0"},
-                     {"next('route') primary", "/next/route/7", 200, "next(route) primary for id=7"},
-                     {"next('router') fallback", "/next/router/resource?allow=false", 403, "next(router) denied by fallback"},
-                     {"next('router') inside router", "/next/router/resource?allow=true", 200, "next(router) router handler"}}) {
+        : testCases({{"next() middleware chain", "/next/basic", 200, "next() reached final handler", "keep-alive"},
+                     {"next('route') fallback", "/next/route/0", 200, "next(route) fallback for id=0", "keep-alive"},
+                     {"next('route') primary", "/next/route/7", 200, "next(route) primary for id=7", "keep-alive"},
+                     {"next('router') fallback", "/next/router/resource?allow=false", 403, "next(router) denied by fallback", "keep-alive"},
+                     {"next('router') inside router", "/next/router/resource?allow=true", 200, "next(router) router handler", "close"}}) {
     }
 
     void run() {
-        client = std::make_shared<Client>(
+        client = std::make_shared<Client>( //
             "testexpressnext-client",
             [this](const std::shared_ptr<MasterRequest>& connectedRequest) {
                 masterRequest = connectedRequest;
                 dispatchNextRequest();
             },
-            [](const std::shared_ptr<MasterRequest>&) {});
+            [](const std::shared_ptr<MasterRequest>&) {
+            });
 
-        client->connect("localhost",
-                        18080,
-                        [this](const Client::SocketAddress&, const core::socket::State& state) {
-                            if (state != core::socket::State::OK) {
-                                ++failures;
-                                LOG(ERROR) << "FAIL: connect failed: " << state.what();
-                                core::timer::Timer::singleshotTimer([] { core::SNodeC::stop(); }, 1);
-                            }
-                        });
+        client->connect( //
+            "localhost",
+            18080,
+            [this](const Client::SocketAddress&, const core::socket::State& state) {
+                if (state != core::socket::State::OK) {
+                    ++failures;
+                    LOG(ERROR) << "FAIL: connect failed: " << state.what();
+                    core::timer::Timer::singleshotTimer(
+                        [] {
+                            core::SNodeC::stop();
+                        },
+                        1);
+                }
+            });
     }
 
     std::size_t getFailures() const {
         return failures;
     }
 
-  private:
+private:
     using Client = web::http::legacy::in::Client;
     using MasterRequest = Client::MasterRequest;
     using Request = Client::Request;
@@ -104,14 +110,22 @@ class NextTester {
             if (masterRequest && masterRequest->isConnected()) {
                 masterRequest->disconnect();
             }
-            core::timer::Timer::singleshotTimer([] { core::SNodeC::stop(); }, 1);
+            core::timer::Timer::singleshotTimer(
+                [] {
+                    core::SNodeC::stop();
+                },
+                1);
             return;
         }
 
         if (!masterRequest || !masterRequest->isConnected()) {
             ++failures;
             LOG(ERROR) << "FAIL: master request not connected";
-            core::timer::Timer::singleshotTimer([] { core::SNodeC::stop(); }, 1);
+            core::timer::Timer::singleshotTimer(
+                [] {
+                    core::SNodeC::stop();
+                },
+                1);
             return;
         }
 
@@ -121,29 +135,27 @@ class NextTester {
         masterRequest->init();
         masterRequest->method = "GET";
         masterRequest->url = current.url;
-        masterRequest->set("Connection", "keep-alive");
+        masterRequest->set("Connection", current.connection);
         masterRequest->end(
-            [this, current](const std::shared_ptr<Request>& req, const std::shared_ptr<Response>& res) {
+            [this, current]([[maybe_unused]] const std::shared_ptr<Request>& req, const std::shared_ptr<Response>& res) {
                 const std::string body(res->body.begin(), res->body.end());
-                const bool statusOk = res->statusCode == current.expectedStatus;
+                const bool statusOk = std::stoi(res->statusCode) == current.expectedStatus;
                 const bool bodyOk = body.find(current.expectedBody) != std::string::npos;
 
                 if (statusOk && bodyOk) {
                     LOG(INFO) << "PASS: " << current.name << " status=" << res->statusCode << " body='" << body << "'";
                 } else {
                     ++failures;
-                    LOG(ERROR) << "FAIL: " << current.name << " expected status=" << current.expectedStatus
-                               << " expected body fragment='" << current.expectedBody << "'"
+                    LOG(ERROR) << "FAIL: " << current.name << " expected status=" << current.expectedStatus << " expected body fragment='"
+                               << current.expectedBody << "'"
                                << " got status=" << res->statusCode << " body='" << body << "'";
                 }
 
-                masterRequest = req->getMasterRequest();
                 dispatchNextRequest();
             },
-            [this, current](const std::shared_ptr<Request>& req, const std::string& reason) {
+            [this, current]([[maybe_unused]] const std::shared_ptr<Request>& req, const std::string& reason) {
                 ++failures;
                 LOG(ERROR) << "FAIL: " << current.name << " parse-error: " << reason;
-                masterRequest = req->getMasterRequest();
                 dispatchNextRequest();
             });
     }
@@ -209,6 +221,8 @@ int main(int argc, char* argv[]) {
         res->status(403).send("next(router) denied by fallback");
     });
 
+    app.getConfig()->setReuseAddress();
+
     app.listen(18080, [](const express::legacy::in::WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
         switch (state) {
             case core::socket::State::OK:
@@ -227,7 +241,11 @@ int main(int argc, char* argv[]) {
     });
 
     NextTester nextTester;
-    core::timer::Timer::singleshotTimer([&nextTester] { nextTester.run(); }, 1);
+    core::timer::Timer::singleshotTimer(
+        [&nextTester] {
+            nextTester.run();
+        },
+        1);
 
     const int rc = core::SNodeC::start();
     if (nextTester.getFailures() > 0) {

--- a/src/apps/http/testexpressnext.cpp
+++ b/src/apps/http/testexpressnext.cpp
@@ -1,0 +1,227 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/timer/Timer.h"
+#include "express/legacy/in/WebApp.h"
+#include "log/Logger.h"
+#include "web/http/legacy/in/Client.h"
+
+#include <deque>
+#include <memory>
+#include <string>
+#include <vector>
+
+using express::Router;
+
+struct TestCase {
+    std::string name;
+    std::string url;
+    int expectedStatus;
+    std::string expectedBody;
+};
+
+class NextTester {
+  public:
+    NextTester()
+        : testCases({{"next() middleware chain", "/next/basic", 200, "next() reached final handler"},
+                     {"next('route') fallback", "/next/route/0", 200, "next(route) fallback for id=0"},
+                     {"next('route') primary", "/next/route/7", 200, "next(route) primary for id=7"},
+                     {"next('router') fallback", "/next/router/resource?allow=false", 403, "next(router) denied by fallback"},
+                     {"next('router') inside router", "/next/router/resource?allow=true", 200, "next(router) router handler"}}) {
+    }
+
+    void run() {
+        dispatchNextRequest();
+    }
+
+    std::size_t getFailures() const {
+        return failures;
+    }
+
+  private:
+    using Client = web::http::legacy::in::Client;
+    using MasterRequest = Client::MasterRequest;
+    using Request = Client::Request;
+    using Response = Client::Response;
+
+    void dispatchNextRequest() {
+        if (testCases.empty()) {
+            LOG(INFO) << "All express next() tests executed. failures=" << failures;
+            core::timer::Timer::singleshotTimer([] { core::SNodeC::stop(); }, 1);
+            return;
+        }
+
+        const TestCase current = testCases.front();
+        testCases.pop_front();
+
+        auto client = std::make_shared<Client>(
+            "testexpressnext-client",
+            [this, current](const std::shared_ptr<MasterRequest>& req) {
+                req->method = "GET";
+                req->url = current.url;
+                req->set("Connection", "close");
+                req->end(
+                    [this, current](const std::shared_ptr<Request>&, const std::shared_ptr<Response>& res) {
+                        const std::string body(res->body.begin(), res->body.end());
+                        const bool statusOk = res->statusCode == current.expectedStatus;
+                        const bool bodyOk = body.find(current.expectedBody) != std::string::npos;
+
+                        if (statusOk && bodyOk) {
+                            LOG(INFO) << "PASS: " << current.name << " status=" << res->statusCode << " body='" << body << "'";
+                        } else {
+                            ++failures;
+                            LOG(ERROR) << "FAIL: " << current.name << " expected status=" << current.expectedStatus
+                                       << " expected body fragment='" << current.expectedBody << "'"
+                                       << " got status=" << res->statusCode << " body='" << body << "'";
+                        }
+
+                        dispatchNextRequest();
+                    },
+                    [this, current](const std::shared_ptr<Request>&, const std::string& reason) {
+                        ++failures;
+                        LOG(ERROR) << "FAIL: " << current.name << " parse-error: " << reason;
+                        dispatchNextRequest();
+                    });
+            });
+
+        activeClients.push_back(client);
+
+        client->connect("localhost",
+                        18080,
+                        [this, current](const Client::SocketAddress&, const core::socket::State& state) {
+                            if (state != core::socket::State::OK) {
+                                ++failures;
+                                LOG(ERROR) << "FAIL: " << current.name << " connect failed: " << state.what();
+                                dispatchNextRequest();
+                            }
+                        });
+    }
+
+    std::deque<TestCase> testCases;
+    std::vector<std::shared_ptr<Client>> activeClients;
+    std::size_t failures = 0;
+};
+
+int main(int argc, char* argv[]) {
+    core::SNodeC::init(argc, argv);
+
+    const express::legacy::in::WebApp app("testexpressnext-server");
+
+    app.get(
+        "/next/basic",
+        [] MIDDLEWARE(req, res, next) {
+            req->setAttribute<std::string>("middleware-seen", "yes");
+            next();
+        },
+        [] APPLICATION(req, res) {
+            std::string marker = "no";
+            req->getAttribute<std::string>(
+                [&](const std::string& value) {
+                    marker = value;
+                },
+                "middleware-seen");
+            res->status(200).send("next() reached final handler (middleware=" + marker + ")");
+        });
+
+    app.get(
+        "/next/route/:id(\\d+)",
+        [] MIDDLEWARE(req, res, next) {
+            if (req->params["id"] == "0") {
+                next("route");
+                return;
+            }
+            next();
+        },
+        [] APPLICATION(req, res) {
+            res->status(200).send("next(route) primary for id=" + req->params["id"]);
+        });
+
+    app.get("/next/route/:id(\\d+)", [] APPLICATION(req, res) {
+        res->status(200).send("next(route) fallback for id=" + req->params["id"]);
+    });
+
+    const Router guarded;
+    guarded.use([] MIDDLEWARE(req, res, next) {
+        if (req->queries["allow"] != "true") {
+            next("router");
+            return;
+        }
+        next();
+    });
+    guarded.get("/resource", [] APPLICATION(req, res) {
+        res->status(200).send("next(router) router handler");
+    });
+
+    app.use("/next/router", guarded);
+    app.get("/next/router/:rest(.*)", [] APPLICATION(req, res) {
+        res->status(403).send("next(router) denied by fallback");
+    });
+
+    app.listen(18080, [](const express::legacy::in::WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
+        switch (state) {
+            case core::socket::State::OK:
+                VLOG(1) << "testexpressnext listening on '" << socketAddress.toString() << "'";
+                break;
+            case core::socket::State::DISABLED:
+                VLOG(1) << "testexpressnext disabled";
+                break;
+            case core::socket::State::ERROR:
+                LOG(ERROR) << "testexpressnext " << socketAddress.toString() << ": " << state.what();
+                break;
+            case core::socket::State::FATAL:
+                LOG(FATAL) << "testexpressnext " << socketAddress.toString() << ": " << state.what();
+                break;
+        }
+    });
+
+    NextTester nextTester;
+    core::timer::Timer::singleshotTimer([&nextTester] { nextTester.run(); }, 1);
+
+    const int rc = core::SNodeC::start();
+    if (nextTester.getFailures() > 0) {
+        LOG(ERROR) << "testexpressnext finished with failures=" << nextTester.getFailures();
+        return 1;
+    }
+
+    LOG(INFO) << "testexpressnext finished successfully";
+    return rc;
+}


### PR DESCRIPTION
### Motivation
- Provide a small, self-contained application to validate express-style `next()` dispatch semantics (middleware chaining, `next("route")`, `next("router")`) inside SNode.C.
- Test these behaviors with an in-process server and an in-process client to get deterministic, reproducible coverage of routing/dispatch logic.

### Description
- Add a new test application `src/apps/http/testexpressnext.cpp` that starts a server exposing endpoints and an in-process HTTP client harness that runs multiple `TestCase`s covering `next()`, `next("route")` (primary + fallback) and `next("router")` (router-handled + fallback).
- Register the executable in `src/apps/http/CMakeLists.txt` as `testexpressnext` and link it against `http-server-express`, `http-client` and `net-in-stream-legacy` with proper `INSTALL_RPATH` and install rules.
- The test harness logs `PASS`/`FAIL` per case and causes the process to return non-zero if any test fails, enabling CI-style detection of regressions in dispatch logic.

### Testing
- Ran CMake configuration with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`, which failed because the required dependency `nlohmann_json>=3.11` (`nlohmann-json3-dev`) is not present in the environment, so the build/configuration did not complete.
- No further automated build or runtime tests were executed due to the configuration failure; the test binary is self-contained and will run its client/server checks when built in an environment with the project dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3d978158c832cbbec843597a43583)