### PR TITLE
Add HTTP server/client component tests

### DIFF
--- a/tests/component/CMakeLists.txt
+++ b/tests/component/CMakeLists.txt
@@ -40,3 +40,4 @@
 
 add_subdirectory(core)
 add_subdirectory(net)
+add_subdirectory(http)

--- a/tests/component/http/CMakeLists.txt
+++ b/tests/component/http/CMakeLists.txt
@@ -1,0 +1,30 @@
+# SNode.C - A Slim Toolkit for Network Communication
+# Copyright (C) Volker Christian <me@vchrist.at>
+#               2020, 2021, 2022, 2023, 2024, 2025, 2026
+
+snodec_add_test(InetHttpServerClientGetRoundTripTest InetHttpServerClientGetRoundTripTest.cpp)
+snodec_add_test(Inet6HttpServerClientGetRoundTripTest Inet6HttpServerClientGetRoundTripTest.cpp)
+snodec_add_test(UnixHttpServerClientGetRoundTripTest UnixHttpServerClientGetRoundTripTest.cpp)
+
+target_link_libraries(InetHttpServerClientGetRoundTripTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(Inet6HttpServerClientGetRoundTripTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in6-stream-legacy)
+target_link_libraries(UnixHttpServerClientGetRoundTripTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-un-stream-legacy)
+
+target_compile_features(InetHttpServerClientGetRoundTripTest PRIVATE cxx_std_20)
+target_compile_features(Inet6HttpServerClientGetRoundTripTest PRIVATE cxx_std_20)
+target_compile_features(UnixHttpServerClientGetRoundTripTest PRIVATE cxx_std_20)
+
+set_tests_properties(InetHttpServerClientGetRoundTripTest PROPERTIES
+                     LABELS "component;http;client;server;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(Inet6HttpServerClientGetRoundTripTest PROPERTIES
+                     LABELS "component;http;client;server;legacy;ipv6"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(UnixHttpServerClientGetRoundTripTest PROPERTIES
+                     LABELS "component;http;client;server;legacy;unix"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)

--- a/tests/component/http/HttpServerClientRoundTripTest.h
+++ b/tests/component/http/HttpServerClientRoundTripTest.h
@@ -1,0 +1,110 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#ifndef TESTS_COMPONENT_HTTP_HTTPSERVERCLIENTROUNDTRIPTEST_H
+#define TESTS_COMPONENT_HTTP_HTTPSERVERCLIENTROUNDTRIPTEST_H
+
+#include "core/SNodeC.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/client/Response.h"
+#include "web/http/server/Response.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace tests::component::http {
+
+    struct RoundTripState {
+        int listenOkCount = 0;
+        int effectiveListenEndpointOkCount = 0;
+        int clientConnectOkCount = 0;
+        int httpConnectedCount = 0;
+        int serverRequestCount = 0;
+        int clientResponseCount = 0;
+        int httpDisconnectedCount = 0;
+        int unexpectedStateCount = 0;
+        int parseErrorCount = 0;
+
+        bool serverSawMethod = false;
+        bool serverSawUrl = false;
+        bool serverSawQuery = false;
+        bool serverSawHeader = false;
+        bool clientSawStatus = false;
+        bool clientSawHeader = false;
+        bool clientSawBody = false;
+    };
+
+    inline std::string toString(const std::vector<char>& bytes) {
+        return std::string(bytes.begin(), bytes.end());
+    }
+
+    template <typename Server, typename Client>
+    void configureHttpRoundTrip(Server& server, Client& client, RoundTripState& state) {
+        server.getConfig()->Instance::forceUnrequired();
+        client.getConfig()->Instance::forceUnrequired();
+    }
+
+    template <typename Request, typename Response>
+    void handleRequest(const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response, RoundTripState& state) {
+        ++state.serverRequestCount;
+        state.serverSawMethod = request->method == "GET";
+        state.serverSawUrl = request->url == "/component/round-trip?transport=legacy";
+        state.serverSawQuery = request->query("transport") == "legacy";
+        state.serverSawHeader = request->get("X-SNodeC-Component") == "http-round-trip";
+
+        response->status(200).type("text/plain").set("X-SNodeC-Response", "component-ok").send("hello from snode.c http component test");
+    }
+
+    template <typename MasterRequest>
+    void sendRequest(const std::shared_ptr<MasterRequest>& request, RoundTripState& state) {
+        ++state.httpConnectedCount;
+        request->method = "GET";
+        request->url = "/component/round-trip";
+        request->query("transport", "legacy");
+        request->set("X-SNodeC-Component", "http-round-trip");
+        request->set("Connection", "close");
+        request->end(
+            [&state](const auto&, const auto& response) {
+                ++state.clientResponseCount;
+                state.clientSawStatus = response->statusCode == "200";
+                state.clientSawHeader = response->get("X-SNodeC-Response") == "component-ok";
+                state.clientSawBody = toString(response->body) == "hello from snode.c http component test";
+                core::SNodeC::stop();
+            },
+            [&state](const auto&, const std::string&) {
+                ++state.parseErrorCount;
+                core::SNodeC::stop();
+            });
+    }
+
+    inline void expectRoundTrip(tests::support::TestResult& testResult,
+                                const RoundTripState& state,
+                                const std::string& transportName,
+                                int startResult) {
+        testResult.expectEqual(0, startResult, "event loop stops successfully after " + transportName + " HTTP round trip");
+        testResult.expectEqual(1, state.listenOkCount, transportName + " HTTP server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, transportName + " HTTP server reports one effective endpoint");
+        testResult.expectEqual(1, state.clientConnectOkCount, transportName + " HTTP client connect callback reports OK exactly once");
+        testResult.expectEqual(1, state.httpConnectedCount, transportName + " HTTP client reaches HTTP-connected callback exactly once");
+        testResult.expectEqual(1, state.serverRequestCount, transportName + " HTTP server observes exactly one request");
+        testResult.expectEqual(1, state.clientResponseCount, transportName + " HTTP client observes exactly one response");
+        testResult.expectEqual(0, state.parseErrorCount, transportName + " HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, transportName + " HTTP round trip reports no unexpected socket states");
+        testResult.expectTrue(state.serverSawMethod, transportName + " HTTP server observes GET method");
+        testResult.expectTrue(state.serverSawUrl, transportName + " HTTP server observes deterministic request target");
+        testResult.expectTrue(state.serverSawQuery, transportName + " HTTP server observes deterministic query value");
+        testResult.expectTrue(state.serverSawHeader, transportName + " HTTP server observes deterministic request header");
+        testResult.expectTrue(state.clientSawStatus, transportName + " HTTP client observes status 200");
+        testResult.expectTrue(state.clientSawHeader, transportName + " HTTP client observes deterministic response header");
+        testResult.expectTrue(state.clientSawBody, transportName + " HTTP client observes deterministic response body");
+    }
+
+} // namespace tests::component::http
+
+#endif // TESTS_COMPONENT_HTTP_HTTPSERVERCLIENTROUNDTRIPTEST_H

--- a/tests/component/http/Inet6HttpServerClientGetRoundTripTest.cpp
+++ b/tests/component/http/Inet6HttpServerClientGetRoundTripTest.cpp
@@ -1,0 +1,68 @@
+#include "HttpServerClientRoundTripTest.h"
+
+#include "net/in6/SocketAddress.h"
+#include "web/http/legacy/in6/Client.h"
+#include "web/http/legacy/in6/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("Inet6HttpServerClientGetRoundTripTest");
+    } else {
+        tests::component::http::RoundTripState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in6::Server;
+        using Client = web::http::legacy::in6::Client;
+
+        const Server server("ipv6-http-round-trip-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleRequest(request, response, state);
+        });
+        Client client(
+            "ipv6-http-round-trip-client",
+            [&state](const auto& request) {
+                tests::component::http::sendRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpRoundTrip(server, client, state);
+
+        server.listen(net::in6::SocketAddress("::1", 0),
+                      [&client, &state](const net::in6::SocketAddress& socketAddress, core::socket::State listenState) {
+                          if (listenState == core::socket::State::OK) {
+                              ++state.listenOkCount;
+                              const std::uint16_t effectivePort = socketAddress.getPort();
+                              if (effectivePort != 0) {
+                                  ++state.effectiveListenEndpointOkCount;
+                                  client.connect(net::in6::SocketAddress("::1", effectivePort),
+                                                 [&state](const net::in6::SocketAddress&, core::socket::State connectState) {
+                                                     if (connectState == core::socket::State::OK) {
+                                                         ++state.clientConnectOkCount;
+                                                     } else {
+                                                         ++state.unexpectedStateCount;
+                                                         core::SNodeC::stop();
+                                                     }
+                                                 });
+                              } else {
+                                  ++state.unexpectedStateCount;
+                                  core::SNodeC::stop();
+                              }
+                          } else {
+                              ++state.unexpectedStateCount;
+                              core::SNodeC::stop();
+                          }
+                      });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectRoundTrip(testResult, state, "IPv6 legacy", startResult);
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/http/InetHttpServerClientGetRoundTripTest.cpp
+++ b/tests/component/http/InetHttpServerClientGetRoundTripTest.cpp
@@ -1,0 +1,68 @@
+#include "HttpServerClientRoundTripTest.h"
+
+#include "net/in/SocketAddress.h"
+#include "web/http/legacy/in/Client.h"
+#include "web/http/legacy/in/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpServerClientGetRoundTripTest");
+    } else {
+        tests::component::http::RoundTripState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in::Server;
+        using Client = web::http::legacy::in::Client;
+
+        const Server server("ipv4-http-round-trip-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleRequest(request, response, state);
+        });
+        Client client(
+            "ipv4-http-round-trip-client",
+            [&state](const auto& request) {
+                tests::component::http::sendRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpRoundTrip(server, client, state);
+
+        server.listen(net::in::SocketAddress("127.0.0.1", 0),
+                      [&client, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+                          if (listenState == core::socket::State::OK) {
+                              ++state.listenOkCount;
+                              const std::uint16_t effectivePort = socketAddress.getPort();
+                              if (effectivePort != 0) {
+                                  ++state.effectiveListenEndpointOkCount;
+                                  client.connect(net::in::SocketAddress("127.0.0.1", effectivePort),
+                                                 [&state](const net::in::SocketAddress&, core::socket::State connectState) {
+                                                     if (connectState == core::socket::State::OK) {
+                                                         ++state.clientConnectOkCount;
+                                                     } else {
+                                                         ++state.unexpectedStateCount;
+                                                         core::SNodeC::stop();
+                                                     }
+                                                 });
+                              } else {
+                                  ++state.unexpectedStateCount;
+                                  core::SNodeC::stop();
+                              }
+                          } else {
+                              ++state.unexpectedStateCount;
+                              core::SNodeC::stop();
+                          }
+                      });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectRoundTrip(testResult, state, "IPv4 legacy", startResult);
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/http/UnixHttpServerClientGetRoundTripTest.cpp
+++ b/tests/component/http/UnixHttpServerClientGetRoundTripTest.cpp
@@ -1,0 +1,74 @@
+#include "HttpServerClientRoundTripTest.h"
+
+#include "web/http/legacy/un/Client.h"
+#include "web/http/legacy/un/Server.h"
+
+#include <filesystem>
+#include <string>
+#include <unistd.h>
+
+namespace {
+
+    std::string makeSocketPath() {
+        return "/tmp/snodec-http-component-" + std::to_string(::getpid()) + ".sock";
+    }
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("UnixHttpServerClientGetRoundTripTest");
+    } else {
+        tests::component::http::RoundTripState state;
+        const std::string socketPath = makeSocketPath();
+        std::filesystem::remove(socketPath);
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::un::Server;
+        using Client = web::http::legacy::un::Client;
+
+        const Server server("unix-http-round-trip-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleRequest(request, response, state);
+        });
+        Client client(
+            "unix-http-round-trip-client",
+            [&state](const auto& request) {
+                tests::component::http::sendRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpRoundTrip(server, client, state);
+
+        server.listen(socketPath, [&client, &socketPath, &state](const auto&, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                ++state.effectiveListenEndpointOkCount;
+                client.connect(socketPath, [&state](const auto&, core::socket::State connectState) {
+                    if (connectState == core::socket::State::OK) {
+                        ++state.clientConnectOkCount;
+                    } else {
+                        ++state.unexpectedStateCount;
+                        core::SNodeC::stop();
+                    }
+                });
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectRoundTrip(testResult, state, "Unix-domain legacy", startResult);
+        result = testResult.processResult();
+        core::SNodeC::free();
+        std::filesystem::remove(socketPath);
+    }
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Provide the first HTTP component-test layer that proves a minimal, deterministic HTTP GET round-trip using real server/client components over legacy stream transports. 
- Keep the scope narrow and incremental after the completed HTTP message-layer unit tests by exercising externally visible request/response behavior only. 

### Description
- Added a dedicated test subtree and registered it from `tests/component/CMakeLists.txt`. 
- Added `tests/component/http/HttpServerClientRoundTripTest.h` providing a small deterministic harness and shared assertions, and added three component tests: `InetHttpServerClientGetRoundTripTest.cpp`, `Inet6HttpServerClientGetRoundTripTest.cpp`, and `UnixHttpServerClientGetRoundTripTest.cpp`. 
- The tests exercise plain HTTP legacy stream transports via `web::http::legacy::in`/`net::in::stream::legacy`, `web::http::legacy::in6`/`net::in6::stream::legacy`, and `web::http::legacy::un`/`net::un::stream::legacy` and use ephemeral TCP ports or a temporary Unix socket path. 
- Tests assert that the server observes `GET`, the request target (including query), a deterministic request header, and that the client observes status `200`, a deterministic response header, and the response body; no production code was modified to enable these tests. 

### Testing
- `git diff --check` — passed. 
- Configured and built tests with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON` and `cmake --build build --target InetHttpServerClientGetRoundTripTest Inet6HttpServerClientGetRoundTripTest UnixHttpServerClientGetRoundTripTest -j2` (installed missing `nlohmann-json3-dev` when requested by the project), and the three test executables were built successfully. 
- Ran `ctest --test-dir build -L component -L http --output-on-failure` which reported the new tests but skipped them under root as expected via the configured root-skip `SKIP_RETURN_CODE 77`. 
- Executed the three tests as an unprivileged user with a temporary `HOME` (example: `runuser -u nobody -- env HOME="$TMP" build/tests/component/http/InetHttpServerClientGetRoundTripTest`), and all three tests returned exit code `0` (IPv4/IPv6/Unix direct runs succeeded). 

Files added/changed
- Modified: `tests/component/CMakeLists.txt` (registered `http` test directory). 
- Added: `tests/component/http/CMakeLists.txt`, `tests/component/http/HttpServerClientRoundTripTest.h`, `tests/component/http/InetHttpServerClientGetRoundTripTest.cpp`, `tests/component/http/Inet6HttpServerClientGetRoundTripTest.cpp`, and `tests/component/http/UnixHttpServerClientGetRoundTripTest.cpp`. 

Scope notes
- Covers only a minimal GET request/200 response round trip over legacy stream transports (IPv4, IPv6, Unix-domain where supported). 
- Intentionally does not add Express routing, middleware, WebSocket upgrades, SSE, MQTT, TLS, DB, chunked transfer, keep-alive/pipelining, multipart/upload, or parser/formatter internals tests. 

Production changes
- No production code was changed; all changes are tests and CMake registrations only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48ede622fc832c8945f38bfad6f54b)