### PR TITLE
Add HTTP fragmentation component tests and preserve queued request header state

### DIFF
--- a/src/web/http/client/Request.cpp
+++ b/src/web/http/client/Request.cpp
@@ -270,6 +270,7 @@ namespace web::http::client {
     MasterRequest::MasterRequest(MasterRequest&& request) noexcept
         : Request(std::move(request))
         , requestCommands(std::move(request.requestCommands))
+        , requestHeaderQueued(request.requestHeaderQueued)
         , contentLengthSent(request.contentLengthSent)
         , onResponseReceived(std::move(request.onResponseReceived))
         , onResponseParseError(std::move(request.onResponseParseError))
@@ -298,6 +299,7 @@ namespace web::http::client {
         cookies.clear();
         trailer.clear();
         requestCommands.clear();
+        requestHeaderQueued = false;
         transferEncoding = TransferEncoding::HTTP10;
         contentLength = 0;
         contentLengthSent = 0;
@@ -502,6 +504,7 @@ namespace web::http::client {
     MasterRequest& MasterRequest::sendHeader() {
         if (isConnected()) {
             requestCommands.push_back(new commands::SendHeaderCommand());
+            requestHeaderQueued = true;
         }
 
         return *this;
@@ -529,7 +532,9 @@ namespace web::http::client {
         if (isConnected()) {
             const std::shared_ptr<MasterRequest> newRequest = std::make_shared<MasterRequest>(std::move(*this));
 
-            newRequest->sendHeader();
+            if (!newRequest->requestHeaderQueued) {
+                newRequest->sendHeader();
+            }
 
             newRequest->requestCommands.push_back(new commands::EndCommand(onResponseReceived, onResponseParseError));
 

--- a/src/web/http/client/Request.h
+++ b/src/web/http/client/Request.h
@@ -220,6 +220,7 @@ namespace web::http::client {
         void onSourceError(int errnum) override;
 
         std::list<RequestCommand*> requestCommands;
+        bool requestHeaderQueued = false;
 
         std::size_t contentLengthSent = 0;
 

--- a/tests/component/http/CMakeLists.txt
+++ b/tests/component/http/CMakeLists.txt
@@ -86,24 +86,32 @@ snodec_add_test(InetHttpServerClientDisconnectLifecycleTest InetHttpServerClient
 snodec_add_test(InetHttpClientPrematureServerCloseTest InetHttpClientPrematureServerCloseTest.cpp)
 snodec_add_test(InetHttpServerClientLargeResponseBodyTest InetHttpServerClientLargeResponseBodyTest.cpp)
 snodec_add_test(InetHttpServerClientLargeRequestBodyTest InetHttpServerClientLargeRequestBodyTest.cpp)
+snodec_add_test(InetHttpServerClientFragmentedResponseTest InetHttpServerClientFragmentedResponseTest.cpp)
+snodec_add_test(InetHttpServerClientFragmentedRequestTest InetHttpServerClientFragmentedRequestTest.cpp)
 
 target_link_libraries(InetHttpServerClientRepeatedRequestTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
 target_link_libraries(InetHttpServerClientDisconnectLifecycleTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
 target_link_libraries(InetHttpClientPrematureServerCloseTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
 target_link_libraries(InetHttpServerClientLargeResponseBodyTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
 target_link_libraries(InetHttpServerClientLargeRequestBodyTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetHttpServerClientFragmentedResponseTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetHttpServerClientFragmentedRequestTest PRIVATE snodec-test-support snodec::http-server snodec::http-client snodec::net-in-stream-legacy)
 
 target_compile_features(InetHttpServerClientRepeatedRequestTest PRIVATE cxx_std_20)
 target_compile_features(InetHttpServerClientDisconnectLifecycleTest PRIVATE cxx_std_20)
 target_compile_features(InetHttpClientPrematureServerCloseTest PRIVATE cxx_std_20)
 target_compile_features(InetHttpServerClientLargeResponseBodyTest PRIVATE cxx_std_20)
 target_compile_features(InetHttpServerClientLargeRequestBodyTest PRIVATE cxx_std_20)
+target_compile_features(InetHttpServerClientFragmentedResponseTest PRIVATE cxx_std_20)
+target_compile_features(InetHttpServerClientFragmentedRequestTest PRIVATE cxx_std_20)
 
 set_tests_properties(InetHttpServerClientRepeatedRequestTest
                      InetHttpServerClientDisconnectLifecycleTest
                      InetHttpClientPrematureServerCloseTest
                      InetHttpServerClientLargeResponseBodyTest
-                     InetHttpServerClientLargeRequestBodyTest PROPERTIES
+                     InetHttpServerClientLargeRequestBodyTest
+                     InetHttpServerClientFragmentedResponseTest
+                     InetHttpServerClientFragmentedRequestTest PROPERTIES
                      LABELS "component;http;client;server;legacy;ipv4"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)

--- a/tests/component/http/HttpServerClientBehaviorTest.h
+++ b/tests/component/http/HttpServerClientBehaviorTest.h
@@ -237,6 +237,75 @@ namespace tests::component::http {
         }
     }
 
+
+
+    template <typename Request, typename Response>
+    void handleFragmentedResponseRequest(const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response, BehaviorState& state) {
+        ++state.serverRequestCount;
+        state.serverUrls.push_back(request->url);
+        response->status(200).type("text/plain").set("Connection", "close").set("Transfer-Encoding", "chunked").sendHeader();
+        response->sendFragment("fragment-");
+        response->sendFragment("response-");
+        response->sendFragment("ok");
+        response->end();
+    }
+
+    template <typename MasterRequest>
+    void sendFragmentedResponseRequest(const std::shared_ptr<MasterRequest>& request, BehaviorState& state) {
+        ++state.httpConnectedCount;
+        request->method = "GET";
+        request->url = "/fragmented-response";
+        request->set("Connection", "close");
+        if (!request->end(
+                [&state](const auto&, const auto& response) {
+                    ++state.clientResponseCount;
+                    state.clientStatuses.push_back(response->statusCode);
+                    state.clientBodies.push_back(toString(response->body));
+                    state.clientSawContentLength = response->get("Transfer-Encoding") == "chunked";
+                    core::SNodeC::stop();
+                },
+                [&state](const auto&, const std::string&) {
+                    ++state.parseErrorCount;
+                    core::SNodeC::stop();
+                })) {
+            ++state.unexpectedStateCount;
+            core::SNodeC::stop();
+        }
+    }
+
+    template <typename Request, typename Response>
+    void handleFragmentedRequestRequest(const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response, BehaviorState& state) {
+        ++state.serverRequestCount;
+        state.serverUrls.push_back(request->url);
+        state.serverBody = toString(request->body);
+        state.clientSawContentLength = request->get("Transfer-Encoding") == "chunked";
+        response->status(200).type("text/plain").set("Connection", "close").send("fragmented-request-ok");
+    }
+
+    template <typename MasterRequest>
+    void sendFragmentedRequestRequest(const std::shared_ptr<MasterRequest>& request, BehaviorState& state) {
+        ++state.httpConnectedCount;
+        request->method = "POST";
+        request->url = "/fragmented-request";
+        request->set("Connection", "close");
+        request->set("Transfer-Encoding", "chunked");
+        request->sendHeader().sendFragment("fragment-").sendFragment("request-").sendFragment("ok");
+        if (!request->end(
+                [&state](const auto&, const auto& response) {
+                    ++state.clientResponseCount;
+                    state.clientStatuses.push_back(response->statusCode);
+                    state.clientBodies.push_back(toString(response->body));
+                    core::SNodeC::stop();
+                },
+                [&state](const auto&, const std::string&) {
+                    ++state.parseErrorCount;
+                    core::SNodeC::stop();
+                })) {
+            ++state.unexpectedStateCount;
+            core::SNodeC::stop();
+        }
+    }
+
     inline void expectBehaviorCommon(tests::support::TestResult& testResult,
                                      const BehaviorState& state,
                                      const std::string& behaviorName,

--- a/tests/component/http/InetHttpServerClientFragmentedRequestTest.cpp
+++ b/tests/component/http/InetHttpServerClientFragmentedRequestTest.cpp
@@ -1,0 +1,73 @@
+#include "HttpServerClientBehaviorTest.h"
+
+#include "net/in/SocketAddress.h"
+#include "web/http/legacy/in/Client.h"
+#include "web/http/legacy/in/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpServerClientFragmentedRequestTest");
+    } else {
+        tests::component::http::BehaviorState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in::Server;
+        using Client = web::http::legacy::in::Client;
+
+        const Server server("ipv4-http-behavior-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleFragmentedRequestRequest(request, response, state);
+        });
+        Client client(
+            "ipv4-http-behavior-client",
+            [&state](const auto& request) {
+                tests::component::http::sendFragmentedRequestRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBehaviorTest(server, client, state);
+
+        server.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const auto&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) {
+                            ++state.clientConnectOkCount;
+                        } else {
+                            ++state.unexpectedStateCount;
+                            core::SNodeC::stop();
+                        }
+                    });
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectBehaviorCommon(testResult, state, "fragmented request", startResult);
+        testResult.expectEqual(1, state.serverRequestCount, "IPv4 legacy HTTP server observes one fragmented-request request");
+        testResult.expectEqual(1, state.clientResponseCount, "IPv4 legacy HTTP client observes one fragmented-request response");
+        testResult.expectTrue(state.serverUrls == std::vector<std::string>({"/fragmented-request"}), "IPv4 legacy HTTP server observes fragmented-request target");
+        testResult.expectTrue(state.serverBody == "fragment-request-ok", "IPv4 legacy HTTP server reassembles fragmented request body");
+        testResult.expectTrue(state.clientSawContentLength, "IPv4 legacy HTTP server observes chunked fragmented request");
+        testResult.expectTrue(state.clientStatuses == std::vector<std::string>({"200"}), "IPv4 legacy HTTP client observes fragmented-request status 200");
+        testResult.expectTrue(state.clientBodies == std::vector<std::string>({"fragmented-request-ok"}), "IPv4 legacy HTTP client observes fragmented-request response body");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/http/InetHttpServerClientFragmentedResponseTest.cpp
+++ b/tests/component/http/InetHttpServerClientFragmentedResponseTest.cpp
@@ -1,0 +1,72 @@
+#include "HttpServerClientBehaviorTest.h"
+
+#include "net/in/SocketAddress.h"
+#include "web/http/legacy/in/Client.h"
+#include "web/http/legacy/in/Server.h"
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpServerClientFragmentedResponseTest");
+    } else {
+        tests::component::http::BehaviorState state;
+
+        core::SNodeC::init(argc, argv);
+
+        using Server = web::http::legacy::in::Server;
+        using Client = web::http::legacy::in::Client;
+
+        const Server server("ipv4-http-behavior-server", [&state](const auto& request, const auto& response) {
+            tests::component::http::handleFragmentedResponseRequest(request, response, state);
+        });
+        Client client(
+            "ipv4-http-behavior-client",
+            [&state](const auto& request) {
+                tests::component::http::sendFragmentedResponseRequest(request, state);
+            },
+            [&state](const auto&) {
+                ++state.httpDisconnectedCount;
+            });
+
+        tests::component::http::configureHttpBehaviorTest(server, client, state);
+
+        server.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const auto&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) {
+                            ++state.clientConnectOkCount;
+                        } else {
+                            ++state.unexpectedStateCount;
+                            core::SNodeC::stop();
+                        }
+                    });
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        tests::component::http::expectBehaviorCommon(testResult, state, "fragmented response", startResult);
+        testResult.expectEqual(1, state.serverRequestCount, "IPv4 legacy HTTP server observes one fragmented-response request");
+        testResult.expectEqual(1, state.clientResponseCount, "IPv4 legacy HTTP client observes one fragmented-response response");
+        testResult.expectTrue(state.serverUrls == std::vector<std::string>({"/fragmented-response"}), "IPv4 legacy HTTP server observes fragmented-response target");
+        testResult.expectTrue(state.clientStatuses == std::vector<std::string>({"200"}), "IPv4 legacy HTTP client observes fragmented-response status 200");
+        testResult.expectTrue(state.clientBodies == std::vector<std::string>({"fragment-response-ok"}), "IPv4 legacy HTTP client reassembles fragmented response body");
+        testResult.expectTrue(state.clientSawContentLength, "IPv4 legacy HTTP client observes chunked fragmented response");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Improve HTTP component coverage for chunked/fragmented flows by adding tests for fragmented server responses and fragmented client requests. 
- Prevent duplicate request header emission when callers explicitly call `sendHeader()` followed by `end(...)` or `sendFragment(...).end(...)` by tracking whether a header was already queued.

### Description
- Added chunked/fragmentation helpers and behaviors to `tests/component/http/HttpServerClientBehaviorTest.h` to emit and consume chunked responses/requests (`handleFragmentedResponseRequest`, `sendFragmentedResponseRequest`, `handleFragmentedRequestRequest`, `sendFragmentedRequestRequest`).
- Added two IPv4 legacy HTTP component tests: `tests/component/http/InetHttpServerClientFragmentedResponseTest.cpp` and `tests/component/http/InetHttpServerClientFragmentedRequestTest.cpp` and registered them in `tests/component/http/CMakeLists.txt` with the same labels, link libraries, and timeout settings as other HTTP component tests.
- Updated the HTTP client `MasterRequest` plumbing in `src/web/http/client/Request.h` and `src/web/http/client/Request.cpp` to add a `requestHeaderQueued` flag that is preserved across moves and set when `sendHeader()` is queued, and checked in `end(...)` to avoid enqueueing a duplicate header.
- Committed the new tests and code changes on the current branch.

### Testing
- Ran `git diff --check` with no problems reported.
- Configured the build with `cmake -S . -B build -DSNODEC_BUILD_TESTS=ON` and built the two new test targets with `cmake --build build --target InetHttpServerClientFragmentedResponseTest InetHttpServerClientFragmentedRequestTest -j2`, which completed successfully.
- Executed `ctest --test-dir build -R 'InetHttpServerClientFragmented(Response|Request)Test' --output-on-failure`; both tests were discovered but were `Skipped` by the repository's root-without-`snodec`-group guard (tests themselves and the build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a494153b810832c9077fa9a12cfe8ca)