### PR TITLE
Protect event loop from user callback exceptions

### DIFF
--- a/src/core/DescriptorEventReceiver.cpp
+++ b/src/core/DescriptorEventReceiver.cpp
@@ -171,6 +171,14 @@ namespace core {
         dispatchEvent();
     }
 
+    void DescriptorEventReceiver::onEventException(std::exception_ptr exceptionPtr) {
+        EventReceiver::onEventException(exceptionPtr);
+
+        if (isEnabled()) {
+            disable();
+        }
+    }
+
     void DescriptorEventReceiver::onSignal(int signum) {
         signalEvent(signum);
     }

--- a/src/core/DescriptorEventReceiver.h
+++ b/src/core/DescriptorEventReceiver.h
@@ -52,6 +52,7 @@ namespace core {
 
 #include "utils/Timeval.h"
 
+#include <exception>
 #include <string>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -108,6 +109,8 @@ namespace core {
         utils::Timeval getTimeout(const utils::Timeval& currentTime) const;
 
         void checkTimeout(const utils::Timeval& currentTime);
+
+        void onEventException(std::exception_ptr exceptionPtr) override;
 
     private:
         void onEvent(const utils::Timeval& currentTime) final;

--- a/src/core/Event.cpp
+++ b/src/core/Event.cpp
@@ -47,6 +47,8 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include <exception>
+
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace core {
@@ -81,7 +83,11 @@ namespace core {
 
     void Event::dispatch(const utils::Timeval& currentTime) {
         published = false;
-        eventReceiver->onEvent(currentTime);
+        try {
+            eventReceiver->onEvent(currentTime);
+        } catch (...) {
+            eventReceiver->onEventException(std::current_exception());
+        }
     }
 
     EventReceiver* Event::getEventReceiver() const {

--- a/src/core/EventReceiver.cpp
+++ b/src/core/EventReceiver.cpp
@@ -43,6 +43,10 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/Logger.h"
+
+#include <exception>
+
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace core {
@@ -74,6 +78,18 @@ namespace core {
 
     void EventReceiver::destruct() {
         delete this;
+    }
+
+    void EventReceiver::onEventException(std::exception_ptr exceptionPtr) {
+        try {
+            if (exceptionPtr != nullptr) {
+                std::rethrow_exception(exceptionPtr);
+            }
+        } catch (const std::exception& ex) {
+            LOG(ERROR) << getName() << ": Unhandled exception in event callback: " << ex.what();
+        } catch (...) {
+            LOG(ERROR) << getName() << ": Unhandled non-standard exception in event callback";
+        }
     }
 
     void EventReceiver::span() {

--- a/src/core/EventReceiver.h
+++ b/src/core/EventReceiver.h
@@ -46,6 +46,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include <exception>
 #include <functional>
 
 namespace utils {
@@ -80,6 +81,7 @@ namespace core {
         void relax();
 
         virtual void onEvent(const utils::Timeval& currentTime) = 0;
+        virtual void onEventException(std::exception_ptr exceptionPtr);
 
         const std::string& getName() const;
 

--- a/src/core/socket/stream/SocketReader.cpp
+++ b/src/core/socket/stream/SocketReader.cpp
@@ -79,6 +79,11 @@ namespace core::socket::stream {
         }
     }
 
+    void SocketReader::onEventException(std::exception_ptr exceptionPtr) {
+        core::eventreceiver::ReadEventReceiver::onEventException(exceptionPtr);
+        onStatus(EIO);
+    }
+
     void SocketReader::signalEvent([[maybe_unused]] int sigNum) { // Do nothing in case a signal was received
     }
 

--- a/src/core/socket/stream/SocketReader.h
+++ b/src/core/socket/stream/SocketReader.h
@@ -48,6 +48,7 @@
 
 #include "utils/Timeval.h"
 
+#include <exception>
 #include <cstddef>
 #include <functional>
 #include <string>
@@ -76,6 +77,7 @@ namespace core::socket::stream {
         virtual void onReceivedFromPeer(std::size_t available) = 0;
 
         void readEvent() final;
+        void onEventException(std::exception_ptr exceptionPtr) override;
 
         std::size_t doRead();
         void signalEvent(int sigNum) final;

--- a/src/core/socket/stream/SocketWriter.cpp
+++ b/src/core/socket/stream/SocketWriter.cpp
@@ -84,6 +84,11 @@ namespace core::socket::stream {
         }
     }
 
+    void SocketWriter::onEventException(std::exception_ptr exceptionPtr) {
+        core::eventreceiver::WriteEventReceiver::onEventException(exceptionPtr);
+        onStatus(EIO);
+    }
+
     ssize_t SocketWriter::write(const char* chunk, std::size_t chunkLen) {
         return core::system::send(this->getRegisteredFd(), chunk, chunkLen, MSG_NOSIGNAL);
     }

--- a/src/core/socket/stream/SocketWriter.h
+++ b/src/core/socket/stream/SocketWriter.h
@@ -52,6 +52,7 @@ namespace core::pipe {
 
 #include "utils/Timeval.h"
 
+#include <exception>
 #include <cstddef>
 #include <functional>
 #include <string>
@@ -79,6 +80,7 @@ namespace core::socket::stream {
     private:
         void writeEvent() final;
         void signalEvent(int sigNum) final;
+        void onEventException(std::exception_ptr exceptionPtr) override;
 
         void doWrite();
 


### PR DESCRIPTION
### Motivation

- Prevent uncaught exceptions in user callbacks from unwinding the event loop and crashing the process.
- Avoid leaving composite resources (e.g. socket reader/writer pairs) in half-open states when one side throws.
- Provide a central recovery hook so individual receiver types can implement domain-appropriate teardown behavior.

### Description

- Add a global safety net in `core::Event::dispatch` that catches all exceptions from `onEvent` and forwards them to a new recovery hook: `EventReceiver::onEventException(std::exception_ptr)`. (files: `src/core/Event.cpp`, `src/core/EventReceiver.h`)  
- Implement a default `EventReceiver::onEventException` that logs the exception (standard and non-standard) using the logging facility. (file: `src/core/EventReceiver.cpp`)  
- For descriptor-backed receivers, override the recovery hook so a failing callback causes the receiver to be disabled, preventing repeated failing callbacks on the same fd. (files: `src/core/DescriptorEventReceiver.h`, `src/core/DescriptorEventReceiver.cpp`)  
- In socket stream code, override the hook for the `SocketReader`/`SocketWriter` paths to route exceptions into the existing error handling path by invoking `onStatus(EIO)`, which triggers the established connection teardown flow and avoids leaving only one side disabled. (files: `src/core/socket/stream/SocketReader.{h,cpp}`, `src/core/socket/stream/SocketWriter.{h,cpp}`)

### Testing

- Ran `git diff --check` to verify no whitespace or diff errors, which passed.
- Ran `cmake -S . -B build` to validate project configuration; configuration failed in this environment due to a missing external dependency (`nlohmann_json>=3.11`) unrelated to these code changes, so a full build was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93d4b41e4832c8a16e72b245cb9e0)