### PR TITLE
Clarify configured and bound socket addresses

### DIFF
--- a/src/core/socket/stream/SocketAcceptor.h
+++ b/src/core/socket/stream/SocketAcceptor.h
@@ -102,7 +102,7 @@ namespace core::socket::stream {
 
     private:
         PhysicalServerSocket physicalServerSocket;
-        SocketAddress bindAddress;
+        SocketAddress configuredAddress;
 
     protected:
         std::function<void(SocketConnection*)> onConnect;

--- a/src/core/socket/stream/SocketAcceptor.hpp
+++ b/src/core/socket/stream/SocketAcceptor.hpp
@@ -100,13 +100,14 @@ namespace core::socket::stream {
         if (!config->getDisabled()) {
             try {
                 core::socket::State state = core::socket::STATE_OK;
+                bool bindSucceeded = false;
 
                 LOG(DEBUG) << config->getInstanceName() << " Listen: starting";
 
-                bindAddress = config->Local::getSocketAddress();
+                configuredAddress = config->Local::getSocketAddress();
 
                 if (physicalServerSocket.open(config->getSocketOptions(), PhysicalServerSocket::Flags::NONBLOCK) < 0) {
-                    PLOG(ERROR) << config->getInstanceName() << " open " << bindAddress.toString();
+                    PLOG(ERROR) << config->getInstanceName() << " open " << configuredAddress.toString();
 
                     switch (errno) {
                         case EMFILE:
@@ -120,10 +121,10 @@ namespace core::socket::stream {
                             break;
                     }
                 } else {
-                    LOG(DEBUG) << config->getInstanceName() << " open " << bindAddress.toString() << ": success";
+                    LOG(DEBUG) << config->getInstanceName() << " open " << configuredAddress.toString() << ": success";
 
-                    if (physicalServerSocket.bind(bindAddress) < 0) {
-                        PLOG(ERROR) << config->getInstanceName() << " bind " << bindAddress.toString();
+                    if (physicalServerSocket.bind(configuredAddress) < 0) {
+                        PLOG(ERROR) << config->getInstanceName() << " bind " << configuredAddress.toString();
 
                         switch (errno) {
                             case EADDRINUSE:
@@ -136,10 +137,11 @@ namespace core::socket::stream {
                                 break;
                         }
                     } else {
-                        LOG(DEBUG) << config->getInstanceName() << " bind " << bindAddress.toString() << ": success";
+                        bindSucceeded = true;
+                        LOG(DEBUG) << config->getInstanceName() << " bind " << physicalServerSocket.getBindAddress().toString() << ": success";
 
                         if (physicalServerSocket.listen(config->getBacklog()) < 0) {
-                            PLOG(ERROR) << config->getInstanceName() << " listen " << bindAddress.toString();
+                            PLOG(ERROR) << config->getInstanceName() << " listen " << physicalServerSocket.getBindAddress().toString();
 
                             switch (errno) {
                                 case EADDRINUSE:
@@ -150,12 +152,12 @@ namespace core::socket::stream {
                                     break;
                             }
                         } else {
-                            LOG(DEBUG) << config->getInstanceName() << " listen " << bindAddress.toString() << ": success";
+                            LOG(DEBUG) << config->getInstanceName() << " listen " << physicalServerSocket.getBindAddress().toString() << ": success";
 
                             if (enable(physicalServerSocket.getFd())) {
-                                LOG(DEBUG) << config->getInstanceName() << " enable " << bindAddress.toString() << ": success";
+                                LOG(DEBUG) << config->getInstanceName() << " enable " << physicalServerSocket.getBindAddress().toString() << ": success";
                             } else {
-                                LOG(ERROR) << config->getInstanceName() << " enable " << bindAddress.toString()
+                                LOG(ERROR) << config->getInstanceName() << " enable " << physicalServerSocket.getBindAddress().toString()
                                            << ": failed. No valid descriptor created";
 
                                 state = core::socket::STATE(core::socket::STATE_FATAL, ECANCELED, "SocketAcceptor not enabled");
@@ -164,8 +166,8 @@ namespace core::socket::stream {
                     }
                 }
 
-                SocketAddress currentLocalAddress = bindAddress;
-                if (bindAddress.useNext()) {
+                SocketAddress currentLocalAddress = bindSucceeded ? physicalServerSocket.getBindAddress() : configuredAddress;
+                if (configuredAddress.useNext()) {
                     onStatus(currentLocalAddress, (state | core::socket::State::NO_RETRY));
 
                     LOG(INFO) << config->getInstanceName()
@@ -206,19 +208,19 @@ namespace core::socket::stream {
 
             do {
                 PhysicalServerSocket connectedPhysicalSocket(physicalServerSocket.accept4(PhysicalServerSocket::Flags::NONBLOCK),
-                                                             bindAddress);
+                                                             physicalServerSocket.getBindAddress());
 
                 if (connectedPhysicalSocket.isValid()) {
                     SocketConnection* socketConnection = new SocketConnection(std::move(connectedPhysicalSocket), onDisconnect, config);
 
-                    LOG(DEBUG) << config->getInstanceName() << " accept " << bindAddress.toString() << ": success";
+                    LOG(DEBUG) << config->getInstanceName() << " accept " << physicalServerSocket.getBindAddress().toString() << ": success";
                     LOG(DEBUG) << "  " << socketConnection->getRemoteAddress().toString() << " -> "
                                << socketConnection->getLocalAddress().toString();
 
                     onConnect(socketConnection);
                     onConnected(socketConnection);
                 } else if (errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
-                    PLOG(WARNING) << config->getInstanceName() << " accept " << bindAddress.toString();
+                    PLOG(WARNING) << config->getInstanceName() << " accept " << physicalServerSocket.getBindAddress().toString();
                 }
             } while (--acceptsPerTick > 0);
         }

--- a/src/core/socket/stream/SocketAcceptor.hpp
+++ b/src/core/socket/stream/SocketAcceptor.hpp
@@ -138,7 +138,15 @@ namespace core::socket::stream {
                         }
                     } else {
                         bindSucceeded = true;
-                        LOG(DEBUG) << config->getInstanceName() << " bind " << physicalServerSocket.getBindAddress().toString() << ": success";
+
+                        const std::string configuredAddressString = configuredAddress.toString();
+                        const std::string effectiveBindAddressString = physicalServerSocket.getBindAddress().toString();
+
+                        LOG(DEBUG) << config->getInstanceName() << " bind " << configuredAddressString
+                                   << (configuredAddressString == effectiveBindAddressString
+                                           ? ""
+                                           : " (effective: " + effectiveBindAddressString + ")")
+                                   << ": success";
 
                         if (physicalServerSocket.listen(config->getBacklog()) < 0) {
                             PLOG(ERROR) << config->getInstanceName() << " listen " << physicalServerSocket.getBindAddress().toString();

--- a/src/core/socket/stream/SocketConnector.hpp
+++ b/src/core/socket/stream/SocketConnector.hpp
@@ -141,7 +141,14 @@ namespace core::socket::stream {
 
                             onStatus(configuredLocalAddress, state);
                         } else {
-                            LOG(TRACE) << config->getInstanceName() << " bind " << configuredLocalAddress.toString() << ": success";
+                            const std::string configuredLocalAddressString = configuredLocalAddress.toString();
+                            const std::string effectiveBindAddressString = physicalClientSocket.getBindAddress().toString();
+
+                            LOG(TRACE) << config->getInstanceName() << " bind " << configuredLocalAddressString
+                                       << (configuredLocalAddressString == effectiveBindAddressString
+                                               ? ""
+                                               : " (effective: " + effectiveBindAddressString + ")")
+                                       << ": success";
 
                             if (physicalClientSocket.connect(remoteAddress) < 0 && !PhysicalClientSocket::connectInProgress(errno)) {
                                 PLOG(DEBUG) << config->getInstanceName() << " connect " << remoteAddress.toString();

--- a/src/core/socket/stream/SocketConnector.hpp
+++ b/src/core/socket/stream/SocketConnector.hpp
@@ -103,13 +103,13 @@ namespace core::socket::stream {
 
                 LOG(DEBUG) << config->getInstanceName() << " Connect: starting";
 
-                SocketAddress bindAddress = config->Local::getSocketAddress();
+                SocketAddress configuredLocalAddress = config->Local::getSocketAddress();
 
                 try {
                     remoteAddress = config->Remote::getSocketAddress();
 
                     if (physicalClientSocket.open(config->getSocketOptions(), PhysicalClientSocket::Flags::NONBLOCK) < 0) {
-                        PLOG(DEBUG) << config->getInstanceName() << " open " << bindAddress.toString();
+                        PLOG(DEBUG) << config->getInstanceName() << " open " << configuredLocalAddress.toString();
 
                         switch (errno) {
                             case EMFILE:
@@ -123,12 +123,12 @@ namespace core::socket::stream {
                                 break;
                         }
 
-                        onStatus(bindAddress, state);
+                        onStatus(configuredLocalAddress, state);
                     } else {
-                        LOG(TRACE) << config->getInstanceName() << " open " << bindAddress.toString() << ": success";
+                        LOG(TRACE) << config->getInstanceName() << " open " << configuredLocalAddress.toString() << ": success";
 
-                        if (physicalClientSocket.bind(bindAddress) < 0) {
-                            PLOG(DEBUG) << config->getInstanceName() << " bind " << bindAddress.toString();
+                        if (physicalClientSocket.bind(configuredLocalAddress) < 0) {
+                            PLOG(DEBUG) << config->getInstanceName() << " bind " << configuredLocalAddress.toString();
 
                             switch (errno) {
                                 case EADDRINUSE:
@@ -139,9 +139,9 @@ namespace core::socket::stream {
                                     break;
                             }
 
-                            onStatus(bindAddress, state);
+                            onStatus(configuredLocalAddress, state);
                         } else {
-                            LOG(TRACE) << config->getInstanceName() << " bind " << bindAddress.toString() << ": success";
+                            LOG(TRACE) << config->getInstanceName() << " bind " << configuredLocalAddress.toString() << ": success";
 
                             if (physicalClientSocket.connect(remoteAddress) < 0 && !PhysicalClientSocket::connectInProgress(errno)) {
                                 PLOG(DEBUG) << config->getInstanceName() << " connect " << remoteAddress.toString();

--- a/src/net/phy/PhysicalSocket.h
+++ b/src/net/phy/PhysicalSocket.h
@@ -85,7 +85,7 @@ namespace net::phy {
 
         int open(const std::map<int, std::map<int, PhysicalSocketOption>>& socketOptionsMapMap, Flags flags);
 
-        int bind(SocketAddress& bindAddress);
+        int bind(SocketAddress& configuredAddress);
 
         bool isValid() const;
 

--- a/src/net/phy/PhysicalSocket.hpp
+++ b/src/net/phy/PhysicalSocket.hpp
@@ -103,11 +103,22 @@ namespace net::phy {
     }
 
     template <typename SocketAddress>
-    int PhysicalSocket<SocketAddress>::bind(SocketAddress& bindAddress) {
-        int ret = core::system::bind(core::Descriptor::getFd(), &bindAddress.getSockAddr(), bindAddress.getSockAddrLen());
+    int PhysicalSocket<SocketAddress>::bind(SocketAddress& configuredAddress) {
+        int ret = core::system::bind(core::Descriptor::getFd(), &configuredAddress.getSockAddr(), configuredAddress.getSockAddrLen());
 
         if (ret == 0) {
-            this->bindAddress = bindAddress;
+            typename SocketAddress::SockAddr effectiveSockAddr = {};
+            typename SocketAddress::SockLen effectiveSockAddrLen = sizeof(effectiveSockAddr);
+
+            if (getSockName(effectiveSockAddr, effectiveSockAddrLen) == 0) {
+                try {
+                    this->bindAddress = SocketAddress(effectiveSockAddr, effectiveSockAddrLen);
+                } catch (const typename SocketAddress::BadSocketAddress&) {
+                    this->bindAddress = configuredAddress;
+                }
+            } else {
+                this->bindAddress = configuredAddress;
+            }
         }
 
         return ret;

--- a/tests/component/net/CMakeLists.txt
+++ b/tests/component/net/CMakeLists.txt
@@ -47,3 +47,21 @@ set_tests_properties(InetLegacyServerClientCompositionTest PROPERTIES
                      LABELS "component;net;stream;legacy;ipv4;composition"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)
+
+
+snodec_add_test(InetLegacyServerEffectiveListenAddressTest InetLegacyServerEffectiveListenAddressTest.cpp)
+snodec_add_test(InetPhysicalServerEffectiveBindAddressTest InetPhysicalServerEffectiveBindAddressTest.cpp)
+
+target_link_libraries(InetLegacyServerEffectiveListenAddressTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
+target_link_libraries(InetPhysicalServerEffectiveBindAddressTest PRIVATE snodec-test-support snodec::net-in-phy-stream)
+target_compile_features(InetLegacyServerEffectiveListenAddressTest PRIVATE cxx_std_20)
+target_compile_features(InetPhysicalServerEffectiveBindAddressTest PRIVATE cxx_std_20)
+
+set_tests_properties(InetLegacyServerEffectiveListenAddressTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv4;listen;effective-address"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetPhysicalServerEffectiveBindAddressTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv4;listen;effective-address"
+                     TIMEOUT 5)

--- a/tests/component/net/InetLegacyServerEffectiveListenAddressTest.cpp
+++ b/tests/component/net/InetLegacyServerEffectiveListenAddressTest.cpp
@@ -1,0 +1,106 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in/SocketAddress.h"
+#include "net/in/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    struct TestState {
+        int listenOkCount = 0;
+        int unexpectedStateCount = 0;
+        std::uint16_t listenPort = 0;
+    };
+
+    class TestSocketContext : public core::socket::stream::SocketContext {
+    public:
+        explicit TestSocketContext(core::socket::stream::SocketConnection* socketConnection)
+            : core::socket::stream::SocketContext(socketConnection) {
+        }
+
+    private:
+        void onConnected() override {
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            return 0;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+    };
+
+    class TestSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestSocketContextFactory(TestState&) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            return new TestSocketContext(socketConnection);
+        }
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetLegacyServerEffectiveListenAddressTest");
+    } else {
+        TestState testState;
+
+        core::SNodeC::init(argc, argv);
+
+        const net::in::stream::legacy::SocketServer<TestSocketContextFactory, TestState&> socketServer("effective-listen-server",
+                                                                                                       testState);
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(net::in::SocketAddress("127.0.0.1", 0),
+                            [&testState](const net::in::SocketAddress& socketAddress, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.listenOkCount;
+                                    testState.listenPort = socketAddress.getPort();
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                }
+
+                                core::SNodeC::stop();
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops after listen status callback");
+        testResult.expectEqual(1, testState.listenOkCount, "IPv4 legacy server listen callback reports OK exactly once");
+        testResult.expectTrue(testState.listenPort != 0, "IPv4 legacy server listen callback reports kernel-selected port");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen callback reports no unexpected states");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/net/InetPhysicalServerEffectiveBindAddressTest.cpp
+++ b/tests/component/net/InetPhysicalServerEffectiveBindAddressTest.cpp
@@ -1,0 +1,31 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#include "net/in/SocketAddress.h"
+#include "net/in/phy/stream/PhysicalSocketServer.h"
+#include "support/TestResult.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <map>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+int main() {
+    tests::support::TestResult testResult;
+
+    net::in::phy::stream::PhysicalSocketServer physicalServerSocket;
+    net::in::SocketAddress configuredAddress("127.0.0.1", 0);
+
+    testResult.expectTrue(physicalServerSocket.open({}, net::in::phy::stream::PhysicalSocketServer::Flags::NONBLOCK) >= 0,
+                          "IPv4 physical server socket opens");
+    testResult.expectTrue(physicalServerSocket.bind(configuredAddress) == 0,
+                          "IPv4 physical server socket binds to loopback port zero");
+    testResult.expectTrue(physicalServerSocket.getBindAddress().getPort() != 0,
+                          "IPv4 physical server socket reports kernel-selected bind port");
+
+    return testResult.processResult();
+}


### PR DESCRIPTION
### Motivation
- Make the distinction explicit between the configured/requested socket address and the actual kernel-selected bound address so diagnostics, retry progression, and accepted sockets report the effective endpoint. 
- Ensure a bind to port 0 stores the kernel-selected non-zero port in the runtime bind address instead of the configured port-0 value. 
- Preserve existing SocketConnection helpers as local connection construction utilities and avoid introducing new shared socket-address helper headers. 

### Description
- Update `PhysicalSocket::bind(...)` to call `getsockname()` after a successful `bind()` and store the effective bound address into `this->bindAddress`, falling back to the configured address if `getsockname()` or address construction fails. 
- Rename the acceptor member `bindAddress` to `configuredAddress` and use `configuredAddress` for pre-bind diagnostics, `physicalServerSocket.bind(configuredAddress)` input, and `useNext()` progression while reporting `physicalServerSocket.getBindAddress()` after a successful bind. 
- When accepting connections, construct accepted `PhysicalSocket` instances with the listener’s effective bound address from `physicalServerSocket.getBindAddress()` rather than the configured (possibly port-0) address. 
- Rename connector local bind locals to `configuredLocalAddress` and use that for client-side bind input and pre-bind diagnostics only. 
- Add two narrow tests: `InetPhysicalServerEffectiveBindAddressTest.cpp` which directly verifies `physicalServerSocket.getBindAddress().getPort() != 0`, and `InetLegacyServerEffectiveListenAddressTest.cpp` which starts a legacy IPv4 server on `127.0.0.1:0` and verifies the listen callback reports a non-zero port, plus CMake registration and `effective-address` labels. 
- Files changed: `src/net/phy/PhysicalSocket.h|hpp`, `src/core/socket/stream/SocketAcceptor.h|hpp`, `src/core/socket/stream/SocketConnector.hpp`, `tests/component/net/CMakeLists.txt`, `tests/component/net/InetLegacyServerEffectiveListenAddressTest.cpp`, and `tests/component/net/InetPhysicalServerEffectiveBindAddressTest.cpp`. 

### Testing
- Build and test commands run: `cmake -S . -B build-configured-bound-address -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF`, `cmake --build build-configured-bound-address --parallel`, `ctest --test-dir build-configured-bound-address --output-on-failure`, and `ctest --test-dir build-configured-bound-address -L "effective-address" --output-on-failure`, and `git diff --check`. 
- Verification results: CMake configured and built successfully, `ctest` reported all run tests passed and the `effective-address` labeled tests passed (the legacy listen component test was skipped by the repository’s existing root/SNodeC-group policy), and `git diff --check` reported no whitespace/check issues. 
- IWYU was not available in the environment (CMake warned `include-what-you-use` is not installed) so no new IWYU diagnostics were produced here. 
- Branch: `codex/configured-vs-bound-address` and commit hash: `bc305c9e14beed2311a5dd0b6c622b51af2de648`, and PR URL is not available from the local environment’s `make_pr` helper.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47e5f26144832caac644d6006a525f)