### PR TITLE
Add Express routing continuation component tests

### DIFF
--- a/tests/component/express/CMakeLists.txt
+++ b/tests/component/express/CMakeLists.txt
@@ -4,11 +4,46 @@
 
 snodec_add_test(InetExpressRoutingMiddlewareTest InetExpressRoutingMiddlewareTest.cpp)
 
+snodec_add_test(Inet6ExpressTransportSmokeTest Inet6ExpressTransportSmokeTest.cpp)
+snodec_add_test(UnixExpressTransportSmokeTest UnixExpressTransportSmokeTest.cpp)
+snodec_add_test(InetExpressMiddlewareShortCircuitTest InetExpressMiddlewareShortCircuitTest.cpp)
+snodec_add_test(InetExpressRoutingEdgeBasicsTest InetExpressRoutingEdgeBasicsTest.cpp)
+
 target_link_libraries(InetExpressRoutingMiddlewareTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
+
+target_link_libraries(Inet6ExpressTransportSmokeTest PRIVATE snodec-test-support snodec::http-server-express-legacy-in6 snodec::http-client snodec::net-in6-stream-legacy)
+target_link_libraries(UnixExpressTransportSmokeTest PRIVATE snodec-test-support snodec::http-server-express-legacy-un snodec::http-client snodec::net-un-stream-legacy)
+target_link_libraries(InetExpressMiddlewareShortCircuitTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetExpressRoutingEdgeBasicsTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
 
 target_compile_features(InetExpressRoutingMiddlewareTest PRIVATE cxx_std_20)
 
+target_compile_features(Inet6ExpressTransportSmokeTest PRIVATE cxx_std_20)
+target_compile_features(UnixExpressTransportSmokeTest PRIVATE cxx_std_20)
+target_compile_features(InetExpressMiddlewareShortCircuitTest PRIVATE cxx_std_20)
+target_compile_features(InetExpressRoutingEdgeBasicsTest PRIVATE cxx_std_20)
+
 set_tests_properties(InetExpressRoutingMiddlewareTest PROPERTIES
                      LABELS "component;express;routing;middleware;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(Inet6ExpressTransportSmokeTest PROPERTIES
+                     LABELS "component;express;routing;legacy;ipv6"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(UnixExpressTransportSmokeTest PROPERTIES
+                     LABELS "component;express;routing;legacy;unix"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetExpressMiddlewareShortCircuitTest PROPERTIES
+                     LABELS "component;express;routing;middleware;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetExpressRoutingEdgeBasicsTest PROPERTIES
+                     LABELS "component;express;routing;legacy;ipv4"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)

--- a/tests/component/express/Inet6ExpressTransportSmokeTest.cpp
+++ b/tests/component/express/Inet6ExpressTransportSmokeTest.cpp
@@ -1,0 +1,116 @@
+#include "core/SNodeC.h"
+#include "express/legacy/in6/WebApp.h"
+#include "net/in6/SocketAddress.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in6/Client.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct State {
+    int listenOkCount = 0;
+    int effectiveListenEndpointOkCount = 0;
+    int clientConnectOkCount = 0;
+    int httpConnectedCount = 0;
+    int clientResponseCount = 0;
+    int parseErrorCount = 0;
+    int unexpectedStateCount = 0;
+    int handlerCount = 0;
+};
+
+std::string toString(const std::vector<char>& bytes) {
+    return std::string(bytes.begin(), bytes.end());
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("Inet6ExpressTransportSmokeTest");
+    } else {
+        State state;
+
+        core::SNodeC::init(argc, argv);
+
+        const express::legacy::in6::WebApp app("ipv6-express-transport-smoke-server");
+        web::http::legacy::in6::Client client(
+            "ipv6-express-transport-smoke-client",
+            [&state](const auto& request) {
+                ++state.httpConnectedCount;
+                request->method = "GET";
+                request->url = "/express/transport-smoke";
+                request->set("Connection", "close");
+                request->end(
+                    [&state](const auto&, const auto& response) {
+                        ++state.clientResponseCount;
+                        if (response->statusCode != "200" || response->get("X-Express-Transport") != "ipv6" ||
+                            toString(response->body) != "express ipv6 transport ok") {
+                            ++state.unexpectedStateCount;
+                        }
+                        core::SNodeC::stop();
+                    },
+                    [&state](const auto&, const std::string&) {
+                        ++state.parseErrorCount;
+                        core::SNodeC::stop();
+                    });
+            },
+            [](const auto&) {
+            });
+
+        app.get("/express/transport-smoke", [&state] APPLICATION(req, res) {
+            ++state.handlerCount;
+            res->status(200).set("X-Express-Transport", "ipv6").send("express ipv6 transport ok");
+        });
+
+        app.getConfig()->Instance::forceUnrequired();
+        client.getConfig()->Instance::forceUnrequired();
+
+        app.listen(net::in6::SocketAddress("::1", 0), [&client, &state](const net::in6::SocketAddress& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in6::SocketAddress("::1", effectivePort), [&state](const net::in6::SocketAddress&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) {
+                            ++state.clientConnectOkCount;
+                        } else {
+                            ++state.unexpectedStateCount;
+                            core::SNodeC::stop();
+                        }
+                    });
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after IPv6 legacy Express request");
+        testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective IPv6 endpoint");
+        testResult.expectEqual(1, state.clientConnectOkCount, "HTTP client connect callback reports OK exactly once");
+        testResult.expectEqual(1, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback exactly once");
+        testResult.expectEqual(1, state.clientResponseCount, "HTTP client observes the Express response");
+        testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, "IPv6 Express transport smoke reports no unexpected states");
+        testResult.expectEqual(1, state.handlerCount, "Express route handler runs exactly once");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/express/InetExpressMiddlewareShortCircuitTest.cpp
+++ b/tests/component/express/InetExpressMiddlewareShortCircuitTest.cpp
@@ -1,0 +1,123 @@
+#include "core/SNodeC.h"
+#include "express/legacy/in/WebApp.h"
+#include "net/in/SocketAddress.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Client.h"
+
+#include <string>
+#include <vector>
+
+namespace {
+
+struct State {
+    int listenOkCount = 0;
+    int effectiveListenEndpointOkCount = 0;
+    int clientConnectOkCount = 0;
+    int httpConnectedCount = 0;
+    int clientResponseCount = 0;
+    int parseErrorCount = 0;
+    int unexpectedStateCount = 0;
+    int middlewareCount = 0;
+    int downstreamHandlerCount = 0;
+};
+
+std::string toString(const std::vector<char>& bytes) {
+    return std::string(bytes.begin(), bytes.end());
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetExpressMiddlewareShortCircuitTest");
+    } else {
+        State state;
+
+        core::SNodeC::init(argc, argv);
+
+        const express::legacy::in::WebApp app("ipv4-express-middleware-short-circuit-server");
+        web::http::legacy::in::Client client(
+            "ipv4-express-middleware-short-circuit-client",
+            [&state](const auto& request) {
+                ++state.httpConnectedCount;
+                request->method = "GET";
+                request->url = "/express/short-circuit";
+                request->set("Connection", "close");
+                request->end(
+                    [&state](const auto&, const auto& response) {
+                        ++state.clientResponseCount;
+                        if (response->statusCode != "403" || response->get("X-Express-Short-Circuit") != "middleware" ||
+                            toString(response->body) != "middleware stopped request") {
+                            ++state.unexpectedStateCount;
+                        }
+                        core::SNodeC::stop();
+                    },
+                    [&state](const auto&, const std::string&) {
+                        ++state.parseErrorCount;
+                        core::SNodeC::stop();
+                    });
+            },
+            [](const auto&) {
+            });
+
+        app.get(
+            "/express/short-circuit",
+            [&state] MIDDLEWARE(req, res, next) {
+                ++state.middlewareCount;
+                res->status(403).set("X-Express-Short-Circuit", "middleware").send("middleware stopped request");
+            },
+            [&state] APPLICATION(req, res) {
+                ++state.downstreamHandlerCount;
+                res->status(200).send("downstream handler should not run");
+            });
+
+        app.getConfig()->Instance::forceUnrequired();
+        client.getConfig()->Instance::forceUnrequired();
+
+        app.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const net::in::SocketAddress&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) {
+                            ++state.clientConnectOkCount;
+                        } else {
+                            ++state.unexpectedStateCount;
+                            core::SNodeC::stop();
+                        }
+                    });
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after IPv4 legacy Express middleware response");
+        testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective IPv4 endpoint");
+        testResult.expectEqual(1, state.clientConnectOkCount, "HTTP client connect callback reports OK exactly once");
+        testResult.expectEqual(1, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback exactly once");
+        testResult.expectEqual(1, state.clientResponseCount, "HTTP client observes the middleware response");
+        testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, "middleware short-circuit case reports no unexpected states");
+        testResult.expectEqual(1, state.middlewareCount, "short-circuit middleware runs exactly once");
+        testResult.expectEqual(0, state.downstreamHandlerCount, "downstream Express handler does not run after middleware response");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/express/InetExpressRoutingEdgeBasicsTest.cpp
+++ b/tests/component/express/InetExpressRoutingEdgeBasicsTest.cpp
@@ -1,0 +1,173 @@
+#include "core/SNodeC.h"
+#include "express/legacy/in/WebApp.h"
+#include "net/in/SocketAddress.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Client.h"
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Case {
+    std::string name;
+    std::string url;
+    std::string headerValue;
+    std::string body;
+};
+
+struct State {
+    int listenOkCount = 0;
+    int effectiveListenEndpointOkCount = 0;
+    int clientConnectOkCount = 0;
+    int httpConnectedCount = 0;
+    int clientResponseCount = 0;
+    int parseErrorCount = 0;
+    int unexpectedStateCount = 0;
+    int strictRouteCount = 0;
+    int caseRouteCount = 0;
+};
+
+std::string toString(const std::vector<char>& bytes) {
+    return std::string(bytes.begin(), bytes.end());
+}
+
+class CaseClientRunner {
+public:
+    explicit CaseClientRunner(State& state)
+        : state(state)
+        , cases({{"non-strict trailing slash", "/express/strict/", "strict-default", "non-strict trailing slash ok"},
+                 {"case-insensitive route", "/Express/Case", "case-default", "case-insensitive route ok"}}) {
+    }
+
+    void run(std::uint16_t port) {
+        this->port = port;
+        dispatchNext();
+    }
+
+private:
+    using Client = web::http::legacy::in::Client;
+    using MasterRequest = Client::MasterRequest;
+
+    void dispatchNext() {
+        if (cases.empty()) {
+            core::SNodeC::stop();
+            return;
+        }
+
+        const std::size_t clientIndex = clients.size();
+        const Case current = cases.front();
+        cases.pop_front();
+
+        clients.emplace_back(std::make_shared<Client>(
+            "ipv4-express-routing-edge-basics-client-" + std::to_string(clientIndex),
+            [this, current](const std::shared_ptr<MasterRequest>& request) {
+                ++state.httpConnectedCount;
+                request->method = "GET";
+                request->url = current.url;
+                request->set("Connection", "close");
+                request->end(
+                    [this, current](const auto&, const auto& response) {
+                        ++state.clientResponseCount;
+                        if (response->statusCode != "200" || response->get("X-Express-Routing-Edge") != current.headerValue ||
+                            toString(response->body) != current.body) {
+                            ++state.unexpectedStateCount;
+                        }
+                        dispatchNext();
+                    },
+                    [this](const auto&, const std::string&) {
+                        ++state.parseErrorCount;
+                        dispatchNext();
+                    });
+            },
+            [](const std::shared_ptr<MasterRequest>&) {
+            }));
+
+        const std::shared_ptr<Client>& client = clients.back();
+        client->getConfig()->Instance::forceUnrequired();
+        client->connect(net::in::SocketAddress("127.0.0.1", port), [this](const net::in::SocketAddress&, core::socket::State connectState) {
+            if (connectState == core::socket::State::OK) {
+                ++state.clientConnectOkCount;
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+    }
+
+    State& state;
+    std::uint16_t port = 0;
+    std::deque<Case> cases;
+    std::vector<std::shared_ptr<Client>> clients;
+};
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetExpressRoutingEdgeBasicsTest");
+    } else {
+        State state;
+
+        core::SNodeC::init(argc, argv);
+
+        const express::legacy::in::WebApp app("ipv4-express-routing-edge-basics-server");
+        app.setStrictRouting(false);
+        app.setCaseInsensitiveRouting(true);
+
+        app.get("/express/strict", [&state] APPLICATION(req, res) {
+            ++state.strictRouteCount;
+            res->status(200).set("X-Express-Routing-Edge", "strict-default").send("non-strict trailing slash ok");
+        });
+
+        app.get("/express/case", [&state] APPLICATION(req, res) {
+            ++state.caseRouteCount;
+            res->status(200).set("X-Express-Routing-Edge", "case-default").send("case-insensitive route ok");
+        });
+
+        app.getConfig()->Instance::forceUnrequired();
+
+        CaseClientRunner caseClientRunner(state);
+        app.listen(net::in::SocketAddress("127.0.0.1", 0), [&caseClientRunner, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    caseClientRunner.run(effectivePort);
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after IPv4 legacy Express edge requests");
+        testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective IPv4 endpoint");
+        testResult.expectEqual(2, state.clientConnectOkCount, "HTTP client connect callbacks report OK once per request");
+        testResult.expectEqual(2, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback once per request");
+        testResult.expectEqual(2, state.clientResponseCount, "HTTP client observes both Express responses");
+        testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, "routing edge basics report no unexpected states");
+        testResult.expectEqual(1, state.strictRouteCount, "non-strict routing route handler runs exactly once");
+        testResult.expectEqual(1, state.caseRouteCount, "case-insensitive route handler runs exactly once");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/express/UnixExpressTransportSmokeTest.cpp
+++ b/tests/component/express/UnixExpressTransportSmokeTest.cpp
@@ -1,0 +1,117 @@
+#include "core/SNodeC.h"
+#include "express/legacy/un/WebApp.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/un/Client.h"
+
+#include <filesystem>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+struct State {
+    int listenOkCount = 0;
+    int effectiveListenEndpointOkCount = 0;
+    int clientConnectOkCount = 0;
+    int httpConnectedCount = 0;
+    int clientResponseCount = 0;
+    int parseErrorCount = 0;
+    int unexpectedStateCount = 0;
+    int handlerCount = 0;
+};
+
+std::string makeSocketPath() {
+    return "/tmp/snodec-express-component-" + std::to_string(::getpid()) + ".sock";
+}
+
+std::string toString(const std::vector<char>& bytes) {
+    return std::string(bytes.begin(), bytes.end());
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("UnixExpressTransportSmokeTest");
+    } else {
+        State state;
+        const std::string socketPath = makeSocketPath();
+        std::filesystem::remove(socketPath);
+
+        core::SNodeC::init(argc, argv);
+
+        const express::legacy::un::WebApp app("unix-express-transport-smoke-server");
+        web::http::legacy::un::Client client(
+            "unix-express-transport-smoke-client",
+            [&state](const auto& request) {
+                ++state.httpConnectedCount;
+                request->method = "GET";
+                request->url = "/express/transport-smoke";
+                request->set("Connection", "close");
+                request->end(
+                    [&state](const auto&, const auto& response) {
+                        ++state.clientResponseCount;
+                        if (response->statusCode != "200" || response->get("X-Express-Transport") != "unix" ||
+                            toString(response->body) != "express unix transport ok") {
+                            ++state.unexpectedStateCount;
+                        }
+                        core::SNodeC::stop();
+                    },
+                    [&state](const auto&, const std::string&) {
+                        ++state.parseErrorCount;
+                        core::SNodeC::stop();
+                    });
+            },
+            [](const auto&) {
+            });
+
+        app.get("/express/transport-smoke", [&state] APPLICATION(req, res) {
+            ++state.handlerCount;
+            res->status(200).set("X-Express-Transport", "unix").send("express unix transport ok");
+        });
+
+        app.getConfig()->Instance::forceUnrequired();
+        client.getConfig()->Instance::forceUnrequired();
+
+        app.listen(socketPath, [&client, &socketPath, &state](const auto&, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                ++state.effectiveListenEndpointOkCount;
+                client.connect(socketPath, [&state](const auto&, core::socket::State connectState) {
+                    if (connectState == core::socket::State::OK) {
+                        ++state.clientConnectOkCount;
+                    } else {
+                        ++state.unexpectedStateCount;
+                        core::SNodeC::stop();
+                    }
+                });
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully after Unix-domain legacy Express request");
+        testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective Unix-domain endpoint");
+        testResult.expectEqual(1, state.clientConnectOkCount, "HTTP client connect callback reports OK exactly once");
+        testResult.expectEqual(1, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback exactly once");
+        testResult.expectEqual(1, state.clientResponseCount, "HTTP client observes the Express response");
+        testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, "Unix-domain Express transport smoke reports no unexpected states");
+        testResult.expectEqual(1, state.handlerCount, "Express route handler runs exactly once");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+        std::filesystem::remove(socketPath);
+    }
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Close out the Express routing/middleware foundation track by adding the deterministic continuation component tests that were intentionally deferred in the IPv4 foundation PR (#126): IPv6 transport smoke, Unix-domain transport smoke, middleware short-circuit, and a tiny routing edge basics check. 
- Keep scope strictly to component-level Express application tests using the existing legacy non-TLS transports and existing public router APIs without changing production semantics.

### Description
- Added four component tests under `tests/component/express`: `Inet6ExpressTransportSmokeTest.cpp`, `UnixExpressTransportSmokeTest.cpp`, `InetExpressMiddlewareShortCircuitTest.cpp`, and `InetExpressRoutingEdgeBasicsTest.cpp`, and registered them in `tests/component/express/CMakeLists.txt`. 
- Tests exercise the existing legacy Express transports: `express::legacy::in6::WebApp` (IPv6), `express::legacy::un::WebApp` (Unix-domain), and `express::legacy::in::WebApp` (IPv4 middleware/edge checks), plus the matching legacy HTTP clients. 
- Each test verifies deterministic external behavior only (status, deterministic response header, deterministic response body, and precise handler invocation counts), uses `Connection: close`, ephemeral ports or temporary socket paths, and reuses helper patterns established in the IPv4 foundation test; `setStrictRouting(false)` and `setCaseInsensitiveRouting(true)` are used for the tiny routing-edge test because those APIs are public and non-invasive. 
- No production code or public API behavior was changed to enable these tests, and CMake entries follow the project conventions (`snodec_add_test`, linking targets, `target_compile_features(... cxx_std_20)`, labels, `TIMEOUT 5`, `SKIP_RETURN_CODE 77`).

### Testing
- Fixed a missing system dependency by running `sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev`, which resolved the initial CMake error about `nlohmann_json`. 
- Configured and generated build files with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON`, which completed (with non-blocking warnings for optional packages like Doxygen/IWYU/BlueZ/libmagic/libmariadb). 
- Built the new tests with `cmake --build build --target Inet6ExpressTransportSmokeTest UnixExpressTransportSmokeTest InetExpressMiddlewareShortCircuitTest InetExpressRoutingEdgeBasicsTest -j2`, which succeeded. 
- Ran the tests with CTest: `ctest --test-dir build -R 'Inet6ExpressTransportSmokeTest|UnixExpressTransportSmokeTest|InetExpressMiddlewareShortCircuitTest|InetExpressRoutingEdgeBasicsTest' --output-on-failure` (under root the tests were reported as skipped per the configured skip return code 77), and ran as an unprivileged user with `runuser -u nobody -- env HOME=/tmp/snodec-nobody-home ctest --test-dir build -R 'Inet6ExpressTransportSmokeTest|UnixExpressTransportSmokeTest|InetExpressMiddlewareShortCircuitTest|InetExpressRoutingEdgeBasicsTest' --output-on-failure`, which passed and validated all four tests and the expected handler-invocation assertions. 

Intentional deferrals: full Express parity, broad strict-routing/case-sensitivity suites, nested routers/mount/regex route/order edge-case suites, WebSocket/SSE/TLS/MQTT/DB/app smoke tests, and parser/formatter unit tests remain out of scope for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49109489ac832ca15b921f4d37ec0d)