### PR TITLE
Logging roadmap round 03 — LogScopeOwner composition helper

### DIFF
--- a/docs/logging/round-03-log-scope-owner-report.md
+++ b/docs/logging/round-03-log-scope-owner-report.md
@@ -1,0 +1,127 @@
+# Logging Roadmap Round 03 Report: `LogScopeOwner` Composition Helper
+
+Branch/report: current work branch / Round 03 `LogScopeOwner` composition helper.
+
+## Implementation summary
+
+Round 03 adds the reusable object-owned semantic identity holder for later composition into framework objects. The implementation stays limited to `src/log`, focused unit-test registration, and this report.
+
+Implemented:
+
+* `logger::LogScopeOwner` in `src/log/LogScopeOwner.h` and `src/log/LogScopeOwner.cpp`.
+* Immediate copying from borrowed `LogScope` into owned `std::string` storage for `component`, optional `instance`, and optional `connection`.
+* Owner-held `origin`, `boundary`, and optional known `role`; unknown roles are represented as absent in owned storage and exposed as `LogRole::Unknown` in borrowed views.
+* `LogScopeOwner::scope() const noexcept`, returning a temporary borrowed `LogScope` view that remains valid only while the owner remains alive.
+* `LogScopeOwner::logger(...)`, returning a `BoundaryLogger` created from the owner's owned identity, so construction does not retain caller-owned `string_view` data.
+* A small Round 2 refactor that exposes one shared owned-scope copy/view model (`OwnedLogScope`, `copyLogScope`, `viewLogScope`, and `knownLogRole`) instead of duplicating ownership logic between `BoundaryLogger` and `LogScopeOwner`.
+* Focused Round 3 unit tests covering borrowed string mutation/destruction, owner views, logger emission, unknown-role JSON omission, and copy/move behavior.
+
+## Exact files changed
+
+* `src/log/CMakeLists.txt` — adds `LogScopeOwner.cpp` and `LogScopeOwner.h` to the `logger` library source/header lists.
+* `src/log/SemanticLogger.h` — exposes the shared owned-scope helper declarations and grants `LogScopeOwner` access to the `BoundaryLogger` owned-scope constructor.
+* `src/log/SemanticLogger.cpp` — refactors Round 2's internal owned-scope copy/view helpers into shared functions used by both Round 2 `BoundaryLogger` construction and Round 3 `LogScopeOwner`.
+* `src/log/LogScopeOwner.h` — declares the Round 3 composition helper.
+* `src/log/LogScopeOwner.cpp` — implements owned construction, borrowed-scope copying, temporary borrowed views, and owner-based `BoundaryLogger` creation.
+* `tests/unit/log/CMakeLists.txt` — registers `LogScopeOwnerRound3Test` and labels it `unit;log;round3`.
+* `tests/unit/log/LogScopeOwnerRound3Test.cpp` — adds the focused Round 3 lifetime, JSON, logger, and copy/move tests.
+* `docs/logging/round-03-log-scope-owner-report.md` — this report.
+
+No socket, HTTP, WebSocket, MQTT, DB, application, `ConfigInstance`, `SocketConnection`, `SocketContext`, `SocketServer`, `SocketClient`, `SocketAcceptor`, or `SocketConnector` production files were changed.
+
+## Exact build commands run
+
+Dependency repair command run because the initial normal configure reported missing `nlohmann_json>=3.11`:
+
+```sh
+apt-get update && apt-get install -y nlohmann-json3-dev
+```
+
+Normal configure/build:
+
+```sh
+git status --short
+git diff --check
+cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON
+cmake --build cmake-build --parallel 2
+```
+
+ASan configure/build:
+
+```sh
+cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON
+cmake --build cmake-build-asan --parallel 2
+```
+
+## Exact test commands run
+
+Normal tests:
+
+```sh
+ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test" --output-on-failure
+ctest --test-dir cmake-build --output-on-failure
+```
+
+ASan tests:
+
+```sh
+ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure
+```
+
+## Sanitizer result
+
+ASan configure, build, and full `ctest` completed successfully. The ASan full test command reported `100% tests passed, 0 tests failed out of 109`; many component tests were skipped by the existing test harness, matching the normal build behavior. The ASan link emitted platform warnings from `libasan.so.8` about `tmpnam_r`, `tmpnam`, and `tempnam`; these warnings are not from Round 3 code and did not fail the build or tests.
+
+## `LogScopeOwner` ownership/lifetime result
+
+`LogScopeOwner` owns the semantic identity bytes needed for later object composition. `component`, `instance`, and `connection` are stored as owned `std::string` values inside the shared `OwnedLogScope` model. Construction from a borrowed `LogScope` copies all borrowed `std::string_view` fields immediately. Tests verify that mutating the original source strings and destroying local source strings after construction do not change `owner.scope()`.
+
+`LogScopeOwner::scope() const noexcept` returns a borrowed `LogScope` view over the owner's storage. This view is intentionally temporary and must not be stored in sinks, async structures, queues, or owned records. Existing `materialize(...)` remains the handoff point that copies borrowed views into owned `LogRecord` bytes.
+
+## BoundaryLogger-from-owner result
+
+`LogScopeOwner::logger(...)` creates a `BoundaryLogger` from the owner's `OwnedLogScope`. `BoundaryLogger` already owns an `OwnedLogScope`, so the returned logger remains independent of caller-owned strings and safe after the original borrowed inputs are modified or destroyed. The Round 3 test verifies that logger records contain the owner's original component, instance, role, and connection values after the source strings have been changed.
+
+## Copy/move behavior result
+
+Copy and move are intentionally enabled with the compiler-generated operations. A copied owner owns independent string storage through `std::string` and `std::optional<std::string>` value semantics. A moved-to owner remains valid. `LogScopeOwnerRound3Test` contains `static_assert` checks for copy/move support and runtime checks for copied and moved-to owner views.
+
+## Macro compatibility result
+
+Round 3 did not change `src/log/Logger.h`, `src/log/Logger.cpp`, or any legacy macro implementation. Round 2's macro compatibility smoke coverage remains in `SemanticLoggerRound2Test`, and the focused Round 2 test was rerun successfully alongside the new Round 3 test.
+
+## Confirmation that `LOG`/`PLOG`/`VLOG` were not changed
+
+Confirmed. Round 3 does not alter the `LOG`, `PLOG`, or `VLOG` macro definitions or behavior.
+
+## Confirmation that no production object integration was added
+
+Confirmed. Round 3 adds only the reusable composition helper in `src/log`; it does not add `SocketContext::log()`, `SocketContext::frameworkLog()`, `SocketConnection::log()`, `ConfigInstance` logging ownership, or SocketServer/SocketClient/SocketAcceptor/SocketConnector logging APIs.
+
+## Confirmation that no production call sites were migrated
+
+Confirmed. No production logging call sites were migrated, and no production framework object now contains `LogScopeOwner`.
+
+## Extended SNode.C and MQTT/mqttsuite review note
+
+For this round, the extended SNode.C/MQTT context was reviewed through the merged Round 1 report and current Round 2 semantic core files before coding. The repo still has MQTT implementation under `src/iot/mqtt`; no separate top-level `mqttsuite` tree was present in the checkout during the earlier roadmap review. Round 3 deliberately leaves MQTT and broader production integration untouched so the helper can be validated in isolation before later roadmap rounds.
+
+## Deliberate deferrals
+
+* No Round 4 object integration.
+* No `SocketContext::log()` or `SocketContext::frameworkLog()`.
+* No `SocketConnection::log()`.
+* No `ConfigInstance` logging ownership.
+* No SocketServer, SocketClient, SocketAcceptor, or SocketConnector logging APIs.
+* No HTTP, WebSocket, MQTT, DB, or application integration.
+* No production call-site migration.
+* No `LogSuperClass`, logging base class, mixin, or inheritance-based logging ownership.
+* No `LOG`/`PLOG`/`VLOG` behavior changes.
+* No backend unification.
+* No startup filter configuration, precedence implementation, `freeze()`, CLI integration, runtime reload, signals, admin endpoints, or mutable atomic thresholds.
+
+## Known non-blocking follow-ups
+
+* Later rounds should integrate `LogScopeOwner` into framework objects by composition only, following the semantic logging contract.
+* Later integration should continue to materialize borrowed views before formatter/sink/async handoff.
+* Future macro compatibility work can add a stronger byte-for-byte or normalized harness if any later round touches legacy macro output paths.

--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -65,9 +65,9 @@ FetchContent_MakeAvailable(spdlog)
 
 set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${TMP_CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
 
-set(LOGGER_CPP Logger.cpp SemanticLogger.cpp)
+set(LOGGER_CPP Logger.cpp SemanticLogger.cpp LogScopeOwner.cpp)
 
-set(LOGGER_H Logger.h SemanticLogger.h)
+set(LOGGER_H Logger.h SemanticLogger.h LogScopeOwner.h)
 
 set(TMP_CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
 unset(CMAKE_CXX_INCLUDE_WHAT_YOU_USE)

--- a/src/log/LogScopeOwner.cpp
+++ b/src/log/LogScopeOwner.cpp
@@ -1,0 +1,39 @@
+#include "log/LogScopeOwner.h"
+
+#include <utility>
+
+namespace logger {
+
+    LogScopeOwner::LogScopeOwner(LogOrigin origin,
+                                 LogBoundary boundary,
+                                 std::string component,
+                                 std::optional<std::string> instance,
+                                 std::optional<LogRole> role,
+                                 std::optional<std::string> connection)
+        : ownedScope{origin, boundary, std::move(component), std::move(instance), std::move(role), std::move(connection)} {
+        if (ownedScope.role && !knownLogRole(*ownedScope.role)) {
+            ownedScope.role = std::nullopt;
+        }
+        if (ownedScope.instance && ownedScope.instance->empty()) {
+            ownedScope.instance = std::nullopt;
+        }
+        if (ownedScope.connection && ownedScope.connection->empty()) {
+            ownedScope.connection = std::nullopt;
+        }
+    }
+
+    LogScopeOwner LogScopeOwner::fromScope(LogScope scope) {
+        return LogScopeOwner(copyLogScope(scope));
+    }
+
+    LogScope LogScopeOwner::scope() const noexcept {
+        return viewLogScope(ownedScope);
+    }
+
+    BoundaryLogger LogScopeOwner::logger(BoundaryLogger::Sink sink, LogLevel threshold, BoundaryLogger::Clock clock) const {
+        return BoundaryLogger(ownedScope, std::move(sink), threshold, std::move(clock));
+    }
+
+    LogScopeOwner::LogScopeOwner(OwnedLogScope scope) : ownedScope(std::move(scope)) {}
+
+} // namespace logger

--- a/src/log/LogScopeOwner.h
+++ b/src/log/LogScopeOwner.h
@@ -1,0 +1,37 @@
+#ifndef LOGGER_LOGSCOPEOWNER_H
+#define LOGGER_LOGSCOPEOWNER_H
+
+#include "log/SemanticLogger.h"
+
+namespace logger {
+
+    class LogScopeOwner {
+    public:
+        LogScopeOwner(LogOrigin origin,
+                      LogBoundary boundary,
+                      std::string component,
+                      std::optional<std::string> instance = std::nullopt,
+                      std::optional<LogRole> role = std::nullopt,
+                      std::optional<std::string> connection = std::nullopt);
+
+        static LogScopeOwner fromScope(LogScope scope);
+
+        LogScopeOwner(const LogScopeOwner&) = default;
+        LogScopeOwner& operator=(const LogScopeOwner&) = default;
+        LogScopeOwner(LogScopeOwner&&) noexcept = default;
+        LogScopeOwner& operator=(LogScopeOwner&&) noexcept = default;
+        ~LogScopeOwner() = default;
+
+        LogScope scope() const noexcept;
+
+        BoundaryLogger logger(BoundaryLogger::Sink sink, LogLevel threshold = LogLevel::Trace, BoundaryLogger::Clock clock = {}) const;
+
+    private:
+        explicit LogScopeOwner(OwnedLogScope scope);
+
+        OwnedLogScope ownedScope;
+    };
+
+} // namespace logger
+
+#endif // LOGGER_LOGSCOPEOWNER_H

--- a/src/log/SemanticLogger.cpp
+++ b/src/log/SemanticLogger.cpp
@@ -5,7 +5,6 @@
 
 namespace logger {
 namespace {
-    bool knownRole(LogRole role) { return role == LogRole::Server || role == LogRole::Client; }
     int rank(LogLevel level) { return static_cast<int>(level); }
     std::string escapeJson(const std::string& value) {
         std::ostringstream out;
@@ -29,21 +28,6 @@ namespace {
         }
         return out.str();
     }
-    OwnedLogScope copyScope(LogScope scope) {
-        OwnedLogScope owned{scope.origin, scope.boundary, std::string(scope.component), std::nullopt, std::nullopt, std::nullopt};
-        if (!scope.instance.empty()) owned.instance = std::string(scope.instance);
-        if (knownRole(scope.role)) owned.role = scope.role;
-        if (!scope.connection.empty()) owned.connection = std::string(scope.connection);
-        return owned;
-    }
-    LogScope viewScope(const OwnedLogScope& scope) {
-        return LogScope{scope.origin,
-                        scope.boundary,
-                        scope.component,
-                        scope.instance ? std::string_view(*scope.instance) : std::string_view(),
-                        scope.role.value_or(LogRole::Unknown),
-                        scope.connection ? std::string_view(*scope.connection) : std::string_view()};
-    }
     void appendField(std::ostringstream& out, bool& first, std::string_view name, const std::string& value) {
         out << (first ? "" : ",") << "\"" << name << "\":\"" << escapeJson(value) << "\"";
         first = false;
@@ -63,7 +47,7 @@ LogRecord materialize(const LogScope& scope, LogLevel level, std::string message
     record.boundary = scope.boundary;
     record.component = std::string(scope.component);
     if (!scope.instance.empty()) record.instance = std::string(scope.instance);
-    if (knownRole(scope.role)) record.role = scope.role;
+    if (knownLogRole(scope.role)) record.role = scope.role;
     if (!scope.connection.empty()) record.connection = std::string(scope.connection);
     if (options.event && !options.event->empty()) record.event = std::string(*options.event);
     record.message = std::move(message);
@@ -171,7 +155,26 @@ LogStream& LogStream::operator=(LogStream&& other) noexcept {
 }
 LogStream::~LogStream() { if (!flushed && enabled && logger != nullptr) logger->emit(level, stream.str()); }
 
-BoundaryLogger BoundaryLogger::createForTest(LogScope scope, Sink sink, LogLevel threshold, Clock clock) { return BoundaryLogger(copyScope(scope), std::move(sink), threshold, std::move(clock)); }
+bool knownLogRole(LogRole role) noexcept { return role == LogRole::Server || role == LogRole::Client; }
+
+OwnedLogScope copyLogScope(LogScope scope) {
+    OwnedLogScope owned{scope.origin, scope.boundary, std::string(scope.component), std::nullopt, std::nullopt, std::nullopt};
+    if (!scope.instance.empty()) owned.instance = std::string(scope.instance);
+    if (knownLogRole(scope.role)) owned.role = scope.role;
+    if (!scope.connection.empty()) owned.connection = std::string(scope.connection);
+    return owned;
+}
+
+LogScope viewLogScope(const OwnedLogScope& scope) noexcept {
+    return LogScope{scope.origin,
+                    scope.boundary,
+                    scope.component,
+                    scope.instance ? std::string_view(*scope.instance) : std::string_view(),
+                    scope.role.value_or(LogRole::Unknown),
+                    scope.connection ? std::string_view(*scope.connection) : std::string_view()};
+}
+
+BoundaryLogger BoundaryLogger::createForTest(LogScope scope, Sink sink, LogLevel threshold, Clock clock) { return BoundaryLogger(copyLogScope(scope), std::move(sink), threshold, std::move(clock)); }
 BoundaryLogger::BoundaryLogger(OwnedLogScope scope, Sink sink, LogLevel threshold, Clock clock) : scope(std::move(scope)), sink(std::move(sink)), threshold(threshold), clock(std::move(clock)) {}
 bool BoundaryLogger::enabled(LogLevel level) const noexcept { return level != LogLevel::Off && rank(level) >= rank(threshold) && threshold != LogLevel::Off; }
 LogStream BoundaryLogger::trace() const { return {this, LogLevel::Trace}; }
@@ -185,7 +188,7 @@ void BoundaryLogger::emit(LogLevel level, std::string message, LogRecordOptions 
     if (options.ts == std::chrono::system_clock::time_point{}) {
         options.ts = clock ? clock() : std::chrono::system_clock::now();
     }
-    sink(materialize(viewScope(scope), level, std::move(message), std::move(options)));
+    sink(materialize(viewLogScope(scope), level, std::move(message), std::move(options)));
 }
 
 } // namespace logger

--- a/src/log/SemanticLogger.h
+++ b/src/log/SemanticLogger.h
@@ -82,6 +82,12 @@ namespace logger {
         std::optional<std::string> connection;
     };
 
+    bool knownLogRole(LogRole role) noexcept;
+    OwnedLogScope copyLogScope(LogScope scope);
+    LogScope viewLogScope(const OwnedLogScope& scope) noexcept;
+
+    class LogScopeOwner;
+
     class LogStream {
     public:
         LogStream() = default;
@@ -192,6 +198,7 @@ namespace logger {
         Clock clock;
 
         friend class LogStream;
+        friend class LogScopeOwner;
     };
 
 } // namespace logger

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -2,3 +2,8 @@ snodec_add_test(SemanticLoggerRound2Test SemanticLoggerRound2Test.cpp)
 target_include_directories(SemanticLoggerRound2Test PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(SemanticLoggerRound2Test PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(SemanticLoggerRound2Test PROPERTIES LABELS "unit;log;round2")
+
+snodec_add_test(LogScopeOwnerRound3Test LogScopeOwnerRound3Test.cpp)
+target_include_directories(LogScopeOwnerRound3Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(LogScopeOwnerRound3Test PRIVATE snodec-test-support snodec::logger)
+set_tests_properties(LogScopeOwnerRound3Test PROPERTIES LABELS "unit;log;round3")

--- a/tests/unit/log/LogScopeOwnerRound3Test.cpp
+++ b/tests/unit/log/LogScopeOwnerRound3Test.cpp
@@ -1,0 +1,97 @@
+#include "log/LogScopeOwner.h"
+#include "tests/support/TestResult.h"
+
+#include <chrono>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+    void expectStringEqual(tests::support::TestResult& result, const std::string& expected, std::string_view actual, const std::string& message) {
+        result.expectTrue(expected == actual, message + " expected='" + expected + "' actual='" + std::string(actual) + "'");
+    }
+
+    std::chrono::system_clock::time_point fixedTimestamp() {
+        using namespace std::chrono;
+        return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
+    }
+
+    logger::LogScopeOwner makeOwnerFromDestroyedStrings() {
+        std::string component = "core.socket.stream";
+        std::string instance = "echo-server";
+        std::string connection = "#7";
+        logger::LogScope borrowed{logger::LogOrigin::Framework, logger::LogBoundary::Connection, component, instance, logger::LogRole::Server, connection};
+        return logger::LogScopeOwner::fromScope(borrowed);
+    }
+}
+
+int main() {
+    tests::support::TestResult result;
+
+    static_assert(std::is_copy_constructible_v<logger::LogScopeOwner>, "LogScopeOwner copy behavior is intentionally supported");
+    static_assert(std::is_copy_assignable_v<logger::LogScopeOwner>, "LogScopeOwner copy assignment is intentionally supported");
+    static_assert(std::is_move_constructible_v<logger::LogScopeOwner>, "LogScopeOwner move behavior is intentionally supported");
+    static_assert(std::is_move_assignable_v<logger::LogScopeOwner>, "LogScopeOwner move assignment is intentionally supported");
+
+    std::string component = "core.socket.stream";
+    std::string instance = "echo-server";
+    std::string connection = "#7";
+    logger::LogScope borrowed{logger::LogOrigin::Framework, logger::LogBoundary::Connection, component, instance, logger::LogRole::Server, connection};
+
+    auto owner = logger::LogScopeOwner::fromScope(borrowed);
+
+    component = "changed.component";
+    instance = "changed-instance";
+    connection = "changed-connection";
+
+    auto scope = owner.scope();
+    result.expectTrue(scope.origin == logger::LogOrigin::Framework, "owner.scope exposes original origin");
+    result.expectTrue(scope.boundary == logger::LogBoundary::Connection, "owner.scope exposes original boundary");
+    expectStringEqual(result, "core.socket.stream", scope.component, "owner copies borrowed component string");
+    expectStringEqual(result, "echo-server", scope.instance, "owner copies borrowed instance string");
+    result.expectTrue(scope.role == logger::LogRole::Server, "owner.scope exposes known role");
+    expectStringEqual(result, "#7", scope.connection, "owner copies borrowed connection string");
+
+    auto destroyedOwner = makeOwnerFromDestroyedStrings();
+    auto destroyedScope = destroyedOwner.scope();
+    expectStringEqual(result, "core.socket.stream", destroyedScope.component, "owner remains valid after source component is destroyed");
+    expectStringEqual(result, "echo-server", destroyedScope.instance, "owner remains valid after source instance is destroyed");
+    expectStringEqual(result, "#7", destroyedScope.connection, "owner remains valid after source connection is destroyed");
+
+    std::vector<logger::LogRecord> records;
+    auto log = owner.logger(
+        [&](logger::LogRecord record) { records.push_back(std::move(record)); },
+        logger::LogLevel::Trace,
+        fixedTimestamp);
+    log.info("hello");
+    result.expectEqual(1, static_cast<int>(records.size()), "BoundaryLogger created from owner emits one record");
+    expectStringEqual(result, "core.socket.stream", records[0].component, "logger from owner emits original component");
+    result.expectTrue(records[0].instance && *records[0].instance == "echo-server", "logger from owner emits original instance");
+    result.expectTrue(records[0].role && *records[0].role == logger::LogRole::Server, "logger from owner emits original known role");
+    result.expectTrue(records[0].connection && *records[0].connection == "#7", "logger from owner emits original connection");
+
+    logger::LogScope unknownRole{logger::LogOrigin::Application, logger::LogBoundary::Context, "EchoServerContext", "", logger::LogRole::Unknown, ""};
+    auto unknownOwner = logger::LogScopeOwner::fromScope(unknownRole);
+    auto unknownScope = unknownOwner.scope();
+    result.expectTrue(unknownScope.role == logger::LogRole::Unknown, "unknown role remains absent in owner and appears as Unknown in borrowed view");
+    auto unknownRecord = logger::materialize(unknownScope, logger::LogLevel::Info, "hello", logger::LogRecordOptions{.ts = fixedTimestamp()});
+    const std::string unknownJson = logger::formatJsonV1(unknownRecord);
+    result.expectTrue(unknownJson.find("role") == std::string::npos, "unknown role remains omitted from JSON");
+    result.expectTrue(unknownJson.find("unknown") == std::string::npos, "unknown role string is not emitted in JSON");
+
+    auto copiedOwner = owner;
+    component = "copy-source-changed";
+    auto copiedScope = copiedOwner.scope();
+    expectStringEqual(result, "core.socket.stream", copiedScope.component, "copied owner has independent component storage");
+    expectStringEqual(result, "echo-server", copiedScope.instance, "copied owner has independent instance storage");
+    expectStringEqual(result, "#7", copiedScope.connection, "copied owner has independent connection storage");
+
+    auto movedOwner = std::move(copiedOwner);
+    auto movedScope = movedOwner.scope();
+    expectStringEqual(result, "core.socket.stream", movedScope.component, "moved-to owner remains valid for component");
+    expectStringEqual(result, "echo-server", movedScope.instance, "moved-to owner remains valid for instance");
+    expectStringEqual(result, "#7", movedScope.connection, "moved-to owner remains valid for connection");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable composition helper that owns semantic identity bytes so framework objects can hold stable, lifetime-safe identity for temporary borrowed `LogScope` views and for creating `BoundaryLogger` instances without retaining caller-owned `string_view` data.
- Ensure `component`, `instance`, and `connection` are owned `std::string` storage, preserve known `role` semantics, and keep JSON emission rules (omit unknown role) consistent with the Round 2 contract.

### Description
- Added `logger::LogScopeOwner` with header `src/log/LogScopeOwner.h` and implementation `src/log/LogScopeOwner.cpp`, supporting `fromScope(LogScope)`, `scope() const noexcept` returning a temporary borrowed view, `logger(...)` creating a lifetime-safe `BoundaryLogger`, and defaulted copy/move operations.
- Centralized the owned-scope model by exposing `OwnedLogScope` plus helpers `knownLogRole`, `copyLogScope`, and `viewLogScope` in `src/log/SemanticLogger.h` and refactoring `src/log/SemanticLogger.cpp` to use these shared helpers so ownership logic is not duplicated.
- Updated build lists in `src/log/CMakeLists.txt` and registered the focused unit test in `tests/unit/log/CMakeLists.txt`, and added the test `tests/unit/log/LogScopeOwnerRound3Test.cpp` exercising construction from borrowed scopes, post-construction mutation/destruction safety, logger-from-owner emission, unknown-role JSON omission, and copy/move behavior.
- Added the round report `docs/logging/round-03-log-scope-owner-report.md` documenting files changed, validation steps, sanitizer results, deferrals, and known follow-ups, while keeping `LOG`/`PLOG`/`VLOG` and production object integration unchanged.

### Testing
- Built the project and ran focused unit tests with `cmake`/`cmake --build` and `ctest` for `SemanticLoggerRound2Test` and `LogScopeOwnerRound3Test`, and both targeted tests passed in the normal build (both tests passed).
- Ran an ASan configure/build and full `ctest` run and observed ASan build and tests complete successfully with all tests passing (ASan `ctest` reported 100% passed, with many component tests skipped by the existing harness).
- The new unit test `LogScopeOwnerRound3Test` passed and verifies copying borrowed `LogScope` data at construction, owner view stability after source mutation/destruction, correct origin/boundary/component/instance/role/connection exposure, logger-from-owner emission of the owned identity, unknown-role omission from JSON, and copy/move semantics.
- Confirmed that macros `LOG`/`PLOG`/`VLOG` were not changed and no production framework objects or call sites were integrated or migrated in this round.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a5de5029c832c866112b22d373f95)