### PR TITLE
Logging roadmap round 02 — semantic src/log core

### DIFF
--- a/docs/logging/round-02-semantic-core-report.md
+++ b/docs/logging/round-02-semantic-core-report.md
@@ -1,0 +1,213 @@
+# Logging Roadmap Round 02 Report: Semantic `src/log` Core
+
+Branch/report: `codex/implement-logging-roadmap-round-2` / Round 02 semantic core
+
+## Implementation diff summary
+
+Round 02 adds the semantic logging engine on a test stand without integrating it into the framework object model. The implementation is intentionally limited to `src/log` production code, unit-test registration, a focused Round 02 unit harness, and this report.
+
+Implemented:
+
+* Semantic enums: `LogLevel`, `LogOrigin`, `LogBoundary`, and `LogRole`.
+* Borrowed `LogScope` with non-owning `std::string_view` fields.
+* Owned `LogRecord` plus optional `LogError` and `LogSource` payloads.
+* `materialize(...)` conversion that copies borrowed scope strings into owned record storage before formatter/sink handoff.
+* JSON v1 formatter with mandatory `v`, `ts`, `level`, `origin`, `boundary`, `component`, and `message` fields.
+* JSON optional fields `instance`, `role`, `connection`, `event`, `error`, and `source`, emitted only when present; absent optionals are omitted and never emitted as `null`.
+* Minimal text formatter generated from the same owned semantic record.
+* `BoundaryLogger` test/local API with format-style calls, stream-style calls, local threshold checks, and `sysError` overloads for `int` and `std::error_code`.
+* Focused macro compatibility smoke harness proving `LOG`, `PLOG`, and `VLOG` still compile/link/run through the existing macro path.
+
+## Exact files changed
+
+* `src/log/CMakeLists.txt` — adds the Round 02 semantic logger source/header to the existing `logger` library.
+* `src/log/SemanticLogger.h` — new semantic types, materialization/formatter declarations, `BoundaryLogger`, and `LogStream` API.
+* `src/log/SemanticLogger.cpp` — new materialization, string rendering, timestamp rendering, JSON v1/text formatting, stream flush, threshold, and sink emission implementation.
+* `tests/unit/CMakeLists.txt` — registers the new `tests/unit/log` subdirectory.
+* `tests/unit/log/CMakeLists.txt` — declares `SemanticLoggerRound2Test` and labels it `unit;log;round2`.
+* `tests/unit/log/SemanticLoggerRound2Test.cpp` — focused Round 02 semantic core and macro compatibility harness.
+* `docs/logging/round-02-semantic-core-report.md` — this report.
+
+No socket, HTTP, WebSocket, MQTT, DB, application, `ConfigInstance`, `SocketConnection`, `SocketContext`, `SocketServer`, `SocketClient`, `SocketAcceptor`, or `SocketConnector` production files were changed.
+
+## Exact build commands run
+
+Dependency gate:
+
+```sh
+pkg-config --modversion nlohmann_json || true
+```
+
+Initial configure before installation failed because `nlohmann_json>=3.11` was missing. The dependency was then installed successfully:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y nlohmann-json3-dev
+```
+
+After installation, `pkg-config --modversion nlohmann_json || true` reported:
+
+```text
+3.11.3
+```
+
+Normal configure/build:
+
+```sh
+cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON
+cmake --build cmake-build --parallel 2
+```
+
+Focused build:
+
+```sh
+cmake --build cmake-build --parallel 2 --target SemanticLoggerRound2Test
+```
+
+## Exact test commands run
+
+Focused Round 02 test:
+
+```sh
+ctest --test-dir cmake-build -R SemanticLoggerRound2Test --output-on-failure
+```
+
+Result: passed, 1/1 tests.
+
+Full normal test suite:
+
+```sh
+ctest --test-dir cmake-build --output-on-failure
+```
+
+Result: passed, 108/108 tests, with many existing component tests reported as skipped by the existing harness/environment skip behavior.
+
+Source-level check:
+
+```sh
+git diff --check
+```
+
+Result: passed with no whitespace errors.
+
+## Sanitizer commands/results
+
+AddressSanitizer configure/build/test:
+
+```sh
+cmake -S . -B cmake-build-asan \
+  -DSNODEC_BUILD_TESTS=ON \
+  -DSNODEC_BUILD_APPS=ON \
+  -DSNODEC_ENABLE_ASAN=ON
+cmake --build cmake-build-asan --parallel 2
+ASAN=$(gcc -print-file-name=libasan.so)
+LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure
+```
+
+Result: passed, 108/108 tests, with many existing component tests reported as skipped by the existing harness/environment skip behavior.
+
+An initial ASan test command without `LD_PRELOAD` failed with:
+
+```text
+ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.
+```
+
+The corrected `LD_PRELOAD=$(gcc -print-file-name=libasan.so)` invocation passed.
+
+## Macro compatibility result
+
+`SemanticLoggerRound2Test` includes `log/Logger.h` and executes representative `LOG`, `PLOG`, and `VLOG` statements after using existing logger hooks (`Logger::init`, `Logger::setDisableColor`, `Logger::setTickResolver`, `Logger::setLogLevel`, and `Logger::setVerboseLevel`). This proves the legacy macros still compile/link/run through the existing macro definitions.
+
+Covered in the harness:
+
+* enabled `LOG(INFO)` smoke path,
+* disabled `LOG(TRACE)` smoke path under the configured level,
+* enabled `PLOG(ERROR)` smoke path with fixed `errno = EACCES`,
+* enabled `VLOG(1)` smoke path,
+* disabled `VLOG(2)` smoke path.
+
+No legacy macro definition was removed or rewritten. No production macro call site was migrated. `VLOG` remains compatibility-only and is not modeled as a third semantic axis.
+
+Byte-for-byte output compatibility capture remains deliberately deferred because Round 02 must not change macro internals, sink plumbing, or backend routing to make capture easier. The Round 02 harness therefore stays at compile/link/run smoke coverage for macro compatibility.
+
+## JSON schema result
+
+The JSON v1 formatter emits the frozen mandatory fields:
+
+* `v`
+* `ts`
+* `level`
+* `origin`
+* `boundary`
+* `component`
+* `message`
+
+The formatter emits optional fields only when present:
+
+* `instance`
+* `role`
+* `connection`
+* `event`
+* `error`
+* `source`
+
+Absent optional fields are omitted rather than emitted as `null`. Unknown role is omitted; Round 02 does not emit `"unknown"`.
+
+## string_view materialization/lifetime result
+
+The test constructs `LogScope` from mutable `std::string` storage, materializes a `LogRecord`, clears the original strings, and verifies that `record.component`, `record.instance`, and `record.connection` still contain the original values. This proves formatter/sink handoff receives owned bytes, not borrowed `LogScope` references.
+
+## sysError result
+
+`BoundaryLogger::sysError` accepts both `int` errno-like values and `std::error_code`. The test verifies that:
+
+* `error.code` is stored,
+* `error.text` is populated,
+* the human message is formatted separately from the error object,
+* JSON emits `error` when present.
+
+Existing `PLOG` behavior was not changed.
+
+## Stream-style API result
+
+`logger.debug() << "received " << 42 << " bytes";` emits one complete record at stream object destruction. The focused test verifies exactly one stream-style record for that expression and no partial fragments.
+
+## Format-style API result
+
+`logger.debug("received {} bytes", 42);` and `logger.info("echo session started");` both work in the focused test. The Round 02 formatter is intentionally minimal and local to the semantic logger test stand.
+
+## Scope/non-goal confirmations
+
+Confirmed:
+
+* No production object `.log()` APIs were added.
+* No `SocketContext::log()` or `SocketContext::frameworkLog()` API was added.
+* No `SocketConnection::log()` API was added.
+* No `LogScopeOwner` was added.
+* `SocketConnection`, `SocketContext`, `ConfigInstance`, `SocketServer`, `SocketClient`, `SocketAcceptor`, and `SocketConnector` integration was not started.
+* No production call sites were migrated.
+* `LOG`, `PLOG`, and `VLOG` runtime behavior was not intentionally changed.
+* Existing `Logger.cpp` CLI/backend behavior was not unified with the semantic logger.
+* Startup filter configuration, filter precedence, `freeze()`, runtime reload, signals, admin endpoints, and mutable atomic thresholds were not implemented.
+
+## Extended SNode.C and MQTT/mqttsuite review note
+
+For this Round 02 implementation I re-read the corrected Round 01 contract/report from the current checkout before coding and kept the implementation constrained to the semantic `src/log` core. The broader SNode.C/MQTT observations remain the same as the corrected Round 01 baseline: no top-level `mqttsuite` source tree is present in this checkout, MQTT code lives under `src/iot/mqtt`, and MQTT call-site migration is explicitly deferred until later roadmap rounds. Round 02 does not modify MQTT production code.
+
+## Deliberate deferrals
+
+* Production framework object integration (`SocketContext`, `SocketConnection`, `ConfigInstance`, server/client/acceptor/connector APIs).
+* `LogScopeOwner` ownership model.
+* Production call-site migration.
+* Backend unification with current `Logger.cpp`, CLI behavior, or spdlog output format.
+* Startup-only logging manager, immutable filtering configuration, and precedence implementation.
+* Runtime log-level reload, signals, admin endpoints, and mutable atomic thresholds.
+* Byte-for-byte legacy macro output capture.
+* A full formatting library implementation; Round 02 uses a small `{}` replacement helper sufficient for the test-stand API proof.
+
+## Known non-blocking follow-ups
+
+* Add a proper output-capture/golden compatibility harness in the later backend unification work.
+* Replace or extend the minimal `{}` formatter if/when the project standardizes on a formatting dependency for semantic logger messages.
+* Decide later whether JSON output should use a shared JSON library or continue using a no-extra-dependency formatter.
+* Wire object-owned scopes and cached thresholds only in the designated future rounds.

--- a/docs/logging/round-02-semantic-core-report.md
+++ b/docs/logging/round-02-semantic-core-report.md
@@ -1,6 +1,6 @@
 # Logging Roadmap Round 02 Report: Semantic `src/log` Core
 
-Branch/report: `codex/implement-logging-roadmap-round-2` / Round 02 semantic core
+Branch/report: `codex/draft-pr-for-logging-roadmap-round-2` / Round 02 semantic core
 
 ## Implementation diff summary
 
@@ -16,13 +16,24 @@ Implemented:
 * JSON optional fields `instance`, `role`, `connection`, `event`, `error`, and `source`, emitted only when present; absent optionals are omitted and never emitted as `null`.
 * Minimal text formatter generated from the same owned semantic record.
 * `BoundaryLogger` test/local API with format-style calls, stream-style calls, local threshold checks, and `sysError` overloads for `int` and `std::error_code`.
+* Owned internal `OwnedLogScope` storage so `BoundaryLogger` does not retain borrowed `LogScope` `std::string_view` fields after construction.
+* Complete JSON escaping for all control characters below `0x20`, including `\b`, `\f`, and `\u00XX` fallback escapes.
 * Focused macro compatibility smoke harness proving `LOG`, `PLOG`, and `VLOG` still compile/link/run through the existing macro path.
 
 ## Exact files changed
 
+Repair-only files changed in this follow-up:
+
+* `src/log/SemanticLogger.h`
+* `src/log/SemanticLogger.cpp`
+* `tests/unit/log/SemanticLoggerRound2Test.cpp`
+* `docs/logging/round-02-semantic-core-report.md`
+
+No other files were changed by this repair. The full Round 02 PR file set remains:
+
 * `src/log/CMakeLists.txt` — adds the Round 02 semantic logger source/header to the existing `logger` library.
-* `src/log/SemanticLogger.h` — new semantic types, materialization/formatter declarations, `BoundaryLogger`, and `LogStream` API.
-* `src/log/SemanticLogger.cpp` — new materialization, string rendering, timestamp rendering, JSON v1/text formatting, stream flush, threshold, and sink emission implementation.
+* `src/log/SemanticLogger.h` — new semantic types, owned internal `OwnedLogScope`, materialization/formatter declarations, `BoundaryLogger`, and `LogStream` API.
+* `src/log/SemanticLogger.cpp` — new materialization, owned-scope copying/viewing for `BoundaryLogger`, complete JSON control-character escaping, string rendering, timestamp rendering, JSON v1/text formatting, stream flush, threshold, and sink emission implementation.
 * `tests/unit/CMakeLists.txt` — registers the new `tests/unit/log` subdirectory.
 * `tests/unit/log/CMakeLists.txt` — declares `SemanticLoggerRound2Test` and labels it `unit;log;round2`.
 * `tests/unit/log/SemanticLoggerRound2Test.cpp` — focused Round 02 semantic core and macro compatibility harness.
@@ -72,7 +83,7 @@ Focused Round 02 test:
 ctest --test-dir cmake-build -R SemanticLoggerRound2Test --output-on-failure
 ```
 
-Result: passed, 1/1 tests.
+Result: passed, 1/1 tests. The focused test now includes the BoundaryLogger construction-time scope-copy check and the JSON control-character escaping check.
 
 Full normal test suite:
 
@@ -82,13 +93,14 @@ ctest --test-dir cmake-build --output-on-failure
 
 Result: passed, 108/108 tests, with many existing component tests reported as skipped by the existing harness/environment skip behavior.
 
-Source-level check:
+Source-level/status checks:
 
 ```sh
+git status --short
 git diff --check
 ```
 
-Result: passed with no whitespace errors.
+Result: `git status --short` showed the four expected modified repair files plus local untracked build directories while validation was running; `git diff --check` passed with no whitespace errors. The build directories were not committed.
 
 ## Sanitizer commands/results
 
@@ -106,7 +118,9 @@ LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure
 
 Result: passed, 108/108 tests, with many existing component tests reported as skipped by the existing harness/environment skip behavior.
 
-An initial ASan test command without `LD_PRELOAD` failed with:
+The ASan run used `LD_PRELOAD=$(gcc -print-file-name=libasan.so)` so the ASan runtime loaded first.
+
+An earlier Round 02 run without `LD_PRELOAD` failed with:
 
 ```text
 ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.
@@ -142,6 +156,8 @@ The JSON v1 formatter emits the frozen mandatory fields:
 * `component`
 * `message`
 
+The formatter escapes all JSON string control characters below `0x20`: common controls use short escapes where applicable and other controls use `\u00XX`. The focused test verifies `\b` and `\u0001` output and checks that the corresponding raw control bytes are absent.
+
 The formatter emits optional fields only when present:
 
 * `instance`
@@ -155,7 +171,9 @@ Absent optional fields are omitted rather than emitted as `null`. Unknown role i
 
 ## string_view materialization/lifetime result
 
-The test constructs `LogScope` from mutable `std::string` storage, materializes a `LogRecord`, clears the original strings, and verifies that `record.component`, `record.instance`, and `record.connection` still contain the original values. This proves formatter/sink handoff receives owned bytes, not borrowed `LogScope` references.
+The direct materialization test constructs `LogScope` from mutable `std::string` storage, materializes a `LogRecord`, clears the original strings, and verifies that `record.component`, `record.instance`, and `record.connection` still contain the original values. This proves formatter/sink handoff receives owned bytes, not borrowed `LogScope` references.
+
+The `BoundaryLogger` lifetime repair adds owned internal scope storage. The test constructs a logger from borrowed strings, mutates those original strings before logging, emits a record, and verifies that the emitted record still contains the original `mqtt.server`, `mqtt-broker`, and `#7` values. This proves logger construction copies the borrowed scope data and later log calls do not read stale caller-owned `std::string_view` storage.
 
 ## sysError result
 
@@ -176,6 +194,10 @@ Existing `PLOG` behavior was not changed.
 
 `logger.debug("received {} bytes", 42);` and `logger.info("echo session started");` both work in the focused test. The Round 02 formatter is intentionally minimal and local to the semantic logger test stand.
 
+## CI result
+
+GitHub PR #143 checks were inspected on GitHub. The visible `CI on: pull_request` / `gcc-debug` job for the PR head shown on GitHub succeeded on July 5, 2026 in 7m 33s, with one Node.js deprecation warning annotation. This local repair commit has not been pushed by this environment, so no newer remote CI result exists for these local changes yet.
+
 ## Scope/non-goal confirmations
 
 Confirmed:
@@ -189,6 +211,19 @@ Confirmed:
 * `LOG`, `PLOG`, and `VLOG` runtime behavior was not intentionally changed.
 * Existing `Logger.cpp` CLI/backend behavior was not unified with the semantic logger.
 * Startup filter configuration, filter precedence, `freeze()`, runtime reload, signals, admin endpoints, and mutable atomic thresholds were not implemented.
+
+## Repair-specific confirmations
+
+Confirmed for this repair:
+
+* `BoundaryLogger` no longer stores a borrowed `LogScope` member.
+* `BoundaryLogger` stores owned internal scope data in `OwnedLogScope`.
+* A focused test proves mutating original scope strings after logger construction does not affect emitted records.
+* The direct `materialize(...)` borrowed-to-owned test still passes.
+* JSON escaping handles all control characters below `0x20`.
+* A focused test covers previously unescaped control characters (`\b` and `\u0001`).
+* The report branch name is `codex/draft-pr-for-logging-roadmap-round-2`.
+* No files outside the expected repair set were changed.
 
 ## Extended SNode.C and MQTT/mqttsuite review note
 

--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -65,9 +65,9 @@ FetchContent_MakeAvailable(spdlog)
 
 set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${TMP_CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
 
-set(LOGGER_CPP Logger.cpp)
+set(LOGGER_CPP Logger.cpp SemanticLogger.cpp)
 
-set(LOGGER_H Logger.h)
+set(LOGGER_H Logger.h SemanticLogger.h)
 
 set(TMP_CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
 unset(CMAKE_CXX_INCLUDE_WHAT_YOU_USE)

--- a/src/log/SemanticLogger.cpp
+++ b/src/log/SemanticLogger.cpp
@@ -1,0 +1,168 @@
+#include "log/SemanticLogger.h"
+
+#include <iomanip>
+#include <sstream>
+
+namespace logger {
+namespace {
+    bool knownRole(LogRole role) { return role == LogRole::Server || role == LogRole::Client; }
+    int rank(LogLevel level) { return static_cast<int>(level); }
+    std::string escapeJson(const std::string& value) {
+        std::ostringstream out;
+        for (const char ch : value) {
+            switch (ch) {
+                case '"': out << "\\\""; break;
+                case '\\': out << "\\\\"; break;
+                case '\n': out << "\\n"; break;
+                case '\r': out << "\\r"; break;
+                case '\t': out << "\\t"; break;
+                default: out << ch; break;
+            }
+        }
+        return out.str();
+    }
+    void appendField(std::ostringstream& out, bool& first, std::string_view name, const std::string& value) {
+        out << (first ? "" : ",") << "\"" << name << "\":\"" << escapeJson(value) << "\"";
+        first = false;
+    }
+    void appendInt(std::ostringstream& out, bool& first, std::string_view name, int value) {
+        out << (first ? "" : ",") << "\"" << name << "\":" << value;
+        first = false;
+    }
+}
+
+LogRecord materialize(const LogScope& scope, LogLevel level, std::string message, LogRecordOptions options) {
+    LogRecord record;
+    record.v = 1;
+    record.ts = options.ts;
+    record.level = level;
+    record.origin = scope.origin;
+    record.boundary = scope.boundary;
+    record.component = std::string(scope.component);
+    if (!scope.instance.empty()) record.instance = std::string(scope.instance);
+    if (knownRole(scope.role)) record.role = scope.role;
+    if (!scope.connection.empty()) record.connection = std::string(scope.connection);
+    if (options.event && !options.event->empty()) record.event = std::string(*options.event);
+    record.message = std::move(message);
+    record.error = std::move(options.error);
+    record.source = std::move(options.source);
+    return record;
+}
+
+std::string toString(LogLevel level) {
+    switch (level) {
+        case LogLevel::Trace: return "trace";
+        case LogLevel::Debug: return "debug";
+        case LogLevel::Info: return "info";
+        case LogLevel::Warn: return "warn";
+        case LogLevel::Error: return "error";
+        case LogLevel::Critical: return "critical";
+        case LogLevel::Off: return "off";
+    }
+    return "off";
+}
+std::string toString(LogOrigin origin) { return origin == LogOrigin::Framework ? "framework" : "application"; }
+std::string toString(LogBoundary boundary) {
+    switch (boundary) {
+        case LogBoundary::Application: return "application";
+        case LogBoundary::Configuration: return "configuration";
+        case LogBoundary::Instance: return "instance";
+        case LogBoundary::Connection: return "connection";
+        case LogBoundary::Context: return "context";
+        case LogBoundary::System: return "system";
+    }
+    return "system";
+}
+std::optional<std::string_view> toString(LogRole role) {
+    if (role == LogRole::Server) return "server";
+    if (role == LogRole::Client) return "client";
+    return std::nullopt;
+}
+
+std::string formatTimestamp(std::chrono::system_clock::time_point ts) {
+    const auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(ts.time_since_epoch()) % 1000;
+    const auto time = std::chrono::system_clock::to_time_t(ts);
+    std::tm tm{};
+    gmtime_r(&time, &tm);
+    std::ostringstream out;
+    out << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S") << '.' << std::setw(3) << std::setfill('0') << millis.count() << 'Z';
+    return out.str();
+}
+
+std::string formatJsonV1(const LogRecord& record) {
+    std::ostringstream out;
+    bool first = true;
+    out << "{";
+    appendInt(out, first, "v", record.v);
+    appendField(out, first, "ts", formatTimestamp(record.ts));
+    appendField(out, first, "level", toString(record.level));
+    appendField(out, first, "origin", toString(record.origin));
+    appendField(out, first, "boundary", toString(record.boundary));
+    appendField(out, first, "component", record.component);
+    if (record.instance) appendField(out, first, "instance", *record.instance);
+    if (record.role) if (auto role = toString(*record.role)) appendField(out, first, "role", std::string(*role));
+    if (record.connection) appendField(out, first, "connection", *record.connection);
+    if (record.event) appendField(out, first, "event", *record.event);
+    appendField(out, first, "message", record.message);
+    if (record.error) {
+        out << (first ? "" : ",") << "\"error\":{";
+        bool errorFirst = true;
+        appendInt(out, errorFirst, "code", record.error->code);
+        appendField(out, errorFirst, "text", record.error->text);
+        out << "}";
+        first = false;
+    }
+    if (record.source) {
+        out << (first ? "" : ",") << "\"source\":{";
+        bool sourceFirst = true;
+        appendField(out, sourceFirst, "file", record.source->file);
+        appendInt(out, sourceFirst, "line", record.source->line);
+        appendField(out, sourceFirst, "func", record.source->func);
+        out << "}";
+        first = false;
+    }
+    out << "}";
+    return out.str();
+}
+
+std::string formatText(const LogRecord& record) {
+    std::ostringstream out;
+    out << formatTimestamp(record.ts) << ' ' << toString(record.level) << ' ' << toString(record.origin) << ' ' << toString(record.boundary) << ' '
+        << record.component;
+    if (record.instance) out << " instance=" << *record.instance;
+    if (record.role) if (auto role = toString(*record.role)) out << " role=" << *role;
+    if (record.connection) out << " connection=" << *record.connection;
+    out << " - " << record.message;
+    if (record.error) out << " error=" << record.error->code << ':' << record.error->text;
+    return out.str();
+}
+
+LogStream::LogStream(const BoundaryLogger* logger, LogLevel level) : logger(logger), level(level), enabled(logger != nullptr && logger->enabled(level)), flushed(false) {}
+LogStream::LogStream(LogStream&& other) noexcept : logger(other.logger), level(other.level), enabled(other.enabled), flushed(other.flushed), stream(std::move(other.stream)) { other.flushed = true; }
+LogStream& LogStream::operator=(LogStream&& other) noexcept {
+    if (this != &other) {
+        if (!flushed && enabled && logger != nullptr) logger->emit(level, stream.str());
+        logger = other.logger; level = other.level; enabled = other.enabled; flushed = other.flushed; stream = std::move(other.stream); other.flushed = true;
+    }
+    return *this;
+}
+LogStream::~LogStream() { if (!flushed && enabled && logger != nullptr) logger->emit(level, stream.str()); }
+
+BoundaryLogger BoundaryLogger::createForTest(LogScope scope, Sink sink, LogLevel threshold, Clock clock) { return BoundaryLogger(scope, std::move(sink), threshold, std::move(clock)); }
+BoundaryLogger::BoundaryLogger(LogScope scope, Sink sink, LogLevel threshold, Clock clock) : scope(scope), sink(std::move(sink)), threshold(threshold), clock(std::move(clock)) {}
+bool BoundaryLogger::enabled(LogLevel level) const noexcept { return level != LogLevel::Off && rank(level) >= rank(threshold) && threshold != LogLevel::Off; }
+LogStream BoundaryLogger::trace() const { return {this, LogLevel::Trace}; }
+LogStream BoundaryLogger::debug() const { return {this, LogLevel::Debug}; }
+LogStream BoundaryLogger::info() const { return {this, LogLevel::Info}; }
+LogStream BoundaryLogger::warn() const { return {this, LogLevel::Warn}; }
+LogStream BoundaryLogger::error() const { return {this, LogLevel::Error}; }
+LogStream BoundaryLogger::critical() const { return {this, LogLevel::Critical}; }
+void BoundaryLogger::emit(LogLevel level, std::string message, LogRecordOptions options) const {
+    if (!enabled(level) || !sink) return;
+    if (options.ts == std::chrono::system_clock::time_point{}) {
+        options.ts = clock ? clock() : std::chrono::system_clock::now();
+    }
+    sink(materialize(scope, level, std::move(message), std::move(options)));
+}
+
+} // namespace logger

--- a/src/log/SemanticLogger.cpp
+++ b/src/log/SemanticLogger.cpp
@@ -9,17 +9,40 @@ namespace {
     int rank(LogLevel level) { return static_cast<int>(level); }
     std::string escapeJson(const std::string& value) {
         std::ostringstream out;
-        for (const char ch : value) {
+        for (const unsigned char ch : value) {
             switch (ch) {
                 case '"': out << "\\\""; break;
                 case '\\': out << "\\\\"; break;
+                case '\b': out << "\\b"; break;
+                case '\f': out << "\\f"; break;
                 case '\n': out << "\\n"; break;
                 case '\r': out << "\\r"; break;
                 case '\t': out << "\\t"; break;
-                default: out << ch; break;
+                default:
+                    if (ch < 0x20) {
+                        out << "\\u00" << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(ch) << std::dec;
+                    } else {
+                        out << static_cast<char>(ch);
+                    }
+                    break;
             }
         }
         return out.str();
+    }
+    OwnedLogScope copyScope(LogScope scope) {
+        OwnedLogScope owned{scope.origin, scope.boundary, std::string(scope.component), std::nullopt, std::nullopt, std::nullopt};
+        if (!scope.instance.empty()) owned.instance = std::string(scope.instance);
+        if (knownRole(scope.role)) owned.role = scope.role;
+        if (!scope.connection.empty()) owned.connection = std::string(scope.connection);
+        return owned;
+    }
+    LogScope viewScope(const OwnedLogScope& scope) {
+        return LogScope{scope.origin,
+                        scope.boundary,
+                        scope.component,
+                        scope.instance ? std::string_view(*scope.instance) : std::string_view(),
+                        scope.role.value_or(LogRole::Unknown),
+                        scope.connection ? std::string_view(*scope.connection) : std::string_view()};
     }
     void appendField(std::ostringstream& out, bool& first, std::string_view name, const std::string& value) {
         out << (first ? "" : ",") << "\"" << name << "\":\"" << escapeJson(value) << "\"";
@@ -148,8 +171,8 @@ LogStream& LogStream::operator=(LogStream&& other) noexcept {
 }
 LogStream::~LogStream() { if (!flushed && enabled && logger != nullptr) logger->emit(level, stream.str()); }
 
-BoundaryLogger BoundaryLogger::createForTest(LogScope scope, Sink sink, LogLevel threshold, Clock clock) { return BoundaryLogger(scope, std::move(sink), threshold, std::move(clock)); }
-BoundaryLogger::BoundaryLogger(LogScope scope, Sink sink, LogLevel threshold, Clock clock) : scope(scope), sink(std::move(sink)), threshold(threshold), clock(std::move(clock)) {}
+BoundaryLogger BoundaryLogger::createForTest(LogScope scope, Sink sink, LogLevel threshold, Clock clock) { return BoundaryLogger(copyScope(scope), std::move(sink), threshold, std::move(clock)); }
+BoundaryLogger::BoundaryLogger(OwnedLogScope scope, Sink sink, LogLevel threshold, Clock clock) : scope(std::move(scope)), sink(std::move(sink)), threshold(threshold), clock(std::move(clock)) {}
 bool BoundaryLogger::enabled(LogLevel level) const noexcept { return level != LogLevel::Off && rank(level) >= rank(threshold) && threshold != LogLevel::Off; }
 LogStream BoundaryLogger::trace() const { return {this, LogLevel::Trace}; }
 LogStream BoundaryLogger::debug() const { return {this, LogLevel::Debug}; }
@@ -162,7 +185,7 @@ void BoundaryLogger::emit(LogLevel level, std::string message, LogRecordOptions 
     if (options.ts == std::chrono::system_clock::time_point{}) {
         options.ts = clock ? clock() : std::chrono::system_clock::now();
     }
-    sink(materialize(scope, level, std::move(message), std::move(options)));
+    sink(materialize(viewScope(scope), level, std::move(message), std::move(options)));
 }
 
 } // namespace logger

--- a/src/log/SemanticLogger.h
+++ b/src/log/SemanticLogger.h
@@ -73,6 +73,15 @@ namespace logger {
 
     class BoundaryLogger;
 
+    struct OwnedLogScope {
+        LogOrigin origin;
+        LogBoundary boundary;
+        std::string component;
+        std::optional<std::string> instance;
+        std::optional<LogRole> role;
+        std::optional<std::string> connection;
+    };
+
     class LogStream {
     public:
         LogStream() = default;
@@ -145,7 +154,7 @@ namespace logger {
         void emit(LogLevel level, std::string message, LogRecordOptions options = {}) const;
 
     private:
-        BoundaryLogger(LogScope scope, Sink sink, LogLevel threshold, Clock clock);
+        BoundaryLogger(OwnedLogScope scope, Sink sink, LogLevel threshold, Clock clock);
 
         template <class... Args>
         void emitFormatted(LogLevel level, std::string_view format, Args&&... args) const {
@@ -177,7 +186,7 @@ namespace logger {
             return result;
         }
 
-        LogScope scope;
+        OwnedLogScope scope;
         Sink sink;
         LogLevel threshold;
         Clock clock;

--- a/src/log/SemanticLogger.h
+++ b/src/log/SemanticLogger.h
@@ -1,0 +1,190 @@
+#ifndef LOGGER_SEMANTICLOGGER_H
+#define LOGGER_SEMANTICLOGGER_H
+
+#include <chrono>
+#include <functional>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace logger {
+
+    enum class LogLevel { Trace, Debug, Info, Warn, Error, Critical, Off };
+    enum class LogOrigin { Framework, Application };
+    enum class LogBoundary { Application, Configuration, Instance, Connection, Context, System };
+    enum class LogRole { Unknown, Server, Client };
+
+    struct LogScope {
+        LogOrigin origin;
+        LogBoundary boundary;
+        std::string_view component;
+        std::string_view instance;
+        LogRole role;
+        std::string_view connection;
+    };
+
+    struct LogError {
+        int code;
+        std::string text;
+    };
+
+    struct LogSource {
+        std::string file;
+        int line;
+        std::string func;
+    };
+
+    struct LogRecord {
+        int v = 1;
+        std::chrono::system_clock::time_point ts;
+        LogLevel level;
+        LogOrigin origin;
+        LogBoundary boundary;
+        std::string component;
+        std::optional<std::string> instance;
+        std::optional<LogRole> role;
+        std::optional<std::string> connection;
+        std::optional<std::string> event;
+        std::string message;
+        std::optional<LogError> error;
+        std::optional<LogSource> source;
+    };
+
+    struct LogRecordOptions {
+        std::optional<std::string_view> event;
+        std::optional<LogError> error;
+        std::optional<LogSource> source;
+        std::chrono::system_clock::time_point ts = {};
+    };
+
+    LogRecord materialize(const LogScope& scope, LogLevel level, std::string message, LogRecordOptions options = {});
+
+    std::string toString(LogLevel level);
+    std::string toString(LogOrigin origin);
+    std::string toString(LogBoundary boundary);
+    std::optional<std::string_view> toString(LogRole role);
+    std::string formatTimestamp(std::chrono::system_clock::time_point ts);
+    std::string formatJsonV1(const LogRecord& record);
+    std::string formatText(const LogRecord& record);
+
+    class BoundaryLogger;
+
+    class LogStream {
+    public:
+        LogStream() = default;
+        LogStream(const BoundaryLogger* logger, LogLevel level);
+        LogStream(LogStream&& other) noexcept;
+        LogStream& operator=(LogStream&& other) noexcept;
+        LogStream(const LogStream&) = delete;
+        LogStream& operator=(const LogStream&) = delete;
+        ~LogStream();
+
+        template <class T>
+        LogStream& operator<<(const T& value) {
+            if (enabled) {
+                stream << value;
+            }
+            return *this;
+        }
+
+    private:
+        const BoundaryLogger* logger = nullptr;
+        LogLevel level = LogLevel::Off;
+        bool enabled = false;
+        bool flushed = true;
+        std::ostringstream stream;
+    };
+
+    class BoundaryLogger {
+    public:
+        using Sink = std::function<void(LogRecord)>;
+        using Clock = std::function<std::chrono::system_clock::time_point()>;
+
+        static BoundaryLogger createForTest(LogScope scope, Sink sink, LogLevel threshold = LogLevel::Trace, Clock clock = {});
+
+        bool enabled(LogLevel level) const noexcept;
+
+        LogStream trace() const;
+        LogStream debug() const;
+        LogStream info() const;
+        LogStream warn() const;
+        LogStream error() const;
+        LogStream critical() const;
+
+        template <class... Args>
+        void trace(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Trace, format, std::forward<Args>(args)...); }
+        template <class... Args>
+        void debug(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Debug, format, std::forward<Args>(args)...); }
+        template <class... Args>
+        void info(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Info, format, std::forward<Args>(args)...); }
+        template <class... Args>
+        void warn(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Warn, format, std::forward<Args>(args)...); }
+        template <class... Args>
+        void error(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Error, format, std::forward<Args>(args)...); }
+        template <class... Args>
+        void critical(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Critical, format, std::forward<Args>(args)...); }
+
+        template <class... Args>
+        void sysError(LogLevel level, int errnum, std::string_view format, Args&&... args) const {
+            LogRecordOptions options;
+            options.error = LogError{errnum, std::error_code(errnum, std::generic_category()).message()};
+            emit(level, formatMessage(format, std::forward<Args>(args)...), std::move(options));
+        }
+
+        template <class... Args>
+        void sysError(LogLevel level, std::error_code errorCode, std::string_view format, Args&&... args) const {
+            LogRecordOptions options;
+            options.error = LogError{errorCode.value(), errorCode.message()};
+            emit(level, formatMessage(format, std::forward<Args>(args)...), std::move(options));
+        }
+
+        void emit(LogLevel level, std::string message, LogRecordOptions options = {}) const;
+
+    private:
+        BoundaryLogger(LogScope scope, Sink sink, LogLevel threshold, Clock clock);
+
+        template <class... Args>
+        void emitFormatted(LogLevel level, std::string_view format, Args&&... args) const {
+            emit(level, formatMessage(format, std::forward<Args>(args)...));
+        }
+
+        static std::vector<std::string> collectArgs() { return {}; }
+        template <class T, class... Args>
+        static std::vector<std::string> collectArgs(T&& value, Args&&... args) {
+            std::ostringstream out;
+            out << std::forward<T>(value);
+            auto values = collectArgs(std::forward<Args>(args)...);
+            values.insert(values.begin(), out.str());
+            return values;
+        }
+        template <class... Args>
+        static std::string formatMessage(std::string_view format, Args&&... args) {
+            const auto values = collectArgs(std::forward<Args>(args)...);
+            std::string result;
+            std::size_t arg = 0;
+            for (std::size_t i = 0; i < format.size(); ++i) {
+                if (format[i] == '{' && i + 1 < format.size() && format[i + 1] == '}' && arg < values.size()) {
+                    result += values[arg++];
+                    ++i;
+                } else {
+                    result += format[i];
+                }
+            }
+            return result;
+        }
+
+        LogScope scope;
+        Sink sink;
+        LogLevel threshold;
+        Clock clock;
+
+        friend class LogStream;
+    };
+
+} // namespace logger
+
+#endif // LOGGER_SEMANTICLOGGER_H

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -43,3 +43,5 @@ add_subdirectory(core)
 add_subdirectory(net)
 
 add_subdirectory(http)
+
+add_subdirectory(log)

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -1,0 +1,4 @@
+snodec_add_test(SemanticLoggerRound2Test SemanticLoggerRound2Test.cpp)
+target_include_directories(SemanticLoggerRound2Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(SemanticLoggerRound2Test PRIVATE snodec-test-support snodec::logger)
+set_tests_properties(SemanticLoggerRound2Test PROPERTIES LABELS "unit;log;round2")

--- a/tests/unit/log/SemanticLoggerRound2Test.cpp
+++ b/tests/unit/log/SemanticLoggerRound2Test.cpp
@@ -1,0 +1,98 @@
+#include "log/SemanticLogger.h"
+#include "log/Logger.h"
+#include "tests/support/TestResult.h"
+
+#include <cerrno>
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace {
+    void expectStringEqual(tests::support::TestResult& result, const std::string& expected, const std::string& actual, const std::string& message) {
+        result.expectTrue(expected == actual, message + " expected='" + expected + "' actual='" + actual + "'");
+    }
+
+    std::chrono::system_clock::time_point fixedTimestamp() {
+        using namespace std::chrono;
+        return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
+    }
+}
+
+int main() {
+    tests::support::TestResult result;
+
+    std::string component = "mqtt.server";
+    std::string instance = "mqtt-broker";
+    std::string connection = "#7";
+    logger::LogScope borrowed{logger::LogOrigin::Framework, logger::LogBoundary::Connection, component, instance, logger::LogRole::Server, connection};
+    auto owned = logger::materialize(borrowed, logger::LogLevel::Info, "ready", logger::LogRecordOptions{.ts = fixedTimestamp()});
+    component.clear();
+    instance.clear();
+    connection.clear();
+    expectStringEqual(result, "mqtt.server", owned.component, "materialize copies component string_view");
+    result.expectTrue(owned.instance && *owned.instance == "mqtt-broker", "materialize copies instance string_view");
+    result.expectTrue(owned.connection && *owned.connection == "#7", "materialize copies connection string_view");
+    result.expectTrue(owned.role && *owned.role == logger::LogRole::Server, "known role is represented as optional role");
+
+    logger::LogScope unknownRole{logger::LogOrigin::Application, logger::LogBoundary::Context, "EchoServerContext", "", logger::LogRole::Unknown, ""};
+    auto minimal = logger::materialize(unknownRole, logger::LogLevel::Info, "echo session started", logger::LogRecordOptions{.ts = fixedTimestamp()});
+    const std::string json = logger::formatJsonV1(minimal);
+    result.expectTrue(json.find("\"v\":1") != std::string::npos, "JSON emits mandatory v");
+    result.expectTrue(json.find("\"ts\":\"2026-07-05T12:34:56.789Z\"") != std::string::npos, "JSON emits mandatory ts timestamp");
+    result.expectTrue(json.find("\"level\":\"info\"") != std::string::npos, "JSON emits lowercase level");
+    result.expectTrue(json.find("\"origin\":\"application\"") != std::string::npos, "JSON emits lowercase origin");
+    result.expectTrue(json.find("\"boundary\":\"context\"") != std::string::npos, "JSON emits lowercase boundary");
+    result.expectTrue(json.find("\"component\":\"EchoServerContext\"") != std::string::npos, "JSON emits mandatory component");
+    result.expectTrue(json.find("\"message\":\"echo session started\"") != std::string::npos, "JSON emits mandatory message");
+    result.expectTrue(json.find("instance") == std::string::npos, "JSON omits absent instance instead of null");
+    result.expectTrue(json.find("role") == std::string::npos, "JSON omits unknown role");
+    result.expectTrue(json.find("connection") == std::string::npos, "JSON omits absent connection instead of null");
+    result.expectTrue(json.find("null") == std::string::npos, "JSON never emits null for absent optionals");
+
+    const std::string text = logger::formatText(owned);
+    result.expectTrue(text.find("2026-07-05T12:34:56.789Z") != std::string::npos && text.find("info framework connection mqtt.server") != std::string::npos && text.find("ready") != std::string::npos,
+                      "text formatter includes timestamp level origin boundary component and message");
+
+    std::vector<logger::LogRecord> records;
+    logger::LogScope scope{logger::LogOrigin::Framework, logger::LogBoundary::Connection, "core.socket.stream", "test-instance", logger::LogRole::Server, "tcp://127.0.0.1:8080"};
+    auto log = logger::BoundaryLogger::createForTest(scope, [&](logger::LogRecord record) { records.push_back(std::move(record)); }, logger::LogLevel::Debug, fixedTimestamp);
+    log.debug("received {} bytes", 42);
+    log.info("echo session started");
+    log.debug() << "received " << 42 << " bytes";
+    result.expectEqual(3, static_cast<int>(records.size()), "format and stream APIs emit expected number of complete records");
+    expectStringEqual(result, "received 42 bytes", records[0].message, "format-style API formats placeholder");
+    expectStringEqual(result, "echo session started", records[1].message, "format-style API supports literal message");
+    expectStringEqual(result, "received 42 bytes", records[2].message, "stream-style API flushes complete expression once");
+
+    auto filtered = logger::BoundaryLogger::createForTest(scope, [&](logger::LogRecord record) { records.push_back(std::move(record)); }, logger::LogLevel::Info, fixedTimestamp);
+    filtered.debug("hidden {}", 1);
+    filtered.debug() << "hidden " << 2;
+    result.expectEqual(3, static_cast<int>(records.size()), "local threshold suppresses disabled format and stream calls");
+
+    log.sysError(logger::LogLevel::Error, 98, "bind failed on {}", "127.0.0.1:8080");
+    result.expectTrue(records.back().error && records.back().error->code == 98, "sysError(int) stores error code");
+    result.expectTrue(records.back().error && !records.back().error->text.empty(), "sysError(int) stores error text");
+    expectStringEqual(result, "bind failed on 127.0.0.1:8080", records.back().message, "sysError formats message separately from error object");
+    const std::string errorJson = logger::formatJsonV1(records.back());
+    result.expectTrue(errorJson.find("\"error\":{") != std::string::npos && errorJson.find("\"code\":98") != std::string::npos, "JSON emits error only when present");
+
+    log.sysError(logger::LogLevel::Warn, std::make_error_code(std::errc::permission_denied), "open failed");
+    result.expectTrue(records.back().error && records.back().error->code != 0, "sysError(std::error_code) stores error code");
+
+    logger::Logger::init();
+    logger::Logger::setDisableColor(true);
+    logger::Logger::setTickResolver([] { return "000000"; });
+    logger::Logger::setLogLevel(1);
+    logger::Logger::setVerboseLevel(1);
+    LOG(INFO) << "round2 compatibility LOG enabled";
+    errno = EACCES;
+    PLOG(ERROR) << "round2 compatibility PLOG enabled";
+    VLOG(1) << "round2 compatibility VLOG enabled";
+    LOG(TRACE) << "round2 compatibility LOG disabled";
+    VLOG(2) << "round2 compatibility VLOG disabled";
+    result.expectTrue(true, "legacy LOG/PLOG/VLOG macros compile/link/run via existing macro path");
+
+    return result.processResult();
+}

--- a/tests/unit/log/SemanticLoggerRound2Test.cpp
+++ b/tests/unit/log/SemanticLoggerRound2Test.cpp
@@ -51,6 +51,12 @@ int main() {
     result.expectTrue(json.find("connection") == std::string::npos, "JSON omits absent connection instead of null");
     result.expectTrue(json.find("null") == std::string::npos, "JSON never emits null for absent optionals");
 
+    auto escapedRecord = logger::materialize(unknownRole, logger::LogLevel::Info, std::string("before") + static_cast<char>(0x08) + static_cast<char>(0x01) + "after", logger::LogRecordOptions{.ts = fixedTimestamp()});
+    const std::string escapedJson = logger::formatJsonV1(escapedRecord);
+    result.expectTrue(escapedJson.find("before\\b\\u0001after") != std::string::npos, "JSON escapes backspace and other control characters");
+    result.expectTrue(escapedJson.find(static_cast<char>(0x08)) == std::string::npos && escapedJson.find(static_cast<char>(0x01)) == std::string::npos,
+                      "JSON does not emit raw control bytes below 0x20");
+
     const std::string text = logger::formatText(owned);
     result.expectTrue(text.find("2026-07-05T12:34:56.789Z") != std::string::npos && text.find("info framework connection mqtt.server") != std::string::npos && text.find("ready") != std::string::npos,
                       "text formatter includes timestamp level origin boundary component and message");
@@ -65,6 +71,25 @@ int main() {
     expectStringEqual(result, "received 42 bytes", records[0].message, "format-style API formats placeholder");
     expectStringEqual(result, "echo session started", records[1].message, "format-style API supports literal message");
     expectStringEqual(result, "received 42 bytes", records[2].message, "stream-style API flushes complete expression once");
+
+
+    std::string loggerComponent = "mqtt.server";
+    std::string loggerInstance = "mqtt-broker";
+    std::string loggerConnection = "#7";
+    std::vector<logger::LogRecord> lifetimeRecords;
+    auto lifetimeLog = logger::BoundaryLogger::createForTest(
+        logger::LogScope{logger::LogOrigin::Framework, logger::LogBoundary::Connection, loggerComponent, loggerInstance, logger::LogRole::Server, loggerConnection},
+        [&](logger::LogRecord record) { lifetimeRecords.push_back(std::move(record)); },
+        logger::LogLevel::Trace,
+        fixedTimestamp);
+    loggerComponent = "changed.component";
+    loggerInstance = "changed-instance";
+    loggerConnection = "changed-connection";
+    lifetimeLog.info("after mutation");
+    result.expectEqual(1, static_cast<int>(lifetimeRecords.size()), "BoundaryLogger emits after original scope strings mutate");
+    expectStringEqual(result, "mqtt.server", lifetimeRecords[0].component, "BoundaryLogger copies component at construction");
+    result.expectTrue(lifetimeRecords[0].instance && *lifetimeRecords[0].instance == "mqtt-broker", "BoundaryLogger copies instance at construction");
+    result.expectTrue(lifetimeRecords[0].connection && *lifetimeRecords[0].connection == "#7", "BoundaryLogger copies connection at construction");
 
     auto filtered = logger::BoundaryLogger::createForTest(scope, [&](logger::LogRecord record) { records.push_back(std::move(record)); }, logger::LogLevel::Info, fixedTimestamp);
     filtered.debug("hidden {}", 1);


### PR DESCRIPTION
### Motivation
- Provide a Round 02 semantic logging core (engine-on-test-stand) implementing the frozen Round 1 contract for owned semantic records, materialization, formatters, and a test-only logger API without integrating into framework objects.
- Prove the format-style and stream-style API shapes, `sysError` behavior, JSON v1 schema rules (mandatory vs optional fields, omission of absent optionals), and that `LogScope` `std::string_view` borrows are materialized into owned bytes before handoff.
- Keep the work strictly confined to `src/log` + focused unit tests and the required Round 02 report, and avoid changing production `LOG`/`PLOG`/`VLOG` behavior or adding framework `.log()` APIs.

### Description
- Added semantic core types and APIs in `src/log`: enums `LogLevel`, `LogOrigin`, `LogBoundary`, `LogRole`, borrowed `LogScope`, owned `LogRecord`, `LogError`, `LogSource`, `materialize(...)`, `formatJsonV1(...)`, `formatText(...)`, `BoundaryLogger`, and `LogStream` (files: `src/log/SemanticLogger.h`, `src/log/SemanticLogger.cpp`).
- Implemented owned materialization that copies `LogScope` `string_view` fields into `LogRecord` owned `std::string` storage so no borrowed references escape the call; implemented JSON v1 formatter that emits mandatory fields `v`, `ts`, `level`, `origin`, `boundary`, `component`, `message` and emits optional `instance`, `role`, `connection`, `event`, `error`, `source` only when present.
- Implemented a minimal `{}` placeholder formatter for format-style calls, stream-style `LogStream` that flushes once at destruction/move, and `BoundaryLogger::sysError` overloads for `int` and `std::error_code` that store `error.code` and `error.text` while formatting the human message separately.
- Hooked the new semantic source into the build (`src/log/CMakeLists.txt`) and added a focused unit test harness `tests/unit/log/SemanticLoggerRound2Test.cpp` plus test CMake files and the Round 02 report `docs/logging/round-02-semantic-core-report.md`; no production object `.log()` APIs, `SocketContext`/`SocketConnection`/`ConfigInstance` integrations, or call-site migrations were added.

### Testing
- Dependency/configure/build: ran `pkg-config --modversion nlohmann_json` and installed `nlohmann-json3-dev` when missing, then `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build --parallel 2` succeeded.
- Unit tests: ran `ctest --test-dir cmake-build -R SemanticLoggerRound2Test --output-on-failure` and the focused `SemanticLoggerRound2Test` passed (verifies materialization, JSON mandatory/optional behavior, text formatting, format-style + stream-style APIs, `sysError`, and local threshold suppression).
- Full test suite: ran `ctest --test-dir cmake-build --output-on-failure` and observed the test run (the new test included); existing skip behavior left several component tests skipped but the run completed successfully.
- AddressSanitizer: configured and built with ASan; initial ASan ctest failed because ASan runtime was not first in the library list, then `ASAN=$(gcc -print-file-name=libasan.so) && LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure` passed for the focused test and full suite.
- Macro compatibility: the harness compiles/links/runs `LOG`, `PLOG`, and `VLOG` through the existing macro path and exercises enabled/disabled code paths (smoke coverage only); no legacy macro was removed and no production macro call sites were migrated.

Notes: the changes are committed locally as `Implement logging roadmap round 2 semantic core`; creating a GitHub draft PR from this environment required upstream remote access which was not available in the session, so the branch/PR creation step was recorded but an actual remote draft PR could not be opened from here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a44ccdbb4832c9092915bdd16beb1)