### PR TITLE
Add legacy stream disconnect lifecycle component tests

### DIFF
--- a/tests/component/net/CMakeLists.txt
+++ b/tests/component/net/CMakeLists.txt
@@ -72,15 +72,23 @@ set_tests_properties(UnixLegacyServerClientCompositionTest PROPERTIES
 
 
 snodec_add_test(UnixLegacyServerClientPayloadExchangeTest UnixLegacyServerClientPayloadExchangeTest.cpp)
+snodec_add_test(UnixLegacyServerClientDisconnectLifecycleTest UnixLegacyServerClientDisconnectLifecycleTest.cpp)
 snodec_add_test(UnixLegacyClientConnectFailureTest UnixLegacyClientConnectFailureTest.cpp)
 
 target_link_libraries(UnixLegacyServerClientPayloadExchangeTest PRIVATE snodec-test-support snodec::net-un-stream-legacy)
+target_link_libraries(UnixLegacyServerClientDisconnectLifecycleTest PRIVATE snodec-test-support snodec::net-un-stream-legacy)
 target_link_libraries(UnixLegacyClientConnectFailureTest PRIVATE snodec-test-support snodec::net-un-stream-legacy)
 target_compile_features(UnixLegacyServerClientPayloadExchangeTest PRIVATE cxx_std_20)
+target_compile_features(UnixLegacyServerClientDisconnectLifecycleTest PRIVATE cxx_std_20)
 target_compile_features(UnixLegacyClientConnectFailureTest PRIVATE cxx_std_20)
 
 set_tests_properties(UnixLegacyServerClientPayloadExchangeTest PROPERTIES
                      LABELS "component;net;stream;legacy;unix;payload"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(UnixLegacyServerClientDisconnectLifecycleTest PROPERTIES
+                     LABELS "component;net;stream;legacy;unix;disconnect"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)
 
@@ -91,23 +99,39 @@ set_tests_properties(UnixLegacyClientConnectFailureTest PROPERTIES
 
 
 snodec_add_test(InetLegacyServerClientPayloadExchangeTest InetLegacyServerClientPayloadExchangeTest.cpp)
+snodec_add_test(InetLegacyServerClientDisconnectLifecycleTest InetLegacyServerClientDisconnectLifecycleTest.cpp)
 
 target_link_libraries(InetLegacyServerClientPayloadExchangeTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
+target_link_libraries(InetLegacyServerClientDisconnectLifecycleTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
 target_compile_features(InetLegacyServerClientPayloadExchangeTest PRIVATE cxx_std_20)
+target_compile_features(InetLegacyServerClientDisconnectLifecycleTest PRIVATE cxx_std_20)
 
 set_tests_properties(InetLegacyServerClientPayloadExchangeTest PROPERTIES
                      LABELS "component;net;stream;legacy;ipv4;payload"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)
 
+set_tests_properties(InetLegacyServerClientDisconnectLifecycleTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv4;disconnect"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
 
 snodec_add_test(Inet6LegacyServerClientPayloadExchangeTest Inet6LegacyServerClientPayloadExchangeTest.cpp)
+snodec_add_test(Inet6LegacyServerClientDisconnectLifecycleTest Inet6LegacyServerClientDisconnectLifecycleTest.cpp)
 
 target_link_libraries(Inet6LegacyServerClientPayloadExchangeTest PRIVATE snodec-test-support snodec::net-in6-stream-legacy)
+target_link_libraries(Inet6LegacyServerClientDisconnectLifecycleTest PRIVATE snodec-test-support snodec::net-in6-stream-legacy)
 target_compile_features(Inet6LegacyServerClientPayloadExchangeTest PRIVATE cxx_std_20)
+target_compile_features(Inet6LegacyServerClientDisconnectLifecycleTest PRIVATE cxx_std_20)
 
 set_tests_properties(Inet6LegacyServerClientPayloadExchangeTest PROPERTIES
                      LABELS "component;net;stream;legacy;ipv6;payload"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(Inet6LegacyServerClientDisconnectLifecycleTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv6;disconnect"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)
 

--- a/tests/component/net/Inet6LegacyServerClientDisconnectLifecycleTest.cpp
+++ b/tests/component/net/Inet6LegacyServerClientDisconnectLifecycleTest.cpp
@@ -1,0 +1,288 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in6/SocketAddress.h"
+#include "net/in6/stream/legacy/SocketClient.h"
+#include "net/in6/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    constexpr std::string_view clientPayload = "snodec-ipv6-disconnect-request";
+    constexpr std::string_view serverPayload = "snodec-ipv6-disconnect-ack";
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int effectiveListenPortOkCount = 0;
+        int zeroEffectiveListenPortCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int serverPayloadReceivedCount = 0;
+        int clientAckReceivedCount = 0;
+        int clientCloseIssuedCount = 0;
+        int serverDisconnectedCount = 0;
+        int clientDisconnectedCount = 0;
+        int unexpectedStateCount = 0;
+        int unexpectedPayloadCount = 0;
+    };
+
+    void stopWhenDisconnectLifecycleIsComplete(TestState& testState) {
+        if (testState.clientDisconnectedCount == 1 && testState.serverDisconnectedCount == 1) {
+            core::SNodeC::stop();
+        }
+    }
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+        }
+
+        void onDisconnected() override {
+            ++testState.serverDisconnectedCount;
+            stopWhenDisconnectLifecycleIsComplete(testState);
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == clientPayload) {
+                    ++testState.serverPayloadReceivedCount;
+                    sendToPeer(serverPayload.data(), serverPayload.size());
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            sendToPeer(clientPayload.data(), clientPayload.size());
+        }
+
+        void onDisconnected() override {
+            ++testState.clientDisconnectedCount;
+            stopWhenDisconnectLifecycleIsComplete(testState);
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == serverPayload) {
+                    ++testState.clientAckReceivedCount;
+                    close();
+                    ++testState.clientCloseIssuedCount;
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+
+        TestState& testState;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestServerSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("Inet6LegacyServerClientDisconnectLifecycleTest");
+    } else {
+        TestState testState;
+
+        core::SNodeC::init(argc, argv);
+
+        net::in6::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv6-disconnect-client",
+                                                                                                       testState);
+        const net::in6::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("ipv6-disconnect-server",
+                                                                                                             testState);
+
+        socketClient.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(net::in6::SocketAddress("::1", 0),
+                            [&socketClient, &testState](const net::in6::SocketAddress& socketAddress, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.serverListenOkCount;
+
+                                    const std::uint16_t effectivePort = socketAddress.getPort();
+                                    if (effectivePort != 0) {
+                                        ++testState.effectiveListenPortOkCount;
+                                        socketClient.connect(net::in6::SocketAddress("::1", effectivePort),
+                                                             [&testState](const net::in6::SocketAddress&, core::socket::State connectState) {
+                                                                 if (connectState == core::socket::State::OK) {
+                                                                     ++testState.clientConnectOkCount;
+                                                                 } else {
+                                                                     ++testState.unexpectedStateCount;
+                                                                     core::SNodeC::stop();
+                                                                 }
+                                                             });
+                                    } else {
+                                        ++testState.zeroEffectiveListenPortCount;
+                                        core::SNodeC::stop();
+                                    }
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                    core::SNodeC::stop();
+                                }
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after controlled IPv6 disconnect lifecycle");
+        testResult.expectEqual(1, testState.serverListenOkCount, "IPv6 legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.effectiveListenPortOkCount, "IPv6 legacy listen callback reports one non-zero effective port");
+        testResult.expectEqual(0, testState.zeroEffectiveListenPortCount, "IPv6 legacy listen callback never reports port zero");
+        testResult.expectEqual(1, testState.clientConnectOkCount, "IPv6 legacy client connect callback reports OK exactly once");
+        testResult.expectEqual(1, testState.serverFactoryCreateCount, "server socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.clientFactoryCreateCount, "client socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.serverConnectedCount, "server socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.clientConnectedCount, "client socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.serverPayloadReceivedCount, "server receives and verifies the client payload exactly once");
+        testResult.expectEqual(1, testState.clientAckReceivedCount, "client receives and verifies the server ack exactly once");
+        testResult.expectEqual(1, testState.clientCloseIssuedCount, "client issues controlled close exactly once after ack");
+        testResult.expectEqual(1, testState.serverDisconnectedCount, "server socket context reaches onDisconnected exactly once");
+        testResult.expectEqual(1, testState.clientDisconnectedCount, "client socket context reaches onDisconnected exactly once");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+        testResult.expectEqual(0, testState.unexpectedPayloadCount, "server and client receive no unexpected payloads");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/net/InetLegacyServerClientDisconnectLifecycleTest.cpp
+++ b/tests/component/net/InetLegacyServerClientDisconnectLifecycleTest.cpp
@@ -1,0 +1,288 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in/SocketAddress.h"
+#include "net/in/stream/legacy/SocketClient.h"
+#include "net/in/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    constexpr std::string_view clientPayload = "snodec-ipv4-disconnect-request";
+    constexpr std::string_view serverPayload = "snodec-ipv4-disconnect-ack";
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int effectiveListenPortOkCount = 0;
+        int zeroEffectiveListenPortCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int serverPayloadReceivedCount = 0;
+        int clientAckReceivedCount = 0;
+        int clientCloseIssuedCount = 0;
+        int serverDisconnectedCount = 0;
+        int clientDisconnectedCount = 0;
+        int unexpectedStateCount = 0;
+        int unexpectedPayloadCount = 0;
+    };
+
+    void stopWhenDisconnectLifecycleIsComplete(TestState& testState) {
+        if (testState.clientDisconnectedCount == 1 && testState.serverDisconnectedCount == 1) {
+            core::SNodeC::stop();
+        }
+    }
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+        }
+
+        void onDisconnected() override {
+            ++testState.serverDisconnectedCount;
+            stopWhenDisconnectLifecycleIsComplete(testState);
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == clientPayload) {
+                    ++testState.serverPayloadReceivedCount;
+                    sendToPeer(serverPayload.data(), serverPayload.size());
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            sendToPeer(clientPayload.data(), clientPayload.size());
+        }
+
+        void onDisconnected() override {
+            ++testState.clientDisconnectedCount;
+            stopWhenDisconnectLifecycleIsComplete(testState);
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == serverPayload) {
+                    ++testState.clientAckReceivedCount;
+                    close();
+                    ++testState.clientCloseIssuedCount;
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+
+        TestState& testState;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestServerSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetLegacyServerClientDisconnectLifecycleTest");
+    } else {
+        TestState testState;
+
+        core::SNodeC::init(argc, argv);
+
+        net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv4-disconnect-client",
+                                                                                                       testState);
+        const net::in::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("ipv4-disconnect-server",
+                                                                                                             testState);
+
+        socketClient.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(net::in::SocketAddress("127.0.0.1", 0),
+                            [&socketClient, &testState](const net::in::SocketAddress& socketAddress, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.serverListenOkCount;
+
+                                    const std::uint16_t effectivePort = socketAddress.getPort();
+                                    if (effectivePort != 0) {
+                                        ++testState.effectiveListenPortOkCount;
+                                        socketClient.connect(net::in::SocketAddress("127.0.0.1", effectivePort),
+                                                             [&testState](const net::in::SocketAddress&, core::socket::State connectState) {
+                                                                 if (connectState == core::socket::State::OK) {
+                                                                     ++testState.clientConnectOkCount;
+                                                                 } else {
+                                                                     ++testState.unexpectedStateCount;
+                                                                     core::SNodeC::stop();
+                                                                 }
+                                                             });
+                                    } else {
+                                        ++testState.zeroEffectiveListenPortCount;
+                                        core::SNodeC::stop();
+                                    }
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                    core::SNodeC::stop();
+                                }
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after controlled IPv4 disconnect lifecycle");
+        testResult.expectEqual(1, testState.serverListenOkCount, "IPv4 legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.effectiveListenPortOkCount, "IPv4 legacy listen callback reports one non-zero effective port");
+        testResult.expectEqual(0, testState.zeroEffectiveListenPortCount, "IPv4 legacy listen callback never reports port zero");
+        testResult.expectEqual(1, testState.clientConnectOkCount, "IPv4 legacy client connect callback reports OK exactly once");
+        testResult.expectEqual(1, testState.serverFactoryCreateCount, "server socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.clientFactoryCreateCount, "client socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.serverConnectedCount, "server socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.clientConnectedCount, "client socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.serverPayloadReceivedCount, "server receives and verifies the client payload exactly once");
+        testResult.expectEqual(1, testState.clientAckReceivedCount, "client receives and verifies the server ack exactly once");
+        testResult.expectEqual(1, testState.clientCloseIssuedCount, "client issues controlled close exactly once after ack");
+        testResult.expectEqual(1, testState.serverDisconnectedCount, "server socket context reaches onDisconnected exactly once");
+        testResult.expectEqual(1, testState.clientDisconnectedCount, "client socket context reaches onDisconnected exactly once");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+        testResult.expectEqual(0, testState.unexpectedPayloadCount, "server and client receive no unexpected payloads");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/net/UnixLegacyServerClientDisconnectLifecycleTest.cpp
+++ b/tests/component/net/UnixLegacyServerClientDisconnectLifecycleTest.cpp
@@ -1,0 +1,294 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/un/SocketAddress.h"
+#include "net/un/stream/legacy/SocketClient.h"
+#include "net/un/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    constexpr std::string_view clientPayload = "snodec-unix-disconnect-request";
+    constexpr std::string_view serverPayload = "snodec-unix-disconnect-ack";
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int serverPayloadReceivedCount = 0;
+        int clientAckReceivedCount = 0;
+        int clientCloseIssuedCount = 0;
+        int serverDisconnectedCount = 0;
+        int clientDisconnectedCount = 0;
+        int unexpectedStateCount = 0;
+        int unexpectedPayloadCount = 0;
+    };
+
+    std::string makeSocketPath() {
+        return "/tmp/snodec-unix-disconnect-" + std::to_string(getpid()) + ".sock";
+    }
+
+    bool socketPathExists(const std::string& socketPath) {
+        return access(socketPath.c_str(), F_OK) == 0;
+    }
+
+    void stopWhenDisconnectLifecycleIsComplete(TestState& testState) {
+        if (testState.clientDisconnectedCount == 1 && testState.serverDisconnectedCount == 1) {
+            core::SNodeC::stop();
+        }
+    }
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+        }
+
+        void onDisconnected() override {
+            ++testState.serverDisconnectedCount;
+            stopWhenDisconnectLifecycleIsComplete(testState);
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == clientPayload) {
+                    ++testState.serverPayloadReceivedCount;
+                    sendToPeer(serverPayload.data(), serverPayload.size());
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            sendToPeer(clientPayload.data(), clientPayload.size());
+        }
+
+        void onDisconnected() override {
+            ++testState.clientDisconnectedCount;
+            stopWhenDisconnectLifecycleIsComplete(testState);
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == serverPayload) {
+                    ++testState.clientAckReceivedCount;
+                    close();
+                    ++testState.clientCloseIssuedCount;
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+
+        TestState& testState;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestServerSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+    const std::string socketPath = makeSocketPath();
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("UnixLegacyServerClientDisconnectLifecycleTest");
+    } else {
+        TestState testState;
+        std::remove(socketPath.c_str());
+        const bool socketPathAbsentBeforeListen = !socketPathExists(socketPath);
+
+        core::SNodeC::init(argc, argv);
+
+        net::un::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("unix-disconnect-client", testState);
+        const net::un::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("unix-disconnect-server",
+                                                                                                             testState);
+
+        socketClient.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(socketPath,
+                            [&socketClient, &socketPath, &testState](const net::un::SocketAddress&, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.serverListenOkCount;
+                                    socketClient.connect(socketPath,
+                                                         [&testState](const net::un::SocketAddress&, core::socket::State connectState) {
+                                                             if (connectState == core::socket::State::OK) {
+                                                                 ++testState.clientConnectOkCount;
+                                                             } else {
+                                                                 ++testState.unexpectedStateCount;
+                                                                 core::SNodeC::stop();
+                                                             }
+                                                         });
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                    core::SNodeC::stop();
+                                }
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        std::remove(socketPath.c_str());
+        const bool socketPathAbsentAfterCleanup = !socketPathExists(socketPath);
+
+        testResult.expectTrue(socketPathAbsentBeforeListen, "Unix-domain socket path is absent before listen");
+        testResult.expectEqual(0, startResult, "event loop stops successfully after controlled Unix-domain disconnect lifecycle");
+        testResult.expectEqual(1, testState.serverListenOkCount, "Unix-domain legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.clientConnectOkCount, "Unix-domain legacy client connect callback reports OK exactly once");
+        testResult.expectEqual(1, testState.serverFactoryCreateCount, "server socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.clientFactoryCreateCount, "client socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.serverConnectedCount, "server socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.clientConnectedCount, "client socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.serverPayloadReceivedCount, "server receives and verifies the client payload exactly once");
+        testResult.expectEqual(1, testState.clientAckReceivedCount, "client receives and verifies the server ack exactly once");
+        testResult.expectEqual(1, testState.clientCloseIssuedCount, "client issues controlled close exactly once after ack");
+        testResult.expectEqual(1, testState.serverDisconnectedCount, "server socket context reaches onDisconnected exactly once");
+        testResult.expectEqual(1, testState.clientDisconnectedCount, "client socket context reaches onDisconnected exactly once");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+        testResult.expectEqual(0, testState.unexpectedPayloadCount, "server and client receive no unexpected payloads");
+        testResult.expectTrue(socketPathAbsentAfterCleanup, "Unix-domain socket path is absent after cleanup");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    std::remove(socketPath.c_str());
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Add focused component tests that verify controlled client-initiated `SocketContext::close()` and the `onDisconnected()` lifecycle for legacy stream sockets over IPv4, IPv6 and Unix-domain sockets. 
- Keep scope strictly to tests (no production code changes) to improve coverage for disconnect lifecycle behavior.

### Description
- Added three new component tests: `InetLegacyServerClientDisconnectLifecycleTest`, `Inet6LegacyServerClientDisconnectLifecycleTest`, and `UnixLegacyServerClientDisconnectLifecycleTest`, each implementing test-local `SocketContextFactory` and `SocketContext` classes, a tiny request/ack handshake, and a `stopWhenDisconnectLifecycleIsComplete(TestState&)` helper to stop the loop only after both sides observed `onDisconnected()`.
- Each test uses explicit server/client types and addresses: `net::in::stream::legacy::SocketServer`/`SocketClient` with `net::in::SocketAddress("127.0.0.1", 0)`, `net::in6::stream::legacy::SocketServer`/`SocketClient` with `net::in6::SocketAddress("::1", 0)`, and `net::un::stream::legacy::SocketServer`/`SocketClient` with a unique `/tmp/snodec-unix-disconnect-<pid>.sock` path (cleaned before/after).
- Added `tests/component/net/CMakeLists.txt` entries to register the three tests, link against `snodec-test-support` and `snodec::net-in-stream-legacy` / `snodec::net-in6-stream-legacy` / `snodec::net-un-stream-legacy`, enable `cxx_std_20`, and set test labels/timeouts/skip codes as requested.
- Tests assert lifecycle counters (listen/connect, payload/ack, client `close()` issued, and both `serverDisconnectedCount` and `clientDisconnectedCount` equal 1) and do not modify any production code.

### Testing
- Configured the project: `cmake -S . -B build-pr-disconnect-lifecycle -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF`, which completed successfully.
- Built the three new test targets directly: `cmake --build build-pr-disconnect-lifecycle --target InetLegacyServerClientDisconnectLifecycleTest Inet6LegacyServerClientDisconnectLifecycleTest UnixLegacyServerClientDisconnectLifecycleTest --parallel 2`, which completed successfully and produced the three executables.
- Ran the new tests by label: `ctest --test-dir build-pr-disconnect-lifecycle -L "disconnect" --output-on-failure`, where all three tests passed (`3/3` passed).
- Ran broader test runs including `ctest --test-dir build-pr-disconnect-lifecycle --output-on-failure` and multiple label-filtered runs (`component`, `net`, `stream`, `legacy`, `ipv4`, `ipv6`, `unix`); the component test suite executed and the disconnect tests passed within those runs (observed 100% pass for the executed suites in this environment).
- Ran `git diff --check` and `cmake -S . -B build-pr-disconnect-lifecycle-default -DCMAKE_BUILD_TYPE=Debug` as part of verification; `git diff --check` reported no issues and config succeeded.
- Note: a full high-parallel repository build reached the new tests but later failed in an unrelated existing target (`net-un-stream-tls`) with undefined references to Unix TLS config symbols; this is outside the scope of these new legacy disconnect tests and no production code was changed to address it.
- The test environment initially skipped component tests when the `snodec` group was missing; a local `snodec` group was created so the component tests executed (this is an environment setup action and not a repository change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a481d115fc0832c9ba2167577d334d7)