### PR TITLE
Add legacy stream multiple-client composition component tests

### DIFF
--- a/tests/component/net/CMakeLists.txt
+++ b/tests/component/net/CMakeLists.txt
@@ -71,6 +71,33 @@ set_tests_properties(UnixLegacyServerClientCompositionTest PROPERTIES
                      TIMEOUT 5)
 
 
+snodec_add_test(InetLegacyServerMultipleClientsCompositionTest InetLegacyServerMultipleClientsCompositionTest.cpp)
+snodec_add_test(Inet6LegacyServerMultipleClientsCompositionTest Inet6LegacyServerMultipleClientsCompositionTest.cpp)
+snodec_add_test(UnixLegacyServerMultipleClientsCompositionTest UnixLegacyServerMultipleClientsCompositionTest.cpp)
+
+target_link_libraries(InetLegacyServerMultipleClientsCompositionTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
+target_link_libraries(Inet6LegacyServerMultipleClientsCompositionTest PRIVATE snodec-test-support snodec::net-in6-stream-legacy)
+target_link_libraries(UnixLegacyServerMultipleClientsCompositionTest PRIVATE snodec-test-support snodec::net-un-stream-legacy)
+target_compile_features(InetLegacyServerMultipleClientsCompositionTest PRIVATE cxx_std_20)
+target_compile_features(Inet6LegacyServerMultipleClientsCompositionTest PRIVATE cxx_std_20)
+target_compile_features(UnixLegacyServerMultipleClientsCompositionTest PRIVATE cxx_std_20)
+
+set_tests_properties(InetLegacyServerMultipleClientsCompositionTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv4;multi-client;composition"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(Inet6LegacyServerMultipleClientsCompositionTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv6;multi-client;composition"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(UnixLegacyServerMultipleClientsCompositionTest PROPERTIES
+                     LABELS "component;net;stream;legacy;unix;multi-client;composition"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+
 snodec_add_test(UnixLegacyServerClientPayloadExchangeTest UnixLegacyServerClientPayloadExchangeTest.cpp)
 snodec_add_test(UnixLegacyServerClientDisconnectLifecycleTest UnixLegacyServerClientDisconnectLifecycleTest.cpp)
 snodec_add_test(UnixLegacyClientConnectFailureTest UnixLegacyClientConnectFailureTest.cpp)

--- a/tests/component/net/Inet6LegacyServerMultipleClientsCompositionTest.cpp
+++ b/tests/component/net/Inet6LegacyServerMultipleClientsCompositionTest.cpp
@@ -1,0 +1,247 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in6/SocketAddress.h"
+#include "net/in6/stream/legacy/SocketClient.h"
+#include "net/in6/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int effectiveListenPortOkCount = 0;
+        int zeroEffectiveListenPortCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int unexpectedStateCount = 0;
+    };
+
+    void stopWhenAllContextsAreConnected(TestState& testState) {
+        if (testState.serverConnectedCount == 2 && testState.clientConnectedCount == 2) {
+            core::SNodeC::stop();
+        }
+    }
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+            stopWhenAllContextsAreConnected(testState);
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            const bool signalHandled = true;
+
+            return signalHandled;
+        }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            stopWhenAllContextsAreConnected(testState);
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            const bool signalHandled = true;
+
+            return signalHandled;
+        }
+
+        TestState& testState;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestServerSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("Inet6LegacyServerMultipleClientsCompositionTest");
+    } else {
+        TestState testState;
+
+        core::SNodeC::init(argc, argv);
+
+        net::in6::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClientA("ipv6-multi-client-a", testState);
+        net::in6::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClientB("ipv6-multi-client-b", testState);
+        const net::in6::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("ipv6-multi-server",
+                                                                                                             testState);
+
+        socketClientA.getConfig()->Instance::forceUnrequired();
+        socketClientB.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(net::in6::SocketAddress("::1", 0),
+                            [&socketClientA, &socketClientB, &testState](const net::in6::SocketAddress& socketAddress, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.serverListenOkCount;
+
+                                    const std::uint16_t effectivePort = socketAddress.getPort();
+                                    if (effectivePort != 0) {
+                                        ++testState.effectiveListenPortOkCount;
+                                        const auto connectCallback = [&testState](const net::in6::SocketAddress&, core::socket::State connectState) {
+                                            if (connectState == core::socket::State::OK) {
+                                                ++testState.clientConnectOkCount;
+                                            } else {
+                                                ++testState.unexpectedStateCount;
+                                                core::SNodeC::stop();
+                                            }
+                                        };
+
+                                        socketClientA.connect(net::in6::SocketAddress("::1", effectivePort), connectCallback);
+                                        socketClientB.connect(net::in6::SocketAddress("::1", effectivePort), connectCallback);
+                                    } else {
+                                        ++testState.zeroEffectiveListenPortCount;
+                                        ++testState.unexpectedStateCount;
+                                        core::SNodeC::stop();
+                                    }
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                    core::SNodeC::stop();
+                                }
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after both composition contexts connect");
+        testResult.expectEqual(1, testState.serverListenOkCount, "IPv6 legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.effectiveListenPortOkCount, "IPv6 legacy listen callback reports one non-zero effective port");
+        testResult.expectEqual(0, testState.zeroEffectiveListenPortCount, "IPv6 legacy listen callback never reports port zero");
+        testResult.expectEqual(2, testState.clientConnectOkCount, "IPv6 legacy client connect callback reports OK exactly twice");
+        testResult.expectEqual(2, testState.serverFactoryCreateCount, "server socket context factory creates exactly two contexts");
+        testResult.expectEqual(2, testState.clientFactoryCreateCount, "client socket context factory creates exactly two contexts");
+        testResult.expectEqual(2, testState.serverConnectedCount, "server socket context reaches onConnected exactly twice");
+        testResult.expectEqual(2, testState.clientConnectedCount, "client socket context reaches onConnected exactly twice");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/net/InetLegacyServerMultipleClientsCompositionTest.cpp
+++ b/tests/component/net/InetLegacyServerMultipleClientsCompositionTest.cpp
@@ -1,0 +1,247 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in/SocketAddress.h"
+#include "net/in/stream/legacy/SocketClient.h"
+#include "net/in/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int effectiveListenPortOkCount = 0;
+        int zeroEffectiveListenPortCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int unexpectedStateCount = 0;
+    };
+
+    void stopWhenAllContextsAreConnected(TestState& testState) {
+        if (testState.serverConnectedCount == 2 && testState.clientConnectedCount == 2) {
+            core::SNodeC::stop();
+        }
+    }
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+            stopWhenAllContextsAreConnected(testState);
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            const bool signalHandled = true;
+
+            return signalHandled;
+        }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            stopWhenAllContextsAreConnected(testState);
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            const bool signalHandled = true;
+
+            return signalHandled;
+        }
+
+        TestState& testState;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestServerSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetLegacyServerMultipleClientsCompositionTest");
+    } else {
+        TestState testState;
+
+        core::SNodeC::init(argc, argv);
+
+        net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClientA("ipv4-multi-client-a", testState);
+        net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClientB("ipv4-multi-client-b", testState);
+        const net::in::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("ipv4-multi-server",
+                                                                                                             testState);
+
+        socketClientA.getConfig()->Instance::forceUnrequired();
+        socketClientB.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(net::in::SocketAddress("127.0.0.1", 0),
+                            [&socketClientA, &socketClientB, &testState](const net::in::SocketAddress& socketAddress, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.serverListenOkCount;
+
+                                    const std::uint16_t effectivePort = socketAddress.getPort();
+                                    if (effectivePort != 0) {
+                                        ++testState.effectiveListenPortOkCount;
+                                        const auto connectCallback = [&testState](const net::in::SocketAddress&, core::socket::State connectState) {
+                                            if (connectState == core::socket::State::OK) {
+                                                ++testState.clientConnectOkCount;
+                                            } else {
+                                                ++testState.unexpectedStateCount;
+                                                core::SNodeC::stop();
+                                            }
+                                        };
+
+                                        socketClientA.connect(net::in::SocketAddress("127.0.0.1", effectivePort), connectCallback);
+                                        socketClientB.connect(net::in::SocketAddress("127.0.0.1", effectivePort), connectCallback);
+                                    } else {
+                                        ++testState.zeroEffectiveListenPortCount;
+                                        ++testState.unexpectedStateCount;
+                                        core::SNodeC::stop();
+                                    }
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                    core::SNodeC::stop();
+                                }
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after both composition contexts connect");
+        testResult.expectEqual(1, testState.serverListenOkCount, "IPv4 legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.effectiveListenPortOkCount, "IPv4 legacy listen callback reports one non-zero effective port");
+        testResult.expectEqual(0, testState.zeroEffectiveListenPortCount, "IPv4 legacy listen callback never reports port zero");
+        testResult.expectEqual(2, testState.clientConnectOkCount, "IPv4 legacy client connect callback reports OK exactly twice");
+        testResult.expectEqual(2, testState.serverFactoryCreateCount, "server socket context factory creates exactly two contexts");
+        testResult.expectEqual(2, testState.clientFactoryCreateCount, "client socket context factory creates exactly two contexts");
+        testResult.expectEqual(2, testState.serverConnectedCount, "server socket context reaches onConnected exactly twice");
+        testResult.expectEqual(2, testState.clientConnectedCount, "client socket context reaches onConnected exactly twice");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/net/UnixLegacyServerMultipleClientsCompositionTest.cpp
+++ b/tests/component/net/UnixLegacyServerMultipleClientsCompositionTest.cpp
@@ -1,0 +1,268 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/un/SocketAddress.h"
+#include "net/un/stream/legacy/SocketClient.h"
+#include "net/un/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdio>
+#include <string>
+#include <unistd.h>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int unexpectedStateCount = 0;
+    };
+
+    std::string makeSocketPath() {
+        return "/tmp/snodec-unix-multi-client-" + std::to_string(getpid()) + ".sock";
+    }
+
+    bool socketPathExists(const std::string& socketPath) {
+        return access(socketPath.c_str(), F_OK) == 0;
+    }
+
+    bool createStaleSocketPathFile(const std::string& socketPath) {
+        FILE* staleSocketPathFile = std::fopen(socketPath.c_str(), "w");
+        const bool created = staleSocketPathFile != nullptr;
+
+        if (staleSocketPathFile != nullptr) {
+            std::fclose(staleSocketPathFile);
+        }
+
+        return created;
+    }
+
+    void stopWhenAllContextsAreConnected(TestState& testState) {
+        if (testState.serverConnectedCount == 2 && testState.clientConnectedCount == 2) {
+            core::SNodeC::stop();
+        }
+    }
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+            stopWhenAllContextsAreConnected(testState);
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            const bool signalHandled = true;
+
+            return signalHandled;
+        }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            stopWhenAllContextsAreConnected(testState);
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            const std::size_t processed = 0;
+
+            return processed;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            const bool signalHandled = true;
+
+            return signalHandled;
+        }
+
+        TestState& testState;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestServerSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+    const std::string socketPath = makeSocketPath();
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("UnixLegacyServerMultipleClientsCompositionTest");
+    } else {
+        TestState testState;
+        const bool staleSocketPathCreated = createStaleSocketPathFile(socketPath);
+        const bool staleSocketPathRemoved = std::remove(socketPath.c_str()) == 0;
+        const bool socketPathAbsentBeforeListen = !socketPathExists(socketPath);
+
+        core::SNodeC::init(argc, argv);
+
+        net::un::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClientA("unix-multi-client-a", testState);
+        net::un::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClientB("unix-multi-client-b", testState);
+        const net::un::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("unix-multi-server",
+                                                                                                             testState);
+
+        socketClientA.getConfig()->Instance::forceUnrequired();
+        socketClientB.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(socketPath,
+                            [&socketClientA, &socketClientB, &socketPath, &testState](const net::un::SocketAddress&, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.serverListenOkCount;
+                                    const auto connectCallback = [&testState](const net::un::SocketAddress&, core::socket::State connectState) {
+                                        if (connectState == core::socket::State::OK) {
+                                            ++testState.clientConnectOkCount;
+                                        } else {
+                                            ++testState.unexpectedStateCount;
+                                            core::SNodeC::stop();
+                                        }
+                                    };
+
+                                    socketClientA.connect(socketPath, connectCallback);
+                                    socketClientB.connect(socketPath, connectCallback);
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                    core::SNodeC::stop();
+                                }
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        std::remove(socketPath.c_str());
+        const bool socketPathAbsentAfterCleanup = !socketPathExists(socketPath);
+
+        testResult.expectTrue(staleSocketPathCreated, "test creates a stale Unix-domain socket path placeholder before listen");
+        testResult.expectTrue(staleSocketPathRemoved, "stale Unix-domain socket path is removed before listen");
+        testResult.expectTrue(socketPathAbsentBeforeListen, "Unix-domain socket path is absent before listen");
+        testResult.expectEqual(0, startResult, "event loop stops successfully after both composition contexts connect");
+        testResult.expectEqual(1, testState.serverListenOkCount, "Unix-domain legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(2, testState.clientConnectOkCount, "Unix-domain legacy client connect callback reports OK exactly twice");
+        testResult.expectEqual(2, testState.serverFactoryCreateCount, "server socket context factory creates exactly two contexts");
+        testResult.expectEqual(2, testState.clientFactoryCreateCount, "client socket context factory creates exactly two contexts");
+        testResult.expectEqual(2, testState.serverConnectedCount, "server socket context reaches onConnected exactly twice");
+        testResult.expectEqual(2, testState.clientConnectedCount, "client socket context reaches onConnected exactly twice");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+        testResult.expectTrue(socketPathAbsentAfterCleanup, "Unix-domain socket path is absent after cleanup");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    std::remove(socketPath.c_str());
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Add narrow component tests to verify a single legacy stream server can accept two clients and create one server-side context per accepted connection for IPv4, IPv6 and Unix-domain transports. 
- Reuse the style and structure of existing composition tests and keep scope strictly test-only without touching production code.

### Description
- Added three new component tests: `tests/component/net/InetLegacyServerMultipleClientsCompositionTest.cpp`, `tests/component/net/Inet6LegacyServerMultipleClientsCompositionTest.cpp`, and `tests/component/net/UnixLegacyServerMultipleClientsCompositionTest.cpp` implementing test-local `SocketContextFactory` and `SocketContext` types and stop helpers that wait until two server and two client contexts have reached `onConnected()` before stopping the event loop. 
- Registered and wired the tests in `tests/component/net/CMakeLists.txt` and linked them against the appropriate legacy stream libraries with `cxx_std_20` and multi-client composition labels. 
- No production code was modified.
- Key technical details: the tests create one server and two clients each and assert the factory create counts, connect callback OK counts, and that both server and client contexts reach `onConnected()` before exiting. Exact server/client types used in tests:
  - IPv4: `net::in::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&>` with two `net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&>` instances (`ipv4-multi-client-a`, `ipv4-multi-client-b`) connecting to `127.0.0.1:0` and using the effective listen port.
  - IPv6: `net::in6::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&>` with two `net::in6::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&>` instances (`ipv6-multi-client-a`, `ipv6-multi-client-b`) connecting to `::1:0` and using the effective listen port.
  - Unix-domain: `net::un::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&>` with two `net::un::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&>` instances (`unix-multi-client-a`, `unix-multi-client-b`) using a unique `/tmp/snodec-unix-multi-client-<pid>.sock` path and cleaning it up afterwards.
- Files changed:
  - Added: `tests/component/net/InetLegacyServerMultipleClientsCompositionTest.cpp`
  - Added: `tests/component/net/Inet6LegacyServerMultipleClientsCompositionTest.cpp`
  - Added: `tests/component/net/UnixLegacyServerMultipleClientsCompositionTest.cpp`
  - Modified: `tests/component/net/CMakeLists.txt` (registered the three tests, links, compile features and properties/labels).

### Testing
- Build and run commands executed (automated):
  - `cmake -S . -B build-pr-multi-client-composition -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF`
  - `cmake --build build-pr-multi-client-composition --parallel`
  - `ctest --test-dir build-pr-multi-client-composition --output-on-failure`
  - Targeted label runs: `ctest -L "component"`, `-L "net"`, `-L "stream"`, `-L "legacy"`, `-L "multi-client"`, `-L "composition"`, `-L "ipv4"`, `-L "ipv6"`, `-L "unix"`.
- Result: All automated test runs passed; the three new tests passed when run together with the existing suite (100% passed in the exercised ctest runs). 
- Specific test targets added and executed successfully: `InetLegacyServerMultipleClientsCompositionTest`, `Inet6LegacyServerMultipleClientsCompositionTest`, `UnixLegacyServerMultipleClientsCompositionTest`.
- Additional checks: `git diff --check` produced no check failures and a default debug configure (`cmake -S . -B build-pr-multi-client-composition-default -DCMAKE_BUILD_TYPE=Debug`) completed successfully in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4833278250832cb041534cf04e6cd5)