### PR TITLE
Add HTTP message parser and formatter unit tests

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -41,3 +41,5 @@
 add_subdirectory(core)
 
 add_subdirectory(net)
+
+add_subdirectory(http)

--- a/tests/unit/http/CMakeLists.txt
+++ b/tests/unit/http/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SNode.C - A Slim Toolkit for Network Communication
+# Copyright (C) Volker Christian <me@vchrist.at>
+#               2020, 2021, 2022, 2023, 2024, 2025, 2026
+
+snodec_add_test(HttpMessageParserTest HttpMessageParserTest.cpp)
+
+target_link_libraries(HttpMessageParserTest PRIVATE snodec-test-support snodec::http-server snodec::http-client)
+
+set_tests_properties(HttpMessageParserTest PROPERTIES LABELS "unit;http;message" TIMEOUT 5)

--- a/tests/unit/http/HttpMessageParserTest.cpp
+++ b/tests/unit/http/HttpMessageParserTest.cpp
@@ -1,0 +1,245 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "support/TestResult.h"
+#include "web/http/CiStringMap.h"
+#include "web/http/client/ResponseParser.h"
+#include "web/http/server/RequestParser.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    class DummySocketAddress : public core::socket::SocketAddress {
+    public:
+        std::string toString(bool = true) const override {
+            return "dummy";
+        }
+    };
+
+    class BufferSocketConnection : public core::socket::stream::SocketConnection {
+    public:
+        explicit BufferSocketConnection(std::string input)
+            : SocketConnection(-1, "HttpMessageParserTest", nullptr)
+            , input(std::move(input)) {
+        }
+
+        int getFd() const override {
+            return -1;
+        }
+
+        void sendToPeer(const char*, std::size_t) override {
+        }
+
+        bool streamToPeer(core::pipe::Source*) override {
+            return false;
+        }
+
+        void streamEof() override {
+        }
+
+        std::size_t readFromPeer(char* chunk, std::size_t chunkLen) override {
+            const std::size_t available = input.size() - offset;
+            const std::size_t toRead = std::min(chunkLen, available);
+
+            if (toRead > 0) {
+                std::memcpy(chunk, input.data() + offset, toRead);
+                offset += toRead;
+            }
+
+            return toRead;
+        }
+
+        void shutdownRead() override {
+        }
+
+        void shutdownWrite() override {
+        }
+
+        const core::socket::SocketAddress& getBindAddress() const override {
+            return address;
+        }
+
+        const core::socket::SocketAddress& getLocalAddress() const override {
+            return address;
+        }
+
+        const core::socket::SocketAddress& getRemoteAddress() const override {
+            return address;
+        }
+
+        void close() override {
+        }
+
+        void setTimeout(const utils::Timeval&) override {
+        }
+
+        void setReadTimeout(const utils::Timeval&) override {
+        }
+
+        void setWriteTimeout(const utils::Timeval&) override {
+        }
+
+        std::size_t getTotalSent() const override {
+            return 0;
+        }
+
+        std::size_t getTotalQueued() const override {
+            return 0;
+        }
+
+        std::size_t getTotalRead() const override {
+            return offset;
+        }
+
+        std::size_t getTotalProcessed() const override {
+            return offset;
+        }
+
+    private:
+        std::string input;
+        std::size_t offset = 0;
+        DummySocketAddress address;
+    };
+
+    class BufferSocketContext : public core::socket::stream::SocketContext {
+    public:
+        explicit BufferSocketContext(core::socket::stream::SocketConnection* socketConnection)
+            : SocketContext(socketConnection) {
+        }
+
+    private:
+        void onConnected() override {
+        }
+
+        void onDisconnected() override {
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            return 0;
+        }
+
+        bool onSignal(int) override {
+            return false;
+        }
+    };
+
+    std::string bodyToString(const std::vector<char>& body) {
+        return std::string(body.begin(), body.end());
+    }
+
+} // namespace
+
+int main() {
+    tests::support::TestResult testResult;
+
+    {
+        web::http::CiStringMap<std::string> headers;
+        headers.emplace("Content-Type", "text/plain");
+        testResult.expectTrue(headers.find("content-type") != headers.end(), "HTTP header map lookup is case-insensitive");
+        testResult.expectTrue(headers["CONTENT-TYPE"] == "text/plain", "HTTP header map retrieves values case-insensitively");
+        testResult.expectTrue(headers.find("Missing") == headers.end(), "HTTP header map reports missing headers");
+    }
+
+    {
+        BufferSocketConnection connection("POST /items/search?q=snode%2Ec&empty= HTTP/1.1\r\nHost: example.test\r\nX-Test: one\r\nx-test: two\r\nContent-Length: 7\r\n\r\npayload");
+        BufferSocketContext context(&connection);
+        bool started = false;
+        bool parsed = false;
+        int errorCode = 0;
+        std::string errorReason;
+        std::optional<web::http::server::Request> parsedRequest;
+
+        web::http::server::RequestParser parser(
+            &context,
+            [&started]() { started = true; },
+            [&parsed, &parsedRequest](web::http::server::Request&& request) {
+                parsed = true;
+                parsedRequest.emplace(std::move(request));
+            },
+            [&errorCode, &errorReason](int code, const std::string& reason) {
+                errorCode = code;
+                errorReason = reason;
+            });
+
+        parser.parse();
+
+        testResult.expectTrue(started, "request parser emits start callback");
+        testResult.expectTrue(parsed, "request parser emits parsed callback");
+        testResult.expectEqual(0, errorCode, "request parser does not emit an error");
+        testResult.expectTrue(errorReason.empty(), "request parser leaves error reason empty on success");
+        testResult.expectTrue(parsedRequest->method == "POST", "request parser captures method");
+        testResult.expectTrue(parsedRequest->url == "/items/search?q=snode%2Ec&empty=", "request parser captures request target");
+        testResult.expectTrue(parsedRequest->httpVersion == "HTTP/1.1", "request parser captures HTTP version token");
+        testResult.expectEqual(1, parsedRequest->httpMajor, "request parser captures HTTP major version");
+        testResult.expectEqual(1, parsedRequest->httpMinor, "request parser captures HTTP minor version");
+        testResult.expectTrue(parsedRequest->query("q") == "snode.c", "request parser decodes exposed query values");
+        testResult.expectTrue(parsedRequest->query("empty").empty(), "request parser exposes empty query values as empty strings");
+        testResult.expectTrue(parsedRequest->get("host") == "example.test", "request parser exposes headers case-insensitively");
+        testResult.expectTrue(parsedRequest->get("X-Test") == "one,two", "request parser combines repeated headers with a comma");
+        testResult.expectTrue(parsedRequest->get("missing").empty(), "request parser returns an empty string for missing headers");
+        testResult.expectTrue(bodyToString(parsedRequest->body) == "payload", "request parser captures Content-Length body");
+    }
+
+    {
+        BufferSocketConnection connection("HTTP/1.1 201 Created\r\nContent-Type: application/json\r\nSet-Cookie: sid=abc; Path=/\r\nContent-Length: 2\r\n\r\n{}");
+        BufferSocketContext context(&connection);
+        bool started = false;
+        bool parsed = false;
+        int errorCode = 0;
+        std::string errorReason;
+        web::http::client::Response* parsedResponse = nullptr;
+
+        web::http::client::ResponseParser parser(
+            &context,
+            [&started]() { started = true; },
+            [&parsed, &parsedResponse](web::http::client::Response& response) {
+                parsed = true;
+                parsedResponse = &response;
+            },
+            [&errorCode, &errorReason](int code, const std::string& reason) {
+                errorCode = code;
+                errorReason = reason;
+            });
+
+        parser.parse();
+
+        testResult.expectTrue(started, "response parser emits start callback");
+        testResult.expectTrue(parsed, "response parser emits parsed callback");
+        testResult.expectEqual(0, errorCode, "response parser does not emit an error");
+        testResult.expectTrue(errorReason.empty(), "response parser leaves error reason empty on success");
+        testResult.expectTrue(parsedResponse != nullptr, "response parser provides a response object");
+        if (parsedResponse != nullptr) {
+            testResult.expectTrue(parsedResponse->httpVersion == "HTTP/1.1", "response parser captures HTTP version token");
+            testResult.expectEqual(1, parsedResponse->httpMajor, "response parser captures HTTP major version");
+            testResult.expectEqual(1, parsedResponse->httpMinor, "response parser captures HTTP minor version");
+            testResult.expectTrue(parsedResponse->statusCode == "201", "response parser captures status code");
+            testResult.expectTrue(parsedResponse->reason == "Created", "response parser captures reason phrase");
+            testResult.expectTrue(parsedResponse->get("content-type") == "application/json", "response parser exposes headers case-insensitively");
+            testResult.expectTrue(parsedResponse->get("set-cookie").empty(), "response parser removes Set-Cookie from plain headers");
+            testResult.expectTrue(parsedResponse->cookie("sid") == "abc", "response parser exposes Set-Cookie values through cookie lookup");
+            testResult.expectTrue(parsedResponse->get("missing").empty(), "response parser returns an empty string for missing headers");
+            testResult.expectTrue(bodyToString(parsedResponse->body) == "{}", "response parser captures Content-Length body");
+        }
+    }
+
+    return testResult.processResult();
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic, pure-unit test foundation for the HTTP message layer (parser/headers/formatting) as the next narrow test track after the completed legacy stream component tests.
- Exercise parser and header behavior without networking, event loop, or server/client integration so parser/formatter semantics remain isolated and repeatable.

### Description
- Added two new test artifacts: `tests/unit/http/HttpMessageParserTest.cpp` (buffered stream doubles + deterministic request/response/header assertions) and `tests/unit/http/CMakeLists.txt` (test registration and linkage).
- Registered the new test directory by updating `tests/unit/CMakeLists.txt` to `add_subdirectory(http)` so the test follows the project’s existing `snodec_add_test` conventions and labels `unit;http;message`.
- The test uses in-test doubles `BufferSocketConnection` and `BufferSocketContext` to feed raw HTTP bytes into existing parsers (`web::http::server::RequestParser` and `web::http::client::ResponseParser`) and verifies `CiStringMap` header behavior, request parsing (method, target, HTTP version, major/minor, query exposure, repeated headers, Content-Length body), and response parsing (version, status, reason, Set-Cookie handling, headers, Content-Length body).
- No production code or public APIs were changed to enable the tests; the PR strictly adds unit tests only.

### Testing
- Configured and built the test target: `cmake -S . -B build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` (configure completed; non-fatal warnings for missing `doxygen`, `iwyu`, `libbluetooth-dev`, and `libmagic-dev`).
- Installed repository dependency required for configure: `apt-get install -y nlohmann-json3-dev` (installed successfully to satisfy Express configure-time dependency).
- Built the new test target: `cmake --build build --target HttpMessageParserTest -j2` (build succeeded and `HttpMessageParserTest` was linked).
- Ran tests: `ctest --test-dir build -R HttpMessageParserTest --output-on-failure` (test passed: 1/1 tests passed), `ctest --test-dir build -L http --output-on-failure` (test passed under `http` label).
- Sanity checks: `git diff --check` returned no whitespace errors.

Files added/changed
- Added: `tests/unit/http/HttpMessageParserTest.cpp` and `tests/unit/http/CMakeLists.txt`.
- Modified: `tests/unit/CMakeLists.txt` to include the new `http` test directory.

Covered test families
- HTTP request parsing: method, request-target, HTTP version tokens and major/minor numbers, exposed query decoding for public API, headers and repeated header combination, Content-Length body capture.
- HTTP response parsing: version, status code, reason phrase, header exposure, `Set-Cookie` extraction and cookie lookup, Content-Length body capture.
- Header behavior: case-insensitive lookup/retrieval and missing-header behavior via `CiStringMap`.

Intentionally deferred
- Any networking/event-loop tests, server/client component tests, Express routing/middleware, WebSocket/SSE/MQTT/TLS/DB/application-level tests, chunked transfer, multipart/file upload, keep-alive/pipelining, and formatter tests that would require socket write paths or broader server plumbing.

Production changes
- None: no changes to production sources, public APIs, parser semantics, formatter semantics, or visibility were made to add these tests.

Exact commands run (high level) and results
- `cmake -S . -B build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` — configure completed (non-fatal warnings reported).
- `apt-get install -y nlohmann-json3-dev` — installed successfully to satisfy configure dependency.
- `cmake --build build --target HttpMessageParserTest -j2` — built successfully; `HttpMessageParserTest` produced.
- `ctest --test-dir build -R HttpMessageParserTest --output-on-failure` — passed (1/1 tests passed).
- `ctest --test-dir build -L http --output-on-failure` — passed under `http` label.
- `git diff --check` — no issues.

Covered now vs deferred HTTP tracks are clearly separated above to keep this PR focused and reviewable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48e197e7dc832cbdf6f64388687b82)