### PR TITLE
Track all active connect/listen event receivers in flow controllers

### DIFF
--- a/src/core/socket/stream/ClientFlowController.cpp
+++ b/src/core/socket/stream/ClientFlowController.cpp
@@ -46,10 +46,12 @@ namespace core::socket::stream {
     }
 
     void ClientFlowController::observeConnectEventReceiver(core::eventreceiver::ConnectEventReceiver* connectEventReceiver) {
-        if (connectEventReceiver != nullptr && connectEventReceiver->isEnabled()) {
-            this->connectEventReceiver = connectEventReceiver;
-        } else {
-            this->connectEventReceiver = nullptr;
+        if (connectEventReceiver != nullptr) {
+            if (connectEventReceiver->isEnabled()) {
+                connectEventReceivers.insert(connectEventReceiver);
+            } else {
+                connectEventReceivers.erase(connectEventReceiver);
+            }
         }
     }
 
@@ -63,8 +65,13 @@ namespace core::socket::stream {
         stopReconnect();
         stopRetry();
 
-        if (connectEventReceiver != nullptr) {
-            connectEventReceiver->stopConnect();
+        const auto stopConnectEventReceivers = connectEventReceivers;
+        connectEventReceivers.clear();
+
+        for (core::eventreceiver::ConnectEventReceiver* connectEventReceiver : stopConnectEventReceivers) {
+            if (connectEventReceiver != nullptr) {
+                connectEventReceiver->stopConnect();
+            }
         }
     }
 

--- a/src/core/socket/stream/ClientFlowController.h
+++ b/src/core/socket/stream/ClientFlowController.h
@@ -60,6 +60,7 @@ namespace core {
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <type_traits>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -88,7 +89,7 @@ namespace core::socket::stream {
 
         bool reconnectEnabled{true};
 
-        core::eventreceiver::ConnectEventReceiver* connectEventReceiver{nullptr};
+        std::set<core::eventreceiver::ConnectEventReceiver*> connectEventReceivers;
 
         std::unique_ptr<core::timer::Timer> reconnectTimer;
 

--- a/src/core/socket/stream/ServerFlowController.cpp
+++ b/src/core/socket/stream/ServerFlowController.cpp
@@ -55,18 +55,25 @@ namespace core::socket::stream {
     }
 
     void ServerFlowController::observeAcceptEventReceiver(core::eventreceiver::AcceptEventReceiver* acceptEventReceiver) {
-        if (acceptEventReceiver != nullptr && acceptEventReceiver->isEnabled()) {
-            this->acceptEventReceiver = acceptEventReceiver;
-        } else {
-            this->acceptEventReceiver = nullptr;
+        if (acceptEventReceiver != nullptr) {
+            if (acceptEventReceiver->isEnabled()) {
+                acceptEventReceivers.insert(acceptEventReceiver);
+            } else {
+                acceptEventReceivers.erase(acceptEventReceiver);
+            }
         }
     }
 
     void ServerFlowController::terminateAsyncSubFlow() {
         stopRetry();
 
-        if (acceptEventReceiver != nullptr) {
-            acceptEventReceiver->stopListen();
+        const auto stopAcceptEventReceivers = acceptEventReceivers;
+        acceptEventReceivers.clear();
+
+        for (core::eventreceiver::AcceptEventReceiver* acceptEventReceiver : stopAcceptEventReceivers) {
+            if (acceptEventReceiver != nullptr) {
+                acceptEventReceiver->stopListen();
+            }
         }
     }
 

--- a/src/core/socket/stream/ServerFlowController.h
+++ b/src/core/socket/stream/ServerFlowController.h
@@ -46,6 +46,12 @@
 
 // IWYU pragma: no_include "core/socket/stream/FlowController.hpp"
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <set>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
 namespace core {
     namespace socket::stream {
         class SocketContextFactory;
@@ -72,7 +78,7 @@ namespace core::socket::stream {
 
         void terminateAsyncSubFlow() override;
 
-        core::eventreceiver::AcceptEventReceiver* acceptEventReceiver{nullptr};
+        std::set<core::eventreceiver::AcceptEventReceiver*> acceptEventReceivers;
 
         template <typename SocketAcceptorT, typename SocketContextFactoryT, typename... Args>
             requires std::is_base_of_v<core::eventreceiver::AcceptEventReceiver, SocketAcceptorT> &&


### PR DESCRIPTION
### Motivation
- The framework allows multiple `.connect()` and `.listen()` calls per Instance but the flow controllers only remembered a single `SocketConnector`/`SocketAcceptor`, preventing full termination of all async subflows. 
- The change ensures all connection/listen flows started for an Instance can be stopped when `terminateAsyncSubFlow()` is invoked. 

### Description
- Replaced the single pointer fields with sets: `std::set<core::eventreceiver::ConnectEventReceiver*> connectEventReceivers` in `ClientFlowController` and `std::set<core::eventreceiver::AcceptEventReceiver*> acceptEventReceivers` in `ServerFlowController` and added the necessary `#include <set>` usages. 
- Updated `observeConnectEventReceiver()` and `observeAcceptEventReceiver()` to `insert` when a receiver is enabled and `erase` when disabled, so all active receivers are tracked. 
- Updated `terminateAsyncSubFlow()` in both controllers to copy the tracked set, clear it, and iterate the copy to call `stopConnect()` / `stopListen()` on each receiver, using a copy-then-clear pattern to avoid mutation issues during callbacks. 
- Small cleanups: cleared sets before iterating to avoid reentrancy/mutation and preserved existing timer/retry teardown behavior (`stopReconnect()`, `stopRetry()`, `cancelReconnectTimer()`). 

### Testing
- Ran CMake configure with `cmake -S . -B build` and attempted `cmake --build build -j4` to validate changes, but configuration failed in this environment due to a missing system dependency (`nlohmann-json3-dev`), so full compile was not completed. 
- No unit test suite was executed in this environment; the repository changes were committed locally (`Track all connector/acceptor flows in flow controllers`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f1beea64832c87c933de58848c13)