### PR TITLE
Add net socket address unit tests

### DIFF
--- a/tests/unit/net/CMakeLists.txt
+++ b/tests/unit/net/CMakeLists.txt
@@ -38,6 +38,14 @@
 # THE SOFTWARE.
 
 
-add_subdirectory(core)
+snodec_add_test(InetSocketAddressTest InetSocketAddressTest.cpp)
+snodec_add_test(Inet6SocketAddressTest Inet6SocketAddressTest.cpp)
+snodec_add_test(UnixSocketAddressTest UnixSocketAddressTest.cpp)
 
-add_subdirectory(net)
+target_link_libraries(InetSocketAddressTest PRIVATE snodec-test-support snodec::net-in)
+target_link_libraries(Inet6SocketAddressTest PRIVATE snodec-test-support snodec::net-in6)
+target_link_libraries(UnixSocketAddressTest PRIVATE snodec-test-support snodec::net-un)
+
+set_tests_properties(InetSocketAddressTest PROPERTIES LABELS "unit;net;address" TIMEOUT 5)
+set_tests_properties(Inet6SocketAddressTest PROPERTIES LABELS "unit;net;address" TIMEOUT 5)
+set_tests_properties(UnixSocketAddressTest PROPERTIES LABELS "unit;net;address" TIMEOUT 5)

--- a/tests/unit/net/Inet6SocketAddressTest.cpp
+++ b/tests/unit/net/Inet6SocketAddressTest.cpp
@@ -1,0 +1,93 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "net/in6/SocketAddress.h"
+#include "support/TestResult.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstdint>
+#include <string>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+int main() {
+    tests::support::TestResult testResult;
+
+    const std::string defaultHost = "::";
+    const std::string host = "::1";
+    const std::string alternateHost = "::";
+    const uint16_t port = 8080;
+    const uint16_t alternatePort = 12345;
+
+    const net::in6::SocketAddress defaultSocketAddress;
+    testResult.expectTrue(defaultSocketAddress.getHost() == defaultHost, "default IPv6 host is ::");
+    testResult.expectEqual(0, defaultSocketAddress.getPort(), "default IPv6 port is 0");
+    testResult.expectTrue(defaultSocketAddress.toString() == ":::0", "default IPv6 address string includes host and port");
+    testResult.expectTrue(defaultSocketAddress.toString(false) == ":::0", "compact default IPv6 address string includes host and port");
+
+    const net::in6::SocketAddress hostSocketAddress(host);
+    testResult.expectTrue(hostSocketAddress.getHost() == host, "IPv6 host constructor stores host");
+    testResult.expectEqual(0, hostSocketAddress.getPort(), "IPv6 host constructor leaves port at 0");
+    testResult.expectTrue(hostSocketAddress.toString() == "::1:0", "IPv6 host constructor string includes host and port");
+
+    const net::in6::SocketAddress portSocketAddress(port);
+    testResult.expectTrue(portSocketAddress.getHost() == defaultHost, "IPv6 port constructor leaves default host");
+    testResult.expectEqual(port, portSocketAddress.getPort(), "IPv6 port constructor stores port");
+    testResult.expectTrue(portSocketAddress.toString() == ":::8080", "IPv6 port constructor string includes host and port");
+
+    net::in6::SocketAddress hostPortSocketAddress(host, port);
+    testResult.expectTrue(hostPortSocketAddress.getHost() == host, "IPv6 host and port constructor stores host");
+    testResult.expectEqual(port, hostPortSocketAddress.getPort(), "IPv6 host and port constructor stores port");
+    testResult.expectTrue(hostPortSocketAddress.toString() == "::1:8080", "IPv6 host and port constructor string includes host and port");
+
+    hostPortSocketAddress.setHost(alternateHost);
+    testResult.expectTrue(hostPortSocketAddress.getHost() == alternateHost, "IPv6 setHost updates host");
+    testResult.expectTrue(hostPortSocketAddress.toString() == ":::8080", "IPv6 string reflects updated host");
+
+    hostPortSocketAddress.setPort(alternatePort);
+    testResult.expectEqual(alternatePort, hostPortSocketAddress.getPort(), "IPv6 setPort updates port");
+    testResult.expectTrue(hostPortSocketAddress.toString() == ":::12345", "IPv6 string reflects updated port");
+
+    const int result = testResult.processResult();
+
+    return result;
+}

--- a/tests/unit/net/InetSocketAddressTest.cpp
+++ b/tests/unit/net/InetSocketAddressTest.cpp
@@ -1,0 +1,95 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "net/in/SocketAddress.h"
+#include "support/TestResult.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstdint>
+#include <string>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+int main() {
+    tests::support::TestResult testResult;
+
+    const std::string defaultHost = "0.0.0.0";
+    const std::string host = "127.0.0.1";
+    const std::string alternateHost = "0.0.0.0";
+    const uint16_t port = 8080;
+    const uint16_t alternatePort = 12345;
+
+    const net::in::SocketAddress defaultSocketAddress;
+    testResult.expectTrue(defaultSocketAddress.getHost() == defaultHost, "default IPv4 host is 0.0.0.0");
+    testResult.expectEqual(0, defaultSocketAddress.getPort(), "default IPv4 port is 0");
+    testResult.expectTrue(defaultSocketAddress.toString() == "0.0.0.0:0", "default IPv4 address string includes host and port");
+    testResult.expectTrue(defaultSocketAddress.toString(false) == "0.0.0.0:0",
+                          "compact default IPv4 address string includes host and port");
+
+    const net::in::SocketAddress hostSocketAddress(host);
+    testResult.expectTrue(hostSocketAddress.getHost() == host, "IPv4 host constructor stores host");
+    testResult.expectEqual(0, hostSocketAddress.getPort(), "IPv4 host constructor leaves port at 0");
+    testResult.expectTrue(hostSocketAddress.toString() == "127.0.0.1:0", "IPv4 host constructor string includes host and port");
+
+    const net::in::SocketAddress portSocketAddress(port);
+    testResult.expectTrue(portSocketAddress.getHost() == defaultHost, "IPv4 port constructor leaves default host");
+    testResult.expectEqual(port, portSocketAddress.getPort(), "IPv4 port constructor stores port");
+    testResult.expectTrue(portSocketAddress.toString() == "0.0.0.0:8080", "IPv4 port constructor string includes host and port");
+
+    net::in::SocketAddress hostPortSocketAddress(host, port);
+    testResult.expectTrue(hostPortSocketAddress.getHost() == host, "IPv4 host and port constructor stores host");
+    testResult.expectEqual(port, hostPortSocketAddress.getPort(), "IPv4 host and port constructor stores port");
+    testResult.expectTrue(hostPortSocketAddress.toString() == "127.0.0.1:8080",
+                          "IPv4 host and port constructor string includes host and port");
+
+    hostPortSocketAddress.setHost(alternateHost);
+    testResult.expectTrue(hostPortSocketAddress.getHost() == alternateHost, "IPv4 setHost updates host");
+    testResult.expectTrue(hostPortSocketAddress.toString() == "0.0.0.0:8080", "IPv4 string reflects updated host");
+
+    hostPortSocketAddress.setPort(alternatePort);
+    testResult.expectEqual(alternatePort, hostPortSocketAddress.getPort(), "IPv4 setPort updates port");
+    testResult.expectTrue(hostPortSocketAddress.toString() == "0.0.0.0:12345", "IPv4 string reflects updated port");
+
+    const int result = testResult.processResult();
+
+    return result;
+}

--- a/tests/unit/net/UnixSocketAddressTest.cpp
+++ b/tests/unit/net/UnixSocketAddressTest.cpp
@@ -1,0 +1,75 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "net/un/SocketAddress.h"
+#include "support/TestResult.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <string>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+int main() {
+    tests::support::TestResult testResult;
+
+    const std::string emptyPath;
+    const std::string path = "/tmp/snodec-test.sock";
+    const std::string alternatePath = "/tmp/snodec-test-alt.sock";
+
+    const net::un::SocketAddress defaultSocketAddress;
+    testResult.expectTrue(defaultSocketAddress.getSunPath() == emptyPath, "default Unix-domain path is empty");
+    testResult.expectTrue(defaultSocketAddress.toString() == "@", "default Unix-domain address string is abstract-empty marker");
+    testResult.expectTrue(defaultSocketAddress.toString(false) == "@",
+                          "compact default Unix-domain address string is abstract-empty marker");
+
+    net::un::SocketAddress pathSocketAddress(path);
+    testResult.expectTrue(pathSocketAddress.getSunPath() == path, "Unix-domain path constructor stores path");
+    testResult.expectTrue(pathSocketAddress.toString() == "@", "Unix-domain string remains uninitialized until init is called");
+
+    pathSocketAddress.setSunPath(alternatePath);
+    testResult.expectTrue(pathSocketAddress.getSunPath() == alternatePath, "Unix-domain setSunPath updates path");
+    testResult.expectTrue(pathSocketAddress.toString() == "@", "Unix-domain string still remains uninitialized after setSunPath only");
+
+    const int result = testResult.processResult();
+
+    return result;
+}

--- a/tests/unit/net/UnixSocketAddressTest.cpp
+++ b/tests/unit/net/UnixSocketAddressTest.cpp
@@ -63,11 +63,16 @@ int main() {
 
     net::un::SocketAddress pathSocketAddress(path);
     testResult.expectTrue(pathSocketAddress.getSunPath() == path, "Unix-domain path constructor stores path");
-    testResult.expectTrue(pathSocketAddress.toString() == "@", "Unix-domain string remains uninitialized until init is called");
+    pathSocketAddress.init();
+    testResult.expectTrue(pathSocketAddress.toString() == path, "initialized Unix-domain string includes path");
+    testResult.expectTrue(pathSocketAddress.toString(false) == path, "compact initialized Unix-domain string includes path");
 
     pathSocketAddress.setSunPath(alternatePath);
     testResult.expectTrue(pathSocketAddress.getSunPath() == alternatePath, "Unix-domain setSunPath updates path");
-    testResult.expectTrue(pathSocketAddress.toString() == "@", "Unix-domain string still remains uninitialized after setSunPath only");
+    pathSocketAddress.init();
+    testResult.expectTrue(pathSocketAddress.toString() == alternatePath, "reinitialized Unix-domain string includes updated path");
+    testResult.expectTrue(pathSocketAddress.toString(false) == alternatePath,
+                          "compact reinitialized Unix-domain string includes updated path");
 
     const int result = testResult.processResult();
 


### PR DESCRIPTION
### Motivation

- Introduce deterministic, local, pure unit tests for the SNode.C socket address value objects to validate basic address semantics before adding any socket lifecycle or loopback tests.
- Reuse the existing test infrastructure (CTest, `snodec_add_test`, and `snodec-test-support`) without altering production code or app targets.

### Description

- Add `tests/unit/net/` with `InetSocketAddressTest.cpp`, `Inet6SocketAddressTest.cpp`, and `UnixSocketAddressTest.cpp` that exercise construction, `set/get` for host/port/path and the current `toString(...)` behavior for `net::in::SocketAddress`, `net::in6::SocketAddress`, and `net::un::SocketAddress` respectively.
- Add `tests/unit/net/CMakeLists.txt` and update `tests/unit/CMakeLists.txt` to include the new `net` subdirectory, and register each test with `snodec_add_test(...)` and labels `unit;net;address` and modest timeouts.
- Link each test only against `snodec-test-support` and the minimal net address targets `snodec::net-in`, `snodec::net-in6`, and `snodec::net-un` as appropriate, and do not link any protocol, HTTP, app, or other large targets.
- No production source files were modified and no app files were added or changed as part of this patch.

### Testing

- Configured and built the project with `cmake -S . -B build-pr3 -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` and `cmake --build build-pr3 --parallel` and verified the build completed successfully.
- Ran `ctest --test-dir build-pr3 --output-on-failure` and observed successful overall results (tests executed and returned `0`; the pre-existing component timer tests were skipped by the existing root-skip handling). 
- Ran filtered test runs `ctest --test-dir build-pr3 -L "unit" --output-on-failure`, `ctest --test-dir build-pr3 -L "net" --output-on-failure`, and `ctest --test-dir build-pr3 -L "address" --output-on-failure` and confirmed the new address tests all passed with no failures.
- Verified `git diff --check` reported no whitespace/file issues and validated the default configure with `cmake -S . -B build-pr3-default -DCMAKE_BUILD_TYPE=Debug` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46ad81c4dc832c895d4e80d983d48f)