### PR TITLE
Add HTTP message formatting unit tests

### DIFF
--- a/tests/unit/http/CMakeLists.txt
+++ b/tests/unit/http/CMakeLists.txt
@@ -3,7 +3,19 @@
 #               2020, 2021, 2022, 2023, 2024, 2025, 2026
 
 snodec_add_test(HttpMessageParserTest HttpMessageParserTest.cpp)
+snodec_add_test(HttpRequestFormatterRawWireTest HttpRequestFormatterRawWireTest.cpp)
+snodec_add_test(HttpResponseFormatterRawWireTest HttpResponseFormatterRawWireTest.cpp)
+snodec_add_test(HttpMessageHeaderCasingTest HttpMessageHeaderCasingTest.cpp)
+snodec_add_test(HttpMessageTargetQueryEdgeTest HttpMessageTargetQueryEdgeTest.cpp)
 
 target_link_libraries(HttpMessageParserTest PRIVATE snodec-test-support snodec::http-server snodec::http-client)
+target_link_libraries(HttpRequestFormatterRawWireTest PRIVATE snodec-test-support snodec::http-server snodec::http-client)
+target_link_libraries(HttpResponseFormatterRawWireTest PRIVATE snodec-test-support snodec::http-server snodec::http-client)
+target_link_libraries(HttpMessageHeaderCasingTest PRIVATE snodec-test-support snodec::http-server snodec::http-client)
+target_link_libraries(HttpMessageTargetQueryEdgeTest PRIVATE snodec-test-support snodec::http-server snodec::http-client)
 
 set_tests_properties(HttpMessageParserTest PROPERTIES LABELS "unit;http;message" TIMEOUT 5)
+set_tests_properties(HttpRequestFormatterRawWireTest PROPERTIES LABELS "unit;http;message;format" TIMEOUT 5)
+set_tests_properties(HttpResponseFormatterRawWireTest PROPERTIES LABELS "unit;http;message;format" TIMEOUT 5)
+set_tests_properties(HttpMessageHeaderCasingTest PROPERTIES LABELS "unit;http;message;headers" TIMEOUT 5)
+set_tests_properties(HttpMessageTargetQueryEdgeTest PROPERTIES LABELS "unit;http;message;target;query" TIMEOUT 5)

--- a/tests/unit/http/HttpMessageHeaderCasingTest.cpp
+++ b/tests/unit/http/HttpMessageHeaderCasingTest.cpp
@@ -1,0 +1,50 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#include "support/TestResult.h"
+#include "web/http/CiStringMap.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <string>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+int main() {
+    tests::support::TestResult testResult;
+
+    {
+        web::http::CiStringMap<std::string> headers;
+        headers.emplace("Content-Type", "text/plain");
+
+        testResult.expectTrue(headers.find("content-type") != headers.end(), "headers are found with lower-case lookup names");
+        testResult.expectTrue(headers.find("CONTENT-TYPE") != headers.end(), "headers are found with upper-case lookup names");
+        testResult.expectTrue(headers.find("Content-Type") != headers.end(), "headers are found with original-case lookup names");
+        testResult.expectTrue(headers["content-type"] == "text/plain", "lower-case lookup returns the stored header value");
+        testResult.expectTrue(headers["CONTENT-TYPE"] == "text/plain", "upper-case lookup returns the stored header value");
+    }
+
+    {
+        web::http::CiStringMap<std::string> headers;
+        headers.emplace("X-Trace", "one");
+        headers.insert_or_assign("x-trace", "two");
+
+        testResult.expectEqual(1, static_cast<int>(headers.size()), "duplicate non-cookie header names with different casing share one map entry");
+        testResult.expectTrue(headers["X-TRACE"] == "two", "insert_or_assign replaces duplicate non-cookie header values case-insensitively");
+        testResult.expectTrue(headers.begin()->first == "X-Trace", "original casing from the first inserted header name is preserved by the map key");
+    }
+
+    {
+        web::http::CiStringMap<std::string> headers;
+        headers.insert_or_assign("Set-Cookie", "a=1");
+        headers.insert_or_assign("set-cookie", "b=2");
+
+        testResult.expectEqual(1, static_cast<int>(headers.size()), "Set-Cookie lookup uses the same case-insensitive header map contract");
+        testResult.expectTrue(headers["SET-COOKIE"] == "b=2", "Set-Cookie replacement is case-insensitive in the header map");
+    }
+
+    return testResult.processResult();
+}

--- a/tests/unit/http/HttpMessageTargetQueryEdgeTest.cpp
+++ b/tests/unit/http/HttpMessageTargetQueryEdgeTest.cpp
@@ -1,0 +1,155 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "support/TestResult.h"
+#include "web/http/server/RequestParser.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <map>
+#include <string>
+#include <utility>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    class DummySocketAddress : public core::socket::SocketAddress {
+    public:
+        std::string toString(bool = true) const override {
+            return "dummy";
+        }
+    };
+
+    class BufferSocketConnection : public core::socket::stream::SocketConnection {
+    public:
+        explicit BufferSocketConnection(std::string input)
+            : SocketConnection(-1, "HttpMessageTargetQueryEdgeTest", nullptr)
+            , input(std::move(input)) {
+        }
+
+        int getFd() const override { return -1; }
+        void sendToPeer(const char*, std::size_t) override {}
+        bool streamToPeer(core::pipe::Source*) override { return false; }
+        void streamEof() override {}
+
+        std::size_t readFromPeer(char* chunk, std::size_t chunkLen) override {
+            const std::size_t available = input.size() - offset;
+            const std::size_t toRead = std::min(chunkLen, available);
+            if (toRead > 0) {
+                std::memcpy(chunk, input.data() + offset, toRead);
+                offset += toRead;
+            }
+            return toRead;
+        }
+
+        void shutdownRead() override {}
+        void shutdownWrite() override {}
+        const core::socket::SocketAddress& getBindAddress() const override { return address; }
+        const core::socket::SocketAddress& getLocalAddress() const override { return address; }
+        const core::socket::SocketAddress& getRemoteAddress() const override { return address; }
+        void close() override {}
+        void setTimeout(const utils::Timeval&) override {}
+        void setReadTimeout(const utils::Timeval&) override {}
+        void setWriteTimeout(const utils::Timeval&) override {}
+        std::size_t getTotalSent() const override { return 0; }
+        std::size_t getTotalQueued() const override { return 0; }
+        std::size_t getTotalRead() const override { return offset; }
+        std::size_t getTotalProcessed() const override { return offset; }
+
+    private:
+        std::string input;
+        std::size_t offset = 0;
+        DummySocketAddress address;
+    };
+
+    class BufferSocketContext : public core::socket::stream::SocketContext {
+    public:
+        explicit BufferSocketContext(core::socket::stream::SocketConnection* socketConnection)
+            : SocketContext(socketConnection) {
+        }
+
+    private:
+        void onConnected() override {}
+        void onDisconnected() override {}
+        std::size_t onReceivedFromPeer() override { return 0; }
+        bool onSignal(int) override { return false; }
+    };
+
+    struct ParsedTarget {
+        std::string url;
+        std::map<std::string, std::string> queries;
+
+        std::string query(const std::string& key) const {
+            const auto it = queries.find(key);
+            return it != queries.end() ? it->second : std::string();
+        }
+    };
+
+    ParsedTarget parseRequestTarget(const std::string& target) {
+        BufferSocketConnection connection("GET " + target + " HTTP/1.1\r\nHost: example.test\r\n\r\n");
+        BufferSocketContext context(&connection);
+        ParsedTarget parsedTarget;
+
+        web::http::server::RequestParser parser(
+            &context,
+            []() {},
+            [&parsedTarget](web::http::server::Request&& request) {
+                parsedTarget.url = request.url;
+                parsedTarget.queries = std::move(request.queries);
+            },
+            [](int, const std::string&) {});
+
+        parser.parse();
+        return parsedTarget;
+    }
+
+} // namespace
+
+int main() {
+    tests::support::TestResult testResult;
+
+    {
+        const ParsedTarget request = parseRequestTarget("/plain");
+        testResult.expectTrue(request.url == "/plain", "parser preserves a target without a query string");
+        testResult.expectTrue(request.queries.empty(), "parser leaves query map empty when no query string is present");
+    }
+
+    {
+        const ParsedTarget request = parseRequestTarget("/search?q=snodec");
+        testResult.expectTrue(request.url == "/search?q=snodec", "parser preserves a target with one query parameter");
+        testResult.expectTrue(request.query("q") == "snodec", "parser exposes a single query parameter value");
+    }
+
+    {
+        const ParsedTarget request = parseRequestTarget("/search?q=snodec&limit=10");
+        testResult.expectTrue(request.query("q") == "snodec", "parser exposes the first query parameter among multiple parameters");
+        testResult.expectTrue(request.query("limit") == "10", "parser exposes the second query parameter among multiple parameters");
+    }
+
+    {
+        const ParsedTarget request = parseRequestTarget("/search?q=");
+        testResult.expectTrue(request.query("q").empty(), "parser exposes empty query values as empty strings");
+    }
+
+    {
+        const ParsedTarget request = parseRequestTarget("/search?q=one&q=two");
+        testResult.expectTrue(request.query("q") == "two", "parser keeps the last value for repeated query keys");
+    }
+
+    {
+        const ParsedTarget request = parseRequestTarget("/search?q=snode%20c");
+        testResult.expectTrue(request.query("q") == "snode c", "parser decodes percent-encoded query values at the message layer");
+    }
+
+    return testResult.processResult();
+}

--- a/tests/unit/http/HttpRequestFormatterRawWireTest.cpp
+++ b/tests/unit/http/HttpRequestFormatterRawWireTest.cpp
@@ -1,0 +1,67 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#include "support/TestResult.h"
+#include "web/http/CiStringMap.h"
+#include "web/http/http_utils.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <map>
+#include <string>
+#include <vector>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    bool contains(const std::string& haystack, const std::string& needle) {
+        return haystack.find(needle) != std::string::npos;
+    }
+
+} // namespace
+
+int main() {
+    tests::support::TestResult testResult;
+
+    {
+        const std::string formatted = httputils::toString("GET",
+                                                         "/index.html",
+                                                         "HTTP/1.1",
+                                                         {},
+                                                         {{"Host", "example.test"}},
+                                                         {},
+                                                         {},
+                                                         {});
+
+        testResult.expectTrue(contains(formatted, "Request"), "request formatter seam identifies request messages");
+        testResult.expectTrue(contains(formatted, "Method : GET"), "request formatter seam preserves the GET method");
+        testResult.expectTrue(contains(formatted, "Url : /index.html"), "request formatter seam preserves the request target");
+        testResult.expectTrue(contains(formatted, "Version : HTTP/1.1"), "request formatter seam preserves the HTTP version");
+        testResult.expectTrue(contains(formatted, "Host : example.test"), "request formatter seam preserves stable headers");
+    }
+
+    {
+        const std::vector<char> body = {'h', 'e', 'l', 'l', 'o'};
+        const std::string formatted = httputils::toString("POST",
+                                                         "/submit",
+                                                         "HTTP/1.1",
+                                                         {},
+                                                         {{"Content-Length", "5"}, {"Content-Type", "text/plain"}, {"Host", "example.test"}},
+                                                         {},
+                                                         {},
+                                                         body);
+
+        testResult.expectTrue(contains(formatted, "Method : POST"), "request formatter seam preserves the POST method");
+        testResult.expectTrue(contains(formatted, "Url : /submit"), "request formatter seam preserves the POST target");
+        testResult.expectTrue(contains(formatted, "Content-Length : 5"), "request formatter seam preserves Content-Length");
+        testResult.expectTrue(contains(formatted, "Content-Type : text/plain"), "request formatter seam preserves Content-Type");
+        testResult.expectTrue(contains(formatted, "Host : example.test"), "request formatter seam preserves Host");
+        testResult.expectTrue(contains(formatted, "68 65 6c 6c 6f"), "request formatter seam preserves the body bytes");
+    }
+
+    return testResult.processResult();
+}

--- a/tests/unit/http/HttpResponseFormatterRawWireTest.cpp
+++ b/tests/unit/http/HttpResponseFormatterRawWireTest.cpp
@@ -1,0 +1,57 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#include "support/TestResult.h"
+#include "web/http/CiStringMap.h"
+#include "web/http/CookieOptions.h"
+#include "web/http/http_utils.h"
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <string>
+#include <vector>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+
+    bool contains(const std::string& haystack, const std::string& needle) {
+        return haystack.find(needle) != std::string::npos;
+    }
+
+} // namespace
+
+int main() {
+    tests::support::TestResult testResult;
+
+    {
+        const std::string formatted = httputils::toString("HTTP/1.1", "200", "OK", {{"Content-Length", "0"}}, {}, {});
+
+        testResult.expectTrue(contains(formatted, "Response"), "response formatter seam identifies response messages");
+        testResult.expectTrue(contains(formatted, "Version : HTTP/1.1"), "response formatter seam preserves the HTTP version");
+        testResult.expectTrue(contains(formatted, "Status : 200"), "response formatter seam preserves the status code");
+        testResult.expectTrue(contains(formatted, "Reason : OK"), "response formatter seam preserves the reason phrase");
+        testResult.expectTrue(contains(formatted, "Content-Length : 0"), "response formatter seam preserves stable headers");
+    }
+
+    {
+        const std::vector<char> body = {'n', 'o', 't', ' ', 'f', 'o', 'u', 'n', 'd'};
+        const std::string formatted = httputils::toString("HTTP/1.1",
+                                                         "404",
+                                                         "Not Found",
+                                                         {{"Content-Length", "9"}, {"Content-Type", "text/plain"}},
+                                                         {},
+                                                         body);
+
+        testResult.expectTrue(contains(formatted, "Status : 404"), "response formatter seam preserves non-200 status codes");
+        testResult.expectTrue(contains(formatted, "Reason : Not Found"), "response formatter seam preserves non-200 reason phrases");
+        testResult.expectTrue(contains(formatted, "Content-Length : 9"), "response formatter seam preserves response Content-Length");
+        testResult.expectTrue(contains(formatted, "Content-Type : text/plain"), "response formatter seam preserves response Content-Type");
+        testResult.expectTrue(contains(formatted, "6e 6f 74 20 66 6f 75 6e 64"), "response formatter seam preserves the body bytes");
+    }
+
+    return testResult.processResult();
+}


### PR DESCRIPTION
### Motivation
- Add focused unit tests for the HTTP message layer to cover request/response formatter diagnostics, header casing semantics, and target/query parsing edge-cases that are part of the canonical backlog items `HTTP-MSG-UNIT-016`..`HTTP-MSG-UNIT-019`.
- Use existing, stable public seams (not runtime socket transports) to verify observable behavior without introducing network, lifecycle, or server/client dependencies.

### Description
- Implemented `HTTP-MSG-UNIT-016` as `HttpRequestFormatterRawWireTest.cpp` which exercises `httputils::toString(...)` for deterministic GET and POST cases and verifies request-line, headers and body bytes via the public diagnostic formatter seam rather than a transport raw-wire emitter.
- Implemented `HTTP-MSG-UNIT-017` as `HttpResponseFormatterRawWireTest.cpp` which exercises `httputils::toString(...)` for 200 and 404 responses and verifies status/reason, headers and body bytes via the public diagnostic formatter seam.
- Implemented `HTTP-MSG-UNIT-018` as `HttpMessageHeaderCasingTest.cpp` which documents current header map behavior including case-insensitive lookup, duplicate non-cookie header replacement, and `Set-Cookie` casing behaviour, without changing production code.
- Implemented `HTTP-MSG-UNIT-019` as `HttpMessageTargetQueryEdgeTest.cpp` which exercises `web::http::server::RequestParser` via a buffer socket shim to validate no-query, single/multiple params, empty values, repeated keys (last-wins), and percent-decoding where the parser performs it, and added test registration in `tests/unit/http/CMakeLists.txt`.

### Testing
- Ran `git diff --check` and observed no whitespace or trailing-line errors (PASS).
- Configured with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF`, which initially failed due to a missing package (`nlohmann-json3-dev`), then installed it with `apt-get update && apt-get install -y nlohmann-json3-dev` and re-ran `cmake` successfully (initial configure: FAIL due to missing package; after install: PASS).
- Built the new tests with `cmake --build build --target HttpRequestFormatterRawWireTest HttpResponseFormatterRawWireTest HttpMessageHeaderCasingTest HttpMessageTargetQueryEdgeTest -j2` and observed the build succeed (PASS).
- Ran the focused test set with `ctest --test-dir build -R "HttpRequestFormatterRawWireTest|HttpResponseFormatterRawWireTest|HttpMessageHeaderCasingTest|HttpMessageTargetQueryEdgeTest" --output-on-failure` and all four new tests passed (PASS).
- Built and ran the existing `HttpMessageParserTest` with `cmake --build build --target HttpMessageParserTest -j2` and `ctest --test-dir build -R "HttpMessageParserTest" --output-on-failure` and it passed (PASS).

Implemented canonical IDs: `HTTP-MSG-UNIT-016`, `HTTP-MSG-UNIT-017`, `HTTP-MSG-UNIT-018`, `HTTP-MSG-UNIT-019`.
Deferred assertions: exact raw-wire CRLF/blank-line serialization assertions for `HTTP-MSG-UNIT-016` and `HTTP-MSG-UNIT-017` were intentionally deferred because the raw transport serialization is coupled to `SocketContext`/transport-side behavior (volatile `Date` header and transport emission) and no transport-free, stable public raw-wire emitter is available; tests use the stable diagnostic `httputils::toString(...)` seam instead.

Files added/changed
- Added: `tests/unit/http/HttpRequestFormatterRawWireTest.cpp`.
- Added: `tests/unit/http/HttpResponseFormatterRawWireTest.cpp`.
- Added: `tests/unit/http/HttpMessageHeaderCasingTest.cpp`.
- Added: `tests/unit/http/HttpMessageTargetQueryEdgeTest.cpp`.
- Updated: `tests/unit/http/CMakeLists.txt` to register and label the new tests.

Production code changes: none.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a495def3de0832cb5832a2b0d465b5a)