### PR TITLE
Refactor flow startup scheduling into FlowController

### DIFF
--- a/src/core/socket/stream/FlowController.h
+++ b/src/core/socket/stream/FlowController.h
@@ -92,6 +92,8 @@ namespace core::socket::stream {
         ConcreteFlowController* onFlowTerminated(const std::function<void(ConcreteFlowController*)>& callback);
         ConcreteFlowController* onFlowStarted(const std::function<void(ConcreteFlowController*)>& callback);
 
+        void startFlow(const std::function<void()>& callback);
+
     protected:
         void reportFlowRetry();
         void reportFlowStarted();

--- a/src/core/socket/stream/FlowController.hpp
+++ b/src/core/socket/stream/FlowController.hpp
@@ -40,6 +40,7 @@
  */
 
 #include "core/socket/stream/FlowController.h"
+#include "core/EventReceiver.h"
 #include "core/timer/Timer.h"
 #include "net/config/ConfigInstance.h"
 
@@ -178,6 +179,17 @@ namespace core::socket::stream {
         };
 
         return dynamic_cast<ConcreteFlowController*>(this);
+    }
+
+
+    template <typename ConcreteFlowController>
+    void FlowController<ConcreteFlowController>::startFlow(const std::function<void()>& callback) {
+        core::EventReceiver::atNextTick([this, callback] {
+            if (!terminated) {
+                reportFlowStarted();
+                callback();
+            }
+        });
     }
 
     template <typename ConcreteFlowController>

--- a/src/core/socket/stream/SocketClient.h
+++ b/src/core/socket/stream/SocketClient.h
@@ -190,9 +190,8 @@ namespace core::socket::stream {
         const SocketClient& realConnect(const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
                                         unsigned int tries,
                                         double retryTimeoutScale) const {
-            core::EventReceiver::atNextTick(
+            sharedContext->flowController->startFlow(
                 [config = this->config, sharedContext = this->sharedContext, onStatus, tries, retryTimeoutScale] {
-                    sharedContext->flowController->reportFlowStarted();
 
                     if (config->Instance::getParent() != nullptr || !config->Instance::getRequired()) {
                         LOG(DEBUG) << config->getInstanceName() << ": Initiating connect";

--- a/src/core/socket/stream/SocketServer.h
+++ b/src/core/socket/stream/SocketServer.h
@@ -185,9 +185,8 @@ namespace core::socket::stream {
         const SocketServer& realListen(const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
                                        unsigned int tries,
                                        double retryTimeoutScale) const {
-            core::EventReceiver::atNextTick(
+            sharedContext->flowController->startFlow(
                 [config = this->config, sharedContext = this->sharedContext, onStatus, tries, retryTimeoutScale] {
-                    sharedContext->flowController->reportFlowStarted();
 
                     if (config->Instance::getParent() != nullptr || !config->Instance::getRequired()) {
                         LOG(DEBUG) << config->getInstanceName() << ": Initiating listen";


### PR DESCRIPTION
### Motivation
- Centralize deferred flow-start scheduling in the flow base class to avoid duplicated `atNextTick` usage in client/server paths.
- Allow flows to be created and immediately terminated before the previously deferred startup callback runs (prevents calling startup callback when flow is already terminated).

### Description
- Added `void startFlow(const std::function<void()>& callback)` to `FlowController` and implemented it to call `core::EventReceiver::atNextTick`, call `reportFlowStarted()` and invoke the provided callback only when `terminated` is false (`FlowController.h/FlowController.hpp`).
- Replaced direct `core::EventReceiver::atNextTick(...)` usage in `SocketClient::realConnect` and `SocketServer::realListen` with `sharedContext->flowController->startFlow(...)` so startup scheduling is centralized (`SocketClient.h` and `SocketServer.h`).
- `startFlow` preserves reporting of flow-start via `reportFlowStarted()` and ensures the callback is not executed if the flow was terminated before the next-tick dispatch.

### Testing
- Ran `cmake -S . -B build && cmake --build build -j2` to validate build integration, and configuration progressed but stopped due to a missing system dependency (`nlohmann-json3-dev`), so a full build could not complete in this environment.
- No automated unit tests were executed as part of this change in the current environment due to the configure failure above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6e471de90832c84d906d82366a231)