### PR TITLE
Add Express routing and middleware component tests

### DIFF
--- a/tests/component/CMakeLists.txt
+++ b/tests/component/CMakeLists.txt
@@ -41,3 +41,4 @@
 add_subdirectory(core)
 add_subdirectory(net)
 add_subdirectory(http)
+add_subdirectory(express)

--- a/tests/component/express/CMakeLists.txt
+++ b/tests/component/express/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SNode.C - A Slim Toolkit for Network Communication
+# Copyright (C) Volker Christian <me@vchrist.at>
+#               2020, 2021, 2022, 2023, 2024, 2025, 2026
+
+snodec_add_test(InetExpressRoutingMiddlewareTest InetExpressRoutingMiddlewareTest.cpp)
+
+target_link_libraries(InetExpressRoutingMiddlewareTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
+
+target_compile_features(InetExpressRoutingMiddlewareTest PRIVATE cxx_std_20)
+
+set_tests_properties(InetExpressRoutingMiddlewareTest PROPERTIES
+                     LABELS "component;express;routing;middleware;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)

--- a/tests/component/express/InetExpressRoutingMiddlewareTest.cpp
+++ b/tests/component/express/InetExpressRoutingMiddlewareTest.cpp
@@ -49,9 +49,9 @@ std::string toString(const std::vector<char>& bytes) {
     return std::string(bytes.begin(), bytes.end());
 }
 
-class SequencedClient {
+class CaseClientRunner {
 public:
-    explicit SequencedClient(State& state)
+    explicit CaseClientRunner(State& state)
         : state(state)
         , cases({{"exact route", "GET", "/express/basic", 200, "X-Express-Test", "exact", "express basic ok"},
                  {"path parameter", "GET", "/express/items/42", 200, "X-Express-Param", "42", "item id=42"},
@@ -62,15 +62,54 @@ public:
     }
 
     void run(const std::uint16_t port) {
-        client = std::make_shared<Client>(
-            "ipv4-express-routing-middleware-client",
-            [this](const std::shared_ptr<MasterRequest>& connectedRequest) {
+        this->port = port;
+        dispatchNext();
+    }
+
+private:
+    using Client = web::http::legacy::in::Client;
+    using MasterRequest = Client::MasterRequest;
+
+    void dispatchNext() {
+        if (cases.empty()) {
+            core::SNodeC::stop();
+            return;
+        }
+
+        const std::size_t clientIndex = clients.size();
+        const Case current = cases.front();
+        cases.pop_front();
+
+        clients.emplace_back(std::make_shared<Client>(
+            "ipv4-express-routing-middleware-client-" + std::to_string(clientIndex),
+            [this, current](const std::shared_ptr<MasterRequest>& request) {
                 ++state.httpConnectedCount;
-                masterRequest = connectedRequest;
-                dispatchNext();
+                request->method = current.method;
+                request->url = current.url;
+                request->set("Connection", "close");
+                request->end(
+                    [this, current](const auto&, const auto& response) {
+                        ++state.clientResponseCount;
+                        if (response->statusCode != std::to_string(current.status)) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.headerName.empty() && response->get(current.headerName) != current.headerValue) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.body.empty() && toString(response->body) != current.body) {
+                            ++state.unexpectedStateCount;
+                        }
+                        dispatchNext();
+                    },
+                    [this](const auto&, const std::string&) {
+                        ++state.parseErrorCount;
+                        dispatchNext();
+                    });
             },
             [](const std::shared_ptr<MasterRequest>&) {
-            });
+            }));
+
+        const std::shared_ptr<Client>& client = clients.back();
         client->getConfig()->Instance::forceUnrequired();
         client->connect(net::in::SocketAddress("127.0.0.1", port), [this](const net::in::SocketAddress&, core::socket::State connectState) {
             if (connectState == core::socket::State::OK) {
@@ -82,50 +121,10 @@ public:
         });
     }
 
-private:
-    using Client = web::http::legacy::in::Client;
-    using MasterRequest = Client::MasterRequest;
-
-    void dispatchNext() {
-        if (cases.empty()) {
-            if (masterRequest && masterRequest->isConnected()) {
-                masterRequest->disconnect();
-            }
-            core::SNodeC::stop();
-            return;
-        }
-
-        const Case current = cases.front();
-        cases.pop_front();
-
-        masterRequest->init();
-        masterRequest->method = current.method;
-        masterRequest->url = current.url;
-        masterRequest->set("Connection", cases.empty() ? "close" : "keep-alive");
-        masterRequest->end(
-            [this, current](const auto&, const auto& response) {
-                ++state.clientResponseCount;
-                if (response->statusCode != std::to_string(current.status)) {
-                    ++state.unexpectedStateCount;
-                }
-                if (!current.headerName.empty() && response->get(current.headerName) != current.headerValue) {
-                    ++state.unexpectedStateCount;
-                }
-                if (!current.body.empty() && toString(response->body) != current.body) {
-                    ++state.unexpectedStateCount;
-                }
-                dispatchNext();
-            },
-            [this](const auto&, const std::string&) {
-                ++state.parseErrorCount;
-                dispatchNext();
-            });
-    }
-
     State& state;
+    std::uint16_t port = 0;
     std::deque<Case> cases;
-    std::shared_ptr<Client> client;
-    std::shared_ptr<MasterRequest> masterRequest;
+    std::vector<std::shared_ptr<Client>> clients;
 };
 
 } // namespace
@@ -198,14 +197,14 @@ int main(int argc, char* argv[]) {
 
         app.getConfig()->Instance::forceUnrequired();
 
-        SequencedClient sequencedClient(state);
-        app.listen(net::in::SocketAddress("127.0.0.1", 0), [&sequencedClient, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+        CaseClientRunner caseClientRunner(state);
+        app.listen(net::in::SocketAddress("127.0.0.1", 0), [&caseClientRunner, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
             if (listenState == core::socket::State::OK) {
                 ++state.listenOkCount;
                 const std::uint16_t effectivePort = socketAddress.getPort();
                 if (effectivePort != 0) {
                     ++state.effectiveListenEndpointOkCount;
-                    sequencedClient.run(effectivePort);
+                    caseClientRunner.run(effectivePort);
                 } else {
                     ++state.unexpectedStateCount;
                     core::SNodeC::stop();
@@ -221,11 +220,11 @@ int main(int argc, char* argv[]) {
         testResult.expectEqual(0, startResult, "event loop stops successfully after IPv4 legacy Express requests");
         testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
         testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective IPv4 endpoint");
-        testResult.expectEqual(1, state.clientConnectOkCount, "HTTP client connect callback reports OK exactly once");
-        testResult.expectEqual(1, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback exactly once");
+        testResult.expectEqual(6, state.clientConnectOkCount, "HTTP client connect callbacks report OK once per Express request");
+        testResult.expectEqual(6, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback once per Express request");
         testResult.expectEqual(6, state.clientResponseCount, "HTTP client observes all Express responses");
         testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
-        testResult.expectEqual(0, state.unexpectedStateCount, "Express routing and middleware sequence reports no unexpected states");
+        testResult.expectEqual(0, state.unexpectedStateCount, "Express routing and middleware cases report no unexpected states");
         testResult.expectEqual(1, state.exactRouteCount, "exact route handler runs exactly once");
         testResult.expectTrue(state.exactRouteObservedRequest, "exact route handler observes deterministic GET request path");
         testResult.expectEqual(1, state.parameterRouteCount, "parameter route handler runs exactly once");

--- a/tests/component/express/InetExpressRoutingMiddlewareTest.cpp
+++ b/tests/component/express/InetExpressRoutingMiddlewareTest.cpp
@@ -1,0 +1,245 @@
+#include "core/SNodeC.h"
+#include "express/legacy/in/WebApp.h"
+#include "net/in/SocketAddress.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Client.h"
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Case {
+    std::string name;
+    std::string method;
+    std::string url;
+    int status;
+    std::string headerName;
+    std::string headerValue;
+    std::string body;
+};
+
+struct State {
+    int listenOkCount = 0;
+    int effectiveListenEndpointOkCount = 0;
+    int clientConnectOkCount = 0;
+    int httpConnectedCount = 0;
+    int clientResponseCount = 0;
+    int parseErrorCount = 0;
+    int unexpectedStateCount = 0;
+
+    int exactRouteCount = 0;
+    int parameterRouteCount = 0;
+    int queryRouteCount = 0;
+    int middlewareFirstCount = 0;
+    int middlewareSecondCount = 0;
+    int middlewareRouteCount = 0;
+
+    bool exactRouteObservedRequest = false;
+    bool parameterRouteObservedId = false;
+    bool queryRouteObservedMode = false;
+    bool middlewareObservedOrder = false;
+};
+
+std::string toString(const std::vector<char>& bytes) {
+    return std::string(bytes.begin(), bytes.end());
+}
+
+class SequencedClient {
+public:
+    explicit SequencedClient(State& state)
+        : state(state)
+        , cases({{"exact route", "GET", "/express/basic", 200, "X-Express-Test", "exact", "express basic ok"},
+                 {"path parameter", "GET", "/express/items/42", 200, "X-Express-Param", "42", "item id=42"},
+                 {"query visibility", "GET", "/express/query?mode=test", 200, "X-Express-Query", "test", "query mode=test"},
+                 {"method mismatch fallback", "POST", "/express/get-only", 404, "", "", ""},
+                 {"404 fallback", "GET", "/express/missing", 404, "", "", ""},
+                 {"middleware order and header", "GET", "/express/middleware", 200, "X-Express-Middleware", "first,second", "middleware order=first,second"}}) {
+    }
+
+    void run(const std::uint16_t port) {
+        client = std::make_shared<Client>(
+            "ipv4-express-routing-middleware-client",
+            [this](const std::shared_ptr<MasterRequest>& connectedRequest) {
+                ++state.httpConnectedCount;
+                masterRequest = connectedRequest;
+                dispatchNext();
+            },
+            [](const std::shared_ptr<MasterRequest>&) {
+            });
+        client->getConfig()->Instance::forceUnrequired();
+        client->connect(net::in::SocketAddress("127.0.0.1", port), [this](const net::in::SocketAddress&, core::socket::State connectState) {
+            if (connectState == core::socket::State::OK) {
+                ++state.clientConnectOkCount;
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+    }
+
+private:
+    using Client = web::http::legacy::in::Client;
+    using MasterRequest = Client::MasterRequest;
+
+    void dispatchNext() {
+        if (cases.empty()) {
+            if (masterRequest && masterRequest->isConnected()) {
+                masterRequest->disconnect();
+            }
+            core::SNodeC::stop();
+            return;
+        }
+
+        const Case current = cases.front();
+        cases.pop_front();
+
+        masterRequest->init();
+        masterRequest->method = current.method;
+        masterRequest->url = current.url;
+        masterRequest->set("Connection", cases.empty() ? "close" : "keep-alive");
+        masterRequest->end(
+            [this, current](const auto&, const auto& response) {
+                ++state.clientResponseCount;
+                if (response->statusCode != std::to_string(current.status)) {
+                    ++state.unexpectedStateCount;
+                }
+                if (!current.headerName.empty() && response->get(current.headerName) != current.headerValue) {
+                    ++state.unexpectedStateCount;
+                }
+                if (!current.body.empty() && toString(response->body) != current.body) {
+                    ++state.unexpectedStateCount;
+                }
+                dispatchNext();
+            },
+            [this](const auto&, const std::string&) {
+                ++state.parseErrorCount;
+                dispatchNext();
+            });
+    }
+
+    State& state;
+    std::deque<Case> cases;
+    std::shared_ptr<Client> client;
+    std::shared_ptr<MasterRequest> masterRequest;
+};
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetExpressRoutingMiddlewareTest");
+    } else {
+        State state;
+
+        core::SNodeC::init(argc, argv);
+
+        const express::legacy::in::WebApp app("ipv4-express-routing-middleware-server");
+
+        app.get("/express/basic", [&state] APPLICATION(req, res) {
+            ++state.exactRouteCount;
+            state.exactRouteObservedRequest = req->method == "GET" && req->path == "/express/basic";
+            res->status(200).set("X-Express-Test", "exact").send("express basic ok");
+        });
+
+        app.get("/express/items/:id", [&state] APPLICATION(req, res) {
+            ++state.parameterRouteCount;
+            state.parameterRouteObservedId = req->param("id") == "42";
+            res->status(200).set("X-Express-Param", req->param("id")).send("item id=" + req->param("id"));
+        });
+
+        app.get("/express/query", [&state] APPLICATION(req, res) {
+            ++state.queryRouteCount;
+            state.queryRouteObservedMode = req->query("mode") == "test";
+            res->status(200).set("X-Express-Query", req->query("mode")).send("query mode=" + req->query("mode"));
+        });
+
+        app.get("/express/get-only", [] APPLICATION(req, res) {
+            res->status(200).send("get-only route should not handle POST");
+        });
+
+        app.get(
+            "/express/middleware",
+            [&state] MIDDLEWARE(req, res, next) {
+                ++state.middlewareFirstCount;
+                req->setAttribute<std::string>("first", "express-middleware-order");
+                next();
+            },
+            [&state] MIDDLEWARE(req, res, next) {
+                ++state.middlewareSecondCount;
+                std::string order;
+                req->getAttribute<std::string>(
+                    [&order](const std::string& value) {
+                        order = value;
+                    },
+                    "express-middleware-order");
+                req->setAttribute<std::string>(order + ",second", "express-middleware-order", true);
+                res->set("X-Express-Middleware", order + ",second");
+                next();
+            },
+            [&state] APPLICATION(req, res) {
+                ++state.middlewareRouteCount;
+                std::string order;
+                req->getAttribute<std::string>(
+                    [&order](const std::string& value) {
+                        order = value;
+                    },
+                    "express-middleware-order");
+                state.middlewareObservedOrder = order == "first,second";
+                res->status(200).send("middleware order=" + order);
+            });
+
+        app.getConfig()->Instance::forceUnrequired();
+
+        SequencedClient sequencedClient(state);
+        app.listen(net::in::SocketAddress("127.0.0.1", 0), [&sequencedClient, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    sequencedClient.run(effectivePort);
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after IPv4 legacy Express requests");
+        testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective IPv4 endpoint");
+        testResult.expectEqual(1, state.clientConnectOkCount, "HTTP client connect callback reports OK exactly once");
+        testResult.expectEqual(1, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback exactly once");
+        testResult.expectEqual(6, state.clientResponseCount, "HTTP client observes all Express responses");
+        testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, "Express routing and middleware sequence reports no unexpected states");
+        testResult.expectEqual(1, state.exactRouteCount, "exact route handler runs exactly once");
+        testResult.expectTrue(state.exactRouteObservedRequest, "exact route handler observes deterministic GET request path");
+        testResult.expectEqual(1, state.parameterRouteCount, "parameter route handler runs exactly once");
+        testResult.expectTrue(state.parameterRouteObservedId, "parameter route handler observes id parameter");
+        testResult.expectEqual(1, state.queryRouteCount, "query route handler runs exactly once");
+        testResult.expectTrue(state.queryRouteObservedMode, "query route handler observes deterministic query value");
+        testResult.expectEqual(1, state.middlewareFirstCount, "first middleware runs exactly once");
+        testResult.expectEqual(1, state.middlewareSecondCount, "second middleware runs exactly once");
+        testResult.expectEqual(1, state.middlewareRouteCount, "middleware route handler runs exactly once");
+        testResult.expectTrue(state.middlewareObservedOrder, "route observes middleware execution order");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Add an initial, narrow component-test layer exercising Express application routing and minimal middleware behavior on top of the already-completed plain HTTP server/client component-test foundation. 
- Keep scope tight and deterministic by using plain non-TLS IPv4 legacy transport and the existing SNode.C test conventions (root skip, `core::SNodeC` lifecycle, `snodec_add_test`).

### Description
- Added `tests/component/express/InetExpressRoutingMiddlewareTest.cpp` which registers an `express::legacy::in::WebApp` and a real `web::http::legacy::in::Client` to validate exact route match, path-parameter extraction, query visibility, method-mismatch fallback (observed 404), 404 fallback for unregistered paths, and two middleware behaviors (ordered execution, middleware-set response header, and `next()` continuation).
- Added `tests/component/express/CMakeLists.txt` and registered the new tests from `tests/component/CMakeLists.txt` using the project `snodec_add_test(...)` convention, C++20 compile feature, labels `component;express;routing;middleware;legacy;ipv4`, `SKIP_RETURN_CODE 77`, and `TIMEOUT 5` consistent with existing component tests.
- Reused existing test helpers and idioms (root-skip `tests::support::shouldSkipRootWithoutSNodeCGroup()`, `tests::support::TestResult`, `core::SNodeC::init/start/stop/free`, and `app.getConfig()->Instance::forceUnrequired()`) without changing production code or public APIs.
- Intentionally deferred broader parity and other transports/features: no IPv6/Unix triplets, no strict routing/case-sensitivity/mount/nested-router/regex edge cases, and no WebSocket/SSE/TLS/MQTT/DB/application smoke tests.

### Testing
- Installed missing build dependency: `apt-get update && apt-get install -y nlohmann-json3-dev` which enabled CMake to find `nlohmann_json` and proceed to build the Express target successfully. (Succeeded.)
- Configured and built the test target: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON` followed by `cmake --build build --target InetExpressRoutingMiddlewareTest -j2`, which completed and produced the `InetExpressRoutingMiddlewareTest` executable. (Succeeded with non-blocking optional warnings.)
- Ran CTest as root which reported the test as skipped due to the repository root-skip policy (`SKIP_RETURN_CODE 77`) with `ctest --test-dir build -R '^InetExpressRoutingMiddlewareTest$' --output-on-failure`. (Skipped as expected under root.)
- Executed the Express test as an unprivileged user to verify behavior: `su -s /bin/bash nobody -c 'cd /workspace/snode.c/build && HOME=/tmp/snodec-nobody XDG_CONFIG_HOME=/tmp/snodec-nobody/.config ctest -R "^InetExpressRoutingMiddlewareTest$" --output-on-failure'`, and also via label `ctest -L "express"`, both of which passed; logs show the client/server exchange and assertions passed. (Succeeded.)

Files added/changed
- Added `tests/component/express/InetExpressRoutingMiddlewareTest.cpp` (new component test).
- Added `tests/component/express/CMakeLists.txt` (test registration and properties).
- Modified `tests/component/CMakeLists.txt` to `add_subdirectory(express)` (register new test dir).

Production code
- No production code or public API changes were made; the PR only adds component tests and CMake registration.

Deferred coverage (explicit)
- Express IPv6/Unix transport smoke coverage deferred, and WebSocket/SSE/TLS/MQTT/DB/application/edge-case Express parity tests are intentionally out of scope for this PR.

Exact commands run and high-level results
- `apt-get update && apt-get install -y nlohmann-json3-dev` — installed missing package (succeeded).
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON` — configure completed (warnings for optional packages only).
- `cmake --build build --target InetExpressRoutingMiddlewareTest -j2` — build completed and produced the test executable (succeeded).
- `ctest --test-dir build -R '^InetExpressRoutingMiddlewareTest$' --output-on-failure` — skipped under root as expected (SKIP_RETURN_CODE 77).
- `su -s /bin/bash nobody -c 'cd build && HOME=/tmp/snodec-nobody XDG_CONFIG_HOME=/tmp/snodec-nobody/.config ctest -R "^InetExpressRoutingMiddlewareTest$" --output-on-failure'` — ran unprivileged and passed (succeeded).

This PR follows the existing HTTP component-test foundation, keeps the scope narrow and reviewable, and provides a deterministic starting point for future Express test additions on other transports and more complex routing behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4909ce9524832ca15a4692fb58c0da)