### PR TITLE
Add legacy stream multi-message payload component tests

### DIFF
--- a/tests/component/net/CMakeLists.txt
+++ b/tests/component/net/CMakeLists.txt
@@ -98,6 +98,33 @@ set_tests_properties(UnixLegacyServerMultipleClientsCompositionTest PROPERTIES
                      TIMEOUT 5)
 
 
+snodec_add_test(InetLegacyServerClientMultiMessagePayloadExchangeTest InetLegacyServerClientMultiMessagePayloadExchangeTest.cpp)
+snodec_add_test(Inet6LegacyServerClientMultiMessagePayloadExchangeTest Inet6LegacyServerClientMultiMessagePayloadExchangeTest.cpp)
+snodec_add_test(UnixLegacyServerClientMultiMessagePayloadExchangeTest UnixLegacyServerClientMultiMessagePayloadExchangeTest.cpp)
+
+target_link_libraries(InetLegacyServerClientMultiMessagePayloadExchangeTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
+target_link_libraries(Inet6LegacyServerClientMultiMessagePayloadExchangeTest PRIVATE snodec-test-support snodec::net-in6-stream-legacy)
+target_link_libraries(UnixLegacyServerClientMultiMessagePayloadExchangeTest PRIVATE snodec-test-support snodec::net-un-stream-legacy)
+target_compile_features(InetLegacyServerClientMultiMessagePayloadExchangeTest PRIVATE cxx_std_20)
+target_compile_features(Inet6LegacyServerClientMultiMessagePayloadExchangeTest PRIVATE cxx_std_20)
+target_compile_features(UnixLegacyServerClientMultiMessagePayloadExchangeTest PRIVATE cxx_std_20)
+
+set_tests_properties(InetLegacyServerClientMultiMessagePayloadExchangeTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv4;multi-message;payload"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(Inet6LegacyServerClientMultiMessagePayloadExchangeTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv6;multi-message;payload"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(UnixLegacyServerClientMultiMessagePayloadExchangeTest PROPERTIES
+                     LABELS "component;net;stream;legacy;unix;multi-message;payload"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+
 snodec_add_test(InetLegacyServerMultipleClientsPayloadExchangeTest InetLegacyServerMultipleClientsPayloadExchangeTest.cpp)
 snodec_add_test(Inet6LegacyServerMultipleClientsPayloadExchangeTest Inet6LegacyServerMultipleClientsPayloadExchangeTest.cpp)
 snodec_add_test(UnixLegacyServerMultipleClientsPayloadExchangeTest UnixLegacyServerMultipleClientsPayloadExchangeTest.cpp)

--- a/tests/component/net/Inet6LegacyServerClientMultiMessagePayloadExchangeTest.cpp
+++ b/tests/component/net/Inet6LegacyServerClientMultiMessagePayloadExchangeTest.cpp
@@ -1,0 +1,268 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in6/SocketAddress.h"
+#include "net/in6/stream/legacy/SocketClient.h"
+#include "net/in6/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    constexpr std::string_view firstClientPayload = "snodec-ipv6-first-request";
+    constexpr std::string_view firstServerReply = "snodec-ipv6-first-reply";
+    constexpr std::string_view secondClientPayload = "snodec-ipv6-second-request";
+    constexpr std::string_view secondServerReply = "snodec-ipv6-second-reply";
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int effectiveListenPortOkCount = 0;
+        int zeroEffectiveListenPortCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int serverFirstPayloadReceivedCount = 0;
+        int serverSecondPayloadReceivedCount = 0;
+        int clientFirstReplyReceivedCount = 0;
+        int clientSecondReplyReceivedCount = 0;
+        int clientSecondPayloadSentCount = 0;
+        int unexpectedStateCount = 0;
+        int unexpectedPayloadCount = 0;
+    };
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == firstClientPayload) {
+                    ++testState.serverFirstPayloadReceivedCount;
+                    sendToPeer(firstServerReply.data(), firstServerReply.size());
+                } else if (payload == secondClientPayload) {
+                    ++testState.serverSecondPayloadReceivedCount;
+                    sendToPeer(secondServerReply.data(), secondServerReply.size());
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override { return true; }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            sendToPeer(firstClientPayload.data(), firstClientPayload.size());
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == firstServerReply) {
+                    ++testState.clientFirstReplyReceivedCount;
+                    sendToPeer(secondClientPayload.data(), secondClientPayload.size());
+                    ++testState.clientSecondPayloadSentCount;
+                } else if (payload == secondServerReply) {
+                    ++testState.clientSecondReplyReceivedCount;
+                    core::SNodeC::stop();
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override { return true; }
+
+        TestState& testState;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState) : testState(testState) {}
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestServerSocketContext(socketConnection, testState);
+            return socketContext;
+        }
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState) : testState(testState) {}
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+            return socketContext;
+        }
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("Inet6LegacyServerClientMultiMessagePayloadExchangeTest");
+    } else {
+        TestState testState;
+        core::SNodeC::init(argc, argv);
+
+        net::in6::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv6-multi-message-client", testState);
+        const net::in6::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("ipv6-multi-message-server", testState);
+
+        socketClient.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(net::in6::SocketAddress("::1", 0),
+                            [&socketClient, &testState](const net::in6::SocketAddress& socketAddress, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.serverListenOkCount;
+                                    const std::uint16_t effectivePort = socketAddress.getPort();
+                                    if (effectivePort != 0) {
+                                        ++testState.effectiveListenPortOkCount;
+                                        socketClient.connect(net::in6::SocketAddress("::1", effectivePort),
+                                                             [&testState](const net::in6::SocketAddress&, core::socket::State connectState) {
+                                                                 if (connectState == core::socket::State::OK) {
+                                                                     ++testState.clientConnectOkCount;
+                                                                 } else {
+                                                                     ++testState.unexpectedStateCount;
+                                                                     core::SNodeC::stop();
+                                                                 }
+                                                             });
+                                    } else {
+                                        ++testState.zeroEffectiveListenPortCount;
+                                        ++testState.unexpectedStateCount;
+                                        core::SNodeC::stop();
+                                    }
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                    core::SNodeC::stop();
+                                }
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after second IPv6 request/reply payload exchange");
+        testResult.expectEqual(1, testState.serverListenOkCount, "IPv6 legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.effectiveListenPortOkCount, "IPv6 legacy listen callback reports one non-zero effective port");
+        testResult.expectEqual(0, testState.zeroEffectiveListenPortCount, "IPv6 legacy listen callback never reports port zero");
+        testResult.expectEqual(1, testState.clientConnectOkCount, "IPv6 legacy client connect callback reports OK exactly once");
+        testResult.expectEqual(1, testState.serverFactoryCreateCount, "server socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.clientFactoryCreateCount, "client socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.serverConnectedCount, "server socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.clientConnectedCount, "client socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.serverFirstPayloadReceivedCount, "server receives and verifies the first client payload exactly once");
+        testResult.expectEqual(1, testState.serverSecondPayloadReceivedCount, "server receives and verifies the second client payload exactly once");
+        testResult.expectEqual(1, testState.clientFirstReplyReceivedCount, "client receives and verifies the first server reply exactly once");
+        testResult.expectEqual(1, testState.clientSecondReplyReceivedCount, "client receives and verifies the second server reply exactly once");
+        testResult.expectEqual(1, testState.clientSecondPayloadSentCount, "client sends the second payload after verifying the first reply exactly once");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+        testResult.expectEqual(0, testState.unexpectedPayloadCount, "server and client receive no unexpected payloads");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/net/InetLegacyServerClientMultiMessagePayloadExchangeTest.cpp
+++ b/tests/component/net/InetLegacyServerClientMultiMessagePayloadExchangeTest.cpp
@@ -1,0 +1,268 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in/SocketAddress.h"
+#include "net/in/stream/legacy/SocketClient.h"
+#include "net/in/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    constexpr std::string_view firstClientPayload = "snodec-ipv4-first-request";
+    constexpr std::string_view firstServerReply = "snodec-ipv4-first-reply";
+    constexpr std::string_view secondClientPayload = "snodec-ipv4-second-request";
+    constexpr std::string_view secondServerReply = "snodec-ipv4-second-reply";
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int effectiveListenPortOkCount = 0;
+        int zeroEffectiveListenPortCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int serverFirstPayloadReceivedCount = 0;
+        int serverSecondPayloadReceivedCount = 0;
+        int clientFirstReplyReceivedCount = 0;
+        int clientSecondReplyReceivedCount = 0;
+        int clientSecondPayloadSentCount = 0;
+        int unexpectedStateCount = 0;
+        int unexpectedPayloadCount = 0;
+    };
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == firstClientPayload) {
+                    ++testState.serverFirstPayloadReceivedCount;
+                    sendToPeer(firstServerReply.data(), firstServerReply.size());
+                } else if (payload == secondClientPayload) {
+                    ++testState.serverSecondPayloadReceivedCount;
+                    sendToPeer(secondServerReply.data(), secondServerReply.size());
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override { return true; }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            sendToPeer(firstClientPayload.data(), firstClientPayload.size());
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == firstServerReply) {
+                    ++testState.clientFirstReplyReceivedCount;
+                    sendToPeer(secondClientPayload.data(), secondClientPayload.size());
+                    ++testState.clientSecondPayloadSentCount;
+                } else if (payload == secondServerReply) {
+                    ++testState.clientSecondReplyReceivedCount;
+                    core::SNodeC::stop();
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override { return true; }
+
+        TestState& testState;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState) : testState(testState) {}
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestServerSocketContext(socketConnection, testState);
+            return socketContext;
+        }
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState) : testState(testState) {}
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+            return socketContext;
+        }
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetLegacyServerClientMultiMessagePayloadExchangeTest");
+    } else {
+        TestState testState;
+        core::SNodeC::init(argc, argv);
+
+        net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv4-multi-message-client", testState);
+        const net::in::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("ipv4-multi-message-server", testState);
+
+        socketClient.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(net::in::SocketAddress("127.0.0.1", 0),
+                            [&socketClient, &testState](const net::in::SocketAddress& socketAddress, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.serverListenOkCount;
+                                    const std::uint16_t effectivePort = socketAddress.getPort();
+                                    if (effectivePort != 0) {
+                                        ++testState.effectiveListenPortOkCount;
+                                        socketClient.connect(net::in::SocketAddress("127.0.0.1", effectivePort),
+                                                             [&testState](const net::in::SocketAddress&, core::socket::State connectState) {
+                                                                 if (connectState == core::socket::State::OK) {
+                                                                     ++testState.clientConnectOkCount;
+                                                                 } else {
+                                                                     ++testState.unexpectedStateCount;
+                                                                     core::SNodeC::stop();
+                                                                 }
+                                                             });
+                                    } else {
+                                        ++testState.zeroEffectiveListenPortCount;
+                                        ++testState.unexpectedStateCount;
+                                        core::SNodeC::stop();
+                                    }
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                    core::SNodeC::stop();
+                                }
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after second IPv4 request/reply payload exchange");
+        testResult.expectEqual(1, testState.serverListenOkCount, "IPv4 legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.effectiveListenPortOkCount, "IPv4 legacy listen callback reports one non-zero effective port");
+        testResult.expectEqual(0, testState.zeroEffectiveListenPortCount, "IPv4 legacy listen callback never reports port zero");
+        testResult.expectEqual(1, testState.clientConnectOkCount, "IPv4 legacy client connect callback reports OK exactly once");
+        testResult.expectEqual(1, testState.serverFactoryCreateCount, "server socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.clientFactoryCreateCount, "client socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.serverConnectedCount, "server socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.clientConnectedCount, "client socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.serverFirstPayloadReceivedCount, "server receives and verifies the first client payload exactly once");
+        testResult.expectEqual(1, testState.serverSecondPayloadReceivedCount, "server receives and verifies the second client payload exactly once");
+        testResult.expectEqual(1, testState.clientFirstReplyReceivedCount, "client receives and verifies the first server reply exactly once");
+        testResult.expectEqual(1, testState.clientSecondReplyReceivedCount, "client receives and verifies the second server reply exactly once");
+        testResult.expectEqual(1, testState.clientSecondPayloadSentCount, "client sends the second payload after verifying the first reply exactly once");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+        testResult.expectEqual(0, testState.unexpectedPayloadCount, "server and client receive no unexpected payloads");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/net/UnixLegacyServerClientMultiMessagePayloadExchangeTest.cpp
+++ b/tests/component/net/UnixLegacyServerClientMultiMessagePayloadExchangeTest.cpp
@@ -1,0 +1,291 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/un/SocketAddress.h"
+#include "net/un/stream/legacy/SocketClient.h"
+#include "net/un/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    constexpr std::string_view firstClientPayload = "snodec-unix-first-request";
+    constexpr std::string_view firstServerReply = "snodec-unix-first-reply";
+    constexpr std::string_view secondClientPayload = "snodec-unix-second-request";
+    constexpr std::string_view secondServerReply = "snodec-unix-second-reply";
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int serverFirstPayloadReceivedCount = 0;
+        int serverSecondPayloadReceivedCount = 0;
+        int clientFirstReplyReceivedCount = 0;
+        int clientSecondReplyReceivedCount = 0;
+        int clientSecondPayloadSentCount = 0;
+        int unexpectedStateCount = 0;
+        int unexpectedPayloadCount = 0;
+    };
+
+    std::string makeSocketPath() {
+        return "/tmp/snodec-unix-multi-message-" + std::to_string(getpid()) + ".sock";
+    }
+
+    bool socketPathExists(const std::string& socketPath) {
+        return access(socketPath.c_str(), F_OK) == 0;
+    }
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == firstClientPayload) {
+                    ++testState.serverFirstPayloadReceivedCount;
+                    sendToPeer(firstServerReply.data(), firstServerReply.size());
+                } else if (payload == secondClientPayload) {
+                    ++testState.serverSecondPayloadReceivedCount;
+                    sendToPeer(secondServerReply.data(), secondServerReply.size());
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+
+        TestState& testState;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            sendToPeer(firstClientPayload.data(), firstClientPayload.size());
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+
+            if (chunkLen > 0) {
+                const std::string payload(chunk, chunkLen);
+
+                if (payload == firstServerReply) {
+                    ++testState.clientFirstReplyReceivedCount;
+                    sendToPeer(secondClientPayload.data(), secondClientPayload.size());
+                    ++testState.clientSecondPayloadSentCount;
+                } else if (payload == secondServerReply) {
+                    ++testState.clientSecondReplyReceivedCount;
+                    core::SNodeC::stop();
+                } else {
+                    ++testState.unexpectedPayloadCount;
+                    core::SNodeC::stop();
+                }
+            }
+
+            return chunkLen;
+        }
+
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+
+        TestState& testState;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestServerSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            core::socket::stream::SocketContext* socketContext = new TestClientSocketContext(socketConnection, testState);
+
+            return socketContext;
+        }
+
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+    const std::string socketPath = makeSocketPath();
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("UnixLegacyServerClientMultiMessagePayloadExchangeTest");
+    } else {
+        TestState testState;
+        std::remove(socketPath.c_str());
+        const bool socketPathAbsentBeforeListen = !socketPathExists(socketPath);
+
+        core::SNodeC::init(argc, argv);
+
+        net::un::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("unix-multi-message-client", testState);
+        const net::un::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("unix-multi-message-server", testState);
+
+        socketClient.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+
+        socketServer.listen(socketPath,
+                            [&socketClient, &socketPath, &testState](const net::un::SocketAddress&, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++testState.serverListenOkCount;
+                                    socketClient.connect(socketPath,
+                                                         [&testState](const net::un::SocketAddress&, core::socket::State connectState) {
+                                                             if (connectState == core::socket::State::OK) {
+                                                                 ++testState.clientConnectOkCount;
+                                                             } else {
+                                                                 ++testState.unexpectedStateCount;
+                                                                 core::SNodeC::stop();
+                                                             }
+                                                         });
+                                } else {
+                                    ++testState.unexpectedStateCount;
+                                    core::SNodeC::stop();
+                                }
+                            });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        std::remove(socketPath.c_str());
+        const bool socketPathAbsentAfterCleanup = !socketPathExists(socketPath);
+
+        testResult.expectTrue(socketPathAbsentBeforeListen, "Unix-domain socket path is absent before listen");
+        testResult.expectEqual(0, startResult, "event loop stops successfully after second Unix-domain request/reply payload exchange");
+        testResult.expectEqual(1, testState.serverListenOkCount, "Unix-domain legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.clientConnectOkCount, "Unix-domain legacy client connect callback reports OK exactly once");
+        testResult.expectEqual(1, testState.serverFactoryCreateCount, "server socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.clientFactoryCreateCount, "client socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.serverConnectedCount, "server socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.clientConnectedCount, "client socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.serverFirstPayloadReceivedCount, "server receives and verifies the first client payload exactly once");
+        testResult.expectEqual(1, testState.serverSecondPayloadReceivedCount, "server receives and verifies the second client payload exactly once");
+        testResult.expectEqual(1, testState.clientFirstReplyReceivedCount, "client receives and verifies the first server reply exactly once");
+        testResult.expectEqual(1, testState.clientSecondReplyReceivedCount, "client receives and verifies the second server reply exactly once");
+        testResult.expectEqual(1, testState.clientSecondPayloadSentCount, "client sends the second payload after verifying the first reply exactly once");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+        testResult.expectEqual(0, testState.unexpectedPayloadCount, "server and client receive no unexpected payloads");
+        testResult.expectTrue(socketPathAbsentAfterCleanup, "Unix-domain socket path is absent after cleanup");
+
+        result = testResult.processResult();
+
+        core::SNodeC::free();
+    }
+
+    std::remove(socketPath.c_str());
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Add narrowly scoped component tests to prove a single legacy stream client and server can exchange two sequential request/reply payloads over one persistent accepted connection for IPv4, IPv6 and Unix-domain transports.
- Keep the change test-only and avoid touching production code while covering a reuse-of-connection multi-message scenario not exercised by the existing single-message tests.

### Description
- Add three new tests: `tests/component/net/InetLegacyServerClientMultiMessagePayloadExchangeTest.cpp`, `tests/component/net/Inet6LegacyServerClientMultiMessagePayloadExchangeTest.cpp`, and `tests/component/net/UnixLegacyServerClientMultiMessagePayloadExchangeTest.cpp`, each implementing test-local `SocketContext` and `SocketContextFactory` classes and the two-step request/reply flow.
- Register the three test targets and set link libraries, compile features and labels in `tests/component/net/CMakeLists.txt`, linking IPv4 to `snodec::net-in-stream-legacy`, IPv6 to `snodec::net-in6-stream-legacy`, and Unix to `snodec::net-un-stream-legacy`.
- Use `net::in::stream::legacy::SocketServer/SocketClient`, `net::in6::stream::legacy::SocketServer/SocketClient`, and `net::un::stream::legacy::SocketServer/SocketClient` respectively, with explicit instance names and `Instance::forceUnrequired()` applied, and ensure IPv4 uses `127.0.0.1:0`, IPv6 uses `::1:0`, and Unix uses a unique `/tmp/...sock` path that is removed before and after the test.
- Confirm no production code or app targets were modified and `onDisconnected()` remains intentionally unasserted in the new contexts.

### Testing
- Configure and build the project with tests enabled using `cmake -S . -B build-pr-multi-message-payload -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` and `cmake --build build-pr-multi-message-payload --parallel`, which completed successfully in the verification environment.
- Run the test suite with `ctest --test-dir build-pr-multi-message-payload --output-on-failure`, and the run reported `32/32` tests passed, including the three new tests labelled `multi-message` and `payload` (the multi-message tests executed and passed).
- Verified focused label queries such as `ctest -L

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48ba8b5ff0832cb619dea7b1ff0e10)