### PR TITLE
Add Express routing continuation component tests

### DIFF
--- a/tests/component/express/CMakeLists.txt
+++ b/tests/component/express/CMakeLists.txt
@@ -9,6 +9,13 @@ snodec_add_test(UnixExpressTransportSmokeTest UnixExpressTransportSmokeTest.cpp)
 snodec_add_test(InetExpressMiddlewareShortCircuitTest InetExpressMiddlewareShortCircuitTest.cpp)
 snodec_add_test(InetExpressRoutingEdgeBasicsTest InetExpressRoutingEdgeBasicsTest.cpp)
 
+snodec_add_test(InetExpressMountedRouterBasicsTest InetExpressMountedRouterBasicsTest.cpp)
+snodec_add_test(InetExpressNestedRouterBasicsTest InetExpressNestedRouterBasicsTest.cpp)
+snodec_add_test(InetExpressRouteParameterRegexTest InetExpressRouteParameterRegexTest.cpp)
+snodec_add_test(InetExpressMiddlewareMountOrderTest InetExpressMiddlewareMountOrderTest.cpp)
+snodec_add_test(InetExpressQueryMountInteractionTest InetExpressQueryMountInteractionTest.cpp)
+snodec_add_test(InetExpressFallbackNotFoundTest InetExpressFallbackNotFoundTest.cpp)
+
 target_link_libraries(InetExpressRoutingMiddlewareTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
 
 target_link_libraries(Inet6ExpressTransportSmokeTest PRIVATE snodec-test-support snodec::http-server-express-legacy-in6 snodec::http-client snodec::net-in6-stream-legacy)
@@ -16,12 +23,26 @@ target_link_libraries(UnixExpressTransportSmokeTest PRIVATE snodec-test-support 
 target_link_libraries(InetExpressMiddlewareShortCircuitTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
 target_link_libraries(InetExpressRoutingEdgeBasicsTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
 
+target_link_libraries(InetExpressMountedRouterBasicsTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetExpressNestedRouterBasicsTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetExpressRouteParameterRegexTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetExpressMiddlewareMountOrderTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetExpressQueryMountInteractionTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetExpressFallbackNotFoundTest PRIVATE snodec-test-support snodec::http-server-express snodec::http-client snodec::net-in-stream-legacy)
+
 target_compile_features(InetExpressRoutingMiddlewareTest PRIVATE cxx_std_20)
 
 target_compile_features(Inet6ExpressTransportSmokeTest PRIVATE cxx_std_20)
 target_compile_features(UnixExpressTransportSmokeTest PRIVATE cxx_std_20)
 target_compile_features(InetExpressMiddlewareShortCircuitTest PRIVATE cxx_std_20)
 target_compile_features(InetExpressRoutingEdgeBasicsTest PRIVATE cxx_std_20)
+
+target_compile_features(InetExpressMountedRouterBasicsTest PRIVATE cxx_std_20)
+target_compile_features(InetExpressNestedRouterBasicsTest PRIVATE cxx_std_20)
+target_compile_features(InetExpressRouteParameterRegexTest PRIVATE cxx_std_20)
+target_compile_features(InetExpressMiddlewareMountOrderTest PRIVATE cxx_std_20)
+target_compile_features(InetExpressQueryMountInteractionTest PRIVATE cxx_std_20)
+target_compile_features(InetExpressFallbackNotFoundTest PRIVATE cxx_std_20)
 
 set_tests_properties(InetExpressRoutingMiddlewareTest PROPERTIES
                      LABELS "component;express;routing;middleware;legacy;ipv4"
@@ -45,5 +66,35 @@ set_tests_properties(InetExpressMiddlewareShortCircuitTest PROPERTIES
 
 set_tests_properties(InetExpressRoutingEdgeBasicsTest PROPERTIES
                      LABELS "component;express;routing;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetExpressMountedRouterBasicsTest PROPERTIES
+                     LABELS "component;express;routing;mounted-router;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetExpressNestedRouterBasicsTest PROPERTIES
+                     LABELS "component;express;routing;nested-router;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetExpressRouteParameterRegexTest PROPERTIES
+                     LABELS "component;express;routing;parameter-regex;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetExpressMiddlewareMountOrderTest PROPERTIES
+                     LABELS "component;express;middleware;mount-order;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetExpressQueryMountInteractionTest PROPERTIES
+                     LABELS "component;express;routing;query;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+
+set_tests_properties(InetExpressFallbackNotFoundTest PROPERTIES
+                     LABELS "component;express;routing;not-found;legacy;ipv4"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)

--- a/tests/component/express/InetExpressFallbackNotFoundTest.cpp
+++ b/tests/component/express/InetExpressFallbackNotFoundTest.cpp
@@ -1,0 +1,166 @@
+#include "core/SNodeC.h"
+#include "express/legacy/in/WebApp.h"
+#include "net/in/SocketAddress.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Client.h"
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct Case {
+    std::string url;
+    int status;
+    std::string headerName;
+    std::string headerValue;
+    std::string body;
+};
+
+std::string toString(const std::vector<char>& bytes) {
+    return std::string(bytes.begin(), bytes.end());
+}
+
+struct State { int listenOkCount=0; int effectiveListenEndpointOkCount=0; int clientConnectOkCount=0; int httpConnectedCount=0; int clientResponseCount=0; int parseErrorCount=0; int unexpectedStateCount=0; int knownRouteCount=0; int fallbackCount=0; };
+
+class CaseClientRunner {
+public:
+    CaseClientRunner(State& state, std::deque<Case> cases)
+        : state(state)
+        , cases(std::move(cases)) {
+    }
+
+    void run(std::uint16_t port) {
+        this->port = port;
+        dispatchNext();
+    }
+
+private:
+    using Client = web::http::legacy::in::Client;
+    using MasterRequest = Client::MasterRequest;
+
+    void dispatchNext() {
+        if (cases.empty()) {
+            core::SNodeC::stop();
+            return;
+        }
+
+        const std::size_t clientIndex = clients.size();
+        const Case current = cases.front();
+        cases.pop_front();
+
+        clients.emplace_back(std::make_shared<Client>(
+            "ipv4-express-continuation-client-" + std::to_string(clientIndex),
+            [this, current](const std::shared_ptr<MasterRequest>& request) {
+                ++state.httpConnectedCount;
+                request->method = "GET";
+                request->url = current.url;
+                request->set("Connection", "close");
+                request->end(
+                    [this, current](const auto&, const auto& response) {
+                        ++state.clientResponseCount;
+                        if (response->statusCode != std::to_string(current.status)) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.headerName.empty() && response->get(current.headerName) != current.headerValue) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.body.empty() && toString(response->body) != current.body) {
+                            ++state.unexpectedStateCount;
+                        }
+                        dispatchNext();
+                    },
+                    [this](const auto&, const std::string&) {
+                        ++state.parseErrorCount;
+                        dispatchNext();
+                    });
+            },
+            [](const std::shared_ptr<MasterRequest>&) {
+            }));
+
+        const std::shared_ptr<Client>& client = clients.back();
+        client->getConfig()->Instance::forceUnrequired();
+        client->connect(net::in::SocketAddress("127.0.0.1", port), [this](const net::in::SocketAddress&, core::socket::State connectState) {
+            if (connectState == core::socket::State::OK) {
+                ++state.clientConnectOkCount;
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+    }
+
+    State& state;
+    std::uint16_t port = 0;
+    std::deque<Case> cases;
+    std::vector<std::shared_ptr<Client>> clients;
+};
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetExpressFallbackNotFoundTest");
+    } else {
+        State state;
+
+        core::SNodeC::init(argc, argv);
+
+        const express::legacy::in::WebApp app("ipv4-expressfallbacknotfound-server");
+
+        app.get("/known", [&state] APPLICATION(req, res) {
+            ++state.knownRouteCount;
+            res->status(200).set("X-Express-Fallback", "known").send("known route ok");
+        });
+        app.use([&state] APPLICATION(req, res) {
+            ++state.fallbackCount;
+            res->status(404).set("X-Express-Fallback", "not-found").send("explicit fallback not found");
+        });
+
+        app.getConfig()->Instance::forceUnrequired();
+
+        CaseClientRunner caseClientRunner(state, {{{"/known", 200, "X-Express-Fallback", "known", "known route ok"}, {"/missing", 404, "X-Express-Fallback", "not-found", "explicit fallback not found"}}});
+        app.listen(net::in::SocketAddress("127.0.0.1", 0), [&caseClientRunner, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    caseClientRunner.run(effectivePort);
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully");
+        testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective IPv4 endpoint");
+        testResult.expectEqual(2, state.clientConnectOkCount, "HTTP client connect callbacks report OK once per request");
+        testResult.expectEqual(2, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback once per request");
+        testResult.expectEqual(2, state.clientResponseCount, "HTTP client observes all Express responses");
+        testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, "test cases report no unexpected states");
+        testResult.expectEqual(1, state.knownRouteCount, "known route handler runs exactly once");
+        testResult.expectEqual(1, state.fallbackCount, "explicit fallback handler runs exactly once");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/express/InetExpressMiddlewareMountOrderTest.cpp
+++ b/tests/component/express/InetExpressMiddlewareMountOrderTest.cpp
@@ -1,0 +1,180 @@
+#include "core/SNodeC.h"
+#include "express/legacy/in/WebApp.h"
+#include "net/in/SocketAddress.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Client.h"
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct Case {
+    std::string url;
+    int status;
+    std::string headerName;
+    std::string headerValue;
+    std::string body;
+};
+
+std::string toString(const std::vector<char>& bytes) {
+    return std::string(bytes.begin(), bytes.end());
+}
+
+struct State { int listenOkCount=0; int effectiveListenEndpointOkCount=0; int clientConnectOkCount=0; int httpConnectedCount=0; int clientResponseCount=0; int parseErrorCount=0; int unexpectedStateCount=0; int appMiddlewareCount=0; int routerMiddlewareCount=0; int handlerCount=0; };
+
+class CaseClientRunner {
+public:
+    CaseClientRunner(State& state, std::deque<Case> cases)
+        : state(state)
+        , cases(std::move(cases)) {
+    }
+
+    void run(std::uint16_t port) {
+        this->port = port;
+        dispatchNext();
+    }
+
+private:
+    using Client = web::http::legacy::in::Client;
+    using MasterRequest = Client::MasterRequest;
+
+    void dispatchNext() {
+        if (cases.empty()) {
+            core::SNodeC::stop();
+            return;
+        }
+
+        const std::size_t clientIndex = clients.size();
+        const Case current = cases.front();
+        cases.pop_front();
+
+        clients.emplace_back(std::make_shared<Client>(
+            "ipv4-express-continuation-client-" + std::to_string(clientIndex),
+            [this, current](const std::shared_ptr<MasterRequest>& request) {
+                ++state.httpConnectedCount;
+                request->method = "GET";
+                request->url = current.url;
+                request->set("Connection", "close");
+                request->end(
+                    [this, current](const auto&, const auto& response) {
+                        ++state.clientResponseCount;
+                        if (response->statusCode != std::to_string(current.status)) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.headerName.empty() && response->get(current.headerName) != current.headerValue) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.body.empty() && toString(response->body) != current.body) {
+                            ++state.unexpectedStateCount;
+                        }
+                        dispatchNext();
+                    },
+                    [this](const auto&, const std::string&) {
+                        ++state.parseErrorCount;
+                        dispatchNext();
+                    });
+            },
+            [](const std::shared_ptr<MasterRequest>&) {
+            }));
+
+        const std::shared_ptr<Client>& client = clients.back();
+        client->getConfig()->Instance::forceUnrequired();
+        client->connect(net::in::SocketAddress("127.0.0.1", port), [this](const net::in::SocketAddress&, core::socket::State connectState) {
+            if (connectState == core::socket::State::OK) {
+                ++state.clientConnectOkCount;
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+    }
+
+    State& state;
+    std::uint16_t port = 0;
+    std::deque<Case> cases;
+    std::vector<std::shared_ptr<Client>> clients;
+};
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetExpressMiddlewareMountOrderTest");
+    } else {
+        State state;
+
+        core::SNodeC::init(argc, argv);
+
+        const express::legacy::in::WebApp app("ipv4-expressmiddlewaremountorder-server");
+
+        express::Router router;
+        app.use([&state] MIDDLEWARE(req, res, next) {
+            ++state.appMiddlewareCount;
+            req->setAttribute<std::string>("app-before", "trace");
+            next();
+        });
+        router.use([&state] MIDDLEWARE(req, res, next) {
+            ++state.routerMiddlewareCount;
+            std::string trace;
+            req->getAttribute<std::string>([&trace](const std::string& value) { trace = value; }, "trace");
+            req->setAttribute<std::string>(trace + ",router-before", "trace", true);
+            next();
+        });
+        router.get("/status", [&state] APPLICATION(req, res) {
+            ++state.handlerCount;
+            std::string trace;
+            req->getAttribute<std::string>([&trace](const std::string& value) { trace = value; }, "trace");
+            trace += ",handler";
+            res->status(200).set("X-Express-Mount-Order", trace).send(trace);
+        });
+        app.use("/api", router);
+
+        app.getConfig()->Instance::forceUnrequired();
+
+        CaseClientRunner caseClientRunner(state, {{{"/api/status", 200, "X-Express-Mount-Order", "app-before,router-before,handler", "app-before,router-before,handler"}, {"/outside", 404, "", "", ""}}});
+        app.listen(net::in::SocketAddress("127.0.0.1", 0), [&caseClientRunner, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    caseClientRunner.run(effectivePort);
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully");
+        testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective IPv4 endpoint");
+        testResult.expectEqual(2, state.clientConnectOkCount, "HTTP client connect callbacks report OK once per request");
+        testResult.expectEqual(2, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback once per request");
+        testResult.expectEqual(2, state.clientResponseCount, "HTTP client observes all Express responses");
+        testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, "test cases report no unexpected states");
+        testResult.expectEqual(2, state.appMiddlewareCount, "application middleware runs for both requests");
+        testResult.expectEqual(1, state.routerMiddlewareCount, "mounted router middleware runs only below mount path");
+        testResult.expectEqual(1, state.handlerCount, "mounted route handler runs exactly once");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/express/InetExpressMountedRouterBasicsTest.cpp
+++ b/tests/component/express/InetExpressMountedRouterBasicsTest.cpp
@@ -1,0 +1,163 @@
+#include "core/SNodeC.h"
+#include "express/legacy/in/WebApp.h"
+#include "net/in/SocketAddress.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Client.h"
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct Case {
+    std::string url;
+    int status;
+    std::string headerName;
+    std::string headerValue;
+    std::string body;
+};
+
+std::string toString(const std::vector<char>& bytes) {
+    return std::string(bytes.begin(), bytes.end());
+}
+
+struct State { int listenOkCount=0; int effectiveListenEndpointOkCount=0; int clientConnectOkCount=0; int httpConnectedCount=0; int clientResponseCount=0; int parseErrorCount=0; int unexpectedStateCount=0; int mountedRouteCount=0; };
+
+class CaseClientRunner {
+public:
+    CaseClientRunner(State& state, std::deque<Case> cases)
+        : state(state)
+        , cases(std::move(cases)) {
+    }
+
+    void run(std::uint16_t port) {
+        this->port = port;
+        dispatchNext();
+    }
+
+private:
+    using Client = web::http::legacy::in::Client;
+    using MasterRequest = Client::MasterRequest;
+
+    void dispatchNext() {
+        if (cases.empty()) {
+            core::SNodeC::stop();
+            return;
+        }
+
+        const std::size_t clientIndex = clients.size();
+        const Case current = cases.front();
+        cases.pop_front();
+
+        clients.emplace_back(std::make_shared<Client>(
+            "ipv4-express-continuation-client-" + std::to_string(clientIndex),
+            [this, current](const std::shared_ptr<MasterRequest>& request) {
+                ++state.httpConnectedCount;
+                request->method = "GET";
+                request->url = current.url;
+                request->set("Connection", "close");
+                request->end(
+                    [this, current](const auto&, const auto& response) {
+                        ++state.clientResponseCount;
+                        if (response->statusCode != std::to_string(current.status)) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.headerName.empty() && response->get(current.headerName) != current.headerValue) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.body.empty() && toString(response->body) != current.body) {
+                            ++state.unexpectedStateCount;
+                        }
+                        dispatchNext();
+                    },
+                    [this](const auto&, const std::string&) {
+                        ++state.parseErrorCount;
+                        dispatchNext();
+                    });
+            },
+            [](const std::shared_ptr<MasterRequest>&) {
+            }));
+
+        const std::shared_ptr<Client>& client = clients.back();
+        client->getConfig()->Instance::forceUnrequired();
+        client->connect(net::in::SocketAddress("127.0.0.1", port), [this](const net::in::SocketAddress&, core::socket::State connectState) {
+            if (connectState == core::socket::State::OK) {
+                ++state.clientConnectOkCount;
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+    }
+
+    State& state;
+    std::uint16_t port = 0;
+    std::deque<Case> cases;
+    std::vector<std::shared_ptr<Client>> clients;
+};
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetExpressMountedRouterBasicsTest");
+    } else {
+        State state;
+
+        core::SNodeC::init(argc, argv);
+
+        const express::legacy::in::WebApp app("ipv4-expressmountedrouterbasics-server");
+
+        express::Router router;
+        router.get("/status", [&state] APPLICATION(req, res) {
+            ++state.mountedRouteCount;
+            res->status(200).set("X-Express-Mounted", "router").send("mounted router ok");
+        });
+        app.use("/api", router);
+
+        app.getConfig()->Instance::forceUnrequired();
+
+        CaseClientRunner caseClientRunner(state, {{{"/api/status", 200, "X-Express-Mounted", "router", "mounted router ok"}, {"/status", 404, "", "", ""}}});
+        app.listen(net::in::SocketAddress("127.0.0.1", 0), [&caseClientRunner, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    caseClientRunner.run(effectivePort);
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully");
+        testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective IPv4 endpoint");
+        testResult.expectEqual(2, state.clientConnectOkCount, "HTTP client connect callbacks report OK once per request");
+        testResult.expectEqual(2, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback once per request");
+        testResult.expectEqual(2, state.clientResponseCount, "HTTP client observes all Express responses");
+        testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, "test cases report no unexpected states");
+        testResult.expectEqual(1, state.mountedRouteCount, "mounted router route handler runs exactly once");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/express/InetExpressNestedRouterBasicsTest.cpp
+++ b/tests/component/express/InetExpressNestedRouterBasicsTest.cpp
@@ -1,0 +1,165 @@
+#include "core/SNodeC.h"
+#include "express/legacy/in/WebApp.h"
+#include "net/in/SocketAddress.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Client.h"
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct Case {
+    std::string url;
+    int status;
+    std::string headerName;
+    std::string headerValue;
+    std::string body;
+};
+
+std::string toString(const std::vector<char>& bytes) {
+    return std::string(bytes.begin(), bytes.end());
+}
+
+struct State { int listenOkCount=0; int effectiveListenEndpointOkCount=0; int clientConnectOkCount=0; int httpConnectedCount=0; int clientResponseCount=0; int parseErrorCount=0; int unexpectedStateCount=0; int nestedRouteCount=0; };
+
+class CaseClientRunner {
+public:
+    CaseClientRunner(State& state, std::deque<Case> cases)
+        : state(state)
+        , cases(std::move(cases)) {
+    }
+
+    void run(std::uint16_t port) {
+        this->port = port;
+        dispatchNext();
+    }
+
+private:
+    using Client = web::http::legacy::in::Client;
+    using MasterRequest = Client::MasterRequest;
+
+    void dispatchNext() {
+        if (cases.empty()) {
+            core::SNodeC::stop();
+            return;
+        }
+
+        const std::size_t clientIndex = clients.size();
+        const Case current = cases.front();
+        cases.pop_front();
+
+        clients.emplace_back(std::make_shared<Client>(
+            "ipv4-express-continuation-client-" + std::to_string(clientIndex),
+            [this, current](const std::shared_ptr<MasterRequest>& request) {
+                ++state.httpConnectedCount;
+                request->method = "GET";
+                request->url = current.url;
+                request->set("Connection", "close");
+                request->end(
+                    [this, current](const auto&, const auto& response) {
+                        ++state.clientResponseCount;
+                        if (response->statusCode != std::to_string(current.status)) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.headerName.empty() && response->get(current.headerName) != current.headerValue) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.body.empty() && toString(response->body) != current.body) {
+                            ++state.unexpectedStateCount;
+                        }
+                        dispatchNext();
+                    },
+                    [this](const auto&, const std::string&) {
+                        ++state.parseErrorCount;
+                        dispatchNext();
+                    });
+            },
+            [](const std::shared_ptr<MasterRequest>&) {
+            }));
+
+        const std::shared_ptr<Client>& client = clients.back();
+        client->getConfig()->Instance::forceUnrequired();
+        client->connect(net::in::SocketAddress("127.0.0.1", port), [this](const net::in::SocketAddress&, core::socket::State connectState) {
+            if (connectState == core::socket::State::OK) {
+                ++state.clientConnectOkCount;
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+    }
+
+    State& state;
+    std::uint16_t port = 0;
+    std::deque<Case> cases;
+    std::vector<std::shared_ptr<Client>> clients;
+};
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetExpressNestedRouterBasicsTest");
+    } else {
+        State state;
+
+        core::SNodeC::init(argc, argv);
+
+        const express::legacy::in::WebApp app("ipv4-expressnestedrouterbasics-server");
+
+        express::Router parentRouter;
+        express::Router childRouter;
+        childRouter.get("/items", [&state] APPLICATION(req, res) {
+            ++state.nestedRouteCount;
+            res->status(200).set("X-Express-Nested", "router").send("nested router items ok");
+        });
+        parentRouter.use("/v1", childRouter);
+        app.use("/api", parentRouter);
+
+        app.getConfig()->Instance::forceUnrequired();
+
+        CaseClientRunner caseClientRunner(state, {{{"/api/v1/items", 200, "X-Express-Nested", "router", "nested router items ok"}, {"/api/v2/items", 404, "", "", ""}}});
+        app.listen(net::in::SocketAddress("127.0.0.1", 0), [&caseClientRunner, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    caseClientRunner.run(effectivePort);
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully");
+        testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective IPv4 endpoint");
+        testResult.expectEqual(2, state.clientConnectOkCount, "HTTP client connect callbacks report OK once per request");
+        testResult.expectEqual(2, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback once per request");
+        testResult.expectEqual(2, state.clientResponseCount, "HTTP client observes all Express responses");
+        testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, "test cases report no unexpected states");
+        testResult.expectEqual(1, state.nestedRouteCount, "nested router route handler runs exactly once");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/express/InetExpressQueryMountInteractionTest.cpp
+++ b/tests/component/express/InetExpressQueryMountInteractionTest.cpp
@@ -1,0 +1,171 @@
+#include "core/SNodeC.h"
+#include "express/legacy/in/WebApp.h"
+#include "net/in/SocketAddress.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Client.h"
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct Case {
+    std::string url;
+    int status;
+    std::string headerName;
+    std::string headerValue;
+    std::string body;
+};
+
+std::string toString(const std::vector<char>& bytes) {
+    return std::string(bytes.begin(), bytes.end());
+}
+
+struct State { int listenOkCount=0; int effectiveListenEndpointOkCount=0; int clientConnectOkCount=0; int httpConnectedCount=0; int clientResponseCount=0; int parseErrorCount=0; int unexpectedStateCount=0; int searchRouteCount=0; bool observedQuery=false; bool observedPath=false; };
+
+class CaseClientRunner {
+public:
+    CaseClientRunner(State& state, std::deque<Case> cases)
+        : state(state)
+        , cases(std::move(cases)) {
+    }
+
+    void run(std::uint16_t port) {
+        this->port = port;
+        dispatchNext();
+    }
+
+private:
+    using Client = web::http::legacy::in::Client;
+    using MasterRequest = Client::MasterRequest;
+
+    void dispatchNext() {
+        if (cases.empty()) {
+            core::SNodeC::stop();
+            return;
+        }
+
+        const std::size_t clientIndex = clients.size();
+        const Case current = cases.front();
+        cases.pop_front();
+
+        clients.emplace_back(std::make_shared<Client>(
+            "ipv4-express-continuation-client-" + std::to_string(clientIndex),
+            [this, current](const std::shared_ptr<MasterRequest>& request) {
+                ++state.httpConnectedCount;
+                request->method = "GET";
+                request->url = current.url;
+                request->set("Connection", "close");
+                request->end(
+                    [this, current](const auto&, const auto& response) {
+                        ++state.clientResponseCount;
+                        if (response->statusCode != std::to_string(current.status)) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.headerName.empty() && response->get(current.headerName) != current.headerValue) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.body.empty() && toString(response->body) != current.body) {
+                            ++state.unexpectedStateCount;
+                        }
+                        dispatchNext();
+                    },
+                    [this](const auto&, const std::string&) {
+                        ++state.parseErrorCount;
+                        dispatchNext();
+                    });
+            },
+            [](const std::shared_ptr<MasterRequest>&) {
+            }));
+
+        const std::shared_ptr<Client>& client = clients.back();
+        client->getConfig()->Instance::forceUnrequired();
+        client->connect(net::in::SocketAddress("127.0.0.1", port), [this](const net::in::SocketAddress&, core::socket::State connectState) {
+            if (connectState == core::socket::State::OK) {
+                ++state.clientConnectOkCount;
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+    }
+
+    State& state;
+    std::uint16_t port = 0;
+    std::deque<Case> cases;
+    std::vector<std::shared_ptr<Client>> clients;
+};
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetExpressQueryMountInteractionTest");
+    } else {
+        State state;
+
+        core::SNodeC::init(argc, argv);
+
+        const express::legacy::in::WebApp app("ipv4-expressquerymountinteraction-server");
+
+        express::Router router;
+        router.get("/search", [&state] APPLICATION(req, res) {
+            ++state.searchRouteCount;
+            if (req->query("q") == "snodec" && req->query("limit") == "10") {
+                state.observedQuery = true;
+            }
+            if (req->path == "/search") {
+                state.observedPath = true;
+            }
+            res->status(200).set("X-Express-Query-Mount", req->query("q") + ":" + req->query("limit")).send("query mount ok");
+        });
+        app.use("/api", router);
+
+        app.getConfig()->Instance::forceUnrequired();
+
+        CaseClientRunner caseClientRunner(state, {{{"/api/search?q=snodec&limit=10", 200, "X-Express-Query-Mount", "snodec:10", "query mount ok"}, {"/api/search?q=snodec&limit=20", 200, "X-Express-Query-Mount", "snodec:20", "query mount ok"}}});
+        app.listen(net::in::SocketAddress("127.0.0.1", 0), [&caseClientRunner, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    caseClientRunner.run(effectivePort);
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully");
+        testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective IPv4 endpoint");
+        testResult.expectEqual(2, state.clientConnectOkCount, "HTTP client connect callbacks report OK once per request");
+        testResult.expectEqual(2, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback once per request");
+        testResult.expectEqual(2, state.clientResponseCount, "HTTP client observes all Express responses");
+        testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, "test cases report no unexpected states");
+        testResult.expectEqual(2, state.searchRouteCount, "mounted search route handler runs once per query-string request");
+        testResult.expectTrue(state.observedQuery, "mounted route observes expected query values through public request API");
+        testResult.expectTrue(state.observedPath, "mounted route path excludes query string");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}

--- a/tests/component/express/InetExpressRouteParameterRegexTest.cpp
+++ b/tests/component/express/InetExpressRouteParameterRegexTest.cpp
@@ -1,0 +1,163 @@
+#include "core/SNodeC.h"
+#include "express/legacy/in/WebApp.h"
+#include "net/in/SocketAddress.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Client.h"
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct Case {
+    std::string url;
+    int status;
+    std::string headerName;
+    std::string headerValue;
+    std::string body;
+};
+
+std::string toString(const std::vector<char>& bytes) {
+    return std::string(bytes.begin(), bytes.end());
+}
+
+struct State { int listenOkCount=0; int effectiveListenEndpointOkCount=0; int clientConnectOkCount=0; int httpConnectedCount=0; int clientResponseCount=0; int parseErrorCount=0; int unexpectedStateCount=0; int regexRouteCount=0; bool observedId=false; };
+
+class CaseClientRunner {
+public:
+    CaseClientRunner(State& state, std::deque<Case> cases)
+        : state(state)
+        , cases(std::move(cases)) {
+    }
+
+    void run(std::uint16_t port) {
+        this->port = port;
+        dispatchNext();
+    }
+
+private:
+    using Client = web::http::legacy::in::Client;
+    using MasterRequest = Client::MasterRequest;
+
+    void dispatchNext() {
+        if (cases.empty()) {
+            core::SNodeC::stop();
+            return;
+        }
+
+        const std::size_t clientIndex = clients.size();
+        const Case current = cases.front();
+        cases.pop_front();
+
+        clients.emplace_back(std::make_shared<Client>(
+            "ipv4-express-continuation-client-" + std::to_string(clientIndex),
+            [this, current](const std::shared_ptr<MasterRequest>& request) {
+                ++state.httpConnectedCount;
+                request->method = "GET";
+                request->url = current.url;
+                request->set("Connection", "close");
+                request->end(
+                    [this, current](const auto&, const auto& response) {
+                        ++state.clientResponseCount;
+                        if (response->statusCode != std::to_string(current.status)) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.headerName.empty() && response->get(current.headerName) != current.headerValue) {
+                            ++state.unexpectedStateCount;
+                        }
+                        if (!current.body.empty() && toString(response->body) != current.body) {
+                            ++state.unexpectedStateCount;
+                        }
+                        dispatchNext();
+                    },
+                    [this](const auto&, const std::string&) {
+                        ++state.parseErrorCount;
+                        dispatchNext();
+                    });
+            },
+            [](const std::shared_ptr<MasterRequest>&) {
+            }));
+
+        const std::shared_ptr<Client>& client = clients.back();
+        client->getConfig()->Instance::forceUnrequired();
+        client->connect(net::in::SocketAddress("127.0.0.1", port), [this](const net::in::SocketAddress&, core::socket::State connectState) {
+            if (connectState == core::socket::State::OK) {
+                ++state.clientConnectOkCount;
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+    }
+
+    State& state;
+    std::uint16_t port = 0;
+    std::deque<Case> cases;
+    std::vector<std::shared_ptr<Client>> clients;
+};
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetExpressRouteParameterRegexTest");
+    } else {
+        State state;
+
+        core::SNodeC::init(argc, argv);
+
+        const express::legacy::in::WebApp app("ipv4-expressrouteparameterregex-server");
+
+        app.get("/items/:id(\\d+)", [&state] APPLICATION(req, res) {
+            ++state.regexRouteCount;
+            state.observedId = req->param("id") == "123";
+            res->status(200).set("X-Express-Regex-Id", req->param("id")).send("regex item id=" + req->param("id"));
+        });
+
+        app.getConfig()->Instance::forceUnrequired();
+
+        CaseClientRunner caseClientRunner(state, {{{"/items/123", 200, "X-Express-Regex-Id", "123", "regex item id=123"}, {"/items/abc", 404, "", "", ""}}});
+        app.listen(net::in::SocketAddress("127.0.0.1", 0), [&caseClientRunner, &state](const net::in::SocketAddress& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    caseClientRunner.run(effectivePort);
+                } else {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            } else {
+                ++state.unexpectedStateCount;
+                core::SNodeC::stop();
+            }
+        });
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        testResult.expectEqual(0, startResult, "event loop stops successfully");
+        testResult.expectEqual(1, state.listenOkCount, "Express server listen callback reports OK exactly once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "Express server reports an effective IPv4 endpoint");
+        testResult.expectEqual(2, state.clientConnectOkCount, "HTTP client connect callbacks report OK once per request");
+        testResult.expectEqual(2, state.httpConnectedCount, "HTTP client reaches HTTP-connected callback once per request");
+        testResult.expectEqual(2, state.clientResponseCount, "HTTP client observes all Express responses");
+        testResult.expectEqual(0, state.parseErrorCount, "HTTP client reports no response parse errors");
+        testResult.expectEqual(0, state.unexpectedStateCount, "test cases report no unexpected states");
+        testResult.expectEqual(1, state.regexRouteCount, "regex-constrained route handler runs exactly once");
+        testResult.expectTrue(state.observedId, "regex-constrained route captures expected id parameter");
+
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Add focused IPv4/legacy Express component tests covering mounted routers, nested routers, route-parameter regex, middleware mount-order, query-string/mount interaction, and explicit fallback/not-found behavior to close the routing component backlog items.
- Keep changes limited to component tests and test registration so existing production behavior is not modified.

### Description
- Implemented canonical IDs `EXPRESS-COMP-006` through `EXPRESS-COMP-011` as new component tests: `InetExpressMountedRouterBasicsTest`, `InetExpressNestedRouterBasicsTest`, `InetExpressRouteParameterRegexTest`, `InetExpressMiddlewareMountOrderTest`, `InetExpressQueryMountInteractionTest`, and `InetExpressFallbackNotFoundTest`.
- Added the six new test source files under `tests/component/express/` and updated `tests/component/express/CMakeLists.txt` to register targets, link libraries, set `cxx_std_20`, add labels `component;express;...`, and set `SKIP_RETURN_CODE 77` and `TIMEOUT 5` per conventions.
- No production code was changed; the only code edits are test sources and the express component CMake file.
- Made a small, test-only tweak in `InetExpressQueryMountInteractionTest.cpp` to record observed query/path flags across the two sequential requests to avoid an inter-request timing/order flake while keeping the intent of the test unchanged.

### Testing
- Ran `git diff --check` which returned clean results before committing.
- Configured the build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF` which initially required `nlohmann-json3-dev` and then completed with normal optional dependency warnings (Doxygen/IWYU/bluez/libmagic/libmariadb) after installing the package with `apt-get install -y nlohmann-json3-dev`.
- Built the new express targets with `cmake --build build --target InetExpressMountedRouterBasicsTest InetExpressNestedRouterBasicsTest InetExpressRouteParameterRegexTest InetExpressMiddlewareMountOrderTest InetExpressQueryMountInteractionTest InetExpressFallbackNotFoundTest -j2` which succeeded.
- Ran `ctest --test-dir build -L express --output-on-failure` as root (observing existing root-skip convention) and confirmed the tests are skipped under root per project policy.
- Executed the express test suite as an unprivileged user per project convention with `su -s /bin/bash codextest -c 'cd /workspace/snode.c && HOME=/home/codextest ctest --test-dir build -L express --output-on-failure'` and observed all Express component tests pass (11/11 when including existing express tests); one initial failure of `InetExpressQueryMountInteractionTest` was observed and fixed by the minor test-only tweak described above, after which the focused tests passed.
- `git diff master...HEAD --name-only` shows only `tests/component/express/CMakeLists.txt` and the new `tests/component/express/*.cpp` files were added.

Files added/changed
- Added: `tests/component/express/InetExpressMountedRouterBasicsTest.cpp`, `InetExpressNestedRouterBasicsTest.cpp`, `InetExpressRouteParameterRegexTest.cpp`, `InetExpressMiddlewareMountOrderTest.cpp`, `InetExpressQueryMountInteractionTest.cpp`, `InetExpressFallbackNotFoundTest.cpp`.
- Modified: `tests/component/express/CMakeLists.txt` to register and label the new tests.

Implemented canonical IDs
- `EXPRESS-COMP-006`, `EXPRESS-COMP-007`, `EXPRESS-COMP-008`, `EXPRESS-COMP-009`, `EXPRESS-COMP-010`, `EXPRESS-COMP-011`.

Deferred canonical IDs
- None.

Production code changes
- None (only test files and CMakeLists.txt were added/edited).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a494e52ddd0832c935ed837692a6195)