### PR TITLE
Add TLS→legacy demo (tlslegacyserver/client) and 2026 review addendum

### DIFF
--- a/docs/landing-pages/github-landing-openai-codex-pullreq/09-extended-review-snodec-and-mqttsuite.md
+++ b/docs/landing-pages/github-landing-openai-codex-pullreq/09-extended-review-snodec-and-mqttsuite.md
@@ -88,3 +88,24 @@ For adoption growth, the key multiplier is excellent documentation and compatibi
 ### Interpretation
 - `spdlog` itself is not the limiting factor here; suppressed-path overhead is lower than easylogging++ due to macro short-circuiting before stream creation; enabled-path overhead is also now below easylogging++ after removing custom line assembly and using native spdlog pattern formatting for timestamp/tick rendering.
 - To approach ~1x parity or better, call sites should progressively move from stream insertion chains to native fmt-style `spdlog` calls and avoid stream-buffer assembly on suppressed paths.
+
+## Additional 2026 engineering review addendum
+
+### SNode.C: concrete technical observations
+
+- **TLS shutdown semantics are intentionally transport-reversible.** In `core/socket/stream/tls`, reads and writes transparently fall back to plain socket I/O once TLS close-notify has been exchanged on the corresponding direction. This is unusual in many frameworks and is a powerful capability for controlled protocol transitions.
+- **Backpressure discipline is explicit and predictable.** Writer-side buffering, shutdown fencing (`shutdownInProgress`), and source suspension combine into a coherent flow-control strategy.
+- **SocketContext switching is elegant but under-documented.** The deferred context switch mechanism (via `newSocketContext`) is robust and could support richer protocol upgrade/downgrade paths with clearer official patterns.
+- **Operational defaults remain practical.** Timeouts, TLS options, and cert paths are all CLI/configurable, enabling production override without recompilation.
+
+### MQTTSuite-focused recommendations
+
+1. **Publish an explicit compatibility target grid** for broker/client versions, QoS permutations, retained messages, and session-resume behavior.
+2. **Ship reference topology manifests** (single broker, broker bridge, edge-to-cloud fan-in, MQTT-over-WS ingress) to reduce adoption friction.
+3. **Formalize performance SLO baselines** (connect rate, publish throughput by payload size/QoS, reconnect recovery time) and include reproducible benchmark harness scripts.
+4. **Expand chaos and fault drills** into CI/nightly pipelines (network jitter, packet reorder/loss, abrupt TLS teardown, broker failover).
+5. **Codify observability conventions** (structured logs, correlation IDs, per-session metrics) so multi-process deployments are easier to operate.
+
+### Strategic verdict
+
+SNode.C remains strongest where fine-grained transport control and protocol composition matter. MQTTSuite should continue to position itself as the operational showcase for those strengths, especially around mixed transport paths (plain TCP, TLS, and MQTT-over-WebSocket) and resilient deployment recipes.

--- a/src/apps/tlslegacy/CMakeLists.txt
+++ b/src/apps/tlslegacy/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.18)
+
+add_library(tlslegacysocketcontext STATIC TlsLegacySocketContext.cpp TlsLegacySocketContext.h)
+target_link_libraries(tlslegacysocketcontext PUBLIC core)
+
+add_executable(tlslegacyserver tlslegacyserver.cpp)
+target_link_libraries(tlslegacyserver PRIVATE tlslegacysocketcontext net-in-stream-tls)
+install(TARGETS tlslegacyserver RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT apps)
+
+add_executable(tlslegacyclient tlslegacyclient.cpp)
+target_link_libraries(tlslegacyclient PRIVATE tlslegacysocketcontext net-in-stream-tls)
+install(TARGETS tlslegacyclient RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT apps)

--- a/src/apps/tlslegacy/TlsLegacySocketContext.cpp
+++ b/src/apps/tlslegacy/TlsLegacySocketContext.cpp
@@ -46,7 +46,7 @@ namespace apps::tlslegacy {
 
         legacyRetryTimer = core::timer::Timer::intervalTimer(
             [this, payload](const std::function<void()>& stop) {
-                if ((role == Role::CLIENT && legacyReplySeen) || (role == Role::SERVER && legacyPayloadSeen)) {
+                if (role == Role::CLIENT && legacyReplySeen) {
                     stop();
                     return;
                 }
@@ -68,7 +68,7 @@ namespace apps::tlslegacy {
             legacyReplySeen = true;
             legacyRetryTimer.cancel();
             VLOG(1) << getSocketConnection()->getConnectionName() << ": got LEGACY ack -> post-TLS plaintext path works";
-            close();
+            shutdownWrite();
         }
     }
 
@@ -82,7 +82,7 @@ namespace apps::tlslegacy {
             legacyRetryTimer.cancel();
             sendToPeer(LEGACY_ACK);
             VLOG(1) << getSocketConnection()->getConnectionName() << ": received LEGACY payload after TLS shutdown";
-            close();
+            shutdownWrite();
         }
     }
 

--- a/src/apps/tlslegacy/TlsLegacySocketContext.cpp
+++ b/src/apps/tlslegacy/TlsLegacySocketContext.cpp
@@ -1,0 +1,124 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#include "TlsLegacySocketContext.h"
+
+#include "log/Logger.h"
+#include "utils/Timeval.h"
+
+namespace {
+    constexpr const char* TLS_HELLO = "TLS_HELLO\n";
+    constexpr const char* TLS_ACK = "TLS_ACK\n";
+    constexpr const char* LEGACY_HELLO = "LEGACY_HELLO\n";
+    constexpr const char* LEGACY_ACK = "LEGACY_ACK\n";
+} // namespace
+
+namespace apps::tlslegacy {
+
+    TlsLegacySocketContext::TlsLegacySocketContext(core::socket::stream::SocketConnection* socketConnection, Role role)
+        : core::socket::stream::SocketContext(socketConnection)
+        , role(role) {
+    }
+
+    void TlsLegacySocketContext::onConnected() {
+        VLOG(1) << getSocketConnection()->getConnectionName() << ": connected";
+
+        if (role == Role::CLIENT) {
+            sendToPeer(TLS_HELLO);
+            VLOG(1) << getSocketConnection()->getConnectionName() << ": sent TLS greeting";
+        }
+    }
+
+    void TlsLegacySocketContext::onDisconnected() {
+        legacyRetryTimer.cancel();
+        VLOG(1) << getSocketConnection()->getConnectionName() << ": disconnected";
+    }
+
+    bool TlsLegacySocketContext::onSignal([[maybe_unused]] int signum) {
+        return true;
+    }
+
+    void TlsLegacySocketContext::startLegacyRetryTimer(const std::string& payload) {
+        legacyRetryTimer.cancel();
+
+        legacyRetryTimer = core::timer::Timer::intervalTimer(
+            [this, payload](const std::function<void()>& stop) {
+                if ((role == Role::CLIENT && legacyReplySeen) || (role == Role::SERVER && legacyPayloadSeen)) {
+                    stop();
+                    return;
+                }
+
+                sendToPeer(payload);
+                VLOG(1) << getSocketConnection()->getConnectionName() << ": trying post-TLS legacy payload: " << payload;
+            },
+            utils::Timeval(0.5));
+    }
+
+    void TlsLegacySocketContext::onClientLine(const std::string& line) {
+        if (line == TLS_ACK && !tlsReplySeen) {
+            tlsReplySeen = true;
+            VLOG(1) << getSocketConnection()->getConnectionName()
+                    << ": got TLS ack, initiating TLS shutdown handshake (close_notify)";
+            shutdownWrite();
+            startLegacyRetryTimer(LEGACY_HELLO);
+        } else if (line == LEGACY_ACK && !legacyReplySeen) {
+            legacyReplySeen = true;
+            legacyRetryTimer.cancel();
+            VLOG(1) << getSocketConnection()->getConnectionName() << ": got LEGACY ack -> post-TLS plaintext path works";
+            close();
+        }
+    }
+
+    void TlsLegacySocketContext::onServerLine(const std::string& line) {
+        if (line == TLS_HELLO && !tlsReplySeen) {
+            tlsReplySeen = true;
+            sendToPeer(TLS_ACK);
+            VLOG(1) << getSocketConnection()->getConnectionName() << ": TLS phase complete, waiting for peer close_notify";
+        } else if (line == LEGACY_HELLO && !legacyPayloadSeen) {
+            legacyPayloadSeen = true;
+            legacyRetryTimer.cancel();
+            sendToPeer(LEGACY_ACK);
+            VLOG(1) << getSocketConnection()->getConnectionName() << ": received LEGACY payload after TLS shutdown";
+            close();
+        }
+    }
+
+    std::size_t TlsLegacySocketContext::onReceivedFromPeer() {
+        char chunk[4096];
+        const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+        if (chunkLen == 0) {
+            return 0;
+        }
+
+        inboundBuffer.append(chunk, chunkLen);
+
+        std::size_t pos = std::string::npos;
+        while ((pos = inboundBuffer.find('\n')) != std::string::npos) {
+            std::string line = inboundBuffer.substr(0, pos + 1);
+            inboundBuffer.erase(0, pos + 1);
+
+            if (role == Role::CLIENT) {
+                onClientLine(line);
+            } else {
+                onServerLine(line);
+            }
+        }
+
+        return chunkLen;
+    }
+
+    core::socket::stream::SocketContext*
+    TlsLegacyServerSocketContextFactory::create(core::socket::stream::SocketConnection* socketConnection) {
+        return new TlsLegacySocketContext(socketConnection, TlsLegacySocketContext::Role::SERVER);
+    }
+
+    core::socket::stream::SocketContext*
+    TlsLegacyClientSocketContextFactory::create(core::socket::stream::SocketConnection* socketConnection) {
+        return new TlsLegacySocketContext(socketConnection, TlsLegacySocketContext::Role::CLIENT);
+    }
+
+} // namespace apps::tlslegacy

--- a/src/apps/tlslegacy/TlsLegacySocketContext.h
+++ b/src/apps/tlslegacy/TlsLegacySocketContext.h
@@ -1,0 +1,56 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#ifndef APPS_TLSLEGACY_TLSLEGACYSOCKETCONTEXT_H
+#define APPS_TLSLEGACY_TLSLEGACYSOCKETCONTEXT_H
+
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "core/timer/Timer.h"
+
+#include <string>
+
+namespace apps::tlslegacy {
+
+    class TlsLegacySocketContext : public core::socket::stream::SocketContext {
+    public:
+        enum class Role { SERVER, CLIENT };
+
+        explicit TlsLegacySocketContext(core::socket::stream::SocketConnection* socketConnection, Role role);
+
+    private:
+        void onConnected() override;
+        void onDisconnected() override;
+        bool onSignal(int signum) override;
+        std::size_t onReceivedFromPeer() override;
+
+        void onClientLine(const std::string& line);
+        void onServerLine(const std::string& line);
+        void startLegacyRetryTimer(const std::string& payload);
+
+        Role role;
+        std::string inboundBuffer;
+
+        bool tlsReplySeen = false;
+        bool legacyReplySeen = false;
+        bool legacyPayloadSeen = false;
+
+        core::timer::Timer legacyRetryTimer;
+    };
+
+    class TlsLegacyServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    private:
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override;
+    };
+
+    class TlsLegacyClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    private:
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override;
+    };
+
+} // namespace apps::tlslegacy
+
+#endif

--- a/src/apps/tlslegacy/tlslegacyclient.cpp
+++ b/src/apps/tlslegacy/tlslegacyclient.cpp
@@ -1,0 +1,32 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#include "TlsLegacySocketContext.h"
+#include "core/SNodeC.h"
+#include "log/Logger.h"
+#include "net/in/stream/tls/SocketClient.h"
+
+int main(int argc, char* argv[]) {
+    core::SNodeC::init(argc, argv);
+
+    using SocketClient = net::in::stream::tls::SocketClient<apps::tlslegacy::TlsLegacyClientSocketContextFactory>;
+    SocketClient client("tls-legacy-client");
+
+    client.getConfig()->setCaCert("certs/Volker_Christian_-_Web_CA.crt");
+    client.getConfig()->setCaCertAcceptUnknown(true);
+    client.getConfig()->setNoCloseNotifyIsEOF(true);
+
+    client.connect([instanceName = client.getConfig()->getInstanceName()](const SocketClient::SocketAddress& socketAddress,
+                                                                          const core::socket::State& state) {
+        if (state == core::socket::State::OK) {
+            VLOG(1) << instanceName << ": connected to " << socketAddress.toString();
+        } else if (state == core::socket::State::ERROR) {
+            LOG(ERROR) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+        }
+    });
+
+    return core::SNodeC::start();
+}

--- a/src/apps/tlslegacy/tlslegacyserver.cpp
+++ b/src/apps/tlslegacy/tlslegacyserver.cpp
@@ -1,0 +1,33 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#include "TlsLegacySocketContext.h"
+#include "core/SNodeC.h"
+#include "log/Logger.h"
+#include "net/in/stream/tls/SocketServer.h"
+
+int main(int argc, char* argv[]) {
+    core::SNodeC::init(argc, argv);
+
+    using SocketServer = net::in::stream::tls::SocketServer<apps::tlslegacy::TlsLegacyServerSocketContextFactory>;
+    SocketServer server("tls-legacy-server");
+
+    server.getConfig()->setCert("certs/snodec.home.vchrist.at_-_snode.c_-_server.pem");
+    server.getConfig()->setCertKey("certs/Volker_Christian_-_Web_-_snode.c_-_server.key.encrypted.pem");
+    server.getConfig()->setCertKeyPassword("snode.c");
+    server.getConfig()->setNoCloseNotifyIsEOF(true);
+
+    server.listen([instanceName = server.getConfig()->getInstanceName()](const SocketServer::SocketAddress& socketAddress,
+                                                                         const core::socket::State& state) {
+        if (state == core::socket::State::OK) {
+            VLOG(1) << instanceName << ": listening on " << socketAddress.toString();
+        } else if (state == core::socket::State::ERROR) {
+            LOG(ERROR) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+        }
+    });
+
+    return core::SNodeC::start();
+}


### PR DESCRIPTION
### Motivation
- Provide a small, self-contained demo that shows how a connection can continue as unencrypted (legacy) after a TLS `close_notify` shutdown to illustrate the post-TLS plaintext path.
- Demonstrate the framework pattern for transitioning protocols on the same socket using SNode.C's TLS shutdown semantics and `setNoCloseNotifyIsEOF(true)` behavior.
- Record a short engineering addendum to the extended review document with concrete observations and MQTTSuite recommendations.

### Description
- Add a new demo module at `src/apps/tlslegacy` with library and executable CMake targets (`tlslegacysocketcontext`, `tlslegacyserver`, `tlslegacyclient`) and an install stanza in `CMakeLists.txt`.
- Implement `TlsLegacySocketContext` in `TlsLegacySocketContext.{h,cpp}` that runs a small line-based two-phase protocol (`TLS_HELLO` / `TLS_ACK` then `LEGACY_HELLO` / `LEGACY_ACK`) and an interval retry timer to emit legacy payloads after TLS shutdown.
- Add `tlslegacyserver` and `tlslegacyclient` apps that use `net::in::stream::tls` and configure TLS material and `setNoCloseNotifyIsEOF(true)` so the connection remains usable for post-shutdown plaintext exchanges.
- Extend the extended review doc `docs/landing-pages/.../09-extended-review-snodec-and-mqttsuite.md` with a “2026 engineering review addendum” containing technical observations and actionable MQTTSuite recommendations.

### Testing
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` to configure the tree, which failed in this environment due to a missing system dependency (`nlohmann-json3-dev`), so a full build was not executed.
- No automated unit/integration tests were run in this environment as configuration did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e211225f08832c8996f168ca1152e4)