### PR TITLE
Logging roadmap round 06 — backend unification

### DIFF
--- a/docs/logging/round-06-backend-unification-report.md
+++ b/docs/logging/round-06-backend-unification-report.md
@@ -1,0 +1,150 @@
+# Logging roadmap round 06 — backend unification report
+
+## Implementation summary
+
+Round 6 replaces the Round 4/5 no-op default semantic loggers with backend-backed default semantic loggers.
+
+The implementation adds a narrow semantic backend path to `logger::Logger` and wires default no-argument semantic logger APIs to that backend. Semantic records are formatted with the existing Round 2 text formatter and emitted through the same `Logger.cpp` stdout/file sink infrastructure used by `LOG`, `PLOG`, and `VLOG`.
+
+The environment had no usable `origin` remote: `git fetch origin` failed with `fatal: 'origin' does not appear to be a git repository`. The checked-out commit already contained merged Round 5 (`b09bffa Merge pull request #146 from SNodeC/codex/implement-logging-for-socket-endpoints`), the working tree was clean, and the Round 6 branch was created from that current commit.
+
+## Exact files changed
+
+- `src/log/Logger.h`
+- `src/log/Logger.cpp`
+- `src/net/config/ConfigInstance.cpp`
+- `src/core/socket/stream/SocketConnection.cpp`
+- `src/core/socket/stream/SocketContext.cpp`
+- `src/core/socket/stream/SocketServer.h`
+- `src/core/socket/stream/SocketClient.h`
+- `src/core/socket/stream/SocketConnector.h`
+- `src/core/socket/stream/SocketAcceptor.h`
+- `tests/unit/log/CMakeLists.txt`
+- `tests/unit/log/SemanticBackendRound6Test.cpp`
+- `docs/logging/round-06-backend-unification-report.md`
+
+## Semantic backend API added
+
+`logger::Logger` now exposes:
+
+- `static void emitSemantic(const logger::LogRecord& record);`
+- `static logger::BoundaryLogger::Sink semanticSink();`
+
+`emitSemantic` is the narrow backend bridge. `semanticSink` returns a `BoundaryLogger` sink that forwards materialized semantic records to `emitSemantic`.
+
+## LogLevel to legacy Level mapping
+
+Round 6 maps semantic levels to existing legacy levels as follows:
+
+- `logger::LogLevel::Trace` -> `logger::Level::TRACE`
+- `logger::LogLevel::Debug` -> `logger::Level::DEBUG`
+- `logger::LogLevel::Info` -> `logger::Level::INFO`
+- `logger::LogLevel::Warn` -> `logger::Level::WARNING`
+- `logger::LogLevel::Error` -> `logger::Level::ERROR`
+- `logger::LogLevel::Critical` -> `logger::Level::FATAL`
+- `logger::LogLevel::Off` -> no emission
+
+Semantic backend emission uses `Logger::shouldLog(...)` through that mapping. Round 6 does not add a second semantic threshold system.
+
+## Default no-argument semantic logger result
+
+The following no-argument APIs now return backend-backed semantic loggers instead of no-op loggers:
+
+- `ConfigInstance::log()`
+- `SocketConnection::log()`
+- `SocketContext::log()`
+- `SocketContext::frameworkLog()`
+- `SocketServer::log()`
+- `SocketClient::log()`
+- `SocketConnector::log()`
+- `SocketAcceptor::log()`
+
+Each default logger uses `logger::Logger::semanticSink()` and therefore emits through the existing logger backend when `Logger::setLogLevel(...)` enables the mapped legacy level.
+
+## Sink-taking overload compatibility result
+
+The sink-taking overloads remain available and continue to bypass/capture semantic records for tests and custom integrations. Existing Round 4 and Round 5 API-shape tests pass, and `SemanticBackendRound6Test` adds a direct custom-sink compatibility assertion.
+
+## Legacy macro compatibility result
+
+`LOG`, `PLOG`, and `VLOG` macro syntax was not changed. No production `LOG`, `PLOG`, or `VLOG` call sites were migrated. A Round 6 test confirms legacy `LOG(INFO)` still emits through the backend while semantic emission uses the same file sink.
+
+Round 6 does not migrate production LOG/PLOG/VLOG call sites. Controlled subsystem migration remains Round 8 work.
+
+## CLI behavior preservation result
+
+Round 6 adds no CLI options, renames no CLI options, and changes no CLI defaults. Existing numeric log-level behavior remains the filtering mechanism for semantic backend emission. Verbose-level behavior and `VLOG` remain unchanged.
+
+## stdout/file/quiet/color/tick behavior result
+
+Semantic default backend emission reuses the existing `Logger.cpp` `emitLine` path, so it inherits:
+
+- stdout logging when not quiet,
+- file logging when `Logger::logToFile(...)` is enabled,
+- `Logger::setQuiet(...)` stdout suppression,
+- existing color-disable behavior for legacy level labels,
+- existing tick resolver / timestamp pattern behavior,
+- existing rotating file sink setup.
+
+The focused Round 6 test uses a controlled file sink and controlled tick resolver to verify file emission and tick resolver use without depending on wall-clock output.
+
+## Filtering result
+
+Filtering is only the existing numeric `Logger::setLogLevel(...)` behavior. There is no semantic precedence and no independent semantic runtime threshold configuration in Round 6.
+
+Round 6 does not implement startup-only semantic filtering. The semantic filter precedence instance > component > boundary > origin > global remains Round 7 work.
+
+## Confirmation of non-goals
+
+- No startup semantic filter configuration was implemented.
+- No global/origin/boundary/component/instance precedence was implemented.
+- No `LogManager::freeze()` or `freeze()` equivalent was implemented.
+- No runtime reload, signals, admin endpoints, or mutable atomic semantic thresholds were implemented.
+- No production call-site migration was done.
+- Backend unification did not start Round 7 or Round 8.
+
+## Exact build commands run
+
+```sh
+git fetch origin
+git checkout master
+git pull --ff-only origin master
+git status --short
+git checkout -b codex/implement-logging-roadmap-round-6
+git status --short
+git diff --check
+cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON
+cmake --build cmake-build --parallel 2
+cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON
+cmake --build cmake-build-asan --parallel 2
+```
+
+`git fetch origin` failed because the environment has no usable `origin` remote. `git checkout master` also could not be used because this environment only had the `work` branch, but that branch pointed at the current Round 5 merge commit listed above.
+
+The first configure attempt failed before installing missing optional/development packages because `nlohmann-json3-dev` was absent. The environment allowed installing `nlohmann-json3-dev`, `libmagic-dev`, and `libbluetooth-dev`, after which the required apps-enabled configure and build succeeded.
+
+## Exact test commands run
+
+```sh
+ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test" --output-on-failure
+ctest --test-dir cmake-build --output-on-failure
+ASAN=$(gcc -print-file-name=libasan.so); LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure
+```
+
+## Sanitizer result
+
+ASan was run successfully. The ASan build completed with linker warnings from `libasan.so.8` about `tmpnam`/`tempnam` use, and the ASan `ctest` run reported 100% tests passed with skipped integration tests matching the normal test run behavior.
+
+## Deliberate deferrals
+
+- Startup-only semantic filter configuration remains Round 7 work.
+- Semantic filter precedence `instance > component > boundary > origin > global` remains Round 7 work.
+- Runtime format selection between text and JSON remains deferred.
+- Controlled production call-site migration remains Round 8 work.
+- Broader CLI-facing semantic configuration remains deferred.
+
+## Known non-blocking follow-ups
+
+- Consider a future runtime format selection API when Round 7 introduces semantic startup configuration.
+- Consider additional direct stdout/quiet/color assertions if a future test sink hook is accepted; Round 6 used controlled file sinks to avoid broad public backend replacement APIs.
+- The broader SNode.C and MQTT suite still have many integration tests skipped in this container due the existing test environment gating; those are not introduced by Round 6.

--- a/src/core/socket/stream/SocketAcceptor.h
+++ b/src/core/socket/stream/SocketAcceptor.h
@@ -45,6 +45,7 @@
 #include "core/eventreceiver/AcceptEventReceiver.h" // IWYU pragma: export
 #include "core/socket/State.h"
 #include "log/LogScopeOwner.h"
+#include "log/Logger.h"
 #include "log/SemanticLogger.h"
 
 namespace core::socket::stream {
@@ -94,11 +95,10 @@ namespace core::socket::stream {
         virtual void init();
 
         logger::BoundaryLogger log() const {
-            // Transitional Round 5 API shape only.
-            // Backend-backed default semantic sinks are introduced in Round 6.
-            // Until then, the no-argument overload returns a no-op logger;
-            // tests and early validation must use the sink-taking overload.
-            return log([](logger::LogRecord) {});
+            // Round 6 backend-backed default semantic logger.
+            // The sink-taking overload remains available for tests and custom capture.
+            // Startup semantic filter configuration is deferred to Round 7.
+            return log(logger::Logger::semanticSink());
         }
 
         logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,

--- a/src/core/socket/stream/SocketClient.h
+++ b/src/core/socket/stream/SocketClient.h
@@ -303,11 +303,10 @@ namespace core::socket::stream {
 
 
         logger::BoundaryLogger log() const {
-            // Transitional Round 5 API shape only.
-            // Backend-backed default semantic sinks are introduced in Round 6.
-            // Until then, the no-argument overload returns a no-op logger;
-            // tests and early validation must use the sink-taking overload.
-            return log([](logger::LogRecord) {});
+            // Round 6 backend-backed default semantic logger.
+            // The sink-taking overload remains available for tests and custom capture.
+            // Startup semantic filter configuration is deferred to Round 7.
+            return log(logger::Logger::semanticSink());
         }
 
         logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,

--- a/src/core/socket/stream/SocketConnection.cpp
+++ b/src/core/socket/stream/SocketConnection.cpp
@@ -121,11 +121,10 @@ namespace core::socket::stream {
     }
 
     logger::BoundaryLogger SocketConnection::log() const {
-        // Transitional Round 4 API shape only.
-        // Backend-backed default semantic sinks are introduced in Round 6.
-        // Until then, the no-argument overload returns a no-op logger;
-        // tests and early validation must use the sink-taking overload.
-        return log([](logger::LogRecord) {});
+        // Round 6 backend-backed default semantic logger.
+        // The sink-taking overload remains available for tests and custom capture.
+        // Startup semantic filter configuration is deferred to Round 7.
+        return log(logger::Logger::semanticSink());
     }
 
     logger::BoundaryLogger SocketConnection::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {

--- a/src/core/socket/stream/SocketConnector.h
+++ b/src/core/socket/stream/SocketConnector.h
@@ -45,6 +45,7 @@
 #include "core/eventreceiver/ConnectEventReceiver.h" // IWYU pragma: export
 #include "core/socket/State.h"
 #include "log/LogScopeOwner.h"
+#include "log/Logger.h"
 #include "log/SemanticLogger.h"
 
 namespace core::socket::stream {
@@ -89,11 +90,10 @@ namespace core::socket::stream {
         virtual void init();
 
         logger::BoundaryLogger log() const {
-            // Transitional Round 5 API shape only.
-            // Backend-backed default semantic sinks are introduced in Round 6.
-            // Until then, the no-argument overload returns a no-op logger;
-            // tests and early validation must use the sink-taking overload.
-            return log([](logger::LogRecord) {});
+            // Round 6 backend-backed default semantic logger.
+            // The sink-taking overload remains available for tests and custom capture.
+            // Startup semantic filter configuration is deferred to Round 7.
+            return log(logger::Logger::semanticSink());
         }
 
         logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,

--- a/src/core/socket/stream/SocketContext.cpp
+++ b/src/core/socket/stream/SocketContext.cpp
@@ -81,11 +81,10 @@ namespace core::socket::stream {
     }
 
     logger::BoundaryLogger SocketContext::log() const {
-        // Transitional Round 4 API shape only.
-        // Backend-backed default semantic sinks are introduced in Round 6.
-        // Until then, the no-argument overload returns a no-op logger;
-        // tests and early validation must use the sink-taking overload.
-        return log([](logger::LogRecord) {});
+        // Round 6 backend-backed default semantic logger.
+        // The sink-taking overload remains available for tests and custom capture.
+        // Startup semantic filter configuration is deferred to Round 7.
+        return log(logger::Logger::semanticSink());
     }
 
     logger::BoundaryLogger SocketContext::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
@@ -93,11 +92,10 @@ namespace core::socket::stream {
     }
 
     logger::BoundaryLogger SocketContext::frameworkLog() const {
-        // Transitional Round 4 API shape only.
-        // Backend-backed default semantic sinks are introduced in Round 6.
-        // Until then, the no-argument overload returns a no-op logger;
-        // tests and early validation must use the sink-taking overload.
-        return frameworkLog([](logger::LogRecord) {});
+        // Round 6 backend-backed default semantic logger.
+        // The sink-taking overload remains available for tests and custom capture.
+        // Startup semantic filter configuration is deferred to Round 7.
+        return frameworkLog(logger::Logger::semanticSink());
     }
 
     logger::BoundaryLogger SocketContext::frameworkLog(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {

--- a/src/core/socket/stream/SocketServer.h
+++ b/src/core/socket/stream/SocketServer.h
@@ -270,11 +270,10 @@ namespace core::socket::stream {
 
 
         logger::BoundaryLogger log() const {
-            // Transitional Round 5 API shape only.
-            // Backend-backed default semantic sinks are introduced in Round 6.
-            // Until then, the no-argument overload returns a no-op logger;
-            // tests and early validation must use the sink-taking overload.
-            return log([](logger::LogRecord) {});
+            // Round 6 backend-backed default semantic logger.
+            // The sink-taking overload remains available for tests and custom capture.
+            // Startup semantic filter configuration is deferred to Round 7.
+            return log(logger::Logger::semanticSink());
         }
 
         logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,

--- a/src/log/Logger.cpp
+++ b/src/log/Logger.cpp
@@ -43,6 +43,8 @@
 
 #include "log/Logger.h"
 
+#include "log/SemanticLogger.h"
+
 #include <algorithm>
 #include <cerrno>
 #include <chrono>
@@ -53,6 +55,8 @@
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <unistd.h>
+
+#include <optional>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -161,6 +165,26 @@ namespace {
         }
 
         return label;
+    }
+
+    std::optional<logger::Level> mapSemanticLevel(const logger::LogLevel level) {
+        switch (level) {
+            case logger::LogLevel::Trace:
+                return logger::Level::TRACE;
+            case logger::LogLevel::Debug:
+                return logger::Level::DEBUG;
+            case logger::LogLevel::Info:
+                return logger::Level::INFO;
+            case logger::LogLevel::Warn:
+                return logger::Level::WARNING;
+            case logger::LogLevel::Error:
+                return logger::Level::ERROR;
+            case logger::LogLevel::Critical:
+                return logger::Level::FATAL;
+            case logger::LogLevel::Off:
+                return std::nullopt;
+        }
+        return std::nullopt;
     }
 
     bool shouldEmit(const logger::Level level) {
@@ -273,6 +297,21 @@ namespace logger {
         if (fileLogger) {
             fileLogger->log(spdlog::level::info, message);
         }
+    }
+
+    void Logger::emitSemantic(const LogRecord& record) {
+        const auto mappedLevel = mapSemanticLevel(record.level);
+        if (!mappedLevel || !shouldLog(*mappedLevel)) {
+            return;
+        }
+
+        emitLine(*mappedLevel, formatText(record), false, 0);
+    }
+
+    BoundaryLogger::Sink Logger::semanticSink() {
+        return [](LogRecord record) {
+            Logger::emitSemantic(record);
+        };
     }
 
     bool Logger::disableColorLog = false;

--- a/src/log/Logger.h
+++ b/src/log/Logger.h
@@ -44,6 +44,8 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/SemanticLogger.h"
+
 #include <functional>
 #include <memory>
 #include <ostream> // IWYU pragma: export
@@ -108,6 +110,9 @@ namespace logger {
 
         static bool shouldLog(Level level);
         static bool shouldVerbose(int verboseLevel);
+
+        static void emitSemantic(const LogRecord& record);
+        static BoundaryLogger::Sink semanticSink();
 
     protected:
         static bool disableColorLog;

--- a/src/net/config/ConfigInstance.cpp
+++ b/src/net/config/ConfigInstance.cpp
@@ -43,6 +43,7 @@
 
 #include "net/config/ConfigInstance.h"
 
+#include "log/Logger.h"
 #include "utils/Config.h"
 
 #include <functional>
@@ -118,11 +119,10 @@ namespace net::config {
     }
 
     logger::BoundaryLogger ConfigInstance::log() const {
-        // Transitional Round 4 API shape only.
-        // Backend-backed default semantic sinks are introduced in Round 6.
-        // Until then, the no-argument overload returns a no-op logger;
-        // tests and early validation must use the sink-taking overload.
-        return log([](logger::LogRecord) {});
+        // Round 6 backend-backed default semantic logger.
+        // The sink-taking overload remains available for tests and custom capture.
+        // Startup semantic filter configuration is deferred to Round 7.
+        return log(logger::Logger::semanticSink());
     }
 
     logger::BoundaryLogger ConfigInstance::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -18,3 +18,8 @@ target_include_directories(SocketEndpointLogApiRound5Test PRIVATE ${PROJECT_SOUR
 target_compile_features(SocketEndpointLogApiRound5Test PRIVATE cxx_std_20)
 target_link_libraries(SocketEndpointLogApiRound5Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
 set_tests_properties(SocketEndpointLogApiRound5Test PROPERTIES LABELS "unit;log;round5")
+
+snodec_add_test(SemanticBackendRound6Test SemanticBackendRound6Test.cpp)
+target_include_directories(SemanticBackendRound6Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(SemanticBackendRound6Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
+set_tests_properties(SemanticBackendRound6Test PROPERTIES LABELS "unit;log;round6")

--- a/tests/unit/log/SemanticBackendRound6Test.cpp
+++ b/tests/unit/log/SemanticBackendRound6Test.cpp
@@ -1,0 +1,167 @@
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "net/config/ConfigInstance.h"
+#include "tests/support/TestResult.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace {
+    std::chrono::system_clock::time_point fixedTimestamp() {
+        using namespace std::chrono;
+        return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
+    }
+
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() { return std::string("ROUND6TICK000"); });
+            logger::Logger::logToFile(logFile);
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+
+    logger::LogScope testScope() {
+        return {logger::LogOrigin::Framework, logger::LogBoundary::System, "round6.component", "round6-instance", logger::LogRole::Server, "round6-connection"};
+    }
+
+    logger::LogRecord record(logger::LogLevel level, std::string message) {
+        logger::LogRecordOptions options;
+        options.ts = fixedTimestamp();
+        return logger::materialize(testScope(), level, std::move(message), std::move(options));
+    }
+
+    class TestConfigInstance : public net::config::ConfigInstance {
+    public:
+        explicit TestConfigInstance(const std::string& instanceName)
+            : ConfigInstance(instanceName, Role::SERVER) {}
+        ~TestConfigInstance() override = default;
+    };
+
+    class TestSocketConnection : public core::socket::stream::SocketConnection {
+    public:
+        explicit TestSocketConnection(const std::string& instanceName)
+            : SocketConnection(7, instanceName, nullptr) {}
+        ~TestSocketConnection() override = default;
+
+        int getFd() const override { return 7; }
+        void sendToPeer(const char*, std::size_t) override {}
+        bool streamToPeer(core::pipe::Source*) override { return false; }
+        void streamEof() override {}
+        std::size_t readFromPeer(char*, std::size_t) override { return 0; }
+        void shutdownRead() override {}
+        void shutdownWrite() override {}
+        const core::socket::SocketAddress& getBindAddress() const override { return unusableAddress(); }
+        const core::socket::SocketAddress& getLocalAddress() const override { return unusableAddress(); }
+        const core::socket::SocketAddress& getRemoteAddress() const override { return unusableAddress(); }
+        void close() override {}
+        void setTimeout(const utils::Timeval&) override {}
+        void setReadTimeout(const utils::Timeval&) override {}
+        void setWriteTimeout(const utils::Timeval&) override {}
+        std::size_t getTotalSent() const override { return 0; }
+        std::size_t getTotalQueued() const override { return 0; }
+        std::size_t getTotalRead() const override { return 0; }
+        std::size_t getTotalProcessed() const override { return 0; }
+
+    private:
+        static const core::socket::SocketAddress& unusableAddress() { return *static_cast<const core::socket::SocketAddress*>(nullptr); }
+    };
+
+    class TestSocketContext : public core::socket::stream::SocketContext {
+    public:
+        explicit TestSocketContext(core::socket::stream::SocketConnection* socketConnection)
+            : SocketContext(socketConnection) {}
+        ~TestSocketContext() override = default;
+
+    private:
+        std::size_t onReceivedFromPeer() override { return 0; }
+        bool onSignal(int) override { return false; }
+        void onConnected() override {}
+        void onDisconnected() override {}
+    };
+}
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto semanticPath = tempLogPath("snodec-round6-semantic.log");
+    {
+        LoggerStateGuard guard(semanticPath.string());
+        logger::Logger::emitSemantic(record(logger::LogLevel::Info, "semantic info emitted"));
+        logger::Logger::emitSemantic(record(logger::LogLevel::Off, "semantic off hidden"));
+        LOG(INFO) << "legacy macro emitted";
+    }
+    const auto semanticLog = readFile(semanticPath);
+    result.expectTrue(semanticLog.find("INFO") != std::string::npos, "semantic info maps to legacy INFO label");
+    result.expectTrue(semanticLog.find("semantic info emitted") != std::string::npos, "semantic info emits through file backend");
+    result.expectTrue(semanticLog.find("semantic off hidden") == std::string::npos, "semantic off emits nothing");
+    result.expectTrue(semanticLog.find("ROUND6TICK000") != std::string::npos, "semantic emission uses legacy tick resolver pattern");
+    result.expectTrue(semanticLog.find("legacy macro emitted") != std::string::npos, "legacy LOG macro still emits through backend");
+
+    const auto filteredPath = tempLogPath("snodec-round6-filtered.log");
+    {
+        LoggerStateGuard guard(filteredPath.string());
+        logger::Logger::setLogLevel(3);
+        logger::Logger::emitSemantic(record(logger::LogLevel::Info, "filtered info hidden"));
+        logger::Logger::emitSemantic(record(logger::LogLevel::Warn, "warning visible"));
+    }
+    const auto filteredLog = readFile(filteredPath);
+    result.expectTrue(filteredLog.find("filtered info hidden") == std::string::npos, "semantic backend respects Logger::setLogLevel for info");
+    result.expectTrue(filteredLog.find("warning visible") != std::string::npos, "semantic backend respects Logger::setLogLevel for warning");
+
+    const auto objectPath = tempLogPath("snodec-round6-objects.log");
+    {
+        LoggerStateGuard guard(objectPath.string());
+        TestConfigInstance config("round6-config");
+        config.log().info("config default backend");
+        TestSocketConnection connection("round6-connection");
+        connection.log().info("connection default backend");
+        TestSocketContext context(&connection);
+        context.log().info("context default backend");
+        context.frameworkLog().info("framework context default backend");
+    }
+    const auto objectLog = readFile(objectPath);
+    result.expectTrue(objectLog.find("config default backend") != std::string::npos, "ConfigInstance no-argument log emits through backend");
+    result.expectTrue(objectLog.find("connection default backend") != std::string::npos, "SocketConnection no-argument log emits through backend");
+    result.expectTrue(objectLog.find("context default backend") != std::string::npos, "SocketContext no-argument log emits through backend");
+    result.expectTrue(objectLog.find("framework context default backend") != std::string::npos, "SocketContext frameworkLog no-argument emits through backend");
+
+    std::vector<logger::LogRecord> captured;
+    logger::BoundaryLogger::createForTest(testScope(), [&](logger::LogRecord capturedRecord) { captured.push_back(std::move(capturedRecord)); }, logger::LogLevel::Trace, fixedTimestamp)
+        .info("custom sink still captures");
+    result.expectEqual(1, static_cast<int>(captured.size()), "sink-taking semantic overloads still capture records");
+    result.expectTrue(captured[0].message == "custom sink still captures", "custom sink receives semantic message");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation
- Unify the semantic logging path with the existing legacy `Logger` backend so no-argument semantic logger APIs emit through the same stdout/file/quiet/color/tick infrastructure used by `LOG`/`PLOG`/`VLOG`.
- Replace the Round 4/5 transitional no-op default semantic loggers with backend-backed defaults while preserving sink-taking overloads for tests and custom capture.
- Preserve existing numeric log-level/verbose/CLI behavior and avoid beginning Round 7 (startup filter config) or Round 8 (call-site migration) work.

### Description
- Added a narrow semantic backend bridge to `logger::Logger` with `static void emitSemantic(const LogRecord& record)` and `static BoundaryLogger::Sink semanticSink()` that map `logger::LogLevel` to legacy `logger::Level` and forward formatted semantic records into the existing `emitLine` path (`formatText` used for text output).
- Implemented the level mapping `Trace->TRACE`, `Debug->DEBUG`, `Info->INFO`, `Warn->WARNING`, `Error->ERROR`, `Critical->FATAL`, and `Off->no emission`, and made semantic emission respect `Logger::shouldLog(...)` / `Logger::setLogLevel(...)`.
- Replaced no-argument semantic logger overloads to return backend-backed `BoundaryLogger` sinks via `logger::Logger::semanticSink()` in object APIs: `ConfigInstance::log()`, `SocketConnection::log()`, `SocketContext::log()` and `frameworkLog()`, `SocketServer::log()`, `SocketClient::log()`, `SocketConnector::log()`, and `SocketAcceptor::log()` while leaving sink-taking overloads unchanged.
- Added focused test `tests/unit/log/SemanticBackendRound6Test.cpp`, registered it in CMake, and added `docs/logging/round-06-backend-unification-report.md` documenting the change set, validation commands, and deliberate deferrals.

### Testing
- Built the project and ran focused unit tests with: `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON && cmake --build cmake-build --parallel 2` and `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test" --output-on-failure`, and all targeted tests passed (Round2/3/4/5 + new Round6).
- Ran full test suite `ctest --test-dir cmake-build --output-on-failure` and ASan validation with `cmake -S . -B cmake-build-asan -DSNODEC_ENABLE_ASAN=ON && cmake --build cmake-build-asan --parallel 2 && ASAN=$(gcc -print-file-name=libasan.so); LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure`, and the ASan run completed successfully with linker warnings from `libasan.so.8` but no test failures.
- The test harness verifies semantic emission to file sinks, that `LogLevel::Off` emits nothing, that `Logger::setLogLevel(...)` filters semantic records as expected, that default no-argument object loggers emit through the unified backend, and that sink-taking overloads still capture records; all assertions passed.
- Note: the environment used for this PR had no usable `origin` remote and the branch was created from the current repository state that already contained the merged Round 5 changes, which is recorded in the included report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a981c2de8832c85c68f03b45eab8b)