### PR TITLE
Add remaining HTTP robustness component tests (HTTP-COMP-019/020/022)

### DIFF
--- a/tests/component/http/CMakeLists.txt
+++ b/tests/component/http/CMakeLists.txt
@@ -154,3 +154,28 @@ set_tests_properties(InetHttpServerClientPipeliningTest PROPERTIES
                      LABELS "component;http;pipelining;legacy;ipv4"
                      SKIP_RETURN_CODE 77
                      TIMEOUT 5)
+
+snodec_add_test(InetHttpServerMalformedRequestBehaviorTest InetHttpServerMalformedRequestBehaviorTest.cpp)
+snodec_add_test(InetHttpClientMalformedResponseBehaviorTest InetHttpClientMalformedResponseBehaviorTest.cpp)
+snodec_add_test(InetHttpServerClientChunkedRequestTest InetHttpServerClientChunkedRequestTest.cpp)
+
+target_link_libraries(InetHttpServerMalformedRequestBehaviorTest PRIVATE snodec-test-support snodec::http-server snodec::net-in-stream-legacy)
+target_link_libraries(InetHttpClientMalformedResponseBehaviorTest PRIVATE snodec-test-support snodec::http-client snodec::net-in-stream-legacy)
+target_link_libraries(InetHttpServerClientChunkedRequestTest PRIVATE snodec-test-support snodec::http-server snodec::net-in-stream-legacy)
+
+target_compile_features(InetHttpServerMalformedRequestBehaviorTest PRIVATE cxx_std_20)
+target_compile_features(InetHttpClientMalformedResponseBehaviorTest PRIVATE cxx_std_20)
+target_compile_features(InetHttpServerClientChunkedRequestTest PRIVATE cxx_std_20)
+
+set_tests_properties(InetHttpServerMalformedRequestBehaviorTest PROPERTIES
+                     LABELS "component;http;malformed-request;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+set_tests_properties(InetHttpClientMalformedResponseBehaviorTest PROPERTIES
+                     LABELS "component;http;malformed-response;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)
+set_tests_properties(InetHttpServerClientChunkedRequestTest PROPERTIES
+                     LABELS "component;http;chunked;request;legacy;ipv4"
+                     SKIP_RETURN_CODE 77
+                     TIMEOUT 5)

--- a/tests/component/http/InetHttpClientMalformedResponseBehaviorTest.cpp
+++ b/tests/component/http/InetHttpClientMalformedResponseBehaviorTest.cpp
@@ -1,0 +1,134 @@
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in/SocketAddress.h"
+#include "net/in/stream/legacy/SocketServer.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Client.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace {
+    constexpr std::string_view malformedResponse =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Length: not-a-number\r\n"
+        "Connection: close\r\n"
+        "\r\n";
+
+    struct State {
+        int listenOkCount = 0, effectiveListenEndpointOkCount = 0, clientConnectOkCount = 0;
+        int serverFactoryCreateCount = 0, rawServerConnectedCount = 0, rawServerDisconnectedCount = 0;
+        int rawServerRequestReadCount = 0, httpConnectedCount = 0, httpDisconnectedCount = 0;
+        int clientResponseCount = 0, parseErrorCount = 0, unexpectedStateCount = 0;
+        bool rawServerSawGet = false;
+        std::string parseErrorMessage;
+    };
+
+    class RawServerContext : public core::socket::stream::SocketContext {
+    public:
+        RawServerContext(core::socket::stream::SocketConnection* socketConnection, State& state)
+            : core::socket::stream::SocketContext(socketConnection), state(state) {}
+    private:
+        void onConnected() override { ++state.rawServerConnectedCount; }
+        void onDisconnected() override { ++state.rawServerDisconnectedCount; }
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+            if (chunkLen > 0) {
+                requestBuffer.append(chunk, chunkLen);
+                if (requestBuffer.find("\r\n\r\n") != std::string::npos) {
+                    ++state.rawServerRequestReadCount;
+                    state.rawServerSawGet = requestBuffer.find("GET /malformed-response HTTP/1.1") != std::string::npos;
+                    sendToPeer(malformedResponse.data(), malformedResponse.size());
+                    shutdownWrite();
+                }
+            }
+            return chunkLen;
+        }
+        bool onSignal([[maybe_unused]] int signum) override { return true; }
+        State& state;
+        std::string requestBuffer;
+    };
+
+    class RawServerFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit RawServerFactory(State& state) : state(state) {}
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++state.serverFactoryCreateCount;
+            return new RawServerContext(socketConnection, state);
+        }
+    private:
+        State& state;
+    };
+}
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpClientMalformedResponseBehaviorTest");
+    } else {
+        State state;
+        core::SNodeC::init(argc, argv);
+        net::in::stream::legacy::SocketServer<RawServerFactory, State&> server("ipv4-http-raw-malformed-response-server", state);
+        web::http::legacy::in::Client client(
+            "ipv4-http-malformed-response-client",
+            [&state](const auto& request) {
+                ++state.httpConnectedCount;
+                request->method = "GET";
+                request->url = "/malformed-response";
+                request->set("Connection", "close");
+                if (!request->end(
+                        [&state](const auto&, const auto&) {
+                            ++state.clientResponseCount;
+                            core::SNodeC::stop();
+                        },
+                        [&state](const auto&, const std::string& message) {
+                            ++state.parseErrorCount;
+                            state.parseErrorMessage = message;
+                            core::SNodeC::stop();
+                        })) {
+                    ++state.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            },
+            [&state](const auto&) { ++state.httpDisconnectedCount; });
+        server.getConfig()->Instance::forceUnrequired();
+        client.getConfig()->Instance::forceUnrequired();
+        server.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const auto&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) ++state.clientConnectOkCount; else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+                    });
+                } else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+            } else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+        });
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        testResult.expectEqual(0, startResult, "event loop stops after malformed response parse error");
+        testResult.expectEqual(1, state.listenOkCount, "listen OK once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "effective endpoint once");
+        testResult.expectEqual(1, state.clientConnectOkCount, "HTTP client connect OK once");
+        testResult.expectEqual(1, state.serverFactoryCreateCount, "raw server factory creates one context");
+        testResult.expectEqual(1, state.rawServerConnectedCount, "raw server connected once");
+        testResult.expectEqual(1, state.rawServerRequestReadCount, "raw server reads one HTTP request");
+        testResult.expectEqual(1, state.httpConnectedCount, "HTTP connected callback once");
+        testResult.expectEqual(1, state.parseErrorCount, "client reports one response parse error");
+        testResult.expectEqual(0, state.clientResponseCount, "client does not report successful response");
+        testResult.expectEqual(0, state.unexpectedStateCount, "no unexpected states");
+        testResult.expectTrue(state.rawServerSawGet, "raw server sees client GET request");
+        testResult.expectTrue(!state.parseErrorMessage.empty(), "parse error provides a message");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+    return result;
+}

--- a/tests/component/http/InetHttpServerClientChunkedRequestTest.cpp
+++ b/tests/component/http/InetHttpServerClientChunkedRequestTest.cpp
@@ -1,0 +1,141 @@
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in/SocketAddress.h"
+#include "net/in/stream/legacy/SocketClient.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Server.h"
+#include "web/http/server/Request.h"
+#include "web/http/server/Response.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+    std::string toString(const std::vector<char>& bytes) { return {bytes.begin(), bytes.end()}; }
+
+    constexpr std::string_view chunkedRequest =
+        "POST /chunked-request HTTP/1.1\r\n"
+        "Host: 127.0.0.1\r\n"
+        "Transfer-Encoding: chunked\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+        "6\r\n"
+        "hello \r\n"
+        "8\r\n"
+        "chunked \r\n"
+        "7\r\n"
+        "request\r\n"
+        "0\r\n"
+        "\r\n";
+
+    struct State {
+        int listenOkCount = 0, effectiveListenEndpointOkCount = 0, clientConnectOkCount = 0;
+        int clientFactoryCreateCount = 0, rawClientConnectedCount = 0, rawClientDisconnectedCount = 0;
+        int rawClientResponseCount = 0, serverRequestCount = 0, unexpectedStateCount = 0;
+        bool serverSawMethod = false, serverSawTarget = false, serverSawBody = false, serverSawTransferEncoding = false;
+        bool rawClientSawStatus = false, rawClientSawBody = false;
+    };
+
+    class RawClientContext : public core::socket::stream::SocketContext {
+    public:
+        RawClientContext(core::socket::stream::SocketConnection* socketConnection, State& state)
+            : core::socket::stream::SocketContext(socketConnection), state(state) {}
+
+    private:
+        void onConnected() override {
+            ++state.rawClientConnectedCount;
+            sendToPeer(chunkedRequest.data(), chunkedRequest.size());
+        }
+        void onDisconnected() override { ++state.rawClientDisconnectedCount; }
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+            if (chunkLen > 0) {
+                responseBuffer.append(chunk, chunkLen);
+                if (responseBuffer.find("chunked-request-ok") != std::string::npos) {
+                    ++state.rawClientResponseCount;
+                    state.rawClientSawStatus = responseBuffer.find("HTTP/1.1 200") != std::string::npos || responseBuffer.find("HTTP/1.0 200") != std::string::npos;
+                    state.rawClientSawBody = true;
+                    core::SNodeC::stop();
+                }
+            }
+            return chunkLen;
+        }
+        bool onSignal([[maybe_unused]] int signum) override { return true; }
+
+        State& state;
+        std::string responseBuffer;
+    };
+
+    class RawClientFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit RawClientFactory(State& state) : state(state) {}
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++state.clientFactoryCreateCount;
+            return new RawClientContext(socketConnection, state);
+        }
+    private:
+        State& state;
+    };
+}
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpServerClientChunkedRequestTest");
+    } else {
+        State state;
+        core::SNodeC::init(argc, argv);
+        using Server = web::http::legacy::in::Server;
+        const Server server("ipv4-http-chunked-request-server", [&state](const auto& request, const auto& response) {
+            ++state.serverRequestCount;
+            state.serverSawMethod = request->method == "POST";
+            state.serverSawTarget = request->url == "/chunked-request";
+            state.serverSawBody = toString(request->body) == "hello chunked request";
+            state.serverSawTransferEncoding = request->get("Transfer-Encoding") == "chunked";
+            response->status(200).type("text/plain").set("Connection", "close").send("chunked-request-ok");
+        });
+        net::in::stream::legacy::SocketClient<RawClientFactory, State&> client("ipv4-http-raw-chunked-request-client", state);
+        server.getConfig()->Instance::forceUnrequired();
+        client.getConfig()->Instance::forceUnrequired();
+        server.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const auto&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) ++state.clientConnectOkCount; else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+                    });
+                } else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+            } else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+        });
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        testResult.expectEqual(0, startResult, "event loop stops after raw chunked request response");
+        testResult.expectEqual(1, state.listenOkCount, "listen OK once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "effective endpoint once");
+        testResult.expectEqual(1, state.clientConnectOkCount, "raw client connect OK once");
+        testResult.expectEqual(1, state.clientFactoryCreateCount, "raw client factory creates one context");
+        testResult.expectEqual(1, state.rawClientConnectedCount, "raw client connected once");
+        testResult.expectEqual(1, state.serverRequestCount, "server handles one request");
+        testResult.expectEqual(1, state.rawClientResponseCount, "raw client receives one matching response");
+        testResult.expectEqual(0, state.unexpectedStateCount, "no unexpected states");
+        testResult.expectTrue(state.serverSawMethod, "server sees POST method");
+        testResult.expectTrue(state.serverSawTarget, "server sees chunked request target");
+        testResult.expectTrue(state.serverSawBody, "server sees reassembled chunked body");
+        testResult.expectTrue(state.serverSawTransferEncoding, "server exposes transfer-encoding header");
+        testResult.expectTrue(state.rawClientSawStatus, "raw client sees 200 response");
+        testResult.expectTrue(state.rawClientSawBody, "raw client sees response body");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+    return result;
+}

--- a/tests/component/http/InetHttpServerMalformedRequestBehaviorTest.cpp
+++ b/tests/component/http/InetHttpServerMalformedRequestBehaviorTest.cpp
@@ -1,0 +1,118 @@
+#include "core/SNodeC.h"
+#include "core/socket/State.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "net/in/SocketAddress.h"
+#include "net/in/stream/legacy/SocketClient.h"
+#include "support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/http/legacy/in/Server.h"
+#include "web/http/server/Response.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace {
+    constexpr std::string_view malformedRequest =
+        "GET /malformed HTTP/1.1\r\n"
+        "Host: 127.0.0.1\r\n"
+        "BadHeaderWithoutColon\r\n"
+        "Connection: close\r\n"
+        "\r\n";
+
+    struct State {
+        int listenOkCount = 0, effectiveListenEndpointOkCount = 0, clientConnectOkCount = 0;
+        int clientFactoryCreateCount = 0, rawClientConnectedCount = 0, rawClientDisconnectedCount = 0;
+        int serverRequestCount = 0, rawClientReadCount = 0, unexpectedStateCount = 0;
+        std::string responseBuffer;
+    };
+
+    class RawClientContext : public core::socket::stream::SocketContext {
+    public:
+        RawClientContext(core::socket::stream::SocketConnection* socketConnection, State& state)
+            : core::socket::stream::SocketContext(socketConnection), state(state) {}
+    private:
+        void onConnected() override {
+            ++state.rawClientConnectedCount;
+            sendToPeer(malformedRequest.data(), malformedRequest.size());
+        }
+        void onDisconnected() override {
+            ++state.rawClientDisconnectedCount;
+            core::SNodeC::stop();
+        }
+        std::size_t onReceivedFromPeer() override {
+            char chunk[4096];
+            const std::size_t chunkLen = readFromPeer(chunk, sizeof(chunk));
+            if (chunkLen > 0) {
+                ++state.rawClientReadCount;
+                state.responseBuffer.append(chunk, chunkLen);
+                if (state.responseBuffer.find("\r\n\r\n") != std::string::npos) {
+                    core::SNodeC::stop();
+                }
+            }
+            return chunkLen;
+        }
+        bool onSignal([[maybe_unused]] int signum) override { return true; }
+        State& state;
+    };
+
+    class RawClientFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        explicit RawClientFactory(State& state) : state(state) {}
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection* socketConnection) override {
+            ++state.clientFactoryCreateCount;
+            return new RawClientContext(socketConnection, state);
+        }
+    private:
+        State& state;
+    };
+}
+
+int main(int argc, char* argv[]) {
+    tests::support::TestResult testResult;
+    int result = tests::support::cTestSkipReturnCode;
+    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage("InetHttpServerMalformedRequestBehaviorTest");
+    } else {
+        State state;
+        core::SNodeC::init(argc, argv);
+        using Server = web::http::legacy::in::Server;
+        const Server server("ipv4-http-malformed-request-server", [&state](const auto&, const auto& response) {
+            ++state.serverRequestCount;
+            response->status(200).set("Connection", "close").send("unexpected-normal-handler");
+        });
+        net::in::stream::legacy::SocketClient<RawClientFactory, State&> client("ipv4-http-raw-malformed-request-client", state);
+        server.getConfig()->Instance::forceUnrequired();
+        client.getConfig()->Instance::forceUnrequired();
+        server.listen(net::in::SocketAddress("127.0.0.1", 0), [&client, &state](const auto& socketAddress, core::socket::State listenState) {
+            if (listenState == core::socket::State::OK) {
+                ++state.listenOkCount;
+                const std::uint16_t effectivePort = socketAddress.getPort();
+                if (effectivePort != 0) {
+                    ++state.effectiveListenEndpointOkCount;
+                    client.connect(net::in::SocketAddress("127.0.0.1", effectivePort), [&state](const auto&, core::socket::State connectState) {
+                        if (connectState == core::socket::State::OK) ++state.clientConnectOkCount; else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+                    });
+                } else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+            } else { ++state.unexpectedStateCount; core::SNodeC::stop(); }
+        });
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        const bool sawBadRequest = state.responseBuffer.find("HTTP/1.1 400") != std::string::npos || state.responseBuffer.find("HTTP/1.0 400") != std::string::npos;
+        const bool didNotReturnNormalOk = state.responseBuffer.find("unexpected-normal-handler") == std::string::npos;
+        testResult.expectEqual(0, startResult, "event loop stops after malformed request is rejected");
+        testResult.expectEqual(1, state.listenOkCount, "listen OK once");
+        testResult.expectEqual(1, state.effectiveListenEndpointOkCount, "effective endpoint once");
+        testResult.expectEqual(1, state.clientConnectOkCount, "raw client connect OK once");
+        testResult.expectEqual(1, state.clientFactoryCreateCount, "raw client factory creates one context");
+        testResult.expectEqual(1, state.rawClientConnectedCount, "raw client connected once");
+        testResult.expectEqual(0, state.serverRequestCount, "malformed request does not reach normal handler");
+        testResult.expectEqual(0, state.unexpectedStateCount, "no unexpected states");
+        testResult.expectTrue(sawBadRequest || (state.rawClientDisconnectedCount == 1 && didNotReturnNormalOk), "server either returns 400 or closes without normal 200 handler response");
+        result = testResult.processResult();
+        core::SNodeC::free();
+    }
+    return result;
+}


### PR DESCRIPTION
### Motivation
- Complete the canonical HTTP robustness component test batch by implementing the three remaining tests that exercise malformed-request, malformed-response, and chunked-request behavior using only public IPv4 legacy stream and HTTP APIs.

### Description
- Add `tests/component/http/InetHttpServerMalformedRequestBehaviorTest.cpp` which starts an IPv4 HTTP server and uses a public raw TCP client to send a deterministic malformed request and assert the normal handler is not invoked or that a `400` / close is observed.
- Add `tests/component/http/InetHttpClientMalformedResponseBehaviorTest.cpp` which starts a public raw TCP IPv4 server that returns a malformed response (`Content-Length: not-a-number`) and asserts the HTTP client fires the parse-error path exactly once and does not deliver a successful response.
- Add `tests/component/http/InetHttpServerClientChunkedRequestTest.cpp` which starts an IPv4 HTTP server and uses a public raw TCP client to send a valid chunked `POST` request and asserts the server reassembles the body and responds `200` with the expected body observed by the raw client.
- Register the three tests in `tests/component/http/CMakeLists.txt` with `snodec_add_test`, appropriate `target_link_libraries`, `target_compile_features(... cxx_std_20)`, labels, `SKIP_RETURN_CODE 77`, and `TIMEOUT 5`.

### Testing
- Ran `git diff --check` and configured the build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF`, which completed successfully.
- Built the focused HTTP component targets with `cmake --build build --target ...InetHttpServerMalformedRequestBehaviorTest InetHttpClientMalformedResponseBehaviorTest InetHttpServerClientChunkedRequestTest -j2` and the build completed successfully.
- Ran focused `ctest` selection and observed all three newly added component tests pass when executed as an unprivileged user (`HOME=/tmp/snodec-test-home`), and the project-level `ctest -L http` run completed with HTTP unit tests passing and component tests skipped as root per project convention.
- Final sanity checks included `git diff --name-only HEAD~1...HEAD` which lists only the three new test files and the `tests/component/http/CMakeLists.txt` change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a497417e2dc832cad95fcd22fd77485)