### PR TITLE
Add legacy stream framed payload component tests

### DIFF
--- a/tests/component/net/CMakeLists.txt
+++ b/tests/component/net/CMakeLists.txt
@@ -251,6 +251,9 @@ set_tests_properties(InetPhysicalServerEffectiveBindAddressTest PROPERTIES
                      TIMEOUT 5)
 
 snodec_add_test(InetLegacyServerClientLargePayloadExchangeTest InetLegacyServerClientLargePayloadExchangeTest.cpp)
+snodec_add_test(InetLegacyServerClientFramedPayloadExchangeTest InetLegacyServerClientFramedPayloadExchangeTest.cpp)
+snodec_add_test(Inet6LegacyServerClientFramedPayloadExchangeTest Inet6LegacyServerClientFramedPayloadExchangeTest.cpp)
+snodec_add_test(UnixLegacyServerClientFramedPayloadExchangeTest UnixLegacyServerClientFramedPayloadExchangeTest.cpp)
 snodec_add_test(Inet6LegacyServerClientLargePayloadExchangeTest Inet6LegacyServerClientLargePayloadExchangeTest.cpp)
 snodec_add_test(UnixLegacyServerClientLargePayloadExchangeTest UnixLegacyServerClientLargePayloadExchangeTest.cpp)
 snodec_add_test(InetLegacyServerControlledCloseLifecycleTest InetLegacyServerControlledCloseLifecycleTest.cpp)
@@ -261,6 +264,9 @@ snodec_add_test(Inet6LegacyServerMultipleClientsDisconnectLifecycleTest Inet6Leg
 snodec_add_test(UnixLegacyServerMultipleClientsDisconnectLifecycleTest UnixLegacyServerMultipleClientsDisconnectLifecycleTest.cpp)
 
 target_link_libraries(InetLegacyServerClientLargePayloadExchangeTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
+target_link_libraries(InetLegacyServerClientFramedPayloadExchangeTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
+target_link_libraries(Inet6LegacyServerClientFramedPayloadExchangeTest PRIVATE snodec-test-support snodec::net-in6-stream-legacy)
+target_link_libraries(UnixLegacyServerClientFramedPayloadExchangeTest PRIVATE snodec-test-support snodec::net-un-stream-legacy)
 target_link_libraries(Inet6LegacyServerClientLargePayloadExchangeTest PRIVATE snodec-test-support snodec::net-in6-stream-legacy)
 target_link_libraries(UnixLegacyServerClientLargePayloadExchangeTest PRIVATE snodec-test-support snodec::net-un-stream-legacy)
 target_link_libraries(InetLegacyServerControlledCloseLifecycleTest PRIVATE snodec-test-support snodec::net-in-stream-legacy)
@@ -271,6 +277,9 @@ target_link_libraries(Inet6LegacyServerMultipleClientsDisconnectLifecycleTest PR
 target_link_libraries(UnixLegacyServerMultipleClientsDisconnectLifecycleTest PRIVATE snodec-test-support snodec::net-un-stream-legacy)
 
 target_compile_features(InetLegacyServerClientLargePayloadExchangeTest PRIVATE cxx_std_20)
+target_compile_features(InetLegacyServerClientFramedPayloadExchangeTest PRIVATE cxx_std_20)
+target_compile_features(Inet6LegacyServerClientFramedPayloadExchangeTest PRIVATE cxx_std_20)
+target_compile_features(UnixLegacyServerClientFramedPayloadExchangeTest PRIVATE cxx_std_20)
 target_compile_features(Inet6LegacyServerClientLargePayloadExchangeTest PRIVATE cxx_std_20)
 target_compile_features(UnixLegacyServerClientLargePayloadExchangeTest PRIVATE cxx_std_20)
 target_compile_features(InetLegacyServerControlledCloseLifecycleTest PRIVATE cxx_std_20)
@@ -282,6 +291,18 @@ target_compile_features(UnixLegacyServerMultipleClientsDisconnectLifecycleTest P
 
 set_tests_properties(InetLegacyServerClientLargePayloadExchangeTest PROPERTIES
                      LABELS "component;net;stream;legacy;ipv4;large-payload"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+set_tests_properties(InetLegacyServerClientFramedPayloadExchangeTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv4;framed-payload"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+set_tests_properties(Inet6LegacyServerClientFramedPayloadExchangeTest PROPERTIES
+                     LABELS "component;net;stream;legacy;ipv6;framed-payload"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+set_tests_properties(UnixLegacyServerClientFramedPayloadExchangeTest PROPERTIES
+                     LABELS "component;net;stream;legacy;unix;framed-payload"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)
 set_tests_properties(Inet6LegacyServerClientLargePayloadExchangeTest PROPERTIES

--- a/tests/component/net/Inet6LegacyServerClientFramedPayloadExchangeTest.cpp
+++ b/tests/component/net/Inet6LegacyServerClientFramedPayloadExchangeTest.cpp
@@ -1,0 +1,352 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "core/timer/Timer.h"
+#include "net/in6/SocketAddress.h"
+#include "net/in6/stream/legacy/SocketClient.h"
+#include "net/in6/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    constexpr std::string_view firstClientPayload = "snodec-ipv6-framed-request-one";
+    constexpr std::string_view secondClientPayload = "snodec-ipv6-framed-request-two";
+    constexpr std::string_view firstServerReply = "snodec-ipv6-framed-reply-one";
+    constexpr std::string_view secondServerReply = "snodec-ipv6-framed-reply-two";
+
+    enum class FrameParseResult {
+        Incomplete,
+        Complete,
+        Malformed
+    };
+
+    std::string encodeFrame(std::string_view payload) {
+        return std::to_string(payload.size()) + "\n" + std::string(payload);
+    }
+
+    std::vector<std::string> makeFragmentPlan(const std::string& stream) {
+        return {stream.substr(0, 1), stream.substr(1, 4), stream.substr(5, 11), stream.substr(16)};
+    }
+
+    FrameParseResult tryExtractFrame(std::string& buffer, std::string& framePayload) {
+        const std::size_t newlinePos = buffer.find('\n');
+        if (newlinePos == std::string::npos) {
+            return FrameParseResult::Incomplete;
+        }
+        if (newlinePos == 0) {
+            return FrameParseResult::Malformed;
+        }
+        std::size_t payloadSize = 0;
+        for (std::size_t i = 0; i < newlinePos; ++i) {
+            const char ch = buffer[i];
+            if (ch < '0' || ch > '9') {
+                return FrameParseResult::Malformed;
+            }
+            payloadSize = payloadSize * 10 + static_cast<std::size_t>(ch - '0');
+        }
+        const std::size_t frameSize = newlinePos + 1 + payloadSize;
+        if (buffer.size() < frameSize) {
+            return FrameParseResult::Incomplete;
+        }
+        framePayload = buffer.substr(newlinePos + 1, payloadSize);
+        buffer.erase(0, frameSize);
+        return FrameParseResult::Complete;
+    }
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int effectiveListenPortOkCount = 0;
+        int zeroEffectiveListenPortCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int clientRequestFragmentSentCount = 0;
+        int serverReplyFragmentSentCount = 0;
+        int serverFirstFrameReceivedCount = 0;
+        int serverSecondFrameReceivedCount = 0;
+        int clientFirstReplyFrameReceivedCount = 0;
+        int clientSecondReplyFrameReceivedCount = 0;
+        int malformedFrameCount = 0;
+        int unexpectedStateCount = 0;
+        int unexpectedPayloadCount = 0;
+    };
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+        }
+        void onDisconnected() override {
+        }
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+            if (chunkLen > 0) {
+                receiveBuffer.append(chunk, chunkLen);
+                while (true) {
+                    std::string framePayload;
+                    const FrameParseResult parseResult = tryExtractFrame(receiveBuffer, framePayload);
+                    if (parseResult == FrameParseResult::Complete) {
+                        handleFrame(framePayload);
+                    } else if (parseResult == FrameParseResult::Incomplete) {
+                        break;
+                    } else {
+                        ++testState.malformedFrameCount;
+                        core::SNodeC::stop();
+                        break;
+                    }
+                }
+            }
+            return chunkLen;
+        }
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+        void handleFrame(const std::string& framePayload) {
+            if (testState.serverFirstFrameReceivedCount == 0 && framePayload == firstClientPayload) {
+                ++testState.serverFirstFrameReceivedCount;
+            } else if (testState.serverFirstFrameReceivedCount == 1 && testState.serverSecondFrameReceivedCount == 0 && framePayload == secondClientPayload) {
+                ++testState.serverSecondFrameReceivedCount;
+                const std::string replyStream = encodeFrame(firstServerReply) + encodeFrame(secondServerReply);
+                replyFragments = makeFragmentPlan(replyStream);
+                sendNextReplyFragment();
+            } else {
+                ++testState.unexpectedPayloadCount;
+                core::SNodeC::stop();
+            }
+        }
+        void sendNextReplyFragment() {
+            if (nextReplyFragmentIndex < replyFragments.size()) {
+                const std::string& fragment = replyFragments[nextReplyFragmentIndex++];
+                sendToPeer(fragment.data(), fragment.size());
+                ++testState.serverReplyFragmentSentCount;
+                if (nextReplyFragmentIndex < replyFragments.size()) {
+                    sendTimer = core::timer::Timer::singleshotTimer([this]() { sendNextReplyFragment(); }, utils::Timeval({0, 1000}));
+                }
+            }
+        }
+        TestState& testState;
+        std::string receiveBuffer;
+        std::vector<std::string> replyFragments;
+        std::size_t nextReplyFragmentIndex = 0;
+        core::timer::Timer sendTimer;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            const std::string requestStream = encodeFrame(firstClientPayload) + encodeFrame(secondClientPayload);
+            requestFragments = makeFragmentPlan(requestStream);
+            sendNextRequestFragment();
+        }
+        void onDisconnected() override {
+        }
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+            if (chunkLen > 0) {
+                receiveBuffer.append(chunk, chunkLen);
+                while (true) {
+                    std::string framePayload;
+                    const FrameParseResult parseResult = tryExtractFrame(receiveBuffer, framePayload);
+                    if (parseResult == FrameParseResult::Complete) {
+                        handleFrame(framePayload);
+                    } else if (parseResult == FrameParseResult::Incomplete) {
+                        break;
+                    } else {
+                        ++testState.malformedFrameCount;
+                        core::SNodeC::stop();
+                        break;
+                    }
+                }
+            }
+            return chunkLen;
+        }
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+        void handleFrame(const std::string& framePayload) {
+            if (testState.clientFirstReplyFrameReceivedCount == 0 && framePayload == firstServerReply) {
+                ++testState.clientFirstReplyFrameReceivedCount;
+            } else if (testState.clientFirstReplyFrameReceivedCount == 1 && testState.clientSecondReplyFrameReceivedCount == 0 && framePayload == secondServerReply) {
+                ++testState.clientSecondReplyFrameReceivedCount;
+                core::SNodeC::stop();
+            } else {
+                ++testState.unexpectedPayloadCount;
+                core::SNodeC::stop();
+            }
+        }
+        void sendNextRequestFragment() {
+            if (nextRequestFragmentIndex < requestFragments.size()) {
+                const std::string& fragment = requestFragments[nextRequestFragmentIndex++];
+                sendToPeer(fragment.data(), fragment.size());
+                ++testState.clientRequestFragmentSentCount;
+                if (nextRequestFragmentIndex < requestFragments.size()) {
+                    sendTimer = core::timer::Timer::singleshotTimer([this]() { sendNextRequestFragment(); }, utils::Timeval({0, 1000}));
+                }
+            }
+        }
+        TestState& testState;
+        std::string receiveBuffer;
+        std::vector<std::string> requestFragments;
+        std::size_t nextRequestFragmentIndex = 0;
+        core::timer::Timer sendTimer;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            return new TestServerSocketContext(socketConnection, testState);
+        }
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            return new TestClientSocketContext(socketConnection, testState);
+        }
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("Inet6LegacyServerClientFramedPayloadExchangeTest");
+    } else {
+        TestState testState;
+        core::SNodeC::init(argc, argv);
+        net::in6::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv6-framed-client", testState);
+        const net::in6::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("ipv6-framed-server", testState);
+        socketClient.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+        socketServer.listen(net::in6::SocketAddress("::1", 0), [&socketClient, &testState](const net::in6::SocketAddress& socketAddress, core::socket::State state) {
+            if (state == core::socket::State::OK) {
+                ++testState.serverListenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++testState.effectiveListenPortOkCount;
+                    socketClient.connect(net::in6::SocketAddress("::1", effectivePort), [&testState](const net::in6::SocketAddress&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) {
+                            ++testState.clientConnectOkCount;
+                        } else {
+                            ++testState.unexpectedStateCount;
+                            core::SNodeC::stop();
+                        }
+                    });
+                } else {
+                    ++testState.zeroEffectiveListenPortCount;
+                    ++testState.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++testState.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        testResult.expectEqual(0, startResult, "event loop stops successfully after framed IPv6 request/reply exchange");
+        testResult.expectEqual(1, testState.serverListenOkCount, "IPv6 legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.effectiveListenPortOkCount, "IPv6 legacy listen callback reports one non-zero effective port");
+        testResult.expectEqual(0, testState.zeroEffectiveListenPortCount, "IPv6 legacy listen callback never reports port zero");
+        testResult.expectEqual(1, testState.clientConnectOkCount, "IPv6 legacy client connect callback reports OK exactly once");
+        testResult.expectEqual(1, testState.serverFactoryCreateCount, "server socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.clientFactoryCreateCount, "client socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.serverConnectedCount, "server socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.clientConnectedCount, "client socket context reaches onConnected exactly once");
+        testResult.expectEqual(4, testState.clientRequestFragmentSentCount, "client sends request stream in four staged fragments");
+        testResult.expectEqual(4, testState.serverReplyFragmentSentCount, "server sends reply stream in four staged fragments");
+        testResult.expectEqual(1, testState.serverFirstFrameReceivedCount, "server reconstructs the first client frame exactly once");
+        testResult.expectEqual(1, testState.serverSecondFrameReceivedCount, "server reconstructs the second client frame exactly once");
+        testResult.expectEqual(1, testState.clientFirstReplyFrameReceivedCount, "client reconstructs the first server reply frame exactly once");
+        testResult.expectEqual(1, testState.clientSecondReplyFrameReceivedCount, "client reconstructs the second server reply frame exactly once");
+        testResult.expectEqual(0, testState.malformedFrameCount, "framed parser reports no malformed frames");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+        testResult.expectEqual(0, testState.unexpectedPayloadCount, "server and client receive no unexpected framed payloads");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+    return result;
+}

--- a/tests/component/net/InetLegacyServerClientFramedPayloadExchangeTest.cpp
+++ b/tests/component/net/InetLegacyServerClientFramedPayloadExchangeTest.cpp
@@ -1,0 +1,352 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "core/timer/Timer.h"
+#include "net/in/SocketAddress.h"
+#include "net/in/stream/legacy/SocketClient.h"
+#include "net/in/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    constexpr std::string_view firstClientPayload = "snodec-ipv4-framed-request-one";
+    constexpr std::string_view secondClientPayload = "snodec-ipv4-framed-request-two";
+    constexpr std::string_view firstServerReply = "snodec-ipv4-framed-reply-one";
+    constexpr std::string_view secondServerReply = "snodec-ipv4-framed-reply-two";
+
+    enum class FrameParseResult {
+        Incomplete,
+        Complete,
+        Malformed
+    };
+
+    std::string encodeFrame(std::string_view payload) {
+        return std::to_string(payload.size()) + "\n" + std::string(payload);
+    }
+
+    std::vector<std::string> makeFragmentPlan(const std::string& stream) {
+        return {stream.substr(0, 1), stream.substr(1, 4), stream.substr(5, 11), stream.substr(16)};
+    }
+
+    FrameParseResult tryExtractFrame(std::string& buffer, std::string& framePayload) {
+        const std::size_t newlinePos = buffer.find('\n');
+        if (newlinePos == std::string::npos) {
+            return FrameParseResult::Incomplete;
+        }
+        if (newlinePos == 0) {
+            return FrameParseResult::Malformed;
+        }
+        std::size_t payloadSize = 0;
+        for (std::size_t i = 0; i < newlinePos; ++i) {
+            const char ch = buffer[i];
+            if (ch < '0' || ch > '9') {
+                return FrameParseResult::Malformed;
+            }
+            payloadSize = payloadSize * 10 + static_cast<std::size_t>(ch - '0');
+        }
+        const std::size_t frameSize = newlinePos + 1 + payloadSize;
+        if (buffer.size() < frameSize) {
+            return FrameParseResult::Incomplete;
+        }
+        framePayload = buffer.substr(newlinePos + 1, payloadSize);
+        buffer.erase(0, frameSize);
+        return FrameParseResult::Complete;
+    }
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int effectiveListenPortOkCount = 0;
+        int zeroEffectiveListenPortCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int clientRequestFragmentSentCount = 0;
+        int serverReplyFragmentSentCount = 0;
+        int serverFirstFrameReceivedCount = 0;
+        int serverSecondFrameReceivedCount = 0;
+        int clientFirstReplyFrameReceivedCount = 0;
+        int clientSecondReplyFrameReceivedCount = 0;
+        int malformedFrameCount = 0;
+        int unexpectedStateCount = 0;
+        int unexpectedPayloadCount = 0;
+    };
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+        }
+        void onDisconnected() override {
+        }
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+            if (chunkLen > 0) {
+                receiveBuffer.append(chunk, chunkLen);
+                while (true) {
+                    std::string framePayload;
+                    const FrameParseResult parseResult = tryExtractFrame(receiveBuffer, framePayload);
+                    if (parseResult == FrameParseResult::Complete) {
+                        handleFrame(framePayload);
+                    } else if (parseResult == FrameParseResult::Incomplete) {
+                        break;
+                    } else {
+                        ++testState.malformedFrameCount;
+                        core::SNodeC::stop();
+                        break;
+                    }
+                }
+            }
+            return chunkLen;
+        }
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+        void handleFrame(const std::string& framePayload) {
+            if (testState.serverFirstFrameReceivedCount == 0 && framePayload == firstClientPayload) {
+                ++testState.serverFirstFrameReceivedCount;
+            } else if (testState.serverFirstFrameReceivedCount == 1 && testState.serverSecondFrameReceivedCount == 0 && framePayload == secondClientPayload) {
+                ++testState.serverSecondFrameReceivedCount;
+                const std::string replyStream = encodeFrame(firstServerReply) + encodeFrame(secondServerReply);
+                replyFragments = makeFragmentPlan(replyStream);
+                sendNextReplyFragment();
+            } else {
+                ++testState.unexpectedPayloadCount;
+                core::SNodeC::stop();
+            }
+        }
+        void sendNextReplyFragment() {
+            if (nextReplyFragmentIndex < replyFragments.size()) {
+                const std::string& fragment = replyFragments[nextReplyFragmentIndex++];
+                sendToPeer(fragment.data(), fragment.size());
+                ++testState.serverReplyFragmentSentCount;
+                if (nextReplyFragmentIndex < replyFragments.size()) {
+                    sendTimer = core::timer::Timer::singleshotTimer([this]() { sendNextReplyFragment(); }, utils::Timeval({0, 1000}));
+                }
+            }
+        }
+        TestState& testState;
+        std::string receiveBuffer;
+        std::vector<std::string> replyFragments;
+        std::size_t nextReplyFragmentIndex = 0;
+        core::timer::Timer sendTimer;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            const std::string requestStream = encodeFrame(firstClientPayload) + encodeFrame(secondClientPayload);
+            requestFragments = makeFragmentPlan(requestStream);
+            sendNextRequestFragment();
+        }
+        void onDisconnected() override {
+        }
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+            if (chunkLen > 0) {
+                receiveBuffer.append(chunk, chunkLen);
+                while (true) {
+                    std::string framePayload;
+                    const FrameParseResult parseResult = tryExtractFrame(receiveBuffer, framePayload);
+                    if (parseResult == FrameParseResult::Complete) {
+                        handleFrame(framePayload);
+                    } else if (parseResult == FrameParseResult::Incomplete) {
+                        break;
+                    } else {
+                        ++testState.malformedFrameCount;
+                        core::SNodeC::stop();
+                        break;
+                    }
+                }
+            }
+            return chunkLen;
+        }
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+        void handleFrame(const std::string& framePayload) {
+            if (testState.clientFirstReplyFrameReceivedCount == 0 && framePayload == firstServerReply) {
+                ++testState.clientFirstReplyFrameReceivedCount;
+            } else if (testState.clientFirstReplyFrameReceivedCount == 1 && testState.clientSecondReplyFrameReceivedCount == 0 && framePayload == secondServerReply) {
+                ++testState.clientSecondReplyFrameReceivedCount;
+                core::SNodeC::stop();
+            } else {
+                ++testState.unexpectedPayloadCount;
+                core::SNodeC::stop();
+            }
+        }
+        void sendNextRequestFragment() {
+            if (nextRequestFragmentIndex < requestFragments.size()) {
+                const std::string& fragment = requestFragments[nextRequestFragmentIndex++];
+                sendToPeer(fragment.data(), fragment.size());
+                ++testState.clientRequestFragmentSentCount;
+                if (nextRequestFragmentIndex < requestFragments.size()) {
+                    sendTimer = core::timer::Timer::singleshotTimer([this]() { sendNextRequestFragment(); }, utils::Timeval({0, 1000}));
+                }
+            }
+        }
+        TestState& testState;
+        std::string receiveBuffer;
+        std::vector<std::string> requestFragments;
+        std::size_t nextRequestFragmentIndex = 0;
+        core::timer::Timer sendTimer;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            return new TestServerSocketContext(socketConnection, testState);
+        }
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            return new TestClientSocketContext(socketConnection, testState);
+        }
+    private:
+        TestState& testState;
+    };
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetLegacyServerClientFramedPayloadExchangeTest");
+    } else {
+        TestState testState;
+        core::SNodeC::init(argc, argv);
+        net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv4-framed-client", testState);
+        const net::in::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("ipv4-framed-server", testState);
+        socketClient.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+        socketServer.listen(net::in::SocketAddress("127.0.0.1", 0), [&socketClient, &testState](const net::in::SocketAddress& socketAddress, core::socket::State state) {
+            if (state == core::socket::State::OK) {
+                ++testState.serverListenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++testState.effectiveListenPortOkCount;
+                    socketClient.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&testState](const net::in::SocketAddress&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) {
+                            ++testState.clientConnectOkCount;
+                        } else {
+                            ++testState.unexpectedStateCount;
+                            core::SNodeC::stop();
+                        }
+                    });
+                } else {
+                    ++testState.zeroEffectiveListenPortCount;
+                    ++testState.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++testState.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        testResult.expectEqual(0, startResult, "event loop stops successfully after framed IPv4 request/reply exchange");
+        testResult.expectEqual(1, testState.serverListenOkCount, "IPv4 legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.effectiveListenPortOkCount, "IPv4 legacy listen callback reports one non-zero effective port");
+        testResult.expectEqual(0, testState.zeroEffectiveListenPortCount, "IPv4 legacy listen callback never reports port zero");
+        testResult.expectEqual(1, testState.clientConnectOkCount, "IPv4 legacy client connect callback reports OK exactly once");
+        testResult.expectEqual(1, testState.serverFactoryCreateCount, "server socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.clientFactoryCreateCount, "client socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.serverConnectedCount, "server socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.clientConnectedCount, "client socket context reaches onConnected exactly once");
+        testResult.expectEqual(4, testState.clientRequestFragmentSentCount, "client sends request stream in four staged fragments");
+        testResult.expectEqual(4, testState.serverReplyFragmentSentCount, "server sends reply stream in four staged fragments");
+        testResult.expectEqual(1, testState.serverFirstFrameReceivedCount, "server reconstructs the first client frame exactly once");
+        testResult.expectEqual(1, testState.serverSecondFrameReceivedCount, "server reconstructs the second client frame exactly once");
+        testResult.expectEqual(1, testState.clientFirstReplyFrameReceivedCount, "client reconstructs the first server reply frame exactly once");
+        testResult.expectEqual(1, testState.clientSecondReplyFrameReceivedCount, "client reconstructs the second server reply frame exactly once");
+        testResult.expectEqual(0, testState.malformedFrameCount, "framed parser reports no malformed frames");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+        testResult.expectEqual(0, testState.unexpectedPayloadCount, "server and client receive no unexpected framed payloads");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+    return result;
+}

--- a/tests/component/net/UnixLegacyServerClientFramedPayloadExchangeTest.cpp
+++ b/tests/component/net/UnixLegacyServerClientFramedPayloadExchangeTest.cpp
@@ -1,0 +1,357 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "core/timer/Timer.h"
+#include "net/un/SocketAddress.h"
+#include "net/un/stream/legacy/SocketClient.h"
+#include "net/un/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <cstddef>
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+#include <vector>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    constexpr std::string_view firstClientPayload = "snodec-unix-framed-request-one";
+    constexpr std::string_view secondClientPayload = "snodec-unix-framed-request-two";
+    constexpr std::string_view firstServerReply = "snodec-unix-framed-reply-one";
+    constexpr std::string_view secondServerReply = "snodec-unix-framed-reply-two";
+
+    enum class FrameParseResult {
+        Incomplete,
+        Complete,
+        Malformed
+    };
+
+    std::string encodeFrame(std::string_view payload) {
+        return std::to_string(payload.size()) + "\n" + std::string(payload);
+    }
+
+    std::vector<std::string> makeFragmentPlan(const std::string& stream) {
+        return {stream.substr(0, 1), stream.substr(1, 4), stream.substr(5, 11), stream.substr(16)};
+    }
+
+    FrameParseResult tryExtractFrame(std::string& buffer, std::string& framePayload) {
+        const std::size_t newlinePos = buffer.find('\n');
+        if (newlinePos == std::string::npos) {
+            return FrameParseResult::Incomplete;
+        }
+        if (newlinePos == 0) {
+            return FrameParseResult::Malformed;
+        }
+        std::size_t payloadSize = 0;
+        for (std::size_t i = 0; i < newlinePos; ++i) {
+            const char ch = buffer[i];
+            if (ch < '0' || ch > '9') {
+                return FrameParseResult::Malformed;
+            }
+            payloadSize = payloadSize * 10 + static_cast<std::size_t>(ch - '0');
+        }
+        const std::size_t frameSize = newlinePos + 1 + payloadSize;
+        if (buffer.size() < frameSize) {
+            return FrameParseResult::Incomplete;
+        }
+        framePayload = buffer.substr(newlinePos + 1, payloadSize);
+        buffer.erase(0, frameSize);
+        return FrameParseResult::Complete;
+    }
+
+    struct TestState {
+        int serverListenOkCount = 0;
+        int clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0;
+        int clientFactoryCreateCount = 0;
+        int serverConnectedCount = 0;
+        int clientConnectedCount = 0;
+        int clientRequestFragmentSentCount = 0;
+        int serverReplyFragmentSentCount = 0;
+        int serverFirstFrameReceivedCount = 0;
+        int serverSecondFrameReceivedCount = 0;
+        int clientFirstReplyFrameReceivedCount = 0;
+        int clientSecondReplyFrameReceivedCount = 0;
+        int malformedFrameCount = 0;
+        int unexpectedStateCount = 0;
+        int unexpectedPayloadCount = 0;
+    };
+
+    class TestServerSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestServerSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.serverConnectedCount;
+        }
+        void onDisconnected() override {
+        }
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+            if (chunkLen > 0) {
+                receiveBuffer.append(chunk, chunkLen);
+                while (true) {
+                    std::string framePayload;
+                    const FrameParseResult parseResult = tryExtractFrame(receiveBuffer, framePayload);
+                    if (parseResult == FrameParseResult::Complete) {
+                        handleFrame(framePayload);
+                    } else if (parseResult == FrameParseResult::Incomplete) {
+                        break;
+                    } else {
+                        ++testState.malformedFrameCount;
+                        core::SNodeC::stop();
+                        break;
+                    }
+                }
+            }
+            return chunkLen;
+        }
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+        void handleFrame(const std::string& framePayload) {
+            if (testState.serverFirstFrameReceivedCount == 0 && framePayload == firstClientPayload) {
+                ++testState.serverFirstFrameReceivedCount;
+            } else if (testState.serverFirstFrameReceivedCount == 1 && testState.serverSecondFrameReceivedCount == 0 && framePayload == secondClientPayload) {
+                ++testState.serverSecondFrameReceivedCount;
+                const std::string replyStream = encodeFrame(firstServerReply) + encodeFrame(secondServerReply);
+                replyFragments = makeFragmentPlan(replyStream);
+                sendNextReplyFragment();
+            } else {
+                ++testState.unexpectedPayloadCount;
+                core::SNodeC::stop();
+            }
+        }
+        void sendNextReplyFragment() {
+            if (nextReplyFragmentIndex < replyFragments.size()) {
+                const std::string& fragment = replyFragments[nextReplyFragmentIndex++];
+                sendToPeer(fragment.data(), fragment.size());
+                ++testState.serverReplyFragmentSentCount;
+                if (nextReplyFragmentIndex < replyFragments.size()) {
+                    sendTimer = core::timer::Timer::singleshotTimer([this]() { sendNextReplyFragment(); }, utils::Timeval({0, 1000}));
+                }
+            }
+        }
+        TestState& testState;
+        std::string receiveBuffer;
+        std::vector<std::string> replyFragments;
+        std::size_t nextReplyFragmentIndex = 0;
+        core::timer::Timer sendTimer;
+    };
+
+    class TestClientSocketContext : public core::socket::stream::SocketContext {
+    public:
+        TestClientSocketContext(core::socket::stream::SocketConnection* socketConnection, TestState& testState)
+            : core::socket::stream::SocketContext(socketConnection)
+            , testState(testState) {
+        }
+
+    private:
+        void onConnected() override {
+            ++testState.clientConnectedCount;
+            const std::string requestStream = encodeFrame(firstClientPayload) + encodeFrame(secondClientPayload);
+            requestFragments = makeFragmentPlan(requestStream);
+            sendNextRequestFragment();
+        }
+        void onDisconnected() override {
+        }
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+            if (chunkLen > 0) {
+                receiveBuffer.append(chunk, chunkLen);
+                while (true) {
+                    std::string framePayload;
+                    const FrameParseResult parseResult = tryExtractFrame(receiveBuffer, framePayload);
+                    if (parseResult == FrameParseResult::Complete) {
+                        handleFrame(framePayload);
+                    } else if (parseResult == FrameParseResult::Incomplete) {
+                        break;
+                    } else {
+                        ++testState.malformedFrameCount;
+                        core::SNodeC::stop();
+                        break;
+                    }
+                }
+            }
+            return chunkLen;
+        }
+        bool onSignal([[maybe_unused]] int signum) override {
+            return true;
+        }
+        void handleFrame(const std::string& framePayload) {
+            if (testState.clientFirstReplyFrameReceivedCount == 0 && framePayload == firstServerReply) {
+                ++testState.clientFirstReplyFrameReceivedCount;
+            } else if (testState.clientFirstReplyFrameReceivedCount == 1 && testState.clientSecondReplyFrameReceivedCount == 0 && framePayload == secondServerReply) {
+                ++testState.clientSecondReplyFrameReceivedCount;
+                core::SNodeC::stop();
+            } else {
+                ++testState.unexpectedPayloadCount;
+                core::SNodeC::stop();
+            }
+        }
+        void sendNextRequestFragment() {
+            if (nextRequestFragmentIndex < requestFragments.size()) {
+                const std::string& fragment = requestFragments[nextRequestFragmentIndex++];
+                sendToPeer(fragment.data(), fragment.size());
+                ++testState.clientRequestFragmentSentCount;
+                if (nextRequestFragmentIndex < requestFragments.size()) {
+                    sendTimer = core::timer::Timer::singleshotTimer([this]() { sendNextRequestFragment(); }, utils::Timeval({0, 1000}));
+                }
+            }
+        }
+        TestState& testState;
+        std::string receiveBuffer;
+        std::vector<std::string> requestFragments;
+        std::size_t nextRequestFragmentIndex = 0;
+        core::timer::Timer sendTimer;
+    };
+
+    class TestServerSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestServerSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.serverFactoryCreateCount;
+            return new TestServerSocketContext(socketConnection, testState);
+        }
+    private:
+        TestState& testState;
+    };
+
+    class TestClientSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit TestClientSocketContextFactory(TestState& testState)
+            : testState(testState) {
+        }
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++testState.clientFactoryCreateCount;
+            return new TestClientSocketContext(socketConnection, testState);
+        }
+    private:
+        TestState& testState;
+    };
+
+    std::string makeSocketPath() {
+        return "/tmp/snodec-unix-framed-" + std::to_string(getpid()) + ".sock";
+    }
+
+    bool socketPathExists(const std::string& socketPath) {
+        return ::access(socketPath.c_str(), F_OK) == 0;
+    }
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+    const std::string socketPath = makeSocketPath();
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("UnixLegacyServerClientFramedPayloadExchangeTest");
+    } else {
+        TestState testState;
+        std::remove(socketPath.c_str());
+        const bool socketPathAbsentBeforeListen = !socketPathExists(socketPath);
+        core::SNodeC::init(argc, argv);
+        net::un::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("unix-framed-client", testState);
+        const net::un::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("unix-framed-server", testState);
+        socketClient.getConfig()->Instance::forceUnrequired();
+        socketServer.getConfig()->Instance::forceUnrequired();
+        socketServer.listen(socketPath, [&socketClient, &socketPath, &testState](const net::un::SocketAddress&, core::socket::State state) {
+            if (state == core::socket::State::OK) {
+                ++testState.serverListenOkCount;
+                socketClient.connect(socketPath, [&testState](const net::un::SocketAddress&, core::socket::State connectState) {
+                    if (connectState == core::socket::State::OK) {
+                        ++testState.clientConnectOkCount;
+                    } else {
+                        ++testState.unexpectedStateCount;
+                        core::SNodeC::stop();
+                    }
+                });
+            } else {
+                ++testState.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        std::remove(socketPath.c_str());
+        const bool socketPathAbsentAfterCleanup = !socketPathExists(socketPath);
+        testResult.expectTrue(socketPathAbsentBeforeListen, "Unix-domain socket path is absent before listen");
+        testResult.expectEqual(0, startResult, "event loop stops successfully after framed Unix-domain request/reply exchange");
+        testResult.expectEqual(1, testState.serverListenOkCount, "Unix-domain legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.clientConnectOkCount, "Unix-domain legacy client connect callback reports OK exactly once");
+        testResult.expectEqual(1, testState.serverFactoryCreateCount, "server socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.clientFactoryCreateCount, "client socket context factory creates exactly one context");
+        testResult.expectEqual(1, testState.serverConnectedCount, "server socket context reaches onConnected exactly once");
+        testResult.expectEqual(1, testState.clientConnectedCount, "client socket context reaches onConnected exactly once");
+        testResult.expectEqual(4, testState.clientRequestFragmentSentCount, "client sends request stream in four staged fragments");
+        testResult.expectEqual(4, testState.serverReplyFragmentSentCount, "server sends reply stream in four staged fragments");
+        testResult.expectEqual(1, testState.serverFirstFrameReceivedCount, "server reconstructs the first client frame exactly once");
+        testResult.expectEqual(1, testState.serverSecondFrameReceivedCount, "server reconstructs the second client frame exactly once");
+        testResult.expectEqual(1, testState.clientFirstReplyFrameReceivedCount, "client reconstructs the first server reply frame exactly once");
+        testResult.expectEqual(1, testState.clientSecondReplyFrameReceivedCount, "client reconstructs the second server reply frame exactly once");
+        testResult.expectEqual(0, testState.malformedFrameCount, "framed parser reports no malformed frames");
+        testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
+        testResult.expectEqual(0, testState.unexpectedPayloadCount, "server and client receive no unexpected framed payloads");
+        testResult.expectTrue(socketPathAbsentAfterCleanup, "Unix-domain socket path is absent after cleanup");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+    std::remove(socketPath.c_str());
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Add narrow component tests to prove application-level length-prefixed framed payload reconstruction over plain stream sockets for IPv4, IPv6 and Unix-domain transports without changing production code.
- Ensure semantic correctness of framing (byte-stream -> receive buffer -> complete framed messages) regardless of receive-callback or packet boundary behavior.

### Description
- Add three test executables: `InetLegacyServerClientFramedPayloadExchangeTest`, `Inet6LegacyServerClientFramedPayloadExchangeTest`, and `UnixLegacyServerClientFramedPayloadExchangeTest`, each containing test-local frame encoder, parser (`<decimal-payload-size>\n<payload>`), socket contexts, and context factories.
- Implement staged send/receive using fragment plans and `core::timer::Timer::singleshotTimer` so both client requests and server replies are sent in at least four fragments while receivers accumulate into a buffer and extract complete frames with a `tryExtractFrame()` helper.
- Register the three tests in `tests/component/net/CMakeLists.txt`, link them to the appropriate legacy stream libraries (`snodec::net-in-stream-legacy`, `snodec::net-in6-stream-legacy`, `snodec::net-un-stream-legacy`), set `cxx_std_20`, and add labels `component;net;stream;legacy;{ipv4|ipv6|unix};framed-payload`.
- No production code changes were made; all framing, parsing, context types and helpers are test-local.

### Testing
- Built tests and ran them with: `cmake -S . -B build-pr-framed-payload -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` and `cmake --build build-pr-framed-payload --parallel`, which completed successfully.
- Executed focused framed-payload tests with `ctest --test-dir build-pr-framed-payload -L "framed-payload" --output-on-failure` and observed all three new tests passed. 
- Ran the broader component/net/stream legacy test sets (`ctest` with various `-L` labels) and observed the test run completed with 100% passing for the local build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48d5ddafa4832c98b43c1576f0ba2f)