### PR TITLE
Fix SubCommand cleanup and parent detach to avoid invalid deletes

### DIFF
--- a/src/utils/SubCommand.cpp
+++ b/src/utils/SubCommand.cpp
@@ -126,6 +126,7 @@ namespace utils {
     }
 
     SubCommand::~SubCommand() {
+        removeSubCommand();
     }
 
     std::string SubCommand::getName() const {
@@ -153,13 +154,22 @@ namespace utils {
     }
 
     void SubCommand::removeSubCommand() {
-        for (const SubCommand* child : childSubCommands) {
+        while (!childSubCommands.empty()) {
+            auto childIt = childSubCommands.begin();
+            SubCommand* child = *childIt;
+            childSubCommands.erase(childIt);
+
             delete child;
         }
-        childSubCommands.clear();
 
         if (parent != nullptr) {
-            parent->subCommandApp->remove_subcommand(subCommandApp);
+            parent->childSubCommands.erase(this);
+
+            if (parent->subCommandApp != nullptr && subCommandApp != nullptr) {
+                parent->subCommandApp->remove_subcommand(subCommandApp);
+            }
+
+            parent = nullptr;
         }
     }
 

--- a/src/utils/SubCommand.h
+++ b/src/utils/SubCommand.h
@@ -256,6 +256,9 @@ namespace utils {
 
     private:
         std::shared_ptr<AppWithPtr> selfAnchoredSubCommandApp;
+        // Owns only SubCommand objects allocated by newSubCommand().
+        // ConfigSection base subobjects registered through multiple inheritance are
+        // attached to the CLI tree but must not be deleted through this set.
         std::set<SubCommand*> childSubCommands;
 
         int requiredCount = 0;


### PR DESCRIPTION
### Motivation

- Prevent crashes and double-free/dangling-pointer issues during subcommand destruction and removal by centralizing and hardening cleanup logic.

### Description

- `~SubCommand()` now calls `removeSubCommand()` to ensure consistent teardown.
- `removeSubCommand()` was rewritten to erase each child from `childSubCommands` before `delete` using a `while` loop to avoid iterator invalidation and accidental double-deletes.
- Parent detach now removes `this` from `parent->childSubCommands`, only calls `parent->subCommandApp->remove_subcommand(subCommandApp)` when both pointers are non-null, and clears the `parent` pointer.
- Added a clarifying ownership comment for `childSubCommands` in the header to document which `SubCommand` pointers are owned and which must not be deleted.

### Testing

- Built the project with `cmake --build .` and executed the test suite with `ctest`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e3a43248832c8536280bf73c2212)