### PR TITLE
Add HTTP component request-body and response-status tests

### DIFF
--- a/tests/component/http/CMakeLists.txt
+++ b/tests/component/http/CMakeLists.txt
@@ -6,13 +6,34 @@ snodec_add_test(InetHttpServerClientGetRoundTripTest InetHttpServerClientGetRoun
 snodec_add_test(Inet6HttpServerClientGetRoundTripTest Inet6HttpServerClientGetRoundTripTest.cpp)
 snodec_add_test(UnixHttpServerClientGetRoundTripTest UnixHttpServerClientGetRoundTripTest.cpp)
 
+snodec_add_test(InetHttpServerClientPostBodyRoundTripTest InetHttpServerClientPostBodyRoundTripTest.cpp)
+snodec_add_test(Inet6HttpServerClientPostBodyRoundTripTest Inet6HttpServerClientPostBodyRoundTripTest.cpp)
+snodec_add_test(UnixHttpServerClientPostBodyRoundTripTest UnixHttpServerClientPostBodyRoundTripTest.cpp)
+snodec_add_test(InetHttpServerClientStatusVariantTest InetHttpServerClientStatusVariantTest.cpp)
+snodec_add_test(Inet6HttpServerClientStatusVariantTest Inet6HttpServerClientStatusVariantTest.cpp)
+snodec_add_test(UnixHttpServerClientStatusVariantTest UnixHttpServerClientStatusVariantTest.cpp)
+
 target_link_libraries(InetHttpServerClientGetRoundTripTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
 target_link_libraries(Inet6HttpServerClientGetRoundTripTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in6-stream-legacy)
 target_link_libraries(UnixHttpServerClientGetRoundTripTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-un-stream-legacy)
 
+target_link_libraries(InetHttpServerClientPostBodyRoundTripTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(Inet6HttpServerClientPostBodyRoundTripTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in6-stream-legacy)
+target_link_libraries(UnixHttpServerClientPostBodyRoundTripTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-un-stream-legacy)
+target_link_libraries(InetHttpServerClientStatusVariantTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(Inet6HttpServerClientStatusVariantTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in6-stream-legacy)
+target_link_libraries(UnixHttpServerClientStatusVariantTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-un-stream-legacy)
+
 target_compile_features(InetHttpServerClientGetRoundTripTest PRIVATE cxx_std_20)
 target_compile_features(Inet6HttpServerClientGetRoundTripTest PRIVATE cxx_std_20)
 target_compile_features(UnixHttpServerClientGetRoundTripTest PRIVATE cxx_std_20)
+
+target_compile_features(InetHttpServerClientPostBodyRoundTripTest PRIVATE cxx_std_20)
+target_compile_features(Inet6HttpServerClientPostBodyRoundTripTest PRIVATE cxx_std_20)
+target_compile_features(UnixHttpServerClientPostBodyRoundTripTest PRIVATE cxx_std_20)
+target_compile_features(InetHttpServerClientStatusVariantTest PRIVATE cxx_std_20)
+target_compile_features(Inet6HttpServerClientStatusVariantTest PRIVATE cxx_std_20)
+target_compile_features(UnixHttpServerClientStatusVariantTest PRIVATE cxx_std_20)
 
 set_tests_properties(InetHttpServerClientGetRoundTripTest PROPERTIES
                      LABELS "component;http;client;server;legacy;ipv4"
@@ -25,6 +46,37 @@ set_tests_properties(Inet6HttpServerClientGetRoundTripTest PROPERTIES
                      TIMEOUT 5)
 
 set_tests_properties(UnixHttpServerClientGetRoundTripTest PROPERTIES
+                     LABELS "component;http;client;server;legacy;unix"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+
+set_tests_properties(InetHttpServerClientPostBodyRoundTripTest PROPERTIES
+                     LABELS "component;http;client;server;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(Inet6HttpServerClientPostBodyRoundTripTest PROPERTIES
+                     LABELS "component;http;client;server;legacy;ipv6"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(UnixHttpServerClientPostBodyRoundTripTest PROPERTIES
+                     LABELS "component;http;client;server;legacy;unix"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetHttpServerClientStatusVariantTest PROPERTIES
+                     LABELS "component;http;client;server;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(Inet6HttpServerClientStatusVariantTest PROPERTIES
+                     LABELS "component;http;client;server;legacy;ipv6"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(UnixHttpServerClientStatusVariantTest PROPERTIES
                      LABELS "component;http;client;server;legacy;unix"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)

--- a/tests/component/http/HttpServerClientBodyStatusTest.h
+++ b/tests/component/http/HttpServerClientBodyStatusTest.h
@@ -1,0 +1,161 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#ifndef TESTS_COMPONENT_HTTP_HTTPSERVERCLIENTBODYSTATUSTEST_H
+#define TESTS_COMPONENT_HTTP_HTTPSERVERCLIENTBODYSTATUSTEST_H
+
+#include "core/SNodeC.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/client/Response.h"
+#include "web/http/server/Response.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace tests::component::http {
+
+    struct BodyStatusState {
+        int listenOkCount = 0;
+        int effectiveListenEndpointOkCount = 0;
+        int clientConnectOkCount = 0;
+        int httpConnectedCount = 0;
+        int serverRequestCount = 0;
+        int clientResponseCount = 0;
+        int httpDisconnectedCount = 0;
+        int unexpectedStateCount = 0;
+        int parseErrorCount = 0;
+
+        bool serverSawMethod = false;
+        bool serverSawUrl = false;
+        bool serverSawQuery = false;
+        bool serverSawHeader = false;
+        bool serverSawBody = false;
+        bool clientSawStatus = false;
+        bool clientSawReason = false;
+        bool clientSawHeader = false;
+        bool clientSawBody = false;
+    };
+
+    inline std::string toString(const std::vector<char>& bytes) {
+        return std::string(bytes.begin(), bytes.end());
+    }
+
+    template <typename Server, typename Client>
+    void configureHttpBodyStatusTest(Server& server, Client& client, BodyStatusState&) {
+        server.getConfig()->Instance::forceUnrequired();
+        client.getConfig()->Instance::forceUnrequired();
+    }
+
+    template <typename Request, typename Response>
+    void handlePostBodyRequest(const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response, BodyStatusState& state) {
+        ++state.serverRequestCount;
+        state.serverSawMethod = request->method == "POST";
+        state.serverSawUrl = request->url == "/component/body?transport=legacy";
+        state.serverSawQuery = request->query("transport") == "legacy";
+        state.serverSawHeader = request->get("Content-Type") == "text/plain; charset=utf-8";
+        state.serverSawBody = toString(request->body) == "deterministic snode.c component request body";
+
+        response->status(200).type("text/plain").set("X-SNodeC-Body", "received").send("received deterministic request body");
+    }
+
+    template <typename MasterRequest>
+    void sendPostBodyRequest(const std::shared_ptr<MasterRequest>& request, BodyStatusState& state) {
+        ++state.httpConnectedCount;
+        request->method = "POST";
+        request->url = "/component/body";
+        request->query("transport", "legacy");
+        request->set("Content-Type", "text/plain; charset=utf-8");
+        request->set("Connection", "close");
+        request->send(
+            "deterministic snode.c component request body",
+            [&state](const auto&, const auto& response) {
+                ++state.clientResponseCount;
+                state.clientSawStatus = response->statusCode == "200";
+                state.clientSawHeader = response->get("X-SNodeC-Body") == "received";
+                state.clientSawBody = toString(response->body) == "received deterministic request body";
+                core::SNodeC::stop();
+            },
+            [&state](const auto&, const std::string&) {
+                ++state.parseErrorCount;
+                core::SNodeC::stop();
+            });
+    }
+
+    template <typename Request, typename Response>
+    void handleStatusVariantRequest(const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response, BodyStatusState& state) {
+        ++state.serverRequestCount;
+        state.serverSawMethod = request->method == "GET";
+        state.serverSawUrl = request->url == "/component/status?transport=legacy";
+        state.serverSawQuery = request->query("transport") == "legacy";
+        state.serverSawHeader = request->get("X-SNodeC-Status") == "want-404";
+
+        response->status(404).type("text/plain").set("X-SNodeC-Status", "not-found").send("deterministic not found body");
+    }
+
+    template <typename MasterRequest>
+    void sendStatusVariantRequest(const std::shared_ptr<MasterRequest>& request, BodyStatusState& state) {
+        ++state.httpConnectedCount;
+        request->method = "GET";
+        request->url = "/component/status";
+        request->query("transport", "legacy");
+        request->set("X-SNodeC-Status", "want-404");
+        request->set("Connection", "close");
+        request->end(
+            [&state](const auto&, const auto& response) {
+                ++state.clientResponseCount;
+                state.clientSawStatus = response->statusCode == "404";
+                state.clientSawReason = response->reason == "Not Found";
+                state.clientSawHeader = response->get("X-SNodeC-Status") == "not-found";
+                state.clientSawBody = toString(response->body) == "deterministic not found body";
+                core::SNodeC::stop();
+            },
+            [&state](const auto&, const std::string&) {
+                ++state.parseErrorCount;
+                core::SNodeC::stop();
+            });
+    }
+
+    inline void expectCommon(tests::support::TestResult& testResult, const BodyStatusState& state, const std::string& transportName) {
+        testResult.expectEqual(1, state.listenOkCount, transportName + " HTTP server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, transportName + " HTTP server reports one effective endpoint");
+        testResult.expectEqual(1, state.clientConnectOkCount, transportName + " HTTP client connect callback reports OK exactly once");
+        testResult.expectEqual(1, state.httpConnectedCount, transportName + " HTTP client reaches HTTP-connected callback exactly once");
+        testResult.expectEqual(1, state.serverRequestCount, transportName + " HTTP server observes exactly one request");
+        testResult.expectEqual(1, state.clientResponseCount, transportName + " HTTP client observes exactly one response");
+        testResult.expectEqual(0, state.parseErrorCount, transportName + " HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, transportName + " HTTP round trip reports no unexpected socket states");
+        testResult.expectTrue(state.serverSawMethod, transportName + " HTTP server observes deterministic method");
+        testResult.expectTrue(state.serverSawUrl, transportName + " HTTP server observes deterministic request target");
+        testResult.expectTrue(state.serverSawQuery, transportName + " HTTP server observes deterministic query value");
+        testResult.expectTrue(state.serverSawHeader, transportName + " HTTP server observes deterministic request header");
+        testResult.expectTrue(state.clientSawStatus, transportName + " HTTP client observes deterministic status");
+        testResult.expectTrue(state.clientSawHeader, transportName + " HTTP client observes deterministic response header");
+        testResult.expectTrue(state.clientSawBody, transportName + " HTTP client observes deterministic response body");
+    }
+
+    inline void expectPostBodyRoundTrip(tests::support::TestResult& testResult,
+                                        const BodyStatusState& state,
+                                        const std::string& transportName,
+                                        int startResult) {
+        testResult.expectEqual(0, startResult, "event loop stops successfully after " + transportName + " HTTP POST body round trip");
+        expectCommon(testResult, state, transportName);
+        testResult.expectTrue(state.serverSawBody, transportName + " HTTP server observes deterministic request body");
+    }
+
+    inline void expectStatusVariantRoundTrip(tests::support::TestResult& testResult,
+                                             const BodyStatusState& state,
+                                             const std::string& transportName,
+                                             int startResult) {
+        testResult.expectEqual(0, startResult, "event loop stops successfully after " + transportName + " HTTP status variant round trip");
+        expectCommon(testResult, state, transportName);
+        testResult.expectTrue(state.clientSawReason, transportName + " HTTP client observes deterministic reason phrase");
+    }
+
+} // namespace tests::component::http
+
+#endif // TESTS_COMPONENT_HTTP_HTTPSERVERCLIENTBODYSTATUSTEST_H

--- a/tests/component/http/Inet6HttpServerClientPostBodyRoundTripTest.cpp
+++ b/tests/component/http/Inet6HttpServerClientPostBodyRoundTripTest.cpp
@@ -1,0 +1,68 @@
+#include "HttpServerClientBodyStatusTest.h"
+
+#include "net/in6/SocketAddress.h"
+#include "web/http/legacy/in6/Client.h"
+#include "web/http/legacy/in6/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("Inet6HttpServerClientPostBodyRoundTripTest");
+    } else {
+        tests::component::http::BodyStatusState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in6::Server;
+        using Client = web::http::legacy::in6::Client;
+
+        const Server server("ipv6-http-postbody-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handlePostBodyRequest(request, response, state);
+        });
+        Client client(
+            "ipv6-http-postbody-client",
+            [&state](const auto& request) {
+                tests::component::http::sendPostBodyRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBodyStatusTest(server, client, state);
+
+        server.listen(net::in6::SocketAddress("::1", 0),
+                      [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+                          if (listenState == core::socket::State::OK) {
+                              ++state.listenOkCount;
+                              const std::uint16_t effectivePort = socketAddress.getPort();
+                              if (effectivePort != 0) {
+                                  ++state.effectiveListenEndpointOkCount;
+                                  client.connect(net::in6::SocketAddress("::1", effectivePort),
+                                                 [&state](const auto&, core::socket::State connectState) {
+                                                     if (connectState == core::socket::State::OK) {
+                                                         ++state.clientConnectOkCount;
+                                                     } else {
+                                                         ++state.unexpectedStateCount;
+                                                         core::SNodeC::stop();
+                                                     }
+                                                 });
+                              } else {
+                                  ++state.unexpectedStateCount;
+                                  core::SNodeC::stop();
+                              }
+                          } else {
+                              ++state.unexpectedStateCount;
+                              core::SNodeC::stop();
+                          }
+                      });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectPostBodyRoundTrip(testResult, state, "IPv6 legacy", startResult);
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/http/Inet6HttpServerClientStatusVariantTest.cpp
+++ b/tests/component/http/Inet6HttpServerClientStatusVariantTest.cpp
@@ -1,0 +1,68 @@
+#include "HttpServerClientBodyStatusTest.h"
+
+#include "net/in6/SocketAddress.h"
+#include "web/http/legacy/in6/Client.h"
+#include "web/http/legacy/in6/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("Inet6HttpServerClientStatusVariantTest");
+    } else {
+        tests::component::http::BodyStatusState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in6::Server;
+        using Client = web::http::legacy::in6::Client;
+
+        const Server server("ipv6-http-statusvariant-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleStatusVariantRequest(request, response, state);
+        });
+        Client client(
+            "ipv6-http-statusvariant-client",
+            [&state](const auto& request) {
+                tests::component::http::sendStatusVariantRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBodyStatusTest(server, client, state);
+
+        server.listen(net::in6::SocketAddress("::1", 0),
+                      [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+                          if (listenState == core::socket::State::OK) {
+                              ++state.listenOkCount;
+                              const std::uint16_t effectivePort = socketAddress.getPort();
+                              if (effectivePort != 0) {
+                                  ++state.effectiveListenEndpointOkCount;
+                                  client.connect(net::in6::SocketAddress("::1", effectivePort),
+                                                 [&state](const auto&, core::socket::State connectState) {
+                                                     if (connectState == core::socket::State::OK) {
+                                                         ++state.clientConnectOkCount;
+                                                     } else {
+                                                         ++state.unexpectedStateCount;
+                                                         core::SNodeC::stop();
+                                                     }
+                                                 });
+                              } else {
+                                  ++state.unexpectedStateCount;
+                                  core::SNodeC::stop();
+                              }
+                          } else {
+                              ++state.unexpectedStateCount;
+                              core::SNodeC::stop();
+                          }
+                      });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectStatusVariantRoundTrip(testResult, state, "IPv6 legacy", startResult);
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/http/InetHttpServerClientPostBodyRoundTripTest.cpp
+++ b/tests/component/http/InetHttpServerClientPostBodyRoundTripTest.cpp
@@ -1,0 +1,68 @@
+#include "HttpServerClientBodyStatusTest.h"
+
+#include "net/in/SocketAddress.h"
+#include "web/http/legacy/in/Client.h"
+#include "web/http/legacy/in/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpServerClientPostBodyRoundTripTest");
+    } else {
+        tests::component::http::BodyStatusState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in::Server;
+        using Client = web::http::legacy::in::Client;
+
+        const Server server("ipv4-http-postbody-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handlePostBodyRequest(request, response, state);
+        });
+        Client client(
+            "ipv4-http-postbody-client",
+            [&state](const auto& request) {
+                tests::component::http::sendPostBodyRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBodyStatusTest(server, client, state);
+
+        server.listen(net::in::SocketAddress("127.0.0.1", 0),
+                      [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+                          if (listenState == core::socket::State::OK) {
+                              ++state.listenOkCount;
+                              const std::uint16_t effectivePort = socketAddress.getPort();
+                              if (effectivePort != 0) {
+                                  ++state.effectiveListenEndpointOkCount;
+                                  client.connect(net::in::SocketAddress("127.0.0.1", effectivePort),
+                                                 [&state](const auto&, core::socket::State connectState) {
+                                                     if (connectState == core::socket::State::OK) {
+                                                         ++state.clientConnectOkCount;
+                                                     } else {
+                                                         ++state.unexpectedStateCount;
+                                                         core::SNodeC::stop();
+                                                     }
+                                                 });
+                              } else {
+                                  ++state.unexpectedStateCount;
+                                  core::SNodeC::stop();
+                              }
+                          } else {
+                              ++state.unexpectedStateCount;
+                              core::SNodeC::stop();
+                          }
+                      });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectPostBodyRoundTrip(testResult, state, "IPv4 legacy", startResult);
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/http/InetHttpServerClientStatusVariantTest.cpp
+++ b/tests/component/http/InetHttpServerClientStatusVariantTest.cpp
@@ -1,0 +1,68 @@
+#include "HttpServerClientBodyStatusTest.h"
+
+#include "net/in/SocketAddress.h"
+#include "web/http/legacy/in/Client.h"
+#include "web/http/legacy/in/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpServerClientStatusVariantTest");
+    } else {
+        tests::component::http::BodyStatusState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in::Server;
+        using Client = web::http::legacy::in::Client;
+
+        const Server server("ipv4-http-statusvariant-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleStatusVariantRequest(request, response, state);
+        });
+        Client client(
+            "ipv4-http-statusvariant-client",
+            [&state](const auto& request) {
+                tests::component::http::sendStatusVariantRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBodyStatusTest(server, client, state);
+
+        server.listen(net::in::SocketAddress("127.0.0.1", 0),
+                      [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+                          if (listenState == core::socket::State::OK) {
+                              ++state.listenOkCount;
+                              const std::uint16_t effectivePort = socketAddress.getPort();
+                              if (effectivePort != 0) {
+                                  ++state.effectiveListenEndpointOkCount;
+                                  client.connect(net::in::SocketAddress("127.0.0.1", effectivePort),
+                                                 [&state](const auto&, core::socket::State connectState) {
+                                                     if (connectState == core::socket::State::OK) {
+                                                         ++state.clientConnectOkCount;
+                                                     } else {
+                                                         ++state.unexpectedStateCount;
+                                                         core::SNodeC::stop();
+                                                     }
+                                                 });
+                              } else {
+                                  ++state.unexpectedStateCount;
+                                  core::SNodeC::stop();
+                              }
+                          } else {
+                              ++state.unexpectedStateCount;
+                              core::SNodeC::stop();
+                          }
+                      });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectStatusVariantRoundTrip(testResult, state, "IPv4 legacy", startResult);
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/http/UnixHttpServerClientPostBodyRoundTripTest.cpp
+++ b/tests/component/http/UnixHttpServerClientPostBodyRoundTripTest.cpp
@@ -1,0 +1,74 @@
+#include "HttpServerClientBodyStatusTest.h"
+
+#include "web/http/legacy/un/Client.h"
+#include "web/http/legacy/un/Server.h"
+
+#include <filesystem>
+#include <string>
+#include <unistd.h>
+
+namespace {
+
+    std::string makeSocketPath() {
+        return "/tmp/snodec-http-component-postbody-" + std::to_string(::getpid()) + ".sock";
+    }
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("UnixHttpServerClientPostBodyRoundTripTest");
+    } else {
+        tests::component::http::BodyStatusState state;
+        const std::string socketPath = makeSocketPath();
+        std::filesystem::remove(socketPath);
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::un::Server;
+        using Client = web::http::legacy::un::Client;
+
+        const Server server("unix-http-postbody-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handlePostBodyRequest(request, response, state);
+        });
+        Client client(
+            "unix-http-postbody-client",
+            [&state](const auto& request) {
+                tests::component::http::sendPostBodyRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBodyStatusTest(server, client, state);
+
+        server.listen(socketPath, [&client, &socketPath, &state](const auto&, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                ++state.effectiveListenEndpointOkCount;
+                client.connect(socketPath, [&state](const auto&, core::socket::State connectState) {
+                    if (connectState == core::socket::State::OK) {
+                        ++state.clientConnectOkCount;
+                    } else {
+                        ++state.unexpectedStateCount;
+                        core::SNodeC::stop();
+                    }
+                });
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectPostBodyRoundTrip(testResult, state, "Unix-domain legacy", startResult);
+        result = testResult.processResult();
+        core::SNodeC::free();
+        std::filesystem::remove(socketPath);
+    }
+
+    return result;
+}

--- a/tests/component/http/UnixHttpServerClientStatusVariantTest.cpp
+++ b/tests/component/http/UnixHttpServerClientStatusVariantTest.cpp
@@ -1,0 +1,74 @@
+#include "HttpServerClientBodyStatusTest.h"
+
+#include "web/http/legacy/un/Client.h"
+#include "web/http/legacy/un/Server.h"
+
+#include <filesystem>
+#include <string>
+#include <unistd.h>
+
+namespace {
+
+    std::string makeSocketPath() {
+        return "/tmp/snodec-http-component-statusvariant-" + std::to_string(::getpid()) + ".sock";
+    }
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("UnixHttpServerClientStatusVariantTest");
+    } else {
+        tests::component::http::BodyStatusState state;
+        const std::string socketPath = makeSocketPath();
+        std::filesystem::remove(socketPath);
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::un::Server;
+        using Client = web::http::legacy::un::Client;
+
+        const Server server("unix-http-statusvariant-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleStatusVariantRequest(request, response, state);
+        });
+        Client client(
+            "unix-http-statusvariant-client",
+            [&state](const auto& request) {
+                tests::component::http::sendStatusVariantRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBodyStatusTest(server, client, state);
+
+        server.listen(socketPath, [&client, &socketPath, &state](const auto&, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                ++state.effectiveListenEndpointOkCount;
+                client.connect(socketPath, [&state](const auto&, core::socket::State connectState) {
+                    if (connectState == core::socket::State::OK) {
+                        ++state.clientConnectOkCount;
+                    } else {
+                        ++state.unexpectedStateCount;
+                        core::SNodeC::stop();
+                    }
+                });
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectStatusVariantRoundTrip(testResult, state, "Unix-domain legacy", startResult);
+        result = testResult.processResult();
+        core::SNodeC::free();
+        std::filesystem::remove(socketPath);
+    }
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Extend the component-level plain legacy HTTP tests added in PR #124 to cover deterministic request-body handling and non-200 response-status behavior without moving to a higher protocol/application layer. 
- Verify externally visible HTTP behavior (request method, path/query, request headers/body, response status/reason/headers/body) over the same legacy stream transports already used by the component tests. 

### Description
- Added a shared narrow helper header `tests/component/http/HttpServerClientBodyStatusTest.h` containing state tracking, request/response handlers, send helpers, and common expectations for POST body and status-variant scenarios. 
- Added six component test executables under `tests/component/http/`: `InetHttpServerClientPostBodyRoundTripTest.cpp`, `Inet6HttpServerClientPostBodyRoundTripTest.cpp`, `UnixHttpServerClientPostBodyRoundTripTest.cpp`, `InetHttpServerClientStatusVariantTest.cpp`, `Inet6HttpServerClientStatusVariantTest.cpp`, and `UnixHttpServerClientStatusVariantTest.cpp`. 
- Registered and configured the new tests in `tests/component/http/CMakeLists.txt` with appropriate `snodec_add_test` entries, `target_link_libraries`, `target_compile_features(... cxx_std_20)`, labels (`component;http;client;server;legacy;ipv4/ipv6/unix`), `TIMEOUT 5` and `SKIP_RETURN_CODE 77` to preserve root-skip behavior. 
- No production code or public API changes were made to enable the tests. 

### Testing
- Ran `git diff --check` which produced no issues. 
- Configured and built with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON` (after installing missing `nlohmann-json3-dev`), and the configure step completed (CMake warned about unrelated optional deps such as Doxygen/iwyu/bluez/libmagic/libmariadb). 
- Built the new tests with `cmake --build build --target InetHttpServerClientPostBodyRoundTripTest Inet6HttpServerClientPostBodyRoundTripTest UnixHttpServerClientPostBodyRoundTripTest InetHttpServerClientStatusVariantTest Inet6HttpServerClientStatusVariantTest UnixHttpServerClientStatusVariantTest -j2` and the build succeeded. 
- Ran the new-tests selection under root with `ctest --test-dir build -R 'HttpServerClient(PostBodyRoundTrip|StatusVariant)Test' --output-on-failure` which reported the tests as skipped under root due to `SKIP_RETURN_CODE 77`, as intended. 
- Executed the tests as an unprivileged user with `su -s /bin/bash nobody -c "HOME=/tmp/snodec-nobody-home ctest --test-dir /workspace/snode.c/build -R 'HttpServerClient(PostBodyRoundTrip|StatusVariant)Test' --output-on-failure"` and all six new tests passed. 
- Built and ran the broader HTTP label to ensure compatibility with existing component tests using `cmake --build build --target HttpMessageParserTest InetHttpServerClientGetRoundTripTest Inet6HttpServerClientGetRoundTripTest UnixHttpServerClientGetRoundTripTest -j2` followed by `su -s /bin/bash nobody -c "HOME=/tmp/snodec-nobody-home ctest --test-dir /workspace/snode.c/build -L http --output-on-failure"`, and the relevant HTTP tests passed as an unprivileged run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48f2584f74832ca964469ad9cb5ab2)