### PR TITLE
Add Unix-domain legacy server/client composition component test

### DIFF
--- a/tests/component/net/CMakeLists.txt
+++ b/tests/component/net/CMakeLists.txt
@@ -60,6 +60,17 @@ set_tests_properties(Inet6LegacyServerClientCompositionTest PROPERTIES
                      TIMEOUT 5)
 
 
+snodec_add_test(UnixLegacyServerClientCompositionTest UnixLegacyServerClientCompositionTest.cpp)
+
+target_link_libraries(UnixLegacyServerClientCompositionTest PRIVATE snodec-test-support snodec::net-un-stream-legacy)
+target_compile_features(UnixLegacyServerClientCompositionTest PRIVATE cxx_std_20)
+
+set_tests_properties(UnixLegacyServerClientCompositionTest PROPERTIES
+                     LABELS "component;net;stream;legacy;unix;composition"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+
 snodec_add_test(InetLegacyServerClientPayloadExchangeTest InetLegacyServerClientPayloadExchangeTest.cpp)
 
 target_link_libraries(InetLegacyServerClientPayloadExchangeTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)

--- a/tests/component/net/UnixLegacyServerClientCompositionTest.cpp
+++ b/tests/component/net/UnixLegacyServerClientCompositionTest.cpp
@@ -1,0 +1,264 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/un/SocketAddress.h"
+#include "net/un/stream/legacy/SocketClient.h"
+#include "net/un/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdio>
+#include <string>
+#include <unistd.h>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int unexpectedStateCount = 0;
+    };
+
+    std::string makeSocketPath() {
+        return "/tmp/snodec-unix-composition-" + std::to_string(getpid()) + ".sock";
+    }
+
+    bool socketPathExists(const std::string& socketPath) {
+        return access(socketPath.c_str(), F_OK) == 0;
+    }
+
+    bool createStaleSocketPathFile(const std::string& socketPath) {
+        FILE* staleSocketPathFile = std::fopen(socketPath.c_str(), "w");
+        const bool created = staleSocketPathFile != nullptr;
+
+        if (staleSocketPathFile != nullptr) {
+            std::fclose(staleSocketPathFile);
+        }
+
+        return created;
+    }
+
+    void stopWhenBothContextsAreConnected(TestState& testState) {
+        if (testState.serverConnectedCount == 1 && testState.clientConnectedCount == 1) {
+            core::SNodeC::stop();
+        }
+    }
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+            stopWhenBothContextsAreConnected(testState);
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            const bool signalHandled = true;
+
+            return signalHandled;
+        }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            stopWhenBothContextsAreConnected(testState);
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            const bool signalHandled = true;
+
+            return signalHandled;
+        }
+
+        TestState& testState;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestServerSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+    const std::string socketPath = makeSocketPath();
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("UnixLegacyServerClientCompositionTest");
+    } else {
+        TestState testState;
+        const bool staleSocketPathCreated = createStaleSocketPathFile(socketPath);
+        const bool staleSocketPathRemoved = std::remove(socketPath.c_str()) == 0;
+        const bool socketPathAbsentBeforeListen = !socketPathExists(socketPath);
+
+        core::SNodeC::init(argc, argv);
+
+        net::un::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("unix-composition-client", testState);
+        const net::un::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("unix-composition-server",
+                                                                                                             testState);
+
+        socketClient.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(socketPath,
+                            [&socketClient, &socketPath, &testState](const net::un::SocketAddress&, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.serverListenOkCount;
+                                    socketClient.connect(socketPath,
+                                                         [&testState](const net::un::SocketAddress&, core::socket::State connectState) {
+                                                             if (connectState == core::socket::State::OK) {
+                                                                 ++testState.clientConnectOkCount;
+                                                             } else {
+                                                                 ++testState.unexpectedStateCount;
+                                                                 core::SNodeC::stop();
+                                                             }
+                                                         });
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                    core::SNodeC::stop();
+                                }
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        std::remove(socketPath.c_str());
+        const bool socketPathAbsentAfterCleanup = !socketPathExists(socketPath);
+
+        testResult.expectTrue(staleSocketPathCreated, "test creates a stale Unix-domain socket path placeholder before listen");
+        testResult.expectTrue(staleSocketPathRemoved, "stale Unix-domain socket path is removed before listen");
+        testResult.expectTrue(socketPathAbsentBeforeListen, "Unix-domain socket path is absent before listen");
+        testResult.expectEqual(0, startResult, "event loop stops successfully after both composition contexts connect");
+        testResult.expectEqual(1, testState.serverListenOkCount, "Unix-domain legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.clientConnectOkCount, "Unix-domain legacy client connect callback reports OK exactly once");
+        testResult.expectEqual(1, testState.serverFactoryCreateCount, "server socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.clientFactoryCreateCount, "client socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.serverConnectedCount, "server socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.clientConnectedCount, "client socket context reaches onConnected exactly once");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+        testResult.expectTrue(socketPathAbsentAfterCleanup, "Unix-domain socket path is absent after cleanup");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    std::remove(socketPath.c_str());
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Provide Unix-domain counterpart to the existing IPv4/IPv6 legacy composition tests to verify server/client factory/context composition and that both contexts reach `onConnected()` without exercising payload exchange.

### Description
- Add a new component test `tests/component/net/UnixLegacyServerClientCompositionTest.cpp` that defines test-local `TestState`, `TestServerSocketContext`/`TestClientSocketContext` and `TestServerSocketContextFactory`/`TestClientSocketContextFactory`, and uses `net::un::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&>` and `net::un::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&>`.
- The test uses a unique filesystem socket path under `/tmp` (PID-based), removes any stale path before `listen`, and ensures cleanup of the socket path after the test.
- Register `UnixLegacyServerClientCompositionTest` in `tests/component/net/CMakeLists.txt` and link it against `snodec-test-support` and `snodec::net-un-stream-legacy` with C++20 and labels `component;net;stream;legacy;unix;composition` and `SKIP_RETURN_CODE 77`.
- No production code was modified; changes are limited to the new test file and the CMake test list.

### Testing
- Built and ran tests with: `cmake -S . -B build-pr-unix-composition -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` and `cmake --build build-pr-unix-composition --parallel`, which completed successfully.
- Executed component/net/stream/legacy/unix composition test runs with `ctest --test-dir build-pr-unix-composition --output-on-failure` and label-filtered runs such as `ctest -L "unix"`, and the new `UnixLegacyServerClientCompositionTest` passed.
- Verified socket cleanup and composition assertions in the test (factory create counts, listen/connect OK counts, both contexts reached `onConnected()`, and no unexpected states) via the automated `ctest` runs, which reported the new test as passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4810d57c34832c941339c53466af5f)