### PR TITLE
Add WebSocket behavior continuation component tests

### DIFF
--- a/tests/component/websocket/CMakeLists.txt
+++ b/tests/component/websocket/CMakeLists.txt
@@ -5,14 +5,26 @@
 snodec_add_test(InetWebSocketServerClientTextEchoTest InetWebSocketServerClientTextEchoTest.cpp)
 snodec_add_test(Inet6WebSocketServerClientTextEchoTest Inet6WebSocketServerClientTextEchoTest.cpp)
 snodec_add_test(UnixWebSocketServerClientTextEchoTest UnixWebSocketServerClientTextEchoTest.cpp)
+snodec_add_test(InetWebSocketServerClientMultiTextMessageTest InetWebSocketServerClientMultiTextMessageTest.cpp)
+snodec_add_test(InetWebSocketServerClientBinaryEchoTest InetWebSocketServerClientBinaryEchoTest.cpp)
+snodec_add_test(InetWebSocketServerClientCloseHandshakeTest InetWebSocketServerClientCloseHandshakeTest.cpp)
+snodec_add_test(InetWebSocketServerClientPingPongTest InetWebSocketServerClientPingPongTest.cpp)
 
 target_link_libraries(InetWebSocketServerClientTextEchoTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::websocket-server snodec::websocket-client snodec::net-in-stream-legacy)
 target_link_libraries(Inet6WebSocketServerClientTextEchoTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::websocket-server snodec::websocket-client snodec::net-in6-stream-legacy)
 target_link_libraries(UnixWebSocketServerClientTextEchoTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::websocket-server snodec::websocket-client snodec::net-un-stream-legacy)
+target_link_libraries(InetWebSocketServerClientMultiTextMessageTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::websocket-server snodec::websocket-client snodec::net-in-stream-legacy)
+target_link_libraries(InetWebSocketServerClientBinaryEchoTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::websocket-server snodec::websocket-client snodec::net-in-stream-legacy)
+target_link_libraries(InetWebSocketServerClientCloseHandshakeTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::websocket-server snodec::websocket-client snodec::net-in-stream-legacy)
+target_link_libraries(InetWebSocketServerClientPingPongTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::websocket-server snodec::websocket-client snodec::net-in-stream-legacy)
 
 target_compile_features(InetWebSocketServerClientTextEchoTest PRIVATE cxx_std_20)
 target_compile_features(Inet6WebSocketServerClientTextEchoTest PRIVATE cxx_std_20)
 target_compile_features(UnixWebSocketServerClientTextEchoTest PRIVATE cxx_std_20)
+target_compile_features(InetWebSocketServerClientMultiTextMessageTest PRIVATE cxx_std_20)
+target_compile_features(InetWebSocketServerClientBinaryEchoTest PRIVATE cxx_std_20)
+target_compile_features(InetWebSocketServerClientCloseHandshakeTest PRIVATE cxx_std_20)
+target_compile_features(InetWebSocketServerClientPingPongTest PRIVATE cxx_std_20)
 
 set_tests_properties(InetWebSocketServerClientTextEchoTest PROPERTIES
                      LABELS "component;websocket;client;server;legacy;ipv4"
@@ -26,5 +38,25 @@ set_tests_properties(Inet6WebSocketServerClientTextEchoTest PROPERTIES
 
 set_tests_properties(UnixWebSocketServerClientTextEchoTest PROPERTIES
                      LABELS "component;websocket;client;server;legacy;unix"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetWebSocketServerClientMultiTextMessageTest PROPERTIES
+                     LABELS "component;websocket;client;server;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetWebSocketServerClientBinaryEchoTest PROPERTIES
+                     LABELS "component;websocket;client;server;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetWebSocketServerClientCloseHandshakeTest PROPERTIES
+                     LABELS "component;websocket;client;server;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetWebSocketServerClientPingPongTest PROPERTIES
+                     LABELS "component;websocket;client;server;legacy;ipv4"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)

--- a/tests/component/websocket/InetWebSocketBehaviorRunner.h
+++ b/tests/component/websocket/InetWebSocketBehaviorRunner.h
@@ -1,0 +1,49 @@
+#ifndef TESTS_COMPONENT_WEBSOCKET_INETWEBSOCKETBEHAVIORRUNNER_H
+#define TESTS_COMPONENT_WEBSOCKET_INETWEBSOCKETBEHAVIORRUNNER_H
+
+#include "WebSocketServerClientBehaviorTest.h"
+
+#include "core/SNodeC.h"
+#include "net/in/SocketAddress.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Client.h"
+#include "web/http/legacy/in/Server.h"
+
+namespace tests::component::websocket::behavior {
+
+    template <typename Expect>
+    int runInetBehaviorTest(int argc, char* argv[], const char* serverName, const char* clientName, State& state, Expect expect) {
+        tests::support::TestResult testResult;
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in::Server;
+        using Client = web::http::legacy::in::Client;
+
+        const Server server(serverName, [&state](const auto& request, const auto& response) { handleUpgradeRequest(request, response, state); });
+        Client client(clientName, [&state](const auto& request) { startUpgrade(request, state); }, [&state](const auto&) { ++state.httpDisconnectedCount; });
+
+        configure(server, client, state);
+        server.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const net::in::SocketAddress&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) ++state.clientConnectOkCount;
+                        else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+                    });
+                } else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+            } else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        expect(testResult, state, startResult);
+        const int result = testResult.processResult();
+        core::SNodeC::free();
+        return result;
+    }
+
+} // namespace tests::component::websocket::behavior
+
+#endif

--- a/tests/component/websocket/InetWebSocketServerClientBinaryEchoTest.cpp
+++ b/tests/component/websocket/InetWebSocketServerClientBinaryEchoTest.cpp
@@ -1,0 +1,29 @@
+#include "InetWebSocketBehaviorRunner.h"
+
+int main(int argc, char* argv[]) {
+    int result = tests::support::cTestSkipReturnCode;
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetWebSocketServerClientBinaryEchoTest");
+    } else {
+        tests::component::websocket::behavior::State state{tests::component::websocket::behavior::Scenario::BinaryEcho};
+        result = tests::component::websocket::behavior::runInetBehaviorTest(
+            argc,
+            argv,
+            "ipv4-websocket-binary-echo-server",
+            "ipv4-websocket-binary-echo-client",
+            state,
+            [](tests::support::TestResult& testResult, const tests::component::websocket::behavior::State& state, int startResult) {
+                using namespace tests::component::websocket::behavior;
+                expectCommon(testResult, state, "IPv4 legacy WebSocket binary echo", startResult);
+                testResult.expectEqual(1, state.serverMessageStartCount, "server observes one binary message start");
+                testResult.expectEqual(1, state.serverMessageEndCount, "server observes one binary message end");
+                testResult.expectEqual(1, state.clientMessageStartCount, "client observes one binary message start");
+                testResult.expectEqual(1, state.clientMessageEndCount, "client observes one binary message end");
+                testResult.expectEqual(1, state.serverBinaryOpcodeCount, "server observes binary opcode");
+                testResult.expectEqual(1, state.clientBinaryOpcodeCount, "client observes binary opcode");
+                testResult.expectTrue(state.serverBinary == binaryRequest, "server receives exact binary request bytes");
+                testResult.expectTrue(state.clientBinary == binaryReply, "client receives exact binary reply bytes");
+            });
+    }
+    return result;
+}

--- a/tests/component/websocket/InetWebSocketServerClientCloseHandshakeTest.cpp
+++ b/tests/component/websocket/InetWebSocketServerClientCloseHandshakeTest.cpp
@@ -1,0 +1,26 @@
+#include "InetWebSocketBehaviorRunner.h"
+
+int main(int argc, char* argv[]) {
+    int result = tests::support::cTestSkipReturnCode;
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetWebSocketServerClientCloseHandshakeTest");
+    } else {
+        tests::component::websocket::behavior::State state{tests::component::websocket::behavior::Scenario::CloseHandshake};
+        result = tests::component::websocket::behavior::runInetBehaviorTest(
+            argc,
+            argv,
+            "ipv4-websocket-close-handshake-server",
+            "ipv4-websocket-close-handshake-client",
+            state,
+            [](tests::support::TestResult& testResult, const tests::component::websocket::behavior::State& state, int startResult) {
+                using namespace tests::component::websocket::behavior;
+                expectCommon(testResult, state, "IPv4 legacy WebSocket close handshake", startResult);
+                testResult.expectEqual(0, state.serverMessageStartCount, "server observes no application message starts during explicit close");
+                testResult.expectEqual(0, state.serverMessageEndCount, "server observes no application message ends during explicit close");
+                testResult.expectEqual(0, state.clientMessageStartCount, "client observes no application message starts during explicit close");
+                testResult.expectEqual(0, state.clientMessageEndCount, "client observes no application message ends during explicit close");
+                testResult.expectEqual(1, state.serverWsDisconnectedCount, "server observes disconnect once after close handshake");
+            });
+    }
+    return result;
+}

--- a/tests/component/websocket/InetWebSocketServerClientMultiTextMessageTest.cpp
+++ b/tests/component/websocket/InetWebSocketServerClientMultiTextMessageTest.cpp
@@ -1,0 +1,29 @@
+#include "InetWebSocketBehaviorRunner.h"
+
+int main(int argc, char* argv[]) {
+    int result = tests::support::cTestSkipReturnCode;
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetWebSocketServerClientMultiTextMessageTest");
+    } else {
+        tests::component::websocket::behavior::State state{tests::component::websocket::behavior::Scenario::MultiText};
+        result = tests::component::websocket::behavior::runInetBehaviorTest(
+            argc,
+            argv,
+            "ipv4-websocket-multi-text-server",
+            "ipv4-websocket-multi-text-client",
+            state,
+            [](tests::support::TestResult& testResult, const tests::component::websocket::behavior::State& state, int startResult) {
+                using namespace tests::component::websocket::behavior;
+                expectCommon(testResult, state, "IPv4 legacy WebSocket multi-text", startResult);
+                testResult.expectEqual(3, state.serverMessageStartCount, "server observes three text message starts");
+                testResult.expectEqual(3, state.serverMessageEndCount, "server observes three text message ends");
+                testResult.expectEqual(3, state.clientMessageStartCount, "client observes three text message starts");
+                testResult.expectEqual(3, state.clientMessageEndCount, "client observes three text message ends");
+                testResult.expectEqual(3, state.serverTextOpcodeCount, "server observes text opcode for each message");
+                testResult.expectEqual(3, state.clientTextOpcodeCount, "client observes text opcode for each reply");
+                testResult.expectTrue(state.serverMessages == textMessages, "server receives exact text message sequence");
+                testResult.expectTrue(state.clientMessages == textReplies, "client receives exact text reply sequence");
+            });
+    }
+    return result;
+}

--- a/tests/component/websocket/InetWebSocketServerClientPingPongTest.cpp
+++ b/tests/component/websocket/InetWebSocketServerClientPingPongTest.cpp
@@ -1,0 +1,26 @@
+#include "InetWebSocketBehaviorRunner.h"
+
+int main(int argc, char* argv[]) {
+    int result = tests::support::cTestSkipReturnCode;
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetWebSocketServerClientPingPongTest");
+    } else {
+        tests::component::websocket::behavior::State state{tests::component::websocket::behavior::Scenario::PingPong};
+        result = tests::component::websocket::behavior::runInetBehaviorTest(
+            argc,
+            argv,
+            "ipv4-websocket-ping-pong-server",
+            "ipv4-websocket-ping-pong-client",
+            state,
+            [](tests::support::TestResult& testResult, const tests::component::websocket::behavior::State& state, int startResult) {
+                using namespace tests::component::websocket::behavior;
+                expectCommon(testResult, state, "IPv4 legacy WebSocket ping/pong", startResult);
+                testResult.expectEqual(0, state.serverMessageStartCount, "server observes no application message starts during ping/pong");
+                testResult.expectEqual(0, state.serverMessageEndCount, "server observes no application message ends during ping/pong");
+                testResult.expectEqual(0, state.clientMessageStartCount, "client observes no application message starts during ping/pong");
+                testResult.expectEqual(0, state.clientMessageEndCount, "client observes no application message ends during ping/pong");
+                testResult.expectEqual(1, state.clientPongReceivedCount, "client observes one pong response");
+            });
+    }
+    return result;
+}

--- a/tests/component/websocket/WebSocketServerClientBehaviorTest.h
+++ b/tests/component/websocket/WebSocketServerClientBehaviorTest.h
@@ -1,0 +1,260 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#ifndef TESTS_COMPONENT_WEBSOCKET_WEBSOCKETSERVERCLIENTBEHAVIORTEST_H
+#define TESTS_COMPONENT_WEBSOCKET_WEBSOCKETSERVERCLIENTBEHAVIORTEST_H
+
+#include "core/SNodeC.h"
+#include "support/TestResult.h"
+#include "web/http/client/Request.h"
+#include "web/http/client/Response.h"
+#include "web/http/server/Request.h"
+#include "web/http/server/Response.h"
+#include "web/websocket/SubProtocolFactory.h"
+#include "web/websocket/client/SocketContextUpgradeFactory.h"
+#include "web/websocket/client/SubProtocol.h"
+#include "web/websocket/client/SubProtocolFactorySelector.h"
+#include "web/websocket/server/SocketContextUpgradeFactory.h"
+#include "web/websocket/server/SubProtocol.h"
+#include "web/websocket/server/SubProtocolFactorySelector.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace tests::component::websocket::behavior {
+
+    constexpr const char* subProtocolName = "component-behavior";
+    constexpr const char* path = "/component/websocket/behavior";
+
+    enum class Scenario { MultiText, BinaryEcho, CloseHandshake, PingPong };
+
+    struct State {
+        Scenario scenario;
+        int listenOkCount = 0;
+        int effectiveListenEndpointOkCount = 0;
+        int clientConnectOkCount = 0;
+        int serverRequestCount = 0;
+        int serverUpgradeOkCount = 0;
+        int clientHttpConnectedCount = 0;
+        int clientUpgradeInitiatedCount = 0;
+        int clientUpgradeResponseCount = 0;
+        int serverWsConnectedCount = 0;
+        int clientWsConnectedCount = 0;
+        int serverMessageStartCount = 0;
+        int serverMessageEndCount = 0;
+        int clientMessageStartCount = 0;
+        int clientMessageEndCount = 0;
+        int serverWsDisconnectedCount = 0;
+        int clientWsDisconnectedCount = 0;
+        int httpDisconnectedCount = 0;
+        int parseErrorCount = 0;
+        int messageErrorCount = 0;
+        int unexpectedStateCount = 0;
+        int clientPongReceivedCount = 0;
+        int serverTextOpcodeCount = 0;
+        int clientTextOpcodeCount = 0;
+        int serverBinaryOpcodeCount = 0;
+        int clientBinaryOpcodeCount = 0;
+        std::string currentServerMessage;
+        std::string currentClientMessage;
+        std::vector<std::string> serverMessages;
+        std::vector<std::string> clientMessages;
+        std::vector<unsigned char> serverBinary;
+        std::vector<unsigned char> clientBinary;
+    };
+
+    inline const std::vector<std::string> textMessages = {"message-1", "message-2", "message-3"};
+    inline const std::vector<std::string> textReplies = {"reply-1", "reply-2", "reply-3"};
+    inline const std::vector<unsigned char> binaryRequest = {0x00, 0x01, 0x02, 0x7f, 0x80, 0xff};
+    inline const std::vector<unsigned char> binaryReply = {0xff, 0x80, 0x7f, 0x02, 0x01, 0x00};
+
+    class ServerSubProtocol : public web::websocket::server::SubProtocol {
+    public:
+        ServerSubProtocol(web::websocket::SubProtocolContext* context, State& state)
+            : web::websocket::server::SubProtocol(context, subProtocolName, 0, 3)
+            , state(state) {
+        }
+
+    private:
+        void onConnected() override { ++state.serverWsConnectedCount; }
+
+        void onMessageStart(int opCode) override {
+            ++state.serverMessageStartCount;
+            state.currentServerMessage.clear();
+            state.serverBinary.clear();
+            if (opCode == 1) ++state.serverTextOpcodeCount;
+            if (opCode == 2) ++state.serverBinaryOpcodeCount;
+        }
+
+        void onMessageData(const char* chunk, std::size_t chunkLen) override {
+            state.currentServerMessage.append(chunk, chunkLen);
+            const auto* begin = reinterpret_cast<const unsigned char*>(chunk);
+            state.serverBinary.insert(state.serverBinary.end(), begin, begin + chunkLen);
+        }
+
+        void onMessageEnd() override {
+            ++state.serverMessageEndCount;
+            if (state.scenario == Scenario::MultiText) {
+                state.serverMessages.push_back(state.currentServerMessage);
+                const std::size_t index = state.serverMessages.size() - 1;
+                if (index < textMessages.size() && state.currentServerMessage == textMessages[index]) {
+                    sendMessage(textReplies[index]);
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else if (state.scenario == Scenario::BinaryEcho) {
+                if (state.serverBinary == binaryRequest) {
+                    sendMessage(reinterpret_cast<const char*>(binaryReply.data()), binaryReply.size());
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        }
+
+        void onMessageError(uint16_t) override { ++state.messageErrorCount; core::SNodeC::stop(); }
+        void onDisconnected() override { ++state.serverWsDisconnectedCount; }
+        bool onSignal(int) override { sendClose(); return false; }
+        State& state;
+    };
+
+    class ClientSubProtocol : public web::websocket::client::SubProtocol {
+    public:
+        ClientSubProtocol(web::websocket::SubProtocolContext* context, State& state)
+            : web::websocket::client::SubProtocol(context, subProtocolName, 0, 3)
+            , state(state) {
+        }
+
+    private:
+        void onConnected() override {
+            ++state.clientWsConnectedCount;
+            if (state.scenario == Scenario::MultiText) sendMessage(textMessages.front());
+            if (state.scenario == Scenario::BinaryEcho) sendMessage(reinterpret_cast<const char*>(binaryRequest.data()), binaryRequest.size());
+            if (state.scenario == Scenario::CloseHandshake) sendClose(1000, "done", 4);
+            if (state.scenario == Scenario::PingPong) sendPing("ping", 4);
+        }
+
+        void onMessageStart(int opCode) override {
+            ++state.clientMessageStartCount;
+            state.currentClientMessage.clear();
+            state.clientBinary.clear();
+            if (opCode == 1) ++state.clientTextOpcodeCount;
+            if (opCode == 2) ++state.clientBinaryOpcodeCount;
+        }
+
+        void onMessageData(const char* chunk, std::size_t chunkLen) override {
+            state.currentClientMessage.append(chunk, chunkLen);
+            const auto* begin = reinterpret_cast<const unsigned char*>(chunk);
+            state.clientBinary.insert(state.clientBinary.end(), begin, begin + chunkLen);
+        }
+
+        void onMessageEnd() override {
+            ++state.clientMessageEndCount;
+            if (state.scenario == Scenario::MultiText) {
+                state.clientMessages.push_back(state.currentClientMessage);
+                const std::size_t index = state.clientMessages.size() - 1;
+                if (index >= textReplies.size() || state.currentClientMessage != textReplies[index]) {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                } else if (state.clientMessages.size() < textMessages.size()) {
+                    sendMessage(textMessages[state.clientMessages.size()]);
+                } else {
+                    sendClose();
+                }
+            } else if (state.scenario == Scenario::BinaryEcho) {
+                if (state.clientBinary == binaryReply) sendClose(); else ++state.unexpectedStateCount;
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        }
+
+        void onMessageError(uint16_t) override { ++state.messageErrorCount; core::SNodeC::stop(); }
+        void onPongReceived() override { ++state.clientPongReceivedCount; sendClose(); }
+        void onDisconnected() override { ++state.clientWsDisconnectedCount; core::SNodeC::stop(); }
+        bool onSignal(int) override { sendClose(); return false; }
+        State& state;
+    };
+
+    class ServerFactory : public web::websocket::SubProtocolFactory<web::websocket::server::SubProtocol> {
+    public:
+        explicit ServerFactory(State& state) : web::websocket::SubProtocolFactory<web::websocket::server::SubProtocol>(tests::component::websocket::behavior::subProtocolName), state(state) {}
+    private:
+        web::websocket::server::SubProtocol* create(web::websocket::SubProtocolContext* context) override { return new ServerSubProtocol(context, state); }
+        State& state;
+    };
+
+    class ClientFactory : public web::websocket::SubProtocolFactory<web::websocket::client::SubProtocol> {
+    public:
+        explicit ClientFactory(State& state) : web::websocket::SubProtocolFactory<web::websocket::client::SubProtocol>(tests::component::websocket::behavior::subProtocolName), state(state) {}
+    private:
+        web::websocket::client::SubProtocol* create(web::websocket::SubProtocolContext* context) override { return new ClientSubProtocol(context, state); }
+        State& state;
+    };
+
+    inline State* linkedState = nullptr;
+    inline web::websocket::SubProtocolFactory<web::websocket::server::SubProtocol>* createServerFactory() { return new ServerFactory(*linkedState); }
+    inline web::websocket::SubProtocolFactory<web::websocket::client::SubProtocol>* createClientFactory() { return new ClientFactory(*linkedState); }
+
+    template <typename Server, typename Client>
+    void configure(Server& server, Client& client, State& state) {
+        linkedState = &state;
+        web::websocket::server::SocketContextUpgradeFactory::link();
+        web::websocket::client::SocketContextUpgradeFactory::link();
+        web::websocket::server::SubProtocolFactorySelector::link(subProtocolName, createServerFactory);
+        web::websocket::client::SubProtocolFactorySelector::link(subProtocolName, createClientFactory);
+        server.getConfig()->Instance::forceUnrequired();
+        client.getConfig()->Instance::forceUnrequired();
+    }
+
+    template <typename Request, typename Response>
+    void handleUpgradeRequest(const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response, State& state) {
+        ++state.serverRequestCount;
+        if (request->url == path && request->get("upgrade") == "websocket") {
+            response->upgrade(request, [&state, response](const std::string& selectedProtocol) {
+                if (selectedProtocol == "websocket") { ++state.serverUpgradeOkCount; response->end(); }
+                else { ++state.unexpectedStateCount; response->sendStatus(400); core::SNodeC::stop(); }
+            });
+        } else { ++state.unexpectedStateCount; response->sendStatus(404); core::SNodeC::stop(); }
+    }
+
+    template <typename MasterRequest>
+    void startUpgrade(const std::shared_ptr<MasterRequest>& request, State& state) {
+        ++state.clientHttpConnectedCount;
+        request->set("Sec-WebSocket-Protocol", subProtocolName);
+        request->upgrade(path, "websocket", [&state](bool success) { if (success) ++state.clientUpgradeInitiatedCount; else { ++state.unexpectedStateCount; core::SNodeC::stop(); } },
+                         [&state](const auto&, const auto& response, bool success) { if (success && response->get("upgrade") == "websocket") ++state.clientUpgradeResponseCount; else { ++state.unexpectedStateCount; core::SNodeC::stop(); } },
+                         [&state](const auto&, const std::string&) { ++state.parseErrorCount; core::SNodeC::stop(); });
+    }
+
+    inline void expectCommon(tests::support::TestResult& testResult, const State& state, const std::string& name, int startResult) {
+        testResult.expectEqual(0, startResult, name + " event loop stops successfully");
+        testResult.expectEqual(1, state.listenOkCount, name + " server listen callback reports OK once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, name + " reports one effective endpoint");
+        testResult.expectEqual(1, state.clientConnectOkCount, name + " client connect callback reports OK once");
+        testResult.expectEqual(1, state.serverRequestCount, name + " server observes one upgrade request");
+        testResult.expectEqual(1, state.serverUpgradeOkCount, name + " server selects websocket upgrade once");
+        testResult.expectEqual(1, state.clientHttpConnectedCount, name + " client reaches HTTP-connected callback once");
+        testResult.expectEqual(1, state.clientUpgradeInitiatedCount, name + " client initiates upgrade once");
+        testResult.expectEqual(1, state.clientUpgradeResponseCount, name + " client observes upgrade response once");
+        testResult.expectEqual(1, state.serverWsConnectedCount, name + " server subprotocol connects once");
+        testResult.expectEqual(1, state.clientWsConnectedCount, name + " client subprotocol connects once");
+        testResult.expectEqual(1, state.clientWsDisconnectedCount, name + " client observes disconnect once");
+        testResult.expectEqual(0, state.parseErrorCount, name + " reports no HTTP parse errors");
+        testResult.expectEqual(0, state.messageErrorCount, name + " reports no message errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, name + " reports no unexpected states");
+    }
+
+} // namespace tests::component::websocket::behavior
+
+#endif // TESTS_COMPONENT_WEBSOCKET_WEBSOCKETSERVERCLIENTBEHAVIORTEST_H


### PR DESCRIPTION
### Motivation

- Continue the WebSocket test track from the transport foundation by adding deterministic behavior component tests that exercise richer WebSocket semantics on the IPv4 legacy transport only. 
- Verify ordered multi-text messaging, binary message round-trip, explicit close handshake, and ping/pong end-to-end using the public subprotocol APIs and the in-test `link()` factory registration strategy without changing production code.

### Description

- Added a narrow behavior test harness and shared header `tests/component/websocket/WebSocketServerClientBehaviorTest.h` that defines deterministic scenarios, an observable `State` struct, server/client subprotocol implementations, and helper functions for upgrade handling and factory linking via `SocketContextUpgradeFactory::link()` and `SubProtocolFactorySelector::link()`.
- Added an IPv4 legacy runner `tests/component/websocket/InetWebSocketBehaviorRunner.h` that starts `core::SNodeC` with a server on `127.0.0.1:0`, connects the legacy client, and drives the event loop with `core::SNodeC::start(utils::Timeval({1, 0}))` and `forceUnrequired()` for configs.
- Added four component tests that use the harness and runner: `InetWebSocketServerClientMultiTextMessageTest` (3-message ordered text sequence), `InetWebSocketServerClientBinaryEchoTest` (binary request/reply echo), `InetWebSocketServerClientCloseHandshakeTest` (explicit client close handshake), and `InetWebSocketServerClientPingPongTest` (ping/pong), each using IPv4 legacy non-TLS only and the public `sendMessage`, `sendMessage(const char*,size_t)`, `sendPing`, `sendClose`, and callback hooks.
- Registered tests and targets in `tests/component/websocket/CMakeLists.txt` with `snodec_add_test`, `target_compile_features(... cxx_std_20)`, labels `component;websocket;client;server;legacy;ipv4`, `SKIP_RETURN_CODE 77`, and `TIMEOUT 5`.
- No production code changes were made; all tests use the existing public APIs and the same runtime factory/subprotocol linking approach used in the WebSocket transport foundation.
- Deferred items: no IPv6/Unix duplicates (transport coverage done in the foundation PR), no TLS WebSocket, MQTT-over-WebSocket, Express routing/upgrade tests, SSE, fragmentation, large payloads, backpressure, malformed-frame/protocol-error tests, HTTP parser/formatter internals, DB, or application smoke tests.

### Testing

- Verified repository state and formatting with `git diff --check` (no issues).
- Configured and built tests: ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON`, which completed successfully after installing the missing system dependency `nlohmann-json3-dev` (CMake emitted non-fatal warnings for optional tools such as Doxygen/iwyu/libmagic/libbluetooth but configuration finished).
- Built the new test targets with `cmake --build build --target InetWebSocketServerClientMultiTextMessageTest InetWebSocketServerClientBinaryEchoTest InetWebSocketServerClientCloseHandshakeTest InetWebSocketServerClientPingPongTest -j2`, and the targets linked and produced executables successfully.
- Ran component tests via CTest: `ctest --test-dir build -R 'WebSocketServerClient.*Test' --output-on-failure` and `ctest --test-dir build -L websocket --output-on-failure`; as expected the test harness uses a root-skip mechanism (`SKIP_RETURN_CODE 77`) so root runs may be skipped, which is the intended behavior.
- Verified full runs as an unprivileged user to exercise tests (pattern used by existing WebSocket tests): `runuser -u snodectest -- env HOME=/home/snodectest ctest --test-dir build -R 'WebSocketServerClient.*Test' --output-on-failure` and `runuser -u snodectest -- env HOME=/home/snodectest ctest --test-dir build -L websocket --output-on-failure`, which completed successfully with all new tests passing (7/7 tests when non-root).
- Summarized results: CMake configure/build passed, new executables were built, and tests passed when executed under the intended unprivileged test user; root-mode CTest returned skips as designed (`SKIP_RETURN_CODE 77`).

Files added/changed (high level):
- Added `tests/component/websocket/WebSocketServerClientBehaviorTest.h` (new harness)
- Added `tests/component/websocket/InetWebSocketBehaviorRunner.h` (shared IPv4 runner)
- Added tests: `InetWebSocketServerClientMultiTextMessageTest.cpp`, `InetWebSocketServerClientBinaryEchoTest.cpp`, `InetWebSocketServerClientCloseHandshakeTest.cpp`, `InetWebSocketServerClientPingPongTest.cpp`
- Updated `tests/component/websocket/CMakeLists.txt` to register/link the new tests

Runtime loading: tests use in-test `SocketContextUpgradeFactory::link()` and `SubProtocolFactorySelector::link()` calls; they do not rely on globally installed SNode.C modules, do not add CTest environment variables, and require no manual `LD_LIBRARY_PATH` changes.

Production code: no production files or public APIs were changed to enable the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a491c0017ec832c9b44dc4c6e3d70d4)