### PR TITLE
Report effective local listen address

### DIFF
--- a/src/core/socket/stream/CMakeLists.txt
+++ b/src/core/socket/stream/CMakeLists.txt
@@ -56,6 +56,8 @@ set(CORE_SOCKET_STREAM_H
     ServerFlowController.h
     SocketAcceptor.h
     SocketAcceptor.hpp
+    SocketAddressUtils.h
+    SocketAddressUtils.hpp
     SocketClient.h
     SocketConnection.h
     SocketConnection.hpp

--- a/src/core/socket/stream/SocketAcceptor.hpp
+++ b/src/core/socket/stream/SocketAcceptor.hpp
@@ -41,6 +41,7 @@
 
 #include "core/State.h"
 #include "core/socket/stream/SocketAcceptor.h"
+#include "core/socket/stream/SocketAddressUtils.hpp"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
@@ -100,6 +101,8 @@ namespace core::socket::stream {
         if (!config->getDisabled()) {
             try {
                 core::socket::State state = core::socket::STATE_OK;
+                SocketAddress currentLocalAddress;
+                bool hasEffectiveLocalAddress = false;
 
                 LOG(DEBUG) << config->getInstanceName() << " Listen: starting";
 
@@ -152,6 +155,9 @@ namespace core::socket::stream {
                         } else {
                             LOG(DEBUG) << config->getInstanceName() << " listen " << bindAddress.toString() << ": success";
 
+                            currentLocalAddress = getLocalSocketAddress<SocketAddress>(physicalServerSocket, config);
+                            hasEffectiveLocalAddress = true;
+
                             if (enable(physicalServerSocket.getFd())) {
                                 LOG(DEBUG) << config->getInstanceName() << " enable " << bindAddress.toString() << ": success";
                             } else {
@@ -164,7 +170,9 @@ namespace core::socket::stream {
                     }
                 }
 
-                SocketAddress currentLocalAddress = bindAddress;
+                if (!hasEffectiveLocalAddress) {
+                    currentLocalAddress = bindAddress;
+                }
                 if (bindAddress.useNext()) {
                     onStatus(currentLocalAddress, (state | core::socket::State::NO_RETRY));
 

--- a/src/core/socket/stream/SocketAddressUtils.h
+++ b/src/core/socket/stream/SocketAddressUtils.h
@@ -1,0 +1,55 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef CORE_SOCKET_STREAM_SOCKETADDRESSUTILS_H
+#define CORE_SOCKET_STREAM_SOCKETADDRESSUTILS_H
+
+namespace core::socket::stream {
+
+    template <typename SocketAddress, typename PhysicalSocket, typename Config>
+    SocketAddress getLocalSocketAddress(PhysicalSocket& physicalSocket, Config& config);
+
+    template <typename SocketAddress, typename PhysicalSocket, typename Config>
+    SocketAddress getRemoteSocketAddress(PhysicalSocket& physicalSocket, Config& config);
+
+} // namespace core::socket::stream
+
+#endif // CORE_SOCKET_STREAM_SOCKETADDRESSUTILS_H

--- a/src/core/socket/stream/SocketAddressUtils.hpp
+++ b/src/core/socket/stream/SocketAddressUtils.hpp
@@ -1,0 +1,105 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef CORE_SOCKET_STREAM_SOCKETADDRESSUTILS_HPP
+#define CORE_SOCKET_STREAM_SOCKETADDRESSUTILS_HPP
+
+#include "core/socket/stream/SocketAddressUtils.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include "log/Logger.h"
+
+#include <iomanip>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace core::socket::stream {
+
+    template <typename SocketAddress, typename PhysicalSocket, typename Config>
+    SocketAddress getLocalSocketAddress(PhysicalSocket& physicalSocket, Config& config) {
+        typename SocketAddress::SockAddr localSockAddr;
+        typename SocketAddress::SockLen localSockAddrLen = sizeof(typename SocketAddress::SockAddr);
+
+        SocketAddress localPeerAddress;
+        if (physicalSocket.getSockName(localSockAddr, localSockAddrLen) == 0) {
+            try {
+                localPeerAddress = config->Local::getSocketAddress(localSockAddr, localSockAddrLen);
+                LOG(TRACE) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
+                           << "  PeerAddress (local): " << localPeerAddress.toString();
+            } catch (const typename SocketAddress::BadSocketAddress& badSocketAddress) {
+                LOG(WARNING) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
+                             << "  PeerAddress (local): " << badSocketAddress.what();
+            }
+        } else {
+            PLOG(WARNING) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
+                          << " PeerAddress (local) not retrievable";
+        }
+
+        return localPeerAddress;
+    }
+
+    template <typename SocketAddress, typename PhysicalSocket, typename Config>
+    SocketAddress getRemoteSocketAddress(PhysicalSocket& physicalSocket, Config& config) {
+        typename SocketAddress::SockAddr remoteSockAddr;
+        typename SocketAddress::SockLen remoteSockAddrLen = sizeof(typename SocketAddress::SockAddr);
+
+        SocketAddress remotePeerAddress;
+        if (physicalSocket.getPeerName(remoteSockAddr, remoteSockAddrLen) == 0) {
+            try {
+                remotePeerAddress = config->Remote::getSocketAddress(remoteSockAddr, remoteSockAddrLen);
+                LOG(TRACE) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
+                           << "  PeerAddress (remote): " << remotePeerAddress.toString();
+            } catch (const typename SocketAddress::BadSocketAddress& badSocketAddress) {
+                LOG(WARNING) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
+                             << "  PeerAddress (remote): " << badSocketAddress.what();
+            }
+        } else {
+            PLOG(WARNING) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
+                          << " PeerAddress (remote) not retrievble";
+        }
+
+        return remotePeerAddress;
+    }
+
+} // namespace core::socket::stream
+
+#endif // CORE_SOCKET_STREAM_SOCKETADDRESSUTILS_HPP

--- a/src/core/socket/stream/SocketConnection.hpp
+++ b/src/core/socket/stream/SocketConnection.hpp
@@ -40,6 +40,7 @@
  */
 
 #include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketAddressUtils.hpp"
 #include "core/socket/stream/SocketContext.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -48,58 +49,11 @@
 #include "utils/PreserveErrno.h"
 #include "utils/system/signal.h"
 
-#include <iomanip>
 #include <utility>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace core::socket::stream {
-
-    template <typename SocketAddress, typename PhysicalSocket, typename Config>
-    SocketAddress getLocalSocketAddress(PhysicalSocket& physicalSocket, Config& config) {
-        typename SocketAddress::SockAddr localSockAddr;
-        typename SocketAddress::SockLen localSockAddrLen = sizeof(typename SocketAddress::SockAddr);
-
-        SocketAddress localPeerAddress;
-        if (physicalSocket.getSockName(localSockAddr, localSockAddrLen) == 0) {
-            try {
-                localPeerAddress = config->Local::getSocketAddress(localSockAddr, localSockAddrLen);
-                LOG(TRACE) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
-                           << "  PeerAddress (local): " << localPeerAddress.toString();
-            } catch (const typename SocketAddress::BadSocketAddress& badSocketAddress) {
-                LOG(WARNING) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
-                             << "  PeerAddress (local): " << badSocketAddress.what();
-            }
-        } else {
-            PLOG(WARNING) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
-                          << " PeerAddress (local) not retrievable";
-        }
-
-        return localPeerAddress;
-    }
-
-    template <typename SocketAddress, typename PhysicalSocket, typename Config>
-    SocketAddress getRemoteSocketAddress(PhysicalSocket& physicalSocket, Config& config) {
-        typename SocketAddress::SockAddr remoteSockAddr;
-        typename SocketAddress::SockLen remoteSockAddrLen = sizeof(typename SocketAddress::SockAddr);
-
-        SocketAddress remotePeerAddress;
-        if (physicalSocket.getPeerName(remoteSockAddr, remoteSockAddrLen) == 0) {
-            try {
-                remotePeerAddress = config->Remote::getSocketAddress(remoteSockAddr, remoteSockAddrLen);
-                LOG(TRACE) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
-                           << "  PeerAddress (remote): " << remotePeerAddress.toString();
-            } catch (const typename SocketAddress::BadSocketAddress& badSocketAddress) {
-                LOG(WARNING) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
-                             << "  PeerAddress (remote): " << badSocketAddress.what();
-            }
-        } else {
-            PLOG(WARNING) << config->getInstanceName() << " [" << physicalSocket.getFd() << "]" << std::setw(25)
-                          << " PeerAddress (remote) not retrievble";
-        }
-
-        return remotePeerAddress;
-    }
 
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
     SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::SocketConnectionT(PhysicalSocket&& physicalSocket,

--- a/tests/component/net/CMakeLists.txt
+++ b/tests/component/net/CMakeLists.txt
@@ -39,11 +39,20 @@
 
 
 snodec_add_test(InetLegacyServerClientCompositionTest InetLegacyServerClientCompositionTest.cpp)
+snodec_add_test(InetLegacyServerEffectiveListenAddressTest InetLegacyServerEffectiveListenAddressTest.cpp)
 
 target_link_libraries(InetLegacyServerClientCompositionTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
 target_compile_features(InetLegacyServerClientCompositionTest PRIVATE cxx_std_20)
 
+target_link_libraries(InetLegacyServerEffectiveListenAddressTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
+target_compile_features(InetLegacyServerEffectiveListenAddressTest PRIVATE cxx_std_20)
+
 set_tests_properties(InetLegacyServerClientCompositionTest PROPERTIES
                      LABELS "component;net;stream;legacy;ipv4;composition"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetLegacyServerEffectiveListenAddressTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv4;listen;effective-address"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)

--- a/tests/component/net/InetLegacyServerEffectiveListenAddressTest.cpp
+++ b/tests/component/net/InetLegacyServerEffectiveListenAddressTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in/SocketAddress.h"
+#include "net/in/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int unexpectedStateCount = 0;
+        std::uint16_t effectivePort = 0;
+    };
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        explicit TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection)
+            : core::socket::stream::SocketContext(socketConnection) {
+        }
+
+    private:
+        void onConnected() override {
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            return 0;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            return new TestServerSocketContext(socketConnection);
+        }
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetLegacyServerEffectiveListenAddressTest");
+    } else {
+        TestState testState;
+
+        core::SNodeC::init(argc, argv);
+
+        const net::in::stream::legacy::SocketServer<TestServerSocketContextFactory> socketServer("effective-listen-address-server");
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(net::in::SocketAddress("127.0.0.1", 0), [&testState](const net::in::SocketAddress& socketAddress,
+                                                                                  core::socket::State state) {
+            if (state == core::socket::State::OK) {
+                ++testState.serverListenOkCount;
+                testState.effectivePort = socketAddress.getPort();
+            } else {
+                ++testState.unexpectedStateCount;
+            }
+
+            core::SNodeC::stop();
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after listen callback");
+        testResult.expectEqual(1, testState.serverListenOkCount, "IPv4 legacy server listen callback reports OK exactly once");
+        testResult.expectTrue(testState.effectivePort != 0, "IPv4 legacy server listen callback reports an effective non-zero port");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen callback reports no unexpected states");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Ensure `SocketAcceptor::init()` reports the effective local listen address (e.g. when binding to port `0`) to status callbacks without mutating configured bind state. 
- Reuse the existing local/remote address helper logic to avoid adding new `PhysicalSocket` API surface. 
- Add a narrow component test that verifies an IPv4 server listening on `127.0.0.1:0` reports a non-zero effective port in its listen callback.

### Description
- Extracted the local/remote socket address helper templates into shared headers `src/core/socket/stream/SocketAddressUtils.h` and `src/core/socket/stream/SocketAddressUtils.hpp` and registered them in the stream CMake headers. 
- Removed duplicate helper definitions from `SocketConnection.hpp` and updated it to include `SocketAddressUtils.hpp` without changing behavior. 
- Updated `SocketAcceptor::init()` (`SocketAcceptor.hpp`) to call `getLocalSocketAddress(...)` after a successful `listen()` and pass that effective address to the `onStatus` callback only when available, otherwise falling back to the configured `bindAddress`; the code does not mutate `bindAddress` or change `getBindAddress()`, and Unix-domain/connector behavior was not altered. 
- Added a component test `tests/component/net/InetLegacyServerEffectiveListenAddressTest.cpp` and CMake registration to assert that a legacy IPv4 server listening on `127.0.0.1:0` receives a listen-callback with a non-zero port; the test stops the event loop deterministically and does not start a client.

### Testing
- Branch: `codex/effective-listen-address` and commit `987fbdcf8b92493175d9b63719eb4b65ebe18384`. 
- PR URL: not available in this checkout (no remote configured). 
- Build and test commands executed: `cmake -S . -B build-effective-address -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF`, `cmake --build build-effective-address --parallel`, `ctest --test-dir build-effective-address --output-on-failure`, and `ctest --test-dir build-effective-address -L "effective-address" --output-on-failure`, and `git diff --check`. 
- Verification results: the project configured and built successfully, all tests passed (11/11 tests passed in the build including the new `InetLegacyServerEffectiveListenAddressTest`), the `effective-address` labeled test passed when run with the label filter, and `git diff --check` reported no issues. 
- Files changed: `src/core/socket/stream/CMakeLists.txt`, `src/core/socket/stream/SocketAcceptor.hpp`, `src/core/socket/stream/SocketConnection.hpp`, added `src/core/socket/stream/SocketAddressUtils.h`, added `src/core/socket/stream/SocketAddressUtils.hpp`, modified `tests/component/net/CMakeLists.txt`, and added `tests/component/net/InetLegacyServerEffectiveListenAddressTest.cpp`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47d1b63494832ca69860e62c2a4100)