### PR TITLE
Add inet native socket address unit tests

### DIFF
--- a/tests/unit/net/CMakeLists.txt
+++ b/tests/unit/net/CMakeLists.txt
@@ -39,16 +39,22 @@
 
 
 snodec_add_test(InetSocketAddressTest InetSocketAddressTest.cpp)
+snodec_add_test(InetSocketAddressNativeTest InetSocketAddressNativeTest.cpp)
 snodec_add_test(Inet6SocketAddressTest Inet6SocketAddressTest.cpp)
+snodec_add_test(Inet6SocketAddressNativeTest Inet6SocketAddressNativeTest.cpp)
 snodec_add_test(UnixSocketAddressTest UnixSocketAddressTest.cpp)
 snodec_add_test(UnixSocketAddressInitTest UnixSocketAddressInitTest.cpp)
 
 target_link_libraries(InetSocketAddressTest PRIVATE snodec-test-support snodec::net-in)
+target_link_libraries(InetSocketAddressNativeTest PRIVATE snodec-test-support snodec::net-in)
 target_link_libraries(Inet6SocketAddressTest PRIVATE snodec-test-support snodec::net-in6)
+target_link_libraries(Inet6SocketAddressNativeTest PRIVATE snodec-test-support snodec::net-in6)
 target_link_libraries(UnixSocketAddressTest PRIVATE snodec-test-support snodec::net-un)
 target_link_libraries(UnixSocketAddressInitTest PRIVATE snodec-test-support snodec::net-un)
 
 set_tests_properties(InetSocketAddressTest PROPERTIES LABELS "unit;net;address" TIMEOUT 5)
+set_tests_properties(InetSocketAddressNativeTest PROPERTIES LABELS "unit;net;address;native;ipv4" TIMEOUT 5)
 set_tests_properties(Inet6SocketAddressTest PROPERTIES LABELS "unit;net;address" TIMEOUT 5)
+set_tests_properties(Inet6SocketAddressNativeTest PROPERTIES LABELS "unit;net;address;native;ipv6" TIMEOUT 5)
 set_tests_properties(UnixSocketAddressTest PROPERTIES LABELS "unit;net;address" TIMEOUT 5)
 set_tests_properties(UnixSocketAddressInitTest PROPERTIES LABELS "unit;net;address;unix;init" TIMEOUT 5)

--- a/tests/unit/net/Inet6SocketAddressNativeTest.cpp
+++ b/tests/unit/net/Inet6SocketAddressNativeTest.cpp
@@ -44,9 +44,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#include <cstdint>
 #include <netinet/in.h>
-#include <sys/socket.h>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 

--- a/tests/unit/net/Inet6SocketAddressNativeTest.cpp
+++ b/tests/unit/net/Inet6SocketAddressNativeTest.cpp
@@ -1,0 +1,87 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "net/in6/SocketAddress.h"
+#include "support/TestResult.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstdint>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+int main() {
+    tests::support::TestResult testResult;
+
+    sockaddr_in6 loopbackSockAddr{};
+    loopbackSockAddr.sin6_family = AF_INET6;
+    loopbackSockAddr.sin6_port = htons(8080);
+    loopbackSockAddr.sin6_addr = in6addr_loopback;
+
+    const net::in6::SocketAddress loopbackSocketAddress(loopbackSockAddr, sizeof(loopbackSockAddr), true);
+    testResult.expectTrue(loopbackSocketAddress.getHost() == "::1", "native IPv6 loopback host is ::1");
+    testResult.expectEqual(8080, loopbackSocketAddress.getPort(), "native IPv6 loopback port is 8080");
+    testResult.expectTrue(loopbackSocketAddress.toString() == "::1:8080", "native IPv6 loopback address string includes host and port");
+    testResult.expectTrue(loopbackSocketAddress.toString(false) == "::1:8080",
+                          "compact native IPv6 loopback address string includes host and port");
+    testResult.expectEqual(AF_INET6, loopbackSocketAddress.getAddressFamily(), "native IPv6 loopback address family is AF_INET6");
+    testResult.expectEqual(
+        sizeof(sockaddr_in6), loopbackSocketAddress.getSockAddrLen(), "native IPv6 loopback sockaddr length is sockaddr_in6 size");
+
+    sockaddr_in6 anySockAddr{};
+    anySockAddr.sin6_family = AF_INET6;
+    anySockAddr.sin6_port = htons(0);
+    anySockAddr.sin6_addr = in6addr_any;
+
+    const net::in6::SocketAddress anySocketAddress(anySockAddr, sizeof(anySockAddr), true);
+    testResult.expectTrue(anySocketAddress.getHost() == "::", "native IPv6 any host is ::");
+    testResult.expectEqual(0, anySocketAddress.getPort(), "native IPv6 any port is 0");
+    testResult.expectTrue(anySocketAddress.toString() == ":::0", "native IPv6 any address string includes host and port");
+    testResult.expectTrue(anySocketAddress.toString(false) == ":::0", "compact native IPv6 any address string includes host and port");
+    testResult.expectEqual(AF_INET6, anySocketAddress.getAddressFamily(), "native IPv6 any address family is AF_INET6");
+    testResult.expectEqual(sizeof(sockaddr_in6), anySocketAddress.getSockAddrLen(), "native IPv6 any sockaddr length is sockaddr_in6 size");
+
+    const int result = testResult.processResult();
+
+    return result;
+}

--- a/tests/unit/net/InetSocketAddressNativeTest.cpp
+++ b/tests/unit/net/InetSocketAddressNativeTest.cpp
@@ -1,0 +1,89 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "net/in/SocketAddress.h"
+#include "support/TestResult.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <arpa/inet.h>
+#include <cstdint>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+int main() {
+    tests::support::TestResult testResult;
+
+    sockaddr_in loopbackSockAddr{};
+    loopbackSockAddr.sin_family = AF_INET;
+    loopbackSockAddr.sin_port = htons(8080);
+    loopbackSockAddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    const net::in::SocketAddress loopbackSocketAddress(loopbackSockAddr, sizeof(loopbackSockAddr), true);
+    testResult.expectTrue(loopbackSocketAddress.getHost() == "127.0.0.1", "native IPv4 loopback host is 127.0.0.1");
+    testResult.expectEqual(8080, loopbackSocketAddress.getPort(), "native IPv4 loopback port is 8080");
+    testResult.expectTrue(loopbackSocketAddress.toString() == "127.0.0.1:8080",
+                          "native IPv4 loopback address string includes host and port");
+    testResult.expectTrue(loopbackSocketAddress.toString(false) == "127.0.0.1:8080",
+                          "compact native IPv4 loopback address string includes host and port");
+    testResult.expectEqual(AF_INET, loopbackSocketAddress.getAddressFamily(), "native IPv4 loopback address family is AF_INET");
+    testResult.expectEqual(
+        sizeof(sockaddr_in), loopbackSocketAddress.getSockAddrLen(), "native IPv4 loopback sockaddr length is sockaddr_in size");
+
+    sockaddr_in anySockAddr{};
+    anySockAddr.sin_family = AF_INET;
+    anySockAddr.sin_port = htons(0);
+    anySockAddr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    const net::in::SocketAddress anySocketAddress(anySockAddr, sizeof(anySockAddr), true);
+    testResult.expectTrue(anySocketAddress.getHost() == "0.0.0.0", "native IPv4 any host is 0.0.0.0");
+    testResult.expectEqual(0, anySocketAddress.getPort(), "native IPv4 any port is 0");
+    testResult.expectTrue(anySocketAddress.toString() == "0.0.0.0:0", "native IPv4 any address string includes host and port");
+    testResult.expectTrue(anySocketAddress.toString(false) == "0.0.0.0:0", "compact native IPv4 any address string includes host and port");
+    testResult.expectEqual(AF_INET, anySocketAddress.getAddressFamily(), "native IPv4 any address family is AF_INET");
+    testResult.expectEqual(sizeof(sockaddr_in), anySocketAddress.getSockAddrLen(), "native IPv4 any sockaddr length is sockaddr_in size");
+
+    const int result = testResult.processResult();
+
+    return result;
+}

--- a/tests/unit/net/InetSocketAddressNativeTest.cpp
+++ b/tests/unit/net/InetSocketAddressNativeTest.cpp
@@ -44,10 +44,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#include <arpa/inet.h>
-#include <cstdint>
 #include <netinet/in.h>
-#include <sys/socket.h>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 


### PR DESCRIPTION
### Motivation

- Provide deterministic, pure unit coverage for constructing IPv4 and IPv6 address objects from already-filled native `sockaddr` structures to lock down numeric constructor behavior without relying on DNS, sockets, or the event loop. 
- Ensure the `net::in::SocketAddress(sockaddr_in, socklen_t, true)` and `net::in6::SocketAddress(sockaddr_in6, socklen_t, true)` code paths produce the exact numeric host, port, string, family and sockaddr-length values expected by callers. 
- Keep the change narrowly scoped to address-object unit tests only and avoid any production, app, filesystem, or network side effects. 

### Description

- Added two new test executables `tests/unit/net/InetSocketAddressNativeTest.cpp` and `tests/unit/net/Inet6SocketAddressNativeTest.cpp` that construct zero-initialized native `sockaddr_in`/`sockaddr_in6`, set family/port/address, call the numeric constructor and assert `getHost()`, `getPort()`, `toString()` / `toString(false)`, `getAddressFamily()` and `getSockAddrLen()`. 
- Updated `tests/unit/net/CMakeLists.txt` to register `InetSocketAddressNativeTest` and `Inet6SocketAddressNativeTest` with `snodec_add_test(...)`, link only against `snodec-test-support` plus `snodec::net-in` (IPv4) or `snodec::net-in6` (IPv6), and add labels `unit;net;address;native;ipv4` and `unit;net;address;native;ipv6` respectively with a 5s timeout. 
- Exact native address cases tested are IPv4 loopback (`INADDR_LOOPBACK`, port `8080`) expecting host `127.0.0.1`, port `8080`, `toString()`/`toString(false)` == `127.0.0.1:8080`, family `AF_INET`, `getSockAddrLen()` == `sizeof(sockaddr_in)`, and IPv4 any (`INADDR_ANY`, port `0`) expecting host `0.0.0.0`, port `0`, `0.0.0.0:0`; and IPv6 loopback (`in6addr_loopback`, port `8080`) expecting host `::1`, port `8080`, `::1:8080`, family `AF_INET6`, `sizeof(sockaddr_in6)`, and IPv6 any (`in6addr_any`, port `0`) expecting host `::`, port `0`, `:::0`. 
- Confirmations: no production source files or app files were modified, the tests do not call `init()`, perform DNS or hostname lookups, open sockets, bind/connect/listen/accept, use the event loop, timers, sleeps, or touch the filesystem. 

### Testing

- Build and test commands run were `cmake -S . -B build-pr5 -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF`, `cmake --build build-pr5 --parallel`, and multiple ctest invocations filtering labels (for example `ctest --test-dir build-pr5 -L "unit" --output-on-failure` and `-L "native"`, `-L "ipv4"`, `-L "ipv6"`). 
- One configuration dependency (`nlohmann-json3-dev`) was installed in the test environment to satisfy configure-time checks, after which the configure and build completed successfully. 
- CTest results: the new tests `InetSocketAddressNativeTest` and `Inet6SocketAddressNativeTest` passed and the full test run reported `100% tests passed, 0 tests failed` (the existing two component timer tests remained skipped by their pre-existing skip logic). 
- Also verified default configure remains valid with `cmake -S . -B build-pr5-default -DCMAKE_BUILD_TYPE=Debug` and ran `git diff --check` with no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4770d4d86c832cbeec4ba0c1076533)