### PR TITLE
Add core timer component tests

### DIFF
--- a/tests/component/CMakeLists.txt
+++ b/tests/component/CMakeLists.txt
@@ -38,12 +38,4 @@
 # THE SOFTWARE.
 
 
-cmake_minimum_required(VERSION 3.18)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-
-include(AddSNodeCTest)
-
-add_subdirectory(support)
-add_subdirectory(unit)
-add_subdirectory(component)
+add_subdirectory(core)

--- a/tests/component/core/CMakeLists.txt
+++ b/tests/component/core/CMakeLists.txt
@@ -38,12 +38,11 @@
 # THE SOFTWARE.
 
 
-cmake_minimum_required(VERSION 3.18)
+snodec_add_test(SingleshotTimerTest SingleshotTimerTest.cpp)
+snodec_add_test(IntervalTimerStopableTest IntervalTimerStopableTest.cpp)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+target_link_libraries(SingleshotTimerTest PRIVATE snodec-test-support snodec::core)
+target_link_libraries(IntervalTimerStopableTest PRIVATE snodec-test-support snodec::core)
 
-include(AddSNodeCTest)
-
-add_subdirectory(support)
-add_subdirectory(unit)
-add_subdirectory(component)
+set_tests_properties(SingleshotTimerTest PROPERTIES LABELS "component;core;timer" SKIP_RETURN_CODE 77)
+set_tests_properties(IntervalTimerStopableTest PROPERTIES LABELS "component;core;timer" SKIP_RETURN_CODE 77)

--- a/tests/component/core/IntervalTimerStopableTest.cpp
+++ b/tests/component/core/IntervalTimerStopableTest.cpp
@@ -47,31 +47,15 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #include <functional>
-#include <grp.h>
-#include <iostream>
-#include <unistd.h>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
-namespace {
-
-    constexpr int cTestSkipReturnCode = 77;
-
-    bool shouldSkipRootWithoutSNodeCGroup() {
-        const bool skip = geteuid() == 0 && getgrnam("snodec") == nullptr;
-
-        return skip;
-    }
-
-} // namespace
-
 int main(int argc, char* argv[]) {
     tests::support::TestResult testResult;
-    int result = cTestSkipReturnCode;
+    int result = tests::support::cTestSkipReturnCode;
 
-    if (shouldSkipRootWithoutSNodeCGroup()) {
-        std::cout << "SKIP: SNode.C timer component test is skipped for uid 0 because the configured snodec group is unavailable"
-                  << std::endl;
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("IntervalTimerStopableTest");
     } else {
         constexpr int expectedCallbackCount = 3;
         int callbackCount = 0;

--- a/tests/component/core/IntervalTimerStopableTest.cpp
+++ b/tests/component/core/IntervalTimerStopableTest.cpp
@@ -1,0 +1,102 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/timer/Timer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <functional>
+#include <grp.h>
+#include <iostream>
+#include <unistd.h>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    constexpr int cTestSkipReturnCode = 77;
+
+    bool shouldSkipRootWithoutSNodeCGroup() {
+        const bool skip = geteuid() == 0 && getgrnam("snodec") == nullptr;
+
+        return skip;
+    }
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = cTestSkipReturnCode;
+
+    if (shouldSkipRootWithoutSNodeCGroup()) {
+        std::cout << "SKIP: SNode.C timer component test is skipped for uid 0 because the configured snodec group is unavailable"
+                  << std::endl;
+    } else {
+        constexpr int expectedCallbackCount = 3;
+        int callbackCount = 0;
+
+        core::SNodeC::init(argc, argv);
+
+        core::timer::Timer intervalTimer = core::timer::Timer::intervalTimer(
+            [&callbackCount, expectedCallbackCount](const std::function<void()>& stop) {
+                ++callbackCount;
+
+                if (callbackCount == expectedCallbackCount) {
+                    stop();
+                    core::SNodeC::stop();
+                }
+            },
+            utils::Timeval({0, 1000}));
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(expectedCallbackCount, callbackCount, "stoppable interval timer fires until the callback stops it");
+        testResult.expectEqual(0, startResult, "event loop stops successfully after the interval timer reaches the expected count");
+
+        core::SNodeC::free();
+        result = testResult.processResult();
+    }
+
+    return result;
+}

--- a/tests/component/core/SingleshotTimerTest.cpp
+++ b/tests/component/core/SingleshotTimerTest.cpp
@@ -1,0 +1,97 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/timer/Timer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <functional>
+#include <grp.h>
+#include <iostream>
+#include <unistd.h>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    constexpr int cTestSkipReturnCode = 77;
+
+    bool shouldSkipRootWithoutSNodeCGroup() {
+        const bool skip = geteuid() == 0 && getgrnam("snodec") == nullptr;
+
+        return skip;
+    }
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = cTestSkipReturnCode;
+
+    if (shouldSkipRootWithoutSNodeCGroup()) {
+        std::cout << "SKIP: SNode.C timer component test is skipped for uid 0 because the configured snodec group is unavailable"
+                  << std::endl;
+    } else {
+        int callbackCount = 0;
+
+        core::SNodeC::init(argc, argv);
+
+        core::timer::Timer singleshotTimer = core::timer::Timer::singleshotTimer(
+            [&callbackCount]() {
+                ++callbackCount;
+                core::SNodeC::stop();
+            },
+            utils::Timeval({0, 1000}));
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(1, callbackCount, "single-shot timer fires exactly once");
+        testResult.expectEqual(0, startResult, "event loop stops successfully from the single-shot timer callback");
+
+        core::SNodeC::free();
+        result = testResult.processResult();
+    }
+
+    return result;
+}

--- a/tests/component/core/SingleshotTimerTest.cpp
+++ b/tests/component/core/SingleshotTimerTest.cpp
@@ -47,31 +47,15 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #include <functional>
-#include <grp.h>
-#include <iostream>
-#include <unistd.h>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
-namespace {
-
-    constexpr int cTestSkipReturnCode = 77;
-
-    bool shouldSkipRootWithoutSNodeCGroup() {
-        const bool skip = geteuid() == 0 && getgrnam("snodec") == nullptr;
-
-        return skip;
-    }
-
-} // namespace
-
 int main(int argc, char* argv[]) {
     tests::support::TestResult testResult;
-    int result = cTestSkipReturnCode;
+    int result = tests::support::cTestSkipReturnCode;
 
-    if (shouldSkipRootWithoutSNodeCGroup()) {
-        std::cout << "SKIP: SNode.C timer component test is skipped for uid 0 because the configured snodec group is unavailable"
-                  << std::endl;
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("SingleshotTimerTest");
     } else {
         int callbackCount = 0;
 

--- a/tests/support/TestResult.cpp
+++ b/tests/support/TestResult.cpp
@@ -44,11 +44,23 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #include <cstdlib>
+#include <grp.h>
 #include <iostream>
+#include <unistd.h>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace tests::support {
+
+    bool shouldSkipRootWithoutSNodeCGroup() {
+        const bool skip = geteuid() == 0 && getgrnam("snodec") == nullptr;
+
+        return skip;
+    }
+
+    void printRootWithoutSNodeCGroupSkipMessage(const std::string& testName) {
+        std::cout << "SKIP: " << testName << " is skipped for uid 0 because the configured snodec group is unavailable" << std::endl;
+    }
 
     TestResult::TestResult()
         : result(EXIT_SUCCESS) {

--- a/tests/support/TestResult.h
+++ b/tests/support/TestResult.h
@@ -50,6 +50,11 @@
 
 namespace tests::support {
 
+    inline constexpr int cTestSkipReturnCode = 77;
+
+    bool shouldSkipRootWithoutSNodeCGroup();
+    void printRootWithoutSNodeCGroupSkipMessage(const std::string& testName);
+
     class TestResult {
     public:
         TestResult();


### PR DESCRIPTION
### Motivation
- Add a minimal, focused component test slice exercising the public core timer and event-loop APIs to verify observable behavior for single-shot and stoppable interval timers.
- Avoid changing production code or introducing app dependencies while integrating with the existing test/CTest infrastructure added previously.

### Description
- Add a new component test subtree under `tests/component/core` and hook it into the test tree by updating `tests/CMakeLists.txt` to descend into `tests/component`.
- Add `SingleshotTimerTest.cpp` which uses `core::SNodeC::init`, `core::timer::Timer::singleshotTimer(...)`, stops the event loop from the timer callback, and calls `core::SNodeC::free()` during cleanup.
- Add `IntervalTimerStopableTest.cpp` which uses `core::timer::Timer::intervalTimer(...)` (stoppable overload) to verify repeated callbacks and that the callback-provided `stop()` stops the timer and event loop after a fixed count.
- Add `tests/component/core/CMakeLists.txt` to register both tests with `snodec_add_test(...)`, link only `snodec-test-support` and `snodec::core`, label them `component;core;timer`, and set `SKIP_RETURN_CODE` to `77` for clear CTest skips on root-runner environments lacking the `snodec` group.

### Testing
- Ran configuration and build with tests-only CI settings: `cmake -S . -B build-pr2 -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` and `cmake --build build-pr2 --parallel` and then executed `ctest --test-dir build-pr2 --output-on-failure` which reported `100% tests passed, 0 tests failed out of 3`.
- Locally the two new timer component tests were skipped (CTest reported them as Skipped) because this execution ran as UID 0 and the configured `snodec` group was unavailable; skip is implemented using return code `77` so the CI runner can still execute the real tests.
- Verified default configure remains valid with `cmake -S . -B build-pr2-default -DCMAKE_BUILD_TYPE=Debug` which completed successfully.
- Confirmed apps were not built in the test configuration by using `-DSNODEC_BUILD_APPS=OFF` during the test build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a469e2cf388832c9cb34e852f7d15a9)