### PR TITLE
Add IPv6 legacy server/client composition component test

### DIFF
--- a/tests/component/net/CMakeLists.txt
+++ b/tests/component/net/CMakeLists.txt
@@ -49,6 +49,17 @@ set_tests_properties(InetLegacyServerClientCompositionTest PROPERTIES
                      TIMEOUT 5)
 
 
+snodec_add_test(Inet6LegacyServerClientCompositionTest Inet6LegacyServerClientCompositionTest.cpp)
+
+target_link_libraries(Inet6LegacyServerClientCompositionTest PRIVATE snodec-test-support snodec::net-in6-stream-legacy)
+target_compile_features(Inet6LegacyServerClientCompositionTest PRIVATE cxx_std_20)
+
+set_tests_properties(Inet6LegacyServerClientCompositionTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv6;composition"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+
 snodec_add_test(InetLegacyServerClientPayloadExchangeTest InetLegacyServerClientPayloadExchangeTest.cpp)
 
 target_link_libraries(InetLegacyServerClientPayloadExchangeTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)

--- a/tests/component/net/Inet6LegacyServerClientCompositionTest.cpp
+++ b/tests/component/net/Inet6LegacyServerClientCompositionTest.cpp
@@ -1,0 +1,243 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in6/SocketAddress.h"
+#include "net/in6/stream/legacy/SocketClient.h"
+#include "net/in6/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int effectiveListenPortOkCount = 0;
+        int zeroEffectiveListenPortCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int unexpectedStateCount = 0;
+    };
+
+    void stopWhenBothContextsAreConnected(TestState& testState) {
+        if (testState.serverConnectedCount == 1 && testState.clientConnectedCount == 1) {
+            core::SNodeC::stop();
+        }
+    }
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+            stopWhenBothContextsAreConnected(testState);
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            const bool signalHandled = true;
+
+            return signalHandled;
+        }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            stopWhenBothContextsAreConnected(testState);
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            const bool signalHandled = true;
+
+            return signalHandled;
+        }
+
+        TestState& testState;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestServerSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("Inet6LegacyServerClientCompositionTest");
+    } else {
+        TestState testState;
+
+        core::SNodeC::init(argc, argv);
+
+        net::in6::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv6-composition-client", testState);
+        const net::in6::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("ipv6-composition-server",
+                                                                                                             testState);
+
+        socketClient.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(net::in6::SocketAddress("::1", 0),
+                            [&socketClient, &testState](const net::in6::SocketAddress& socketAddress, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.serverListenOkCount;
+
+                                    const std::uint16_t effectivePort = socketAddress.getPort();
+                                    if (effectivePort != 0) {
+                                        ++testState.effectiveListenPortOkCount;
+                                        socketClient.connect(net::in6::SocketAddress("::1", effectivePort),
+                                                             [&testState](const net::in6::SocketAddress&, core::socket::State connectState) {
+                                                                 if (connectState == core::socket::State::OK) {
+                                                                     ++testState.clientConnectOkCount;
+                                                                 } else {
+                                                                     ++testState.unexpectedStateCount;
+                                                                     core::SNodeC::stop();
+                                                                 }
+                                                             });
+                                    } else {
+                                        ++testState.zeroEffectiveListenPortCount;
+                                        ++testState.unexpectedStateCount;
+                                        core::SNodeC::stop();
+                                    }
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                    core::SNodeC::stop();
+                                }
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after both composition contexts connect");
+        testResult.expectEqual(1, testState.serverListenOkCount, "IPv6 legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.effectiveListenPortOkCount, "IPv6 legacy listen callback reports one non-zero effective port");
+        testResult.expectEqual(0, testState.zeroEffectiveListenPortCount, "IPv6 legacy listen callback never reports port zero");
+        testResult.expectEqual(1, testState.clientConnectOkCount, "IPv6 legacy client connect callback reports OK exactly once");
+        testResult.expectEqual(1, testState.serverFactoryCreateCount, "server socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.clientFactoryCreateCount, "client socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.serverConnectedCount, "server socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.clientConnectedCount, "client socket context reaches onConnected exactly once");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    return result;
+}


### PR DESCRIPTION
### Motivation

- Provide an IPv6 counterpart to the existing IPv4 legacy composition test to validate server/client composition behavior for IPv6 loopback `::1` using ephemeral ports. 
- Keep the test narrow and composition-only: verify factory/context creation and `onConnected()` lifecycle without payload exchange or protocol layers. 

### Description

- Add test source `tests/component/net/Inet6LegacyServerClientCompositionTest.cpp` which defines test-local `TestState`, `TestServerSocketContext`/`TestClientSocketContext`, and `TestServerSocketContextFactory`/`TestClientSocketContextFactory`, and stops the event loop when both contexts reached `onConnected()`. 
- Use exact IPv6 legacy types `net::in6::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&>` and `net::in6::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&>` and listen on `net::in6::SocketAddress("::1", 0)`; the listen callback asserts the effective listen port is non-zero and the client connects to that reported port. 
- Register the new test in `tests/component/net/CMakeLists.txt` as target `Inet6LegacyServerClientCompositionTest` linking with `snodec-test-support` and `snodec::net-in6-stream-legacy`, set `cxx_std_20`, and apply labels `component;net;stream;legacy;ipv6;composition`. 
- Do not change any production code; only the new test file and the tests CMake list were added. 

### Testing

- Ran configuration and build: `cmake -S . -B build-pr-ipv6-composition -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` and `cmake --build build-pr-ipv6-composition --parallel`, which completed successfully and produced the `Inet6LegacyServerClientCompositionTest` executable. 
- Ran test suites via `ctest --test-dir build-pr-ipv6-composition --output-on-failure` and label-filtered runs; overall CTest passed but the newly added component (and related root-level component tests) were skipped in this root container due to the existing root-without-snodec-group guard (`Inet6LegacyServerClientCompositionTest` reported as skipped). 
- Verified `git diff --check` passed and `cmake -S . -B build-pr-ipv6-composition-default -DCMAKE_BUILD_TYPE=Debug` configures successfully. 
- Confirmations from the change and local build/run: the new test target/file exists, it uses `::1` with port `0`, the listen callback code checks for a non-zero effective port and connects the client to that reported port, each factory is implemented to create exactly one context, both contexts increment and reach `onConnected()`, and no payload exchange is performed; no production code was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48034e207c832cbd22d9c0abb7dd27)