### PR TITLE
Add core lifecycle and timer component tests

### DIFF
--- a/tests/component/core/CMakeLists.txt
+++ b/tests/component/core/CMakeLists.txt
@@ -40,9 +40,24 @@
 
 snodec_add_test(SingleshotTimerTest SingleshotTimerTest.cpp)
 snodec_add_test(IntervalTimerStopableTest IntervalTimerStopableTest.cpp)
+snodec_add_test(SNodeCStopFromCallbackTest SNodeCStopFromCallbackTest.cpp)
+snodec_add_test(TimerCancelBeforeFireTest TimerCancelBeforeFireTest.cpp)
+snodec_add_test(IntervalTimerCancelFromCallbackTest IntervalTimerCancelFromCallbackTest.cpp)
 
 target_link_libraries(SingleshotTimerTest PRIVATE snodec-test-support snodec::core)
 target_link_libraries(IntervalTimerStopableTest PRIVATE snodec-test-support snodec::core)
+target_link_libraries(SNodeCStopFromCallbackTest PRIVATE snodec-test-support snodec::core)
+target_link_libraries(TimerCancelBeforeFireTest PRIVATE snodec-test-support snodec::core)
+target_link_libraries(IntervalTimerCancelFromCallbackTest PRIVATE snodec-test-support snodec::core)
+
+target_compile_features(SingleshotTimerTest PRIVATE cxx_std_20)
+target_compile_features(IntervalTimerStopableTest PRIVATE cxx_std_20)
+target_compile_features(SNodeCStopFromCallbackTest PRIVATE cxx_std_20)
+target_compile_features(TimerCancelBeforeFireTest PRIVATE cxx_std_20)
+target_compile_features(IntervalTimerCancelFromCallbackTest PRIVATE cxx_std_20)
 
 set_tests_properties(SingleshotTimerTest PROPERTIES LABELS "component;core;timer" SKIP_RETURN_CODE 77)
 set_tests_properties(IntervalTimerStopableTest PROPERTIES LABELS "component;core;timer" SKIP_RETURN_CODE 77)
+set_tests_properties(SNodeCStopFromCallbackTest PROPERTIES LABELS "component;core;lifecycle" SKIP_RETURN_CODE 77 TIMEOUT 5)
+set_tests_properties(TimerCancelBeforeFireTest PROPERTIES LABELS "component;core;timer" SKIP_RETURN_CODE 77 TIMEOUT 5)
+set_tests_properties(IntervalTimerCancelFromCallbackTest PROPERTIES LABELS "component;core;timer" SKIP_RETURN_CODE 77 TIMEOUT 5)

--- a/tests/component/core/IntervalTimerCancelFromCallbackTest.cpp
+++ b/tests/component/core/IntervalTimerCancelFromCallbackTest.cpp
@@ -1,0 +1,85 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/timer/Timer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <functional>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("IntervalTimerCancelFromCallbackTest");
+    } else {
+        int intervalCallbackCount = 0;
+        bool intervalStoppedFromCallback = false;
+
+        core::SNodeC::init(argc, argv);
+
+        core::timer::Timer intervalTimer = core::timer::Timer::intervalTimer(
+            [&intervalCallbackCount, &intervalStoppedFromCallback](const std::function<void()>& stop) {
+                ++intervalCallbackCount;
+                stop();
+                intervalStoppedFromCallback = true;
+                core::SNodeC::stop();
+            },
+            utils::Timeval({0, 1000}));
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(1, intervalCallbackCount, "interval timer callback fires exactly once before stopping itself");
+        testResult.expectTrue(intervalStoppedFromCallback, "interval timer was stopped from inside its callback");
+        testResult.expectEqual(0, startResult, "event loop exits cleanly after interval timer cancellation");
+
+        core::SNodeC::free();
+        result = testResult.processResult();
+    }
+
+    return result;
+}

--- a/tests/component/core/SNodeCStopFromCallbackTest.cpp
+++ b/tests/component/core/SNodeCStopFromCallbackTest.cpp
@@ -1,0 +1,84 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/timer/Timer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <functional>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("SNodeCStopFromCallbackTest");
+    } else {
+        int callbackCount = 0;
+        bool stopRequestedFromCallback = false;
+
+        core::SNodeC::init(argc, argv);
+
+        core::timer::Timer stopTimer = core::timer::Timer::singleshotTimer(
+            [&callbackCount, &stopRequestedFromCallback]() {
+                ++callbackCount;
+                stopRequestedFromCallback = true;
+                core::SNodeC::stop();
+            },
+            utils::Timeval({0, 1000}));
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(1, callbackCount, "stop callback executes exactly once");
+        testResult.expectTrue(stopRequestedFromCallback, "stop was requested from inside the callback");
+        testResult.expectEqual(0, startResult, "event loop exits cleanly without using the timeout path");
+
+        core::SNodeC::free();
+        result = testResult.processResult();
+    }
+
+    return result;
+}

--- a/tests/component/core/TimerCancelBeforeFireTest.cpp
+++ b/tests/component/core/TimerCancelBeforeFireTest.cpp
@@ -1,0 +1,90 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "core/SNodeC.h"
+#include "core/timer/Timer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <functional>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("TimerCancelBeforeFireTest");
+    } else {
+        int cancelledCallbackCount = 0;
+        int stopCallbackCount = 0;
+
+        core::SNodeC::init(argc, argv);
+
+        core::timer::Timer cancelledTimer = core::timer::Timer::singleshotTimer(
+            [&cancelledCallbackCount]() {
+                ++cancelledCallbackCount;
+            },
+            utils::Timeval({0, 100000}));
+        cancelledTimer.cancel();
+
+        core::timer::Timer stopTimer = core::timer::Timer::singleshotTimer(
+            [&stopCallbackCount]() {
+                ++stopCallbackCount;
+                core::SNodeC::stop();
+            },
+            utils::Timeval({0, 1000}));
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, cancelledCallbackCount, "cancelled timer callback does not execute");
+        testResult.expectEqual(1, stopCallbackCount, "stop callback executes exactly once");
+        testResult.expectEqual(0, startResult, "event loop exits cleanly after the stop callback");
+
+        core::SNodeC::free();
+        result = testResult.processResult();
+    }
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Add deterministic component tests covering core lifecycle and timer semantics from the canonical backlog to increase coverage of event-loop/timer/descriptor behavior without touching networking or HTTP code.
- Verify that the public timer API and core lifecycle behave as documented for stop-from-callback, timer cancellation, and stoppable-interval semantics.

### Description
- Implemented `CORE-COMP-003` with `tests/component/core/SNodeCStopFromCallbackTest.cpp` to verify the event loop can be stopped from inside a scheduled callback and that the callback runs exactly once.
- Implemented `CORE-COMP-005` with `tests/component/core/TimerCancelBeforeFireTest.cpp` to verify `Timer::cancel()` prevents a singleshot timer from firing before a separate deterministic stop timer exits the loop.
- Implemented `CORE-COMP-006` with `tests/component/core/IntervalTimerCancelFromCallbackTest.cpp` to verify an interval timer can stop itself from inside its callback and that the loop exits cleanly after the expected callbacks.
- Updated `tests/component/core/CMakeLists.txt` to register the new tests, link `snodec-test-support` and `snodec::core`, require `cxx_std_20`, and set `LABELS`, `SKIP_RETURN_CODE 77`, and `TIMEOUT 5` for the new targets.
- Deferred `CORE-COMP-004` because repeated in-process `init()`/`start()`/`free()` cycles triggered an initialization error (`CLI::OptionAlreadyAdded`) during an exploratory attempt, so no production changes or forced tests were made.
- Deferred `CORE-COMP-007` because descriptor close-during-callback is not cleanly testable via a stable public descriptor/event-source API without relying on protected internals or POSIX-specific side effects.
- No production code or HTTP/protocol/app/packaging/CI changes were made.

### Testing
- Ran `git diff --check` which produced no whitespace/format errors.
- Configured the build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` which completed after installing the missing dependency `nlohmann-json3-dev` (non-fatal warnings for Doxygen/iwyu/libmagic/libmariadb remained but did not block configure).
- Built focused targets with `cmake --build build --target SNodeCStopFromCallbackTest TimerCancelBeforeFireTest IntervalTimerCancelFromCallbackTest SingleshotTimerTest IntervalTimerStopableTest SNodeCInitFreeSmokeTest -j2` and the build succeeded for those targets.
- Ran `ctest --test-dir build -L core --output-on-failure` as root where root-gated component tests were skipped (returned `SKIP_RETURN_CODE 77`) and no failures occurred in the configured run.
- Re-ran `ctest` as an unprivileged user with `HOME=/home/testuser` (via `su -s /bin/bash testuser -c 'cd /workspace/snode.c && HOME=/home/testuser ctest --test-dir build -L core --output-on-failure'`) and all focused core tests passed (6/6 focused core tests passed).
- Observed an aborted exploratory run of a multiple-lifecycle test producing `terminate called after throwing an instance of 'CLI::OptionAlreadyAdded'` which motivated deferral of `CORE-COMP-004` rather than making production changes.

Files added/changed
- Added: `tests/component/core/SNodeCStopFromCallbackTest.cpp`
- Added: `tests/component/core/TimerCancelBeforeFireTest.cpp`
- Added: `tests/component/core/IntervalTimerCancelFromCallbackTest.cpp`
- Modified: `tests/component/core/CMakeLists.txt`

Commands run (representative)
- `git diff --check`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF`
- `cmake --build build --target SNodeCStopFromCallbackTest TimerCancelBeforeFireTest IntervalTimerCancelFromCallbackTest SingleshotTimerTest IntervalTimerStopableTest SNodeCInitFreeSmokeTest -j2`
- `ctest --test-dir build -L core --output-on-failure` (as root; component tests skipped via return code 77)
- `su -s /bin/bash testuser -c 'cd /workspace/snode.c && HOME=/home/testuser ctest --test-dir build -L core --output-on-failure'` (unprivileged run; all focused tests passed)

Implemented canonical Core IDs: `CORE-COMP-003`, `CORE-COMP-005`, `CORE-COMP-006`.
Deferred canonical Core IDs: `CORE-COMP-004` (repeated lifecycle unsupported without production change) and `CORE-COMP-007` (descriptor close-during-callback not cleanly testable via public API).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4944f43f90832ca06101f1a7266e17)