### PR TITLE
Add HTTP behavior continuation component tests

### DIFF
--- a/tests/component/http/CMakeLists.txt
+++ b/tests/component/http/CMakeLists.txt
@@ -80,3 +80,30 @@ set_tests_properties(UnixHttpServerClientStatusVariantTest PROPERTIES
                      LABELS "component;http;client;server;legacy;unix"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)
+
+snodec_add_test(InetHttpServerClientRepeatedRequestTest InetHttpServerClientRepeatedRequestTest.cpp)
+snodec_add_test(InetHttpServerClientDisconnectLifecycleTest InetHttpServerClientDisconnectLifecycleTest.cpp)
+snodec_add_test(InetHttpClientPrematureServerCloseTest InetHttpClientPrematureServerCloseTest.cpp)
+snodec_add_test(InetHttpServerClientLargeResponseBodyTest InetHttpServerClientLargeResponseBodyTest.cpp)
+snodec_add_test(InetHttpServerClientLargeRequestBodyTest InetHttpServerClientLargeRequestBodyTest.cpp)
+
+target_link_libraries(InetHttpServerClientRepeatedRequestTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetHttpServerClientDisconnectLifecycleTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetHttpClientPrematureServerCloseTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetHttpServerClientLargeResponseBodyTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetHttpServerClientLargeRequestBodyTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
+
+target_compile_features(InetHttpServerClientRepeatedRequestTest PRIVATE cxx_std_20)
+target_compile_features(InetHttpServerClientDisconnectLifecycleTest PRIVATE cxx_std_20)
+target_compile_features(InetHttpClientPrematureServerCloseTest PRIVATE cxx_std_20)
+target_compile_features(InetHttpServerClientLargeResponseBodyTest PRIVATE cxx_std_20)
+target_compile_features(InetHttpServerClientLargeRequestBodyTest PRIVATE cxx_std_20)
+
+set_tests_properties(InetHttpServerClientRepeatedRequestTest
+                     InetHttpServerClientDisconnectLifecycleTest
+                     InetHttpClientPrematureServerCloseTest
+                     InetHttpServerClientLargeResponseBodyTest
+                     InetHttpServerClientLargeRequestBodyTest PROPERTIES
+                     LABELS "component;http;client;server;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)

--- a/tests/component/http/HttpServerClientBehaviorTest.h
+++ b/tests/component/http/HttpServerClientBehaviorTest.h
@@ -1,0 +1,255 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#ifndef TESTS_COMPONENT_HTTP_HTTPSERVERCLIENTBEHAVIORTEST_H
+#define TESTS_COMPONENT_HTTP_HTTPSERVERCLIENTBEHAVIORTEST_H
+
+#include "core/SNodeC.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/server/Request.h"
+#include "web/http/server/Response.h"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace tests::component::http {
+
+    inline constexpr std::size_t boundedBodySize = 64U * 1024U;
+
+    struct BehaviorState {
+        int listenOkCount = 0;
+        int effectiveListenEndpointOkCount = 0;
+        int clientConnectOkCount = 0;
+        int httpConnectedCount = 0;
+        int httpDisconnectedCount = 0;
+        int serverRequestCount = 0;
+        int clientResponseCount = 0;
+        int parseErrorCount = 0;
+        int unexpectedStateCount = 0;
+        int queuedRequestCount = 0;
+
+        std::vector<std::string> serverUrls;
+        std::vector<std::string> clientBodies;
+        std::vector<std::string> clientStatuses;
+        std::string serverBody;
+        bool clientSawContentLength = false;
+    };
+
+    inline std::string toString(const std::vector<char>& bytes) {
+        return std::string(bytes.begin(), bytes.end());
+    }
+
+    inline std::string makePatternBody(std::size_t size) {
+        std::string body;
+        body.reserve(size);
+        for (std::size_t i = 0; i < size; ++i) {
+            body.push_back(static_cast<char>('A' + (i % 26)));
+        }
+        return body;
+    }
+
+    template <typename Server, typename Client>
+    void configureHttpBehaviorTest(Server& server, Client& client, BehaviorState&) {
+        server.getConfig()->Instance::forceUnrequired();
+        client.getConfig()->Instance::forceUnrequired();
+    }
+
+    template <typename Request, typename Response>
+    void handleRepeatedRequest(const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response, BehaviorState& state) {
+        ++state.serverRequestCount;
+        state.serverUrls.push_back(request->url);
+
+        if (request->url == "/first") {
+            response->status(200).type("text/plain").set("Connection", "keep-alive").send("first-response");
+        } else if (request->url == "/second") {
+            response->status(200).type("text/plain").set("Connection", "close").send("second-response");
+        } else {
+            ++state.unexpectedStateCount;
+            response->status(404).set("Connection", "close").send("unexpected repeated request target");
+        }
+    }
+
+    template <typename MasterRequest>
+    void sendRepeatedRequests(const std::shared_ptr<MasterRequest>& request, BehaviorState& state) {
+        ++state.httpConnectedCount;
+        request->method = "GET";
+        request->url = "/first";
+        request->set("Connection", "keep-alive");
+        if (request->end(
+                [&state, request](const auto&, const auto& response) {
+                    ++state.clientResponseCount;
+                    state.clientStatuses.push_back(response->statusCode);
+                    state.clientBodies.push_back(toString(response->body));
+
+                    request->method = "GET";
+                    request->url = "/second";
+                    request->set("Connection", "close");
+                    if (request->end(
+                            [&state](const auto&, const auto& secondResponse) {
+                                ++state.clientResponseCount;
+                                state.clientStatuses.push_back(secondResponse->statusCode);
+                                state.clientBodies.push_back(toString(secondResponse->body));
+                                core::SNodeC::stop();
+                            },
+                            [&state](const auto&, const std::string&) {
+                                ++state.parseErrorCount;
+                                core::SNodeC::stop();
+                            })) {
+                        ++state.queuedRequestCount;
+                    } else {
+                        ++state.unexpectedStateCount;
+                        core::SNodeC::stop();
+                    }
+                },
+                [&state](const auto&, const std::string&) {
+                    ++state.parseErrorCount;
+                    core::SNodeC::stop();
+                })) {
+            ++state.queuedRequestCount;
+        } else {
+            ++state.unexpectedStateCount;
+            core::SNodeC::stop();
+        }
+    }
+
+    template <typename Request, typename Response>
+    void handleDisconnectRequest(const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response, BehaviorState& state) {
+        ++state.serverRequestCount;
+        state.serverUrls.push_back(request->url);
+        response->status(200).type("text/plain").set("Connection", "close").send("disconnect-ok");
+    }
+
+    template <typename MasterRequest>
+    void sendDisconnectRequest(const std::shared_ptr<MasterRequest>& request, BehaviorState& state) {
+        ++state.httpConnectedCount;
+        request->method = "GET";
+        request->url = "/disconnect";
+        request->set("Connection", "close");
+        if (!request->end(
+                [&state](const auto&, const auto& response) {
+                    ++state.clientResponseCount;
+                    state.clientStatuses.push_back(response->statusCode);
+                    state.clientBodies.push_back(toString(response->body));
+                },
+                [&state](const auto&, const std::string&) {
+                    ++state.parseErrorCount;
+                    core::SNodeC::stop();
+                })) {
+            ++state.unexpectedStateCount;
+            core::SNodeC::stop();
+        }
+    }
+
+    template <typename Request, typename Response>
+    void handlePrematureCloseRequest(const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response, BehaviorState& state) {
+        ++state.serverRequestCount;
+        state.serverUrls.push_back(request->url);
+        response->getSocketContext()->close();
+    }
+
+    template <typename MasterRequest>
+    void sendPrematureCloseRequest(const std::shared_ptr<MasterRequest>& request, BehaviorState& state) {
+        ++state.httpConnectedCount;
+        request->method = "GET";
+        request->url = "/premature-close";
+        request->set("Connection", "close");
+        if (!request->end(
+                [&state](const auto&, const auto& response) {
+                    ++state.clientResponseCount;
+                    state.clientStatuses.push_back(response->statusCode);
+                    state.clientBodies.push_back(response->reason);
+                    core::SNodeC::stop();
+                },
+                [&state](const auto&, const std::string&) {
+                    ++state.parseErrorCount;
+                    core::SNodeC::stop();
+                })) {
+            ++state.unexpectedStateCount;
+            core::SNodeC::stop();
+        }
+    }
+
+    template <typename Request, typename Response>
+    void handleLargeResponseRequest(const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response, BehaviorState& state) {
+        ++state.serverRequestCount;
+        state.serverUrls.push_back(request->url);
+        const std::string body = makePatternBody(boundedBodySize);
+        response->status(200).type("application/octet-stream").set("Connection", "close").send(body);
+    }
+
+    template <typename MasterRequest>
+    void sendLargeResponseRequest(const std::shared_ptr<MasterRequest>& request, BehaviorState& state) {
+        ++state.httpConnectedCount;
+        request->method = "GET";
+        request->url = "/large-response";
+        request->set("Connection", "close");
+        if (!request->end(
+                [&state](const auto&, const auto& response) {
+                    ++state.clientResponseCount;
+                    state.clientStatuses.push_back(response->statusCode);
+                    state.clientBodies.push_back(toString(response->body));
+                    state.clientSawContentLength = response->get("Content-Length") == std::to_string(boundedBodySize);
+                    core::SNodeC::stop();
+                },
+                [&state](const auto&, const std::string&) {
+                    ++state.parseErrorCount;
+                    core::SNodeC::stop();
+                })) {
+            ++state.unexpectedStateCount;
+            core::SNodeC::stop();
+        }
+    }
+
+    template <typename Request, typename Response>
+    void handleLargeRequestRequest(const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response, BehaviorState& state) {
+        ++state.serverRequestCount;
+        state.serverUrls.push_back(request->url);
+        state.serverBody = toString(request->body);
+        response->status(200).type("text/plain").set("Connection", "close").send("large-request-ok");
+    }
+
+    template <typename MasterRequest>
+    void sendLargeRequestRequest(const std::shared_ptr<MasterRequest>& request, BehaviorState& state) {
+        ++state.httpConnectedCount;
+        request->method = "POST";
+        request->url = "/large-request";
+        request->set("Connection", "close");
+        if (!request->send(
+                makePatternBody(boundedBodySize),
+                [&state](const auto&, const auto& response) {
+                    ++state.clientResponseCount;
+                    state.clientStatuses.push_back(response->statusCode);
+                    state.clientBodies.push_back(toString(response->body));
+                    core::SNodeC::stop();
+                },
+                [&state](const auto&, const std::string&) {
+                    ++state.parseErrorCount;
+                    core::SNodeC::stop();
+                })) {
+            ++state.unexpectedStateCount;
+            core::SNodeC::stop();
+        }
+    }
+
+    inline void expectBehaviorCommon(tests::support::TestResult& testResult,
+                                     const BehaviorState& state,
+                                     const std::string& behaviorName,
+                                     int startResult) {
+        testResult.expectEqual(0, startResult, "event loop stops successfully after IPv4 legacy HTTP " + behaviorName);
+        testResult.expectEqual(1, state.listenOkCount, "IPv4 legacy HTTP server listen callback reports OK exactly once for " + behaviorName);
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "IPv4 legacy HTTP server reports one effective endpoint for " + behaviorName);
+        testResult.expectEqual(1, state.clientConnectOkCount, "IPv4 legacy HTTP client connect callback reports OK exactly once for " + behaviorName);
+        testResult.expectEqual(1, state.httpConnectedCount, "IPv4 legacy HTTP client reaches HTTP-connected callback exactly once for " + behaviorName);
+        testResult.expectEqual(0, state.parseErrorCount, "IPv4 legacy HTTP client reports no response parse errors for " + behaviorName);
+        testResult.expectEqual(0, state.unexpectedStateCount, "IPv4 legacy HTTP reports no unexpected socket states for " + behaviorName);
+    }
+
+} // namespace tests::component::http
+
+#endif // TESTS_COMPONENT_HTTP_HTTPSERVERCLIENTBEHAVIORTEST_H

--- a/tests/component/http/InetHttpClientPrematureServerCloseTest.cpp
+++ b/tests/component/http/InetHttpClientPrematureServerCloseTest.cpp
@@ -1,0 +1,71 @@
+#include "HttpServerClientBehaviorTest.h"
+
+#include "net/in/SocketAddress.h"
+#include "web/http/legacy/in/Client.h"
+#include "web/http/legacy/in/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpClientPrematureServerCloseTest");
+    } else {
+        tests::component::http::BehaviorState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in::Server;
+        using Client = web::http::legacy::in::Client;
+
+        const Server server("ipv4-http-behavior-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handlePrematureCloseRequest(request, response, state);
+        });
+        Client client(
+            "ipv4-http-behavior-client",
+            [&state](const auto& request) {
+                tests::component::http::sendPrematureCloseRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBehaviorTest(server, client, state);
+
+        server.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const auto&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) {
+                            ++state.clientConnectOkCount;
+                        } else {
+                            ++state.unexpectedStateCount;
+                            core::SNodeC::stop();
+                        }
+                    });
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectBehaviorCommon(testResult, state, "premature server close", startResult);
+        testResult.expectEqual(1, state.serverRequestCount, "IPv4 legacy HTTP server observes one premature-close request");
+        testResult.expectEqual(1, state.clientResponseCount, "IPv4 legacy HTTP client observes connection-loss response");
+        testResult.expectTrue(state.serverUrls == std::vector<std::string>({"/premature-close"}), "IPv4 legacy HTTP server observes premature-close target");
+        testResult.expectTrue(state.clientStatuses == std::vector<std::string>({"0"}), "IPv4 legacy HTTP client maps premature close to status 0");
+        testResult.expectTrue(state.clientBodies == std::vector<std::string>({"Connection loss"}), "IPv4 legacy HTTP client reports connection-loss reason");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/http/InetHttpServerClientDisconnectLifecycleTest.cpp
+++ b/tests/component/http/InetHttpServerClientDisconnectLifecycleTest.cpp
@@ -1,0 +1,73 @@
+#include "HttpServerClientBehaviorTest.h"
+
+#include "net/in/SocketAddress.h"
+#include "web/http/legacy/in/Client.h"
+#include "web/http/legacy/in/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpServerClientDisconnectLifecycleTest");
+    } else {
+        tests::component::http::BehaviorState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in::Server;
+        using Client = web::http::legacy::in::Client;
+
+        const Server server("ipv4-http-behavior-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleDisconnectRequest(request, response, state);
+        });
+        Client client(
+            "ipv4-http-behavior-client",
+            [&state](const auto& request) {
+                tests::component::http::sendDisconnectRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+                core::SNodeC::stop();
+            });
+
+        tests::component::http::configureHttpBehaviorTest(server, client, state);
+
+        server.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const auto&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) {
+                            ++state.clientConnectOkCount;
+                        } else {
+                            ++state.unexpectedStateCount;
+                            core::SNodeC::stop();
+                        }
+                    });
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectBehaviorCommon(testResult, state, "disconnect lifecycle", startResult);
+        testResult.expectEqual(1, state.serverRequestCount, "IPv4 legacy HTTP server observes one disconnect request");
+        testResult.expectEqual(1, state.clientResponseCount, "IPv4 legacy HTTP client observes one disconnect response");
+        testResult.expectEqual(1, state.httpDisconnectedCount, "IPv4 legacy HTTP client observes one HTTP disconnect callback");
+        testResult.expectTrue(state.serverUrls == std::vector<std::string>({"/disconnect"}), "IPv4 legacy HTTP server observes disconnect target");
+        testResult.expectTrue(state.clientStatuses == std::vector<std::string>({"200"}), "IPv4 legacy HTTP client observes disconnect status 200");
+        testResult.expectTrue(state.clientBodies == std::vector<std::string>({"disconnect-ok"}), "IPv4 legacy HTTP client observes disconnect body");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/http/InetHttpServerClientLargeRequestBodyTest.cpp
+++ b/tests/component/http/InetHttpServerClientLargeRequestBodyTest.cpp
@@ -1,0 +1,73 @@
+#include "HttpServerClientBehaviorTest.h"
+
+#include "net/in/SocketAddress.h"
+#include "web/http/legacy/in/Client.h"
+#include "web/http/legacy/in/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpServerClientLargeRequestBodyTest");
+    } else {
+        tests::component::http::BehaviorState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in::Server;
+        using Client = web::http::legacy::in::Client;
+
+        const Server server("ipv4-http-behavior-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleLargeRequestRequest(request, response, state);
+        });
+        Client client(
+            "ipv4-http-behavior-client",
+            [&state](const auto& request) {
+                tests::component::http::sendLargeRequestRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBehaviorTest(server, client, state);
+
+        server.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const auto&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) {
+                            ++state.clientConnectOkCount;
+                        } else {
+                            ++state.unexpectedStateCount;
+                            core::SNodeC::stop();
+                        }
+                    });
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectBehaviorCommon(testResult, state, "large request body", startResult);
+        testResult.expectEqual(1, state.serverRequestCount, "IPv4 legacy HTTP server observes one large-request request");
+        testResult.expectEqual(1, state.clientResponseCount, "IPv4 legacy HTTP client observes one large-request response");
+        testResult.expectTrue(state.serverUrls == std::vector<std::string>({"/large-request"}), "IPv4 legacy HTTP server observes large-request target");
+        testResult.expectEqual(static_cast<int>(tests::component::http::boundedBodySize), static_cast<int>(state.serverBody.size()), "IPv4 legacy HTTP server observes large-request body size");
+        testResult.expectTrue(state.serverBody == tests::component::http::makePatternBody(tests::component::http::boundedBodySize), "IPv4 legacy HTTP server observes exact large-request body");
+        testResult.expectTrue(state.clientStatuses == std::vector<std::string>({"200"}), "IPv4 legacy HTTP client observes large-request status 200");
+        testResult.expectTrue(state.clientBodies == std::vector<std::string>({"large-request-ok"}), "IPv4 legacy HTTP client observes large-request response body");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/http/InetHttpServerClientLargeResponseBodyTest.cpp
+++ b/tests/component/http/InetHttpServerClientLargeResponseBodyTest.cpp
@@ -1,0 +1,73 @@
+#include "HttpServerClientBehaviorTest.h"
+
+#include "net/in/SocketAddress.h"
+#include "web/http/legacy/in/Client.h"
+#include "web/http/legacy/in/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpServerClientLargeResponseBodyTest");
+    } else {
+        tests::component::http::BehaviorState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in::Server;
+        using Client = web::http::legacy::in::Client;
+
+        const Server server("ipv4-http-behavior-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleLargeResponseRequest(request, response, state);
+        });
+        Client client(
+            "ipv4-http-behavior-client",
+            [&state](const auto& request) {
+                tests::component::http::sendLargeResponseRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBehaviorTest(server, client, state);
+
+        server.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const auto&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) {
+                            ++state.clientConnectOkCount;
+                        } else {
+                            ++state.unexpectedStateCount;
+                            core::SNodeC::stop();
+                        }
+                    });
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectBehaviorCommon(testResult, state, "large response body", startResult);
+        testResult.expectEqual(1, state.serverRequestCount, "IPv4 legacy HTTP server observes one large-response request");
+        testResult.expectEqual(1, state.clientResponseCount, "IPv4 legacy HTTP client observes one large-response response");
+        testResult.expectTrue(state.serverUrls == std::vector<std::string>({"/large-response"}), "IPv4 legacy HTTP server observes large-response target");
+        testResult.expectTrue(state.clientStatuses == std::vector<std::string>({"200"}), "IPv4 legacy HTTP client observes large-response status 200");
+        testResult.expectEqual(static_cast<int>(tests::component::http::boundedBodySize), static_cast<int>(state.clientBodies.front().size()), "IPv4 legacy HTTP client observes large-response body size");
+        testResult.expectTrue(state.clientBodies.front() == tests::component::http::makePatternBody(tests::component::http::boundedBodySize), "IPv4 legacy HTTP client observes exact large-response body");
+        testResult.expectTrue(state.clientSawContentLength, "IPv4 legacy HTTP client observes expected large-response Content-Length");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/http/InetHttpServerClientRepeatedRequestTest.cpp
+++ b/tests/component/http/InetHttpServerClientRepeatedRequestTest.cpp
@@ -1,0 +1,72 @@
+#include "HttpServerClientBehaviorTest.h"
+
+#include "net/in/SocketAddress.h"
+#include "web/http/legacy/in/Client.h"
+#include "web/http/legacy/in/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpServerClientRepeatedRequestTest");
+    } else {
+        tests::component::http::BehaviorState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in::Server;
+        using Client = web::http::legacy::in::Client;
+
+        const Server server("ipv4-http-behavior-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleRepeatedRequest(request, response, state);
+        });
+        Client client(
+            "ipv4-http-behavior-client",
+            [&state](const auto& request) {
+                tests::component::http::sendRepeatedRequests(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBehaviorTest(server, client, state);
+
+        server.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const auto&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) {
+                            ++state.clientConnectOkCount;
+                        } else {
+                            ++state.unexpectedStateCount;
+                            core::SNodeC::stop();
+                        }
+                    });
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectBehaviorCommon(testResult, state, "repeated request", startResult);
+        testResult.expectEqual(2, state.queuedRequestCount, "IPv4 legacy HTTP queues both keep-alive requests");
+        testResult.expectEqual(2, state.serverRequestCount, "IPv4 legacy HTTP server observes both repeated requests");
+        testResult.expectEqual(2, state.clientResponseCount, "IPv4 legacy HTTP client observes both repeated responses");
+        testResult.expectTrue(state.serverUrls == std::vector<std::string>({"/first", "/second"}), "IPv4 legacy HTTP server observes repeated targets in order");
+        testResult.expectTrue(state.clientStatuses == std::vector<std::string>({"200", "200"}), "IPv4 legacy HTTP client observes repeated status codes in order");
+        testResult.expectTrue(state.clientBodies == std::vector<std::string>({"first-response", "second-response"}), "IPv4 legacy HTTP client observes repeated bodies in order");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}


### PR DESCRIPTION
### Motivation

- Add deterministic component tests for HTTP behavior continuation (keep-alive/reuse, disconnect lifecycle, premature server close, bounded large request/response) on the plain legacy HTTP stack to continue the test-track after the EventSource continuation work.  

### Description

- Added a focused test helper `tests/component/http/HttpServerClientBehaviorTest.h` that defines shared `BehaviorState`, a 64 KiB deterministic pattern generator `makePatternBody()`, request/response handler callbacks, and common assertions.  
- Added five IPv4-only component tests under `tests/component/http/`: `InetHttpServerClientRepeatedRequestTest.cpp`, `InetHttpServerClientDisconnectLifecycleTest.cpp`, `InetHttpClientPrematureServerCloseTest.cpp`, `InetHttpServerClientLargeResponseBodyTest.cpp`, and `InetHttpServerClientLargeRequestBodyTest.cpp`.  
- Registered the new tests in `tests/component/http/CMakeLists.txt` with `snodec_add_test(...)`, appropriate `target_link_libraries`, `target_compile_features(... PRIVATE cxx_std_20)`, `SKIP_RETURN_CODE 77`, `TIMEOUT 5`, and labels `component;http;client;server;legacy;ipv4`.  
- Behaviors covered: true keep-alive repeated-request reuse across `/first` then `/second`; clean disconnect lifecycle for `/disconnect`; deterministic premature server close for `/premature-close` (server closes socket context immediately after seeing request); bounded 64 KiB deterministic response for `/large-response`; bounded 64 KiB deterministic POST for `/large-request`.  
- True keep-alive reuse: covered (single client connection issues two sequential requests with `Connection: keep-alive` then `Connection: close`).  
- Premature server close: covered deterministically via `response->getSocketContext()->close()` from server handler; client-observable behavior is asserted as mapping to a response with status `0` and reason `Connection loss`.  
- Bounded body sizes: tests use `boundedBodySize = 64 * 1024` (64 KiB) and deterministic alphabetic pattern for exact content checks.  
- IPv4-only: these tests target `127.0.0.1` only because they are behavior-focused and not a transport matrix expansion.  
- Production code changes: none.  

### Testing

- Ran `git diff --check` with no problems.  
- Configured with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` (installed missing `nlohmann-json3-dev` in the environment); configuration succeeded (only optional warnings for Doxygen/IWYU/libmagic/etc.).  
- Built the new targets: `cmake --build build --target InetHttpServerClientRepeatedRequestTest InetHttpServerClientDisconnectLifecycleTest InetHttpClientPrematureServerCloseTest InetHttpServerClientLargeResponseBodyTest InetHttpServerClientLargeRequestBodyTest -j2` and the build succeeded.  
- Ran focused component tests (root): `ctest --test-dir build -R 'Http.*(Repeated|Sequential|Disconnect|Premature|Large)' --output-on-failure` which passed with expected root-skip behavior for privileged runs.  
- Verified unprivileged execution: `HOME=/home/snodectest ctest --test-dir /workspace/snode.c/build -R 'Http.*(Repeated|Sequential|Disconnect|Premature|Large)' --output-on-failure` as an unprivileged user executed all five new tests and they all passed.  
- Ran broader http label run: `ctest --test-dir build -L http --output-on-failure` which passed with the expected project root-skip behavior for component tests.  

Deferred/explicit exclusions: IPv6/Unix duplicates, TLS/HTTPS, Express, WebSocket, SSE/EventSource, MQTT, DB, application smoke tests, parser torture/backpressure/stress tests (intentionally out-of-scope for this narrow behavior continuation change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a493c5d9470832c8746d184d8866780)