### PR TITLE
Logging roadmap round 04 — object log APIs

### DIFF
--- a/docs/logging/round-04-object-log-api-report.md
+++ b/docs/logging/round-04-object-log-api-report.md
@@ -78,7 +78,7 @@ cmake --build cmake-build-asan --parallel 2
 ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure
 ```
 
-Result: ASan configure/build/test passed, 110/110 tests, with the existing environment-dependent component tests reported as skipped by the existing harness. The ASan build emitted linker warnings from libasan about tmpnam/tempnam usage, but the ASan ctest run completed successfully.
+Initial Round 4 result: ASan configure/build/test passed, 110/110 tests, with the existing environment-dependent component tests reported as skipped by the existing harness. The ASan build emitted linker warnings from libasan about tmpnam/tempnam usage, but the ASan ctest run completed successfully. Follow-up result: ASan was rerun after the ConfigInstance role/no-op documentation fix and passed, 110/110 tests, with the same existing environment-dependent skips.
 
 ## ConfigInstance log API result
 
@@ -91,11 +91,11 @@ logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
                            logger::BoundaryLogger::Clock clock = {}) const;
 ```
 
-The zero-argument API returns a lifetime-safe no-op semantic logger. The sink-taking overload is used by tests to prove emitted semantic records contain the expected object scope.
+The zero-argument API intentionally returns a no-op `BoundaryLogger` in Round 4 because backend unification is deferred to Round 6. It exists to establish the object API shape only. No production call sites were migrated to it, and broad migration must not happen before a real default backend sink exists. The sink-taking overload is used by tests to prove emitted semantic records contain the expected object scope.
 
 ## SocketConnection log API result
 
-`SocketConnection` now owns a `logger::LogScopeOwner` member and exposes the same `log()` and sink-taking `log(...)` API shape. The owned scope is initialized after `instanceName` and `connectionName` have been constructed.
+`SocketConnection` now owns a `logger::LogScopeOwner` member and exposes the same `log()` and sink-taking `log(...)` API shape. The zero-argument API intentionally returns a no-op `BoundaryLogger` in Round 4 because backend unification is deferred to Round 6. It exists to establish the object API shape only. No production call sites were migrated to it, and broad migration must not happen before a real default backend sink exists. The owned scope is initialized after `instanceName` and `connectionName` have been constructed.
 
 ## SocketContext log/frameworkLog API result
 
@@ -104,7 +104,7 @@ The zero-argument API returns a lifetime-safe no-op semantic logger. The sink-ta
 * `applicationLogScope`, returned by `log()` with `logger::LogOrigin::Application`
 * `frameworkLogScope`, returned by `frameworkLog()` with `logger::LogOrigin::Framework`
 
-The public APIs are:
+The no-argument `log()`/`frameworkLog()` overloads intentionally return no-op `BoundaryLogger` instances in Round 4 because backend unification is deferred to Round 6. They exist to establish the object API shape only. No production call sites were migrated to them, and broad migration must not happen before a real default backend sink exists. The public APIs are:
 
 ```cpp
 logger::BoundaryLogger log() const;
@@ -125,7 +125,7 @@ logger::BoundaryLogger frameworkLog(logger::BoundaryLogger::Sink sink,
 * boundary: `configuration`
 * component: `configuration`
 * instance: configured instance name when non-empty
-* role: unknown/absent
+* role: server/client mapped from `ConfigInstance::Role`
 * connection: absent
 
 The configuration boundary was chosen because `ConfigInstance` represents configuration identity in the net configuration tree. No fake instance name is invented for empty instance names.

--- a/docs/logging/round-04-object-log-api-report.md
+++ b/docs/logging/round-04-object-log-api-report.md
@@ -1,0 +1,180 @@
+# Logging Roadmap Round 04 Report: Object Log APIs
+
+Branch/report: `codex/implement-logging-roadmap-round-4` / Round 04 object log API plumbing.
+
+## Implementation summary
+
+Round 04 adds object-owned semantic logging API surfaces to the three agreed production areas only:
+
+* `net::config::ConfigInstance`
+* `core::socket::stream::SocketConnection`
+* `core::socket::stream::SocketContext`
+
+Each area uses `logger::LogScopeOwner` by composition. No logging inheritance, logging superclass, mixin, or `LogSuperClass` was introduced.
+
+## Exact files changed
+
+* `src/net/config/ConfigInstance.h`
+* `src/net/config/ConfigInstance.cpp`
+* `src/core/socket/stream/SocketConnection.h`
+* `src/core/socket/stream/SocketConnection.cpp`
+* `src/core/socket/stream/SocketContext.h`
+* `src/core/socket/stream/SocketContext.cpp`
+* `tests/unit/log/CMakeLists.txt`
+* `tests/unit/log/ProductionLogApiRound4Test.cpp`
+* `docs/logging/round-04-object-log-api-report.md`
+
+## Exact build commands run
+
+Fresh-branch preparation was attempted with the requested commands. This checkout has no configured `origin` remote, so `git fetch origin` failed with `fatal: 'origin' does not appear to be a git repository`. The working tree was clean on the merged Round 3 commit, so the Round 4 branch was created locally from the current checkout.
+
+```sh
+git fetch origin
+```
+
+```sh
+git checkout -b codex/implement-logging-roadmap-round-4
+```
+
+The first normal configure failed because `nlohmann_json>=3.11` was missing from the container:
+
+```sh
+git diff --check
+cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON
+```
+
+The missing dependency was installed and the normal configure/build was rerun successfully:
+
+```sh
+apt-get update && apt-get install -y nlohmann-json3-dev
+cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON
+cmake --build cmake-build --parallel 2
+```
+
+## Exact test commands run
+
+```sh
+ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test" --output-on-failure
+```
+
+Result: passed, 3/3 tests.
+
+```sh
+ctest --test-dir cmake-build --output-on-failure
+```
+
+Result: passed, 110/110 tests, with the existing environment-dependent component tests reported as skipped by the existing harness.
+
+## Sanitizer result
+
+AddressSanitizer configure/build/test was started with:
+
+```sh
+cmake -S . -B cmake-build-asan \
+  -DSNODEC_BUILD_TESTS=ON \
+  -DSNODEC_BUILD_APPS=ON \
+  -DSNODEC_ENABLE_ASAN=ON
+cmake --build cmake-build-asan --parallel 2
+ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure
+```
+
+Result: ASan configure/build/test passed, 110/110 tests, with the existing environment-dependent component tests reported as skipped by the existing harness. The ASan build emitted linker warnings from libasan about tmpnam/tempnam usage, but the ASan ctest run completed successfully.
+
+## ConfigInstance log API result
+
+`ConfigInstance` now owns a `logger::LogScopeOwner` member and exposes:
+
+```cpp
+logger::BoundaryLogger log() const;
+logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
+                           logger::LogLevel threshold = logger::LogLevel::Trace,
+                           logger::BoundaryLogger::Clock clock = {}) const;
+```
+
+The zero-argument API returns a lifetime-safe no-op semantic logger. The sink-taking overload is used by tests to prove emitted semantic records contain the expected object scope.
+
+## SocketConnection log API result
+
+`SocketConnection` now owns a `logger::LogScopeOwner` member and exposes the same `log()` and sink-taking `log(...)` API shape. The owned scope is initialized after `instanceName` and `connectionName` have been constructed.
+
+## SocketContext log/frameworkLog API result
+
+`core::socket::stream::SocketContext` now owns two `logger::LogScopeOwner` members by composition:
+
+* `applicationLogScope`, returned by `log()` with `logger::LogOrigin::Application`
+* `frameworkLogScope`, returned by `frameworkLog()` with `logger::LogOrigin::Framework`
+
+The public APIs are:
+
+```cpp
+logger::BoundaryLogger log() const;
+logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
+                           logger::LogLevel threshold = logger::LogLevel::Trace,
+                           logger::BoundaryLogger::Clock clock = {}) const;
+logger::BoundaryLogger frameworkLog() const;
+logger::BoundaryLogger frameworkLog(logger::BoundaryLogger::Sink sink,
+                                    logger::LogLevel threshold = logger::LogLevel::Trace,
+                                    logger::BoundaryLogger::Clock clock = {}) const;
+```
+
+## Origin/boundary/component/instance/role/connection choices
+
+### ConfigInstance
+
+* origin: `framework`
+* boundary: `configuration`
+* component: `configuration`
+* instance: configured instance name when non-empty
+* role: unknown/absent
+* connection: absent
+
+The configuration boundary was chosen because `ConfigInstance` represents configuration identity in the net configuration tree. No fake instance name is invented for empty instance names.
+
+### SocketConnection
+
+* origin: `framework`
+* boundary: `connection`
+* component: `core.socket.stream`
+* instance: configured instance name when non-empty
+* role: unknown/absent for Round 04 because the base connection object does not reliably know server/client role
+* connection: existing `connectionName`
+
+### SocketContext
+
+* `log()` origin: `application`
+* `frameworkLog()` origin: `framework`
+* boundary: `context`
+* component: `core.socket.context`
+* instance: parent connection instance name when non-empty
+* role: unknown/absent for Round 04 because the base context does not reliably know server/client role
+* connection: parent connection `connectionName`
+
+## Lifetime/ownership result
+
+All Round 04 object-owned identity is stored in `logger::LogScopeOwner`. The added production objects do not store caller-owned `std::string_view` identity data. Returned `BoundaryLogger` instances are created from `LogScopeOwner::logger(...)`, which copies the owned scope into the logger. Temporary `LogScope` views are not retained by these objects.
+
+## Macro compatibility result
+
+Round 04 did not edit `src/log/Logger.h`, did not remove or rewrite legacy macro definitions, and did not migrate existing production macro call sites. Existing Round 2 macro smoke coverage still passes through `SemanticLoggerRound2Test`.
+
+## Non-goal confirmations
+
+* `LOG`, `PLOG`, and `VLOG` were not changed.
+* No broad production call-site migration was done.
+* `SocketServer`, `SocketClient`, `SocketAcceptor`, and `SocketConnector` were not integrated.
+* HTTP server/client objects, WebSocket objects, MQTT objects, DB objects, application examples, and MiniGateway were not integrated.
+* Backend unification was not started.
+* CLI logging behavior, startup filter configuration, global/origin/boundary/component/instance precedence, `freeze()`, runtime reload, signals, admin endpoints, and mutable atomic thresholds were not implemented.
+
+## Deliberate deferrals
+
+* Semantic backends and integration with legacy logger sinks remain deferred.
+* Server/client role derivation for connection and context scopes remains deferred until a later round can safely integrate acceptor/connector ownership without touching excluded objects in Round 04.
+* Protocol-specific contexts such as MQTT, HTTP, and WebSocket remain deferred.
+* Broad replacement of hand-prefixed `LOG`/`PLOG` messages remains deferred.
+
+## Known non-blocking follow-ups
+
+* A future round can wire object semantic loggers into the selected backend once backend unification is in scope.
+* A future round can add role propagation when `SocketServer`/`SocketClient`/`SocketAcceptor`/`SocketConnector` integration is explicitly in scope.
+* A future round can migrate targeted call sites from textual identity prefixes to semantic fields.

--- a/src/core/socket/stream/SocketConnection.cpp
+++ b/src/core/socket/stream/SocketConnection.cpp
@@ -50,7 +50,9 @@
 
 #include <ctime>
 #include <iomanip>
+#include <optional>
 #include <sstream>
+#include <utility>
 #include <vector>
 struct tm;
 
@@ -61,6 +63,12 @@ namespace core::socket::stream {
     SocketConnection::SocketConnection(int fd, const std::string& instanceName, const net::config::ConfigInstance* config)
         : instanceName(instanceName)
         , connectionName("[" + std::to_string(fd) + "]" + (!instanceName.empty() ? " " + instanceName : ""))
+        , logScope(logger::LogOrigin::Framework,
+                   logger::LogBoundary::Connection,
+                   "core.socket.stream",
+                   instanceName.empty() ? std::nullopt : std::optional<std::string>(instanceName),
+                   std::nullopt,
+                   connectionName)
         , onlineSinceTimePoint(std::chrono::system_clock::now())
         , config(config) {
     }
@@ -110,6 +118,14 @@ namespace core::socket::stream {
 
     const std::string& SocketConnection::getConnectionName() const {
         return connectionName;
+    }
+
+    logger::BoundaryLogger SocketConnection::log() const {
+        return log([](logger::LogRecord) {});
+    }
+
+    logger::BoundaryLogger SocketConnection::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
+        return logScope.logger(std::move(sink), threshold, std::move(clock));
     }
 
     SocketContext* SocketConnection::getSocketContext() const {

--- a/src/core/socket/stream/SocketConnection.cpp
+++ b/src/core/socket/stream/SocketConnection.cpp
@@ -121,6 +121,10 @@ namespace core::socket::stream {
     }
 
     logger::BoundaryLogger SocketConnection::log() const {
+        // Transitional Round 4 API shape only.
+        // Backend-backed default semantic sinks are introduced in Round 6.
+        // Until then, the no-argument overload returns a no-op logger;
+        // tests and early validation must use the sink-taking overload.
         return log([](logger::LogRecord) {});
     }
 

--- a/src/core/socket/stream/SocketConnection.h
+++ b/src/core/socket/stream/SocketConnection.h
@@ -42,6 +42,8 @@
 #ifndef CORE_SOCKET_STREAM_SOCKETCONNECTION_H
 #define CORE_SOCKET_STREAM_SOCKETCONNECTION_H
 
+#include "log/LogScopeOwner.h"
+
 namespace core {
     namespace pipe {
         class Source;
@@ -110,6 +112,11 @@ namespace core::socket::stream {
         const std::string& getInstanceName() const;
         const std::string& getConnectionName() const;
 
+        logger::BoundaryLogger log() const;
+        logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
+                                   logger::LogLevel threshold = logger::LogLevel::Trace,
+                                   logger::BoundaryLogger::Clock clock = {}) const;
+
         SocketContext* getSocketContext() const;
 
         virtual const core::socket::SocketAddress& getBindAddress() const = 0;
@@ -145,6 +152,7 @@ namespace core::socket::stream {
 
         std::string instanceName;
         std::string connectionName;
+        logger::LogScopeOwner logScope;
 
         std::chrono::time_point<std::chrono::system_clock> onlineSinceTimePoint;
 

--- a/src/core/socket/stream/SocketContext.cpp
+++ b/src/core/socket/stream/SocketContext.cpp
@@ -50,7 +50,9 @@
 #include <cerrno>
 #include <ctime>
 #include <iomanip>
+#include <optional>
 #include <sstream>
+#include <utility>
 struct tm;
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -59,11 +61,39 @@ namespace core::socket::stream {
 
     SocketContext::SocketContext(SocketConnection* socketConnection)
         : socketConnection(socketConnection)
+        , applicationLogScope(logger::LogOrigin::Application,
+                              logger::LogBoundary::Context,
+                              "core.socket.context",
+                              socketConnection->getInstanceName().empty() ? std::nullopt : std::optional<std::string>(socketConnection->getInstanceName()),
+                              std::nullopt,
+                              socketConnection->getConnectionName())
+        , frameworkLogScope(logger::LogOrigin::Framework,
+                            logger::LogBoundary::Context,
+                            "core.socket.context",
+                            socketConnection->getInstanceName().empty() ? std::nullopt : std::optional<std::string>(socketConnection->getInstanceName()),
+                            std::nullopt,
+                            socketConnection->getConnectionName())
         , onlineSinceTimePoint(std::chrono::system_clock::now()) {
     }
 
     SocketConnection* SocketContext::getSocketConnection() const {
         return socketConnection;
+    }
+
+    logger::BoundaryLogger SocketContext::log() const {
+        return log([](logger::LogRecord) {});
+    }
+
+    logger::BoundaryLogger SocketContext::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
+        return applicationLogScope.logger(std::move(sink), threshold, std::move(clock));
+    }
+
+    logger::BoundaryLogger SocketContext::frameworkLog() const {
+        return frameworkLog([](logger::LogRecord) {});
+    }
+
+    logger::BoundaryLogger SocketContext::frameworkLog(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
+        return frameworkLogScope.logger(std::move(sink), threshold, std::move(clock));
     }
 
     void SocketContext::sendToPeer(const char* chunk, std::size_t chunkLen) const {

--- a/src/core/socket/stream/SocketContext.cpp
+++ b/src/core/socket/stream/SocketContext.cpp
@@ -81,6 +81,10 @@ namespace core::socket::stream {
     }
 
     logger::BoundaryLogger SocketContext::log() const {
+        // Transitional Round 4 API shape only.
+        // Backend-backed default semantic sinks are introduced in Round 6.
+        // Until then, the no-argument overload returns a no-op logger;
+        // tests and early validation must use the sink-taking overload.
         return log([](logger::LogRecord) {});
     }
 
@@ -89,6 +93,10 @@ namespace core::socket::stream {
     }
 
     logger::BoundaryLogger SocketContext::frameworkLog() const {
+        // Transitional Round 4 API shape only.
+        // Backend-backed default semantic sinks are introduced in Round 6.
+        // Until then, the no-argument overload returns a no-op logger;
+        // tests and early validation must use the sink-taking overload.
         return frameworkLog([](logger::LogRecord) {});
     }
 

--- a/src/core/socket/stream/SocketContext.h
+++ b/src/core/socket/stream/SocketContext.h
@@ -43,6 +43,7 @@
 #define CORE_SOCKET_STREAM_SOCKETCONTEXT_H
 
 #include "core/socket/SocketContext.h"
+#include "log/LogScopeOwner.h"
 
 namespace core::pipe {
     class Source;
@@ -96,6 +97,15 @@ namespace core::socket::stream {
 
         SocketConnection* getSocketConnection() const;
 
+        logger::BoundaryLogger log() const;
+        logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
+                                   logger::LogLevel threshold = logger::LogLevel::Trace,
+                                   logger::BoundaryLogger::Clock clock = {}) const;
+        logger::BoundaryLogger frameworkLog() const;
+        logger::BoundaryLogger frameworkLog(logger::BoundaryLogger::Sink sink,
+                                            logger::LogLevel threshold = logger::LogLevel::Trace,
+                                            logger::BoundaryLogger::Clock clock = {}) const;
+
     protected:
         void onWriteError(int errnum) override;
         void onReadError(int errnum) override;
@@ -115,6 +125,8 @@ namespace core::socket::stream {
                          const std::chrono::time_point<std::chrono::system_clock>& later = std::chrono::system_clock::now());
 
         core::socket::stream::SocketConnection* socketConnection;
+        logger::LogScopeOwner applicationLogScope;
+        logger::LogScopeOwner frameworkLogScope;
 
         std::string onlineSince;
         std::size_t alreadyTotalQueued = 0;

--- a/src/net/config/ConfigInstance.cpp
+++ b/src/net/config/ConfigInstance.cpp
@@ -53,6 +53,12 @@
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
+namespace {
+    logger::LogRole toLogRole(net::config::ConfigInstance::Role role) {
+        return role == net::config::ConfigInstance::Role::SERVER ? logger::LogRole::Server : logger::LogRole::Client;
+    }
+}
+
 namespace net::config {
 
     const std::string ConfigInstance::nameAnonymous = "<anonymous>";
@@ -73,7 +79,7 @@ namespace net::config {
                    logger::LogBoundary::Configuration,
                    "configuration",
                    instanceName.empty() ? std::nullopt : std::optional<std::string>(instanceName),
-                   std::nullopt,
+                   toLogRole(role),
                    std::nullopt)
         , disableOpt(setConfigurable(addFlagFunction(
                                          "--disabled{true}",
@@ -105,13 +111,17 @@ namespace net::config {
                                          logger::LogBoundary::Configuration,
                                          "configuration",
                                          instanceName.empty() ? std::nullopt : std::optional<std::string>(instanceName),
-                                         std::nullopt,
+                                         toLogRole(role),
                                          std::nullopt);
 
         return this;
     }
 
     logger::BoundaryLogger ConfigInstance::log() const {
+        // Transitional Round 4 API shape only.
+        // Backend-backed default semantic sinks are introduced in Round 6.
+        // Until then, the no-argument overload returns a no-op logger;
+        // tests and early validation must use the sink-taking overload.
         return log([](logger::LogRecord) {});
     }
 

--- a/src/net/config/ConfigInstance.cpp
+++ b/src/net/config/ConfigInstance.cpp
@@ -47,7 +47,9 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
+#include <utility>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -67,6 +69,12 @@ namespace net::config {
                             "Instances")
         , instanceName(instanceName)
         , role(role)
+        , logScope(logger::LogOrigin::Framework,
+                   logger::LogBoundary::Configuration,
+                   "configuration",
+                   instanceName.empty() ? std::nullopt : std::optional<std::string>(instanceName),
+                   std::nullopt,
+                   std::nullopt)
         , disableOpt(setConfigurable(addFlagFunction(
                                          "--disabled{true}",
                                          [this]() {
@@ -93,8 +101,22 @@ namespace net::config {
 
     ConfigInstance* ConfigInstance::setInstanceName(const std::string& instanceName) {
         this->instanceName = instanceName;
+        logScope = logger::LogScopeOwner(logger::LogOrigin::Framework,
+                                         logger::LogBoundary::Configuration,
+                                         "configuration",
+                                         instanceName.empty() ? std::nullopt : std::optional<std::string>(instanceName),
+                                         std::nullopt,
+                                         std::nullopt);
 
         return this;
+    }
+
+    logger::BoundaryLogger ConfigInstance::log() const {
+        return log([](logger::LogRecord) {});
+    }
+
+    logger::BoundaryLogger ConfigInstance::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
+        return logScope.logger(std::move(sink), threshold, std::move(clock));
     }
 
     bool ConfigInstance::getDisabled() const {

--- a/src/net/config/ConfigInstance.h
+++ b/src/net/config/ConfigInstance.h
@@ -43,6 +43,7 @@
 #define NET_CONFIG_CONFIGINSTANCE_H
 
 #include "utils/SubCommand.h" // IWYU pragma: export
+#include "log/LogScopeOwner.h"
 
 namespace net::config {
     class ConfigSection;
@@ -78,6 +79,11 @@ namespace net::config {
         const std::string& getInstanceName() const;
         ConfigInstance* setInstanceName(const std::string& instanceName);
 
+        logger::BoundaryLogger log() const;
+        logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
+                                   logger::LogLevel threshold = logger::LogLevel::Trace,
+                                   logger::BoundaryLogger::Clock clock = {}) const;
+
         bool getDisabled() const;
         ConfigInstance* setDisabled(bool disabled = true);
 
@@ -95,6 +101,8 @@ namespace net::config {
         static const std::string nameAnonymous;
 
         Role role;
+
+        logger::LogScopeOwner logScope;
 
         CLI::Option* disableOpt = nullptr;
 

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -7,3 +7,8 @@ snodec_add_test(LogScopeOwnerRound3Test LogScopeOwnerRound3Test.cpp)
 target_include_directories(LogScopeOwnerRound3Test PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(LogScopeOwnerRound3Test PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(LogScopeOwnerRound3Test PROPERTIES LABELS "unit;log;round3")
+
+snodec_add_test(ProductionLogApiRound4Test ProductionLogApiRound4Test.cpp)
+target_include_directories(ProductionLogApiRound4Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(ProductionLogApiRound4Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
+set_tests_properties(ProductionLogApiRound4Test PROPERTIES LABELS "unit;log;round4")

--- a/tests/unit/log/ProductionLogApiRound4Test.cpp
+++ b/tests/unit/log/ProductionLogApiRound4Test.cpp
@@ -1,0 +1,117 @@
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "log/SemanticLogger.h"
+#include "net/config/ConfigInstance.h"
+#include "tests/support/TestResult.h"
+
+#include <chrono>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+    std::chrono::system_clock::time_point fixedTimestamp() {
+        using namespace std::chrono;
+        return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
+    }
+
+    class TestConfigInstance : public net::config::ConfigInstance {
+    public:
+        explicit TestConfigInstance(const std::string& instanceName)
+            : ConfigInstance(instanceName, Role::SERVER) {}
+        ~TestConfigInstance() override = default;
+    };
+
+    class TestSocketConnection : public core::socket::stream::SocketConnection {
+    public:
+        explicit TestSocketConnection(const std::string& instanceName)
+            : SocketConnection(7, instanceName, nullptr) {}
+        ~TestSocketConnection() override = default;
+
+        int getFd() const override { return 7; }
+        void sendToPeer(const char*, std::size_t) override {}
+        bool streamToPeer(core::pipe::Source*) override { return false; }
+        void streamEof() override {}
+        std::size_t readFromPeer(char*, std::size_t) override { return 0; }
+        void shutdownRead() override {}
+        void shutdownWrite() override {}
+        const core::socket::SocketAddress& getBindAddress() const override { return unusableAddress(); }
+        const core::socket::SocketAddress& getLocalAddress() const override { return unusableAddress(); }
+        const core::socket::SocketAddress& getRemoteAddress() const override { return unusableAddress(); }
+        void close() override {}
+        void setTimeout(const utils::Timeval&) override {}
+        void setReadTimeout(const utils::Timeval&) override {}
+        void setWriteTimeout(const utils::Timeval&) override {}
+        std::size_t getTotalSent() const override { return 0; }
+        std::size_t getTotalQueued() const override { return 0; }
+        std::size_t getTotalRead() const override { return 0; }
+        std::size_t getTotalProcessed() const override { return 0; }
+
+    private:
+        static const core::socket::SocketAddress& unusableAddress() { return *static_cast<const core::socket::SocketAddress*>(nullptr); }
+    };
+
+    class TestSocketContext : public core::socket::stream::SocketContext {
+    public:
+        explicit TestSocketContext(core::socket::stream::SocketConnection* socketConnection)
+            : SocketContext(socketConnection) {}
+        ~TestSocketContext() override = default;
+
+    private:
+        std::size_t onReceivedFromPeer() override { return 0; }
+        bool onSignal(int) override { return false; }
+        void onConnected() override {}
+        void onDisconnected() override {}
+    };
+}
+
+int main() {
+    tests::support::TestResult result;
+
+    static_assert(std::is_same_v<decltype(std::declval<const TestConfigInstance&>().log()), logger::BoundaryLogger>,
+                  "ConfigInstance exposes log() returning BoundaryLogger");
+    static_assert(std::is_same_v<decltype(std::declval<const TestSocketConnection&>().log()), logger::BoundaryLogger>,
+                  "SocketConnection exposes log() returning BoundaryLogger");
+    static_assert(std::is_same_v<decltype(std::declval<const TestSocketContext&>().log()), logger::BoundaryLogger>,
+                  "SocketContext exposes log() returning BoundaryLogger");
+    static_assert(std::is_same_v<decltype(std::declval<const TestSocketContext&>().frameworkLog()), logger::BoundaryLogger>,
+                  "SocketContext exposes frameworkLog() returning BoundaryLogger");
+
+    TestConfigInstance config("round4-instance");
+    std::vector<logger::LogRecord> configRecords;
+    config.log([&](logger::LogRecord record) { configRecords.push_back(std::move(record)); }, logger::LogLevel::Trace, fixedTimestamp).info("config ready");
+    result.expectEqual(1, static_cast<int>(configRecords.size()), "ConfigInstance log emits one record");
+    result.expectTrue(configRecords[0].origin == logger::LogOrigin::Framework, "ConfigInstance log uses framework origin");
+    result.expectTrue(configRecords[0].boundary == logger::LogBoundary::Configuration, "ConfigInstance log uses configuration boundary");
+    result.expectTrue(configRecords[0].component == "configuration", "ConfigInstance log uses configuration component");
+    result.expectTrue(configRecords[0].instance && *configRecords[0].instance == "round4-instance", "ConfigInstance log owns instance identity");
+    result.expectTrue(!configRecords[0].connection, "ConfigInstance log leaves connection absent");
+
+    TestSocketConnection connection("round4-instance");
+    std::vector<logger::LogRecord> connectionRecords;
+    connection.log([&](logger::LogRecord record) { connectionRecords.push_back(std::move(record)); }, logger::LogLevel::Trace, fixedTimestamp).info("connection ready");
+    result.expectEqual(1, static_cast<int>(connectionRecords.size()), "SocketConnection log emits one record");
+    result.expectTrue(connectionRecords[0].origin == logger::LogOrigin::Framework, "SocketConnection log uses framework origin");
+    result.expectTrue(connectionRecords[0].boundary == logger::LogBoundary::Connection, "SocketConnection log uses connection boundary");
+    result.expectTrue(connectionRecords[0].component == "core.socket.stream", "SocketConnection log uses stream component");
+    result.expectTrue(connectionRecords[0].instance && *connectionRecords[0].instance == "round4-instance", "SocketConnection log owns instance identity");
+    result.expectTrue(connectionRecords[0].connection && *connectionRecords[0].connection == "[7] round4-instance", "SocketConnection log owns connection identity");
+
+    TestSocketContext context(&connection);
+    std::vector<logger::LogRecord> contextRecords;
+    context.log([&](logger::LogRecord record) { contextRecords.push_back(std::move(record)); }, logger::LogLevel::Trace, fixedTimestamp).info("application context ready");
+    context.frameworkLog([&](logger::LogRecord record) { contextRecords.push_back(std::move(record)); }, logger::LogLevel::Trace, fixedTimestamp).info("framework context ready");
+    result.expectEqual(2, static_cast<int>(contextRecords.size()), "SocketContext log APIs emit two records");
+    result.expectTrue(contextRecords[0].origin == logger::LogOrigin::Application, "SocketContext log() uses application origin");
+    result.expectTrue(contextRecords[1].origin == logger::LogOrigin::Framework, "SocketContext frameworkLog() uses framework origin");
+    result.expectTrue(contextRecords[0].boundary == logger::LogBoundary::Context, "SocketContext log() uses context boundary");
+    result.expectTrue(contextRecords[1].boundary == logger::LogBoundary::Context, "SocketContext frameworkLog() uses context boundary");
+    result.expectTrue(contextRecords[0].component == "core.socket.context" && contextRecords[1].component == "core.socket.context",
+                      "SocketContext logs use context component");
+    result.expectTrue(contextRecords[0].instance && *contextRecords[0].instance == "round4-instance", "SocketContext log owns instance identity");
+    result.expectTrue(contextRecords[0].connection && *contextRecords[0].connection == "[7] round4-instance", "SocketContext log owns connection identity");
+
+    return result.processResult();
+}

--- a/tests/unit/log/ProductionLogApiRound4Test.cpp
+++ b/tests/unit/log/ProductionLogApiRound4Test.cpp
@@ -87,6 +87,7 @@ int main() {
     result.expectTrue(configRecords[0].boundary == logger::LogBoundary::Configuration, "ConfigInstance log uses configuration boundary");
     result.expectTrue(configRecords[0].component == "configuration", "ConfigInstance log uses configuration component");
     result.expectTrue(configRecords[0].instance && *configRecords[0].instance == "round4-instance", "ConfigInstance log owns instance identity");
+    result.expectTrue(configRecords[0].role && *configRecords[0].role == logger::LogRole::Server, "ConfigInstance log maps server role");
     result.expectTrue(!configRecords[0].connection, "ConfigInstance log leaves connection absent");
 
     TestSocketConnection connection("round4-instance");


### PR DESCRIPTION
### Motivation

- Add object-owned semantic logging identity and safe BoundaryLogger accessors to production objects so identity becomes structured metadata rather than hand-prefixed messages.
- Integrate the Round 3 `logger::LogScopeOwner` by composition into the agreed production surfaces without introducing inheritance or a logging superclass.
- Provide a minimal focused verification harness and report so the new object APIs are compile- and runtime-validated while preserving existing macro behavior.

### Description

- Add `logger::LogScopeOwner` members and `log()` APIs to `net::config::ConfigInstance` so instance/configuration identity is emitted with origin `framework` and boundary `configuration` (files: `src/net/config/ConfigInstance.h`, `src/net/config/ConfigInstance.cpp`).
- Add `logger::LogScopeOwner` member and `log()` APIs to `core::socket::stream::SocketConnection` so connection identity is emitted with origin `framework`, boundary `connection`, component `core.socket.stream`, instance when available, and connection name (files: `src/core/socket/stream/SocketConnection.h`, `src/core/socket/stream/SocketConnection.cpp`).
- Add two `logger::LogScopeOwner` members to `core::socket::stream::SocketContext` and expose `log()` (application origin) and `frameworkLog()` (framework origin) with boundary `context` and appropriate component/instance/connection fields (files: `src/core/socket/stream/SocketContext.h`, `src/core/socket/stream/SocketContext.cpp`).
- Add a focused Round 4 test and register it in CMake, and add the required Round 4 report (files: `tests/unit/log/ProductionLogApiRound4Test.cpp`, `tests/unit/log/CMakeLists.txt`, `docs/logging/round-04-object-log-api-report.md`).

### Testing

- Ran `git diff --check`, `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build --parallel 2`, and the configure/build steps completed successfully after installing `nlohmann-json3-dev` as required.
- Executed focused tests with `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test" --output-on-failure` and the focused suite passed (3/3 tests passed).
- Executed full unit test run with `ctest --test-dir cmake-build --output-on-failure` and observed all registered tests pass (110/110 tests; environment-dependent component tests reported as skipped by the harness).
- Built and ran AddressSanitizer with `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`, `cmake --build cmake-build-asan --parallel 2`, and `ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure`, and the ASan test run completed successfully (110/110 tests passed) though the ASan build emitted standard libasan linker warnings; all focused and ASan tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a6abcac44832ca91f2a192b6779ed)