### PR TITLE
Add IPv4 and IPv6 legacy connect-failure component tests

### DIFF
--- a/tests/component/net/CMakeLists.txt
+++ b/tests/component/net/CMakeLists.txt
@@ -100,11 +100,14 @@ set_tests_properties(UnixLegacyClientConnectFailureTest PROPERTIES
 
 snodec_add_test(InetLegacyServerClientPayloadExchangeTest InetLegacyServerClientPayloadExchangeTest.cpp)
 snodec_add_test(InetLegacyServerClientDisconnectLifecycleTest InetLegacyServerClientDisconnectLifecycleTest.cpp)
+snodec_add_test(InetLegacyClientConnectFailureTest InetLegacyClientConnectFailureTest.cpp)
 
 target_link_libraries(InetLegacyServerClientPayloadExchangeTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
 target_link_libraries(InetLegacyServerClientDisconnectLifecycleTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
+target_link_libraries(InetLegacyClientConnectFailureTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
 target_compile_features(InetLegacyServerClientPayloadExchangeTest PRIVATE cxx_std_20)
 target_compile_features(InetLegacyServerClientDisconnectLifecycleTest PRIVATE cxx_std_20)
+target_compile_features(InetLegacyClientConnectFailureTest PRIVATE cxx_std_20)
 
 set_tests_properties(InetLegacyServerClientPayloadExchangeTest PROPERTIES
                      LABELS "component;net;stream;legacy;ipv4;payload"
@@ -116,14 +119,22 @@ set_tests_properties(InetLegacyServerClientDisconnectLifecycleTest PROPERTIES
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)
 
+set_tests_properties(InetLegacyClientConnectFailureTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv4;connect-failure"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
 
 snodec_add_test(Inet6LegacyServerClientPayloadExchangeTest Inet6LegacyServerClientPayloadExchangeTest.cpp)
 snodec_add_test(Inet6LegacyServerClientDisconnectLifecycleTest Inet6LegacyServerClientDisconnectLifecycleTest.cpp)
+snodec_add_test(Inet6LegacyClientConnectFailureTest Inet6LegacyClientConnectFailureTest.cpp)
 
 target_link_libraries(Inet6LegacyServerClientPayloadExchangeTest PRIVATE snodec-test-support snodec::net-in6-stream-legacy)
 target_link_libraries(Inet6LegacyServerClientDisconnectLifecycleTest PRIVATE snodec-test-support snodec::net-in6-stream-legacy)
+target_link_libraries(Inet6LegacyClientConnectFailureTest PRIVATE snodec-test-support snodec::net-in6-stream-legacy)
 target_compile_features(Inet6LegacyServerClientPayloadExchangeTest PRIVATE cxx_std_20)
 target_compile_features(Inet6LegacyServerClientDisconnectLifecycleTest PRIVATE cxx_std_20)
+target_compile_features(Inet6LegacyClientConnectFailureTest PRIVATE cxx_std_20)
 
 set_tests_properties(Inet6LegacyServerClientPayloadExchangeTest PROPERTIES
                      LABELS "component;net;stream;legacy;ipv6;payload"
@@ -132,6 +143,11 @@ set_tests_properties(Inet6LegacyServerClientPayloadExchangeTest PROPERTIES
 
 set_tests_properties(Inet6LegacyServerClientDisconnectLifecycleTest PROPERTIES
                      LABELS "component;net;stream;legacy;ipv6;disconnect"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(Inet6LegacyClientConnectFailureTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv6;connect-failure"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)
 

--- a/tests/component/net/Inet6LegacyClientConnectFailureTest.cpp
+++ b/tests/component/net/Inet6LegacyClientConnectFailureTest.cpp
@@ -1,0 +1,159 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in6/SocketAddress.h"
+#include "net/in6/stream/legacy/SocketClient.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    struct TestState {
+        int clientConnectFailureCount = 0;
+        int unexpectedConnectOkCount = 0;
+        int clientFactoryCreateCount = 0;
+        int clientConnectedCount = 0;
+        int unexpectedStateCount = 0;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("Inet6LegacyClientConnectFailureTest");
+    } else {
+        TestState testState;
+
+        core::SNodeC::init(argc, argv);
+
+        net::in6::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv6-connect-failure-client", testState);
+
+        socketClient.getConfig()->Instance::forceUnrequired();
+
+        const net::in6::SocketAddress failingAddress("::1", static_cast<std::uint16_t>(0));
+
+        socketClient.connect(failingAddress, [&testState](const net::in6::SocketAddress&, core::socket::State connectState) {
+            if (connectState != core::socket::State::OK) {
+                ++testState.clientConnectFailureCount;
+            } else {
+                ++testState.unexpectedConnectOkCount;
+                ++testState.unexpectedStateCount;
+            }
+
+            core::SNodeC::stop();
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after IPv6 connect failure");
+        testResult.expectEqual(1, testState.clientConnectFailureCount, "IPv6 legacy client connect callback reports one failure");
+        testResult.expectEqual(0, testState.unexpectedConnectOkCount, "IPv6 legacy client connect callback never reports OK");
+        testResult.expectEqual(0, testState.clientFactoryCreateCount, "client socket context factory is not called for connect failure");
+        testResult.expectEqual(0, testState.clientConnectedCount, "client socket context never reaches onConnected");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "connect callback reports no unexpected states");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/net/InetLegacyClientConnectFailureTest.cpp
+++ b/tests/component/net/InetLegacyClientConnectFailureTest.cpp
@@ -1,0 +1,159 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in/SocketAddress.h"
+#include "net/in/stream/legacy/SocketClient.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    struct TestState {
+        int clientConnectFailureCount = 0;
+        int unexpectedConnectOkCount = 0;
+        int clientFactoryCreateCount = 0;
+        int clientConnectedCount = 0;
+        int unexpectedStateCount = 0;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetLegacyClientConnectFailureTest");
+    } else {
+        TestState testState;
+
+        core::SNodeC::init(argc, argv);
+
+        net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv4-connect-failure-client", testState);
+
+        socketClient.getConfig()->Instance::forceUnrequired();
+
+        const net::in::SocketAddress failingAddress("127.0.0.1", static_cast<std::uint16_t>(0));
+
+        socketClient.connect(failingAddress, [&testState](const net::in::SocketAddress&, core::socket::State connectState) {
+            if (connectState != core::socket::State::OK) {
+                ++testState.clientConnectFailureCount;
+            } else {
+                ++testState.unexpectedConnectOkCount;
+                ++testState.unexpectedStateCount;
+            }
+
+            core::SNodeC::stop();
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after IPv4 connect failure");
+        testResult.expectEqual(1, testState.clientConnectFailureCount, "IPv4 legacy client connect callback reports one failure");
+        testResult.expectEqual(0, testState.unexpectedConnectOkCount, "IPv4 legacy client connect callback never reports OK");
+        testResult.expectEqual(0, testState.clientFactoryCreateCount, "client socket context factory is not called for connect failure");
+        testResult.expectEqual(0, testState.clientConnectedCount, "client socket context never reaches onConnected");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "connect callback reports no unexpected states");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    return result;
+}


### PR DESCRIPTION
### Motivation

- Add narrow component tests to verify legacy IPv4/IPv6 stream client behavior when connecting to a non-listening loopback endpoint without creating a socket context.

### Description

- Add `tests/component/net/InetLegacyClientConnectFailureTest.cpp` which instantiates `net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&>` and connects to `127.0.0.1:0`, verifying the connect callback reports a non-OK state and that no `SocketContext` is created and `onConnected()` is never reached.
- Add `tests/component/net/Inet6LegacyClientConnectFailureTest.cpp` which instantiates `net::in6::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&>` and connects to `::1:0`, verifying the connect callback reports a non-OK state and that no `SocketContext` is created and `onConnected()` is never reached.
- Update `tests/component/net/CMakeLists.txt` to register both tests, link IPv4 against `snodec::net-in-stream-legacy` and IPv6 against `snodec::net-in6-stream-legacy`, set C++20, labels, `SKIP_RETURN_CODE 77`, and `TIMEOUT 5`.
- No production code changes were made and test-local `SocketContext` and `SocketContextFactory` implementations are used inside the tests.

### Testing

- Configured and built with `cmake -S . -B build-pr-ip-connect-failure -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` and `cmake --build build-pr-ip-connect-failure --parallel` which completed successfully.
- Ran component test selection and connect-failure focused runs with `ctest` (by directory and by labels); the new tests `InetLegacyClientConnectFailureTest` and `Inet6LegacyClientConnectFailureTest` executed and passed along with existing component tests.
- Verified `git diff --check` and a default configure with `cmake -S . -B build-pr-ip-connect-failure-default -DCMAKE_BUILD_TYPE=Debug` also completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a482d9c06a8832caa2948d63667f11a)