### PR TITLE
Logging roadmap round 07 — startup semantic filters

### DIFF
--- a/docs/logging/round-07-startup-filter-configuration-report.md
+++ b/docs/logging/round-07-startup-filter-configuration-report.md
@@ -1,0 +1,156 @@
+# Logging roadmap round 07 — startup-only semantic filter configuration
+
+## Implementation summary
+
+Round 7 implements startup-only semantic filtering and format selection.
+
+Round 7 implements precedence:
+instance > component > boundary > origin > global.
+
+The implementation adds `logger::LogManager` as the startup semantic policy surface. `LogManager::init()` resets policy to permissive defaults; startup setters configure global, origin, boundary, component, instance, and semantic output format; `freeze()` makes the policy immutable; `effectiveLevel(...)`, `shouldEmit(...)`, `format()`, and `formatRecord(...)` expose frozen lookups for semantic emission.
+
+`logger::Logger::emitSemantic(...)` now applies the semantic policy before mapping to the existing legacy backend level. Records must still pass the existing `Logger::setLogLevel(...)` numeric backend gate before output reaches existing spdlog-backed sinks. No second backend was added.
+
+## Files changed
+
+- `src/log/SemanticLogger.h` — added the `logger::LogManager` public API and `Format { Text, Json }`.
+- `src/log/SemanticLogger.cpp` — added startup policy storage, precedence lookup, freeze enforcement, `shouldEmit`, and semantic format selection.
+- `src/log/Logger.cpp` — integrated semantic filtering and selected Text/JSON formatting into `Logger::emitSemantic(...)` before legacy backend emission.
+- `tests/unit/log/SemanticFilterRound7Test.cpp` — added focused Round 7 coverage.
+- `tests/unit/log/CMakeLists.txt` — registered `SemanticFilterRound7Test`.
+- `docs/logging/round-07-startup-filter-configuration-report.md` — this report.
+
+## Build commands run
+
+- `git fetch origin` — failed because this Codex environment has no usable `origin` remote: `'origin' does not appear to be a git repository`.
+- `git checkout master` — failed because this Codex environment has no local `master` branch.
+- `git status --short` — clean before changes.
+- `git log --oneline -- docs/logging/round-06-backend-unification-report.md | head` — confirmed current checkout includes merged Round 6 commit `a3da6b7 Logging roadmap round 06 backend unification` and HEAD `38388e0 Merge pull request #147...`.
+- `git checkout -b codex/implement-logging-roadmap-round-7`
+- `apt-get update && apt-get install -y nlohmann-json3-dev` — installed missing configure dependency needed by `SNODEC_BUILD_APPS=ON`.
+- `git diff --check`
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2`
+- `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`
+- `cmake --build cmake-build-asan --parallel 2`
+
+## Test commands run
+
+- `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test" --output-on-failure`
+- `ctest --test-dir cmake-build --output-on-failure`
+- `ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure`
+
+## Sanitizer result
+
+ASan configure, build, and full `ctest` completed successfully. The ASan test run reported `100% tests passed, 0 tests failed out of 113`; many component tests skipped by existing environment/group gating, consistent with the non-ASan run.
+
+## LogManager API added
+
+Added startup-only API:
+
+- `LogManager::init()`
+- `setGlobalLevel(LogLevel)`
+- `setOriginLevel(LogOrigin, LogLevel)`
+- `setBoundaryLevel(LogBoundary, LogLevel)`
+- `setComponentLevel(std::string, LogLevel)`
+- `setInstanceLevel(std::string, LogLevel)`
+- `setFormat(LogManager::Format)`
+- `freeze()`
+- `isFrozen()`
+- `effectiveLevel(LogScope)` / `effectiveLevel(LogRecord)`
+- `shouldEmit(LogRecord)`
+- `format()` / `formatRecord(LogRecord)`
+
+## Startup-only freeze behavior
+
+Before `freeze()`, setters mutate startup policy. `freeze()` marks the policy immutable. After freeze, repeated effective-level lookups are stable because no setter can modify the policy. No runtime reload, signal handler, admin endpoint, mutable atomic threshold, or dynamic runtime reconfiguration was added.
+
+## Post-freeze setter behavior
+
+Post-freeze setters reject changes by throwing `std::logic_error`. The Round 7 test verifies the throw and verifies the effective level and selected format remain unchanged afterward.
+
+## Default policy
+
+`LogManager::init()` resets to:
+
+- global level: `Trace`
+- format: `Text`
+- no origin, boundary, component, or instance overrides
+- not frozen
+
+This preserves Round 6 default behavior unless a user configures semantic filtering.
+
+## Precedence implementation result
+
+Lookup is exactly:
+
+1. instance override
+2. component override
+3. boundary override
+4. origin override
+5. global level fallback
+
+Threshold ordering uses existing semantic enum order: `Trace < Debug < Info < Warn < Error < Critical < Off`. `Off` is treated only as a suppression threshold and is not emitted as a severity.
+
+## Component/instance matching rule
+
+Component and instance overrides use exact string matching only. No regex, glob, or prefix matching was added. Empty component and instance override keys are rejected with `std::invalid_argument`, so they cannot become surprising wildcard keys. An absent record instance does not match instance overrides.
+
+## Text/Json format selection result
+
+`LogManager::Format::Text` uses existing `formatText(record)`. `LogManager::Format::Json` uses existing `formatJsonV1(record)`. Format selection is part of startup policy and is frozen by `freeze()`.
+
+## JSON v1 compatibility result
+
+JSON output continues to use the existing JSON v1 formatter. Mandatory fields remain `v`, `ts`, `level`, `origin`, `boundary`, `component`, and `message`. Optional fields remain omitted when absent rather than emitted as `null`.
+
+## Integration with Logger::emitSemantic result
+
+`Logger::emitSemantic(record)` now first calls `LogManager::shouldEmit(record)`. If the semantic policy allows the record, it maps the semantic level to the existing legacy level and still applies `Logger::shouldLog(...)` / `Logger::setLogLevel(...)` before using existing backend sinks.
+
+## Default no-argument object logger filtering result
+
+No-argument object loggers continue to route through `Logger::semanticSink()` and therefore through `Logger::emitSemantic(...)`; they now respect the semantic policy without storing `BoundaryLogger` in production objects or broad constructor churn.
+
+## Sink-taking overload compatibility result
+
+Sink-taking overloads remain available and unchanged. Explicit test/custom capture sinks still receive records according to their supplied `BoundaryLogger` threshold and are not forced through the default backend bridge.
+
+## Legacy Logger::setLogLevel backend-gate result
+
+The existing numeric backend gate remains the final gate. Round 7 tests configure semantic global `Trace`, freeze policy, then set `Logger::setLogLevel(3)` and verify semantic `Info` is suppressed while semantic `Warn` is emitted.
+
+## Legacy macro compatibility result
+
+Legacy `LOG`/`PLOG`/`VLOG` syntax and backend behavior are unchanged. Round 7 tests verify legacy `LOG(INFO)` and `LOG(WARNING)` still obey the existing numeric backend gate and are not affected by semantic Text/JSON format selection.
+
+## CLI behavior preservation result
+
+No CLI parsing, CLI defaults, app startup behavior, `Logger::logToFile(...)`, `Logger::disableLogToFile()`, `Logger::setQuiet(...)`, `Logger::setTickResolver(...)`, or `Logger::setDisableColor(...)` semantics were changed.
+
+## Production call-site migration / Round 8 status
+
+Round 7 does not migrate production LOG/PLOG/VLOG call sites.
+
+Round 7 does not add runtime reload, signals, admin endpoints, or mutable atomic runtime thresholds.
+
+Round 7 does not start controlled subsystem migration; that remains Round 8.
+
+No protocol-specific logging migration was done for HTTP, WebSocket, MQTT, DB, application examples, or MiniGateway.
+
+## Deliberate deferrals
+
+- Prefix/glob/regex component matching is deferred; Round 7 uses exact string matches only.
+- Runtime reload, signals, admin endpoints, and mutable atomic runtime thresholds are intentionally not implemented.
+- Controlled subsystem migration remains deferred to Round 8.
+- Protocol-specific logging migration remains deferred.
+
+## Known non-blocking follow-ups
+
+- Future rounds can decide whether startup configuration should be wired to CLI/config-file surfaces.
+- Future rounds can decide whether component hierarchy prefix matching is useful after exact-match operational behavior is validated.
+- Future Round 8 work can begin controlled subsystem migration using the now-frozen semantic policy surface.
+
+## General SNode.C and mqttsuite review note
+
+As part of the requested broader review, this Round 7 pass built the full SNode.C tree with apps and tests enabled, including MQTT-related targets (`mqtt-types`, `mqtt-packets`, `mqtt-broker`, `mqtt`, `mqtt-server`, `mqtt-client`, `mqtt-server-websocket`, and `mqtt-client-websocket`) in both the normal and ASan build configurations. The semantic logging change deliberately did not migrate MQTT or mqttsuite production call sites; no mqttsuite-specific source edits were made in Round 7.

--- a/src/log/Logger.cpp
+++ b/src/log/Logger.cpp
@@ -300,12 +300,16 @@ namespace logger {
     }
 
     void Logger::emitSemantic(const LogRecord& record) {
+        if (!LogManager::shouldEmit(record)) {
+            return;
+        }
+
         const auto mappedLevel = mapSemanticLevel(record.level);
         if (!mappedLevel || !shouldLog(*mappedLevel)) {
             return;
         }
 
-        emitLine(*mappedLevel, formatText(record), false, 0);
+        emitLine(*mappedLevel, LogManager::formatRecord(record), false, 0);
     }
 
     BoundaryLogger::Sink Logger::semanticSink() {

--- a/src/log/SemanticLogger.cpp
+++ b/src/log/SemanticLogger.cpp
@@ -1,7 +1,10 @@
 #include "log/SemanticLogger.h"
 
 #include <iomanip>
+#include <map>
+#include <stdexcept>
 #include <sstream>
+#include <utility>
 
 namespace logger {
 namespace {
@@ -36,6 +39,34 @@ namespace {
         out << (first ? "" : ",") << "\"" << name << "\":" << value;
         first = false;
     }
+
+    struct SemanticPolicy {
+        LogLevel globalLevel = LogLevel::Trace;
+        std::map<LogOrigin, LogLevel> originLevels;
+        std::map<LogBoundary, LogLevel> boundaryLevels;
+        std::map<std::string, LogLevel> componentLevels;
+        std::map<std::string, LogLevel> instanceLevels;
+        LogManager::Format format = LogManager::Format::Text;
+        bool frozen = false;
+    };
+
+    SemanticPolicy& policy() {
+        static SemanticPolicy current;
+        return current;
+    }
+
+    void ensureMutable() {
+        if (policy().frozen) {
+            throw std::logic_error("logger::LogManager semantic policy is frozen");
+        }
+    }
+
+    void ensureNonEmptyKey(const std::string& key, const char* name) {
+        if (key.empty()) {
+            throw std::invalid_argument(std::string("logger::LogManager ") + name + " key must not be empty");
+        }
+    }
+
 }
 
 LogRecord materialize(const LogScope& scope, LogLevel level, std::string message, LogRecordOptions options) {
@@ -54,6 +85,87 @@ LogRecord materialize(const LogScope& scope, LogLevel level, std::string message
     record.error = std::move(options.error);
     record.source = std::move(options.source);
     return record;
+}
+
+
+void LogManager::init() {
+    policy() = SemanticPolicy{};
+}
+
+void LogManager::setGlobalLevel(LogLevel level) {
+    ensureMutable();
+    policy().globalLevel = level;
+}
+
+void LogManager::setOriginLevel(LogOrigin origin, LogLevel level) {
+    ensureMutable();
+    policy().originLevels[origin] = level;
+}
+
+void LogManager::setBoundaryLevel(LogBoundary boundary, LogLevel level) {
+    ensureMutable();
+    policy().boundaryLevels[boundary] = level;
+}
+
+void LogManager::setComponentLevel(std::string component, LogLevel level) {
+    ensureMutable();
+    ensureNonEmptyKey(component, "component");
+    policy().componentLevels[std::move(component)] = level;
+}
+
+void LogManager::setInstanceLevel(std::string instance, LogLevel level) {
+    ensureMutable();
+    ensureNonEmptyKey(instance, "instance");
+    policy().instanceLevels[std::move(instance)] = level;
+}
+
+void LogManager::setFormat(Format format) {
+    ensureMutable();
+    policy().format = format;
+}
+
+void LogManager::freeze() {
+    policy().frozen = true;
+}
+
+bool LogManager::isFrozen() {
+    return policy().frozen;
+}
+
+LogLevel LogManager::effectiveLevel(const LogScope& scope) {
+    const auto& current = policy();
+    if (!scope.instance.empty()) {
+        if (const auto it = current.instanceLevels.find(std::string(scope.instance)); it != current.instanceLevels.end()) return it->second;
+    }
+    if (!scope.component.empty()) {
+        if (const auto it = current.componentLevels.find(std::string(scope.component)); it != current.componentLevels.end()) return it->second;
+    }
+    if (const auto it = current.boundaryLevels.find(scope.boundary); it != current.boundaryLevels.end()) return it->second;
+    if (const auto it = current.originLevels.find(scope.origin); it != current.originLevels.end()) return it->second;
+    return current.globalLevel;
+}
+
+LogLevel LogManager::effectiveLevel(const LogRecord& record) {
+    LogScope scope{record.origin,
+                   record.boundary,
+                   record.component,
+                   record.instance ? std::string_view(*record.instance) : std::string_view(),
+                   record.role.value_or(LogRole::Unknown),
+                   record.connection ? std::string_view(*record.connection) : std::string_view()};
+    return effectiveLevel(scope);
+}
+
+bool LogManager::shouldEmit(const LogRecord& record) {
+    const LogLevel threshold = effectiveLevel(record);
+    return record.level != LogLevel::Off && threshold != LogLevel::Off && rank(record.level) >= rank(threshold);
+}
+
+LogManager::Format LogManager::format() {
+    return policy().format;
+}
+
+std::string LogManager::formatRecord(const LogRecord& record) {
+    return format() == Format::Json ? formatJsonV1(record) : formatText(record);
 }
 
 std::string toString(LogLevel level) {

--- a/src/log/SemanticLogger.h
+++ b/src/log/SemanticLogger.h
@@ -71,6 +71,30 @@ namespace logger {
     std::string formatJsonV1(const LogRecord& record);
     std::string formatText(const LogRecord& record);
 
+    class LogManager {
+    public:
+        enum class Format { Text, Json };
+
+        LogManager() = delete;
+        ~LogManager() = delete;
+
+        static void init();
+        static void setGlobalLevel(LogLevel level);
+        static void setOriginLevel(LogOrigin origin, LogLevel level);
+        static void setBoundaryLevel(LogBoundary boundary, LogLevel level);
+        static void setComponentLevel(std::string component, LogLevel level);
+        static void setInstanceLevel(std::string instance, LogLevel level);
+        static void setFormat(Format format);
+        static void freeze();
+        static bool isFrozen();
+
+        static LogLevel effectiveLevel(const LogScope& scope);
+        static LogLevel effectiveLevel(const LogRecord& record);
+        static bool shouldEmit(const LogRecord& record);
+        static Format format();
+        static std::string formatRecord(const LogRecord& record);
+    };
+
     class BoundaryLogger;
 
     struct OwnedLogScope {

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -23,3 +23,8 @@ snodec_add_test(SemanticBackendRound6Test SemanticBackendRound6Test.cpp)
 target_include_directories(SemanticBackendRound6Test PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(SemanticBackendRound6Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
 set_tests_properties(SemanticBackendRound6Test PROPERTIES LABELS "unit;log;round6")
+
+snodec_add_test(SemanticFilterRound7Test SemanticFilterRound7Test.cpp)
+target_include_directories(SemanticFilterRound7Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(SemanticFilterRound7Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
+set_tests_properties(SemanticFilterRound7Test PROPERTIES LABELS "unit;log;round7")

--- a/tests/unit/log/SemanticFilterRound7Test.cpp
+++ b/tests/unit/log/SemanticFilterRound7Test.cpp
@@ -1,0 +1,193 @@
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "net/config/ConfigInstance.h"
+#include "tests/support/TestResult.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+namespace {
+    std::chrono::system_clock::time_point fixedTimestamp() {
+        using namespace std::chrono;
+        return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
+    }
+
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() { return std::string("ROUND7TICK000"); });
+            logger::Logger::logToFile(logFile);
+        }
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+
+    logger::LogScope scope(std::string_view instance = "round7-instance") {
+        return {logger::LogOrigin::Framework,
+                logger::LogBoundary::Connection,
+                "core.socket.stream",
+                instance,
+                logger::LogRole::Server,
+                "round7-connection"};
+    }
+
+    logger::LogRecord record(logger::LogLevel level, std::string message, std::string_view instance = "round7-instance") {
+        logger::LogRecordOptions options;
+        options.ts = fixedTimestamp();
+        return logger::materialize(scope(instance), level, std::move(message), std::move(options));
+    }
+
+    class TestConfigInstance : public net::config::ConfigInstance {
+    public:
+        explicit TestConfigInstance(const std::string& instanceName)
+            : ConfigInstance(instanceName, Role::SERVER) {}
+        ~TestConfigInstance() override = default;
+    };
+}
+
+int main() {
+    tests::support::TestResult result;
+
+    logger::LogManager::init();
+    result.expectTrue(!logger::LogManager::isFrozen(), "LogManager init leaves policy mutable");
+    result.expectTrue(logger::LogManager::effectiveLevel(scope()) == logger::LogLevel::Trace, "LogManager default global level is Trace");
+    result.expectTrue(logger::LogManager::format() == logger::LogManager::Format::Text, "LogManager default format is Text");
+
+    logger::LogManager::setGlobalLevel(logger::LogLevel::Warn);
+    result.expectTrue(!logger::LogManager::shouldEmit(record(logger::LogLevel::Info, "hidden by global")), "global Warn filters Info");
+    result.expectTrue(logger::LogManager::shouldEmit(record(logger::LogLevel::Warn, "allowed by global")), "global Warn allows Warn");
+
+    logger::LogManager::init();
+    logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+    logger::LogManager::setOriginLevel(logger::LogOrigin::Framework, logger::LogLevel::Warn);
+    result.expectTrue(logger::LogManager::effectiveLevel(scope()) == logger::LogLevel::Warn, "origin overrides global");
+    logger::LogManager::setBoundaryLevel(logger::LogBoundary::Connection, logger::LogLevel::Debug);
+    result.expectTrue(logger::LogManager::effectiveLevel(scope()) == logger::LogLevel::Debug, "boundary overrides origin");
+    logger::LogManager::setComponentLevel("core.socket.stream", logger::LogLevel::Info);
+    result.expectTrue(logger::LogManager::effectiveLevel(scope()) == logger::LogLevel::Info, "component overrides boundary");
+    logger::LogManager::setInstanceLevel("round7-instance", logger::LogLevel::Trace);
+    result.expectTrue(logger::LogManager::effectiveLevel(scope()) == logger::LogLevel::Trace, "instance overrides component");
+    result.expectTrue(logger::LogManager::effectiveLevel(scope("")) == logger::LogLevel::Info, "missing instance does not match instance override");
+
+    logger::LogManager::init();
+    logger::LogManager::setGlobalLevel(logger::LogLevel::Off);
+    result.expectTrue(!logger::LogManager::shouldEmit(record(logger::LogLevel::Critical, "off hides critical")), "LogLevel::Off suppresses records");
+
+    logger::LogManager::init();
+    logger::LogManager::setGlobalLevel(logger::LogLevel::Info);
+    logger::LogManager::setFormat(logger::LogManager::Format::Json);
+    logger::LogManager::freeze();
+    bool threw = false;
+    try {
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+    } catch (const std::logic_error&) {
+        threw = true;
+    }
+    result.expectTrue(threw, "post-freeze setters throw std::logic_error");
+    result.expectTrue(logger::LogManager::effectiveLevel(scope()) == logger::LogLevel::Info, "post-freeze setter does not mutate policy");
+    result.expectTrue(logger::LogManager::format() == logger::LogManager::Format::Json, "format is frozen with policy");
+
+    const auto sample = record(logger::LogLevel::Info, "format sample");
+    logger::LogManager::init();
+    logger::LogManager::setFormat(logger::LogManager::Format::Text);
+    result.expectTrue(logger::LogManager::formatRecord(sample) == logger::formatText(sample), "Text format uses formatText");
+    logger::LogManager::setFormat(logger::LogManager::Format::Json);
+    const std::string json = logger::LogManager::formatRecord(sample);
+    result.expectTrue(json == logger::formatJsonV1(sample), "Json format uses formatJsonV1");
+    result.expectTrue(json.find("\"v\"") != std::string::npos && json.find("\"ts\"") != std::string::npos && json.find("\"level\"") != std::string::npos &&
+                          json.find("\"origin\"") != std::string::npos && json.find("\"boundary\"") != std::string::npos && json.find("\"component\"") != std::string::npos &&
+                          json.find("\"message\"") != std::string::npos,
+                      "Json output includes mandatory JSON v1 fields");
+    const auto minimal = logger::materialize({logger::LogOrigin::Application, logger::LogBoundary::Application, "round7.minimal", "", logger::LogRole::Unknown, ""},
+                                             logger::LogLevel::Info,
+                                             "minimal",
+                                             logger::LogRecordOptions{.ts = fixedTimestamp()});
+    const std::string minimalJson = logger::formatJsonV1(minimal);
+    result.expectTrue(minimalJson.find(":null") == std::string::npos && minimalJson.find("\"instance\"") == std::string::npos && minimalJson.find("\"role\"") == std::string::npos &&
+                          minimalJson.find("\"connection\"") == std::string::npos,
+                      "Json output omits absent optional fields rather than null");
+
+    const auto semanticPath = tempLogPath("snodec-round7-semantic-filter.log");
+    {
+        LoggerStateGuard guard(semanticPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Warn);
+        logger::LogManager::freeze();
+        logger::Logger::emitSemantic(record(logger::LogLevel::Info, "semantic info hidden"));
+        logger::Logger::emitSemantic(record(logger::LogLevel::Warn, "semantic warning visible"));
+    }
+    const auto semanticLog = readFile(semanticPath);
+    result.expectTrue(semanticLog.find("semantic info hidden") == std::string::npos, "Logger::emitSemantic honors semantic filter");
+    result.expectTrue(semanticLog.find("semantic warning visible") != std::string::npos, "Logger::emitSemantic emits allowed record");
+
+    const auto objectPath = tempLogPath("snodec-round7-object-filter.log");
+    {
+        LoggerStateGuard guard(objectPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        TestConfigInstance config("round7-config");
+        config.log().info("object info hidden");
+        config.log().error("object error visible");
+    }
+    const auto objectLog = readFile(objectPath);
+    result.expectTrue(objectLog.find("object info hidden") == std::string::npos, "default no-argument object logger respects semantic filtering");
+    result.expectTrue(objectLog.find("object error visible") != std::string::npos, "default no-argument object logger emits allowed semantic record");
+
+    const auto gatePath = tempLogPath("snodec-round7-backend-gate.log");
+    {
+        LoggerStateGuard guard(gatePath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        logger::Logger::setLogLevel(3);
+        logger::Logger::emitSemantic(record(logger::LogLevel::Info, "backend info hidden"));
+        logger::Logger::emitSemantic(record(logger::LogLevel::Warn, "backend warn visible"));
+        LOG(INFO) << "legacy info hidden";
+        LOG(WARNING) << "legacy warning visible";
+    }
+    const auto gateLog = readFile(gatePath);
+    result.expectTrue(gateLog.find("backend info hidden") == std::string::npos, "Logger::setLogLevel remains final backend gate");
+    result.expectTrue(gateLog.find("backend warn visible") != std::string::npos, "backend gate emits warning");
+    result.expectTrue(gateLog.find("legacy info hidden") == std::string::npos && gateLog.find("legacy warning visible") != std::string::npos,
+                      "legacy LOG macro behavior remains unchanged");
+
+    const auto jsonPath = tempLogPath("snodec-round7-json-format.log");
+    {
+        LoggerStateGuard guard(jsonPath.string());
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        logger::Logger::emitSemantic(record(logger::LogLevel::Info, "json backend visible"));
+    }
+    const auto jsonLog = readFile(jsonPath);
+    result.expectTrue(jsonLog.find("{\"v\":1") != std::string::npos && jsonLog.find("\"message\":\"json backend visible\"") != std::string::npos,
+                      "Json format reaches semantic backend output");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation

- Introduce a startup-only semantic policy surface so callers can set semantic thresholds and output format before the legacy backend receives records.
- Apply semantic filtering and format selection prior to the existing Round 6 backend while preserving the legacy numeric `Logger::setLogLevel(...)` gate and existing sink behavior.

### Description

- Added `logger::LogManager` startup API with `init()`, `setGlobalLevel()`, `setOriginLevel()`, `setBoundaryLevel()`, `setComponentLevel()`, `setInstanceLevel()`, `setFormat(Format::Text|Json)`, `freeze()`, `isFrozen()`, `effectiveLevel(...)`, `shouldEmit(...)`, and `formatRecord(...)`; default policy is global `Trace` and `Text` format. (files: `src/log/SemanticLogger.h`, `src/log/SemanticLogger.cpp`).
- Implemented exact-match component/instance overrides and the required precedence `instance > component > boundary > origin > global`, treating `Off` as suppression and using the existing semantic enum ordering for thresholds. (files: `src/log/SemanticLogger.cpp`).
- Freeze semantics make the policy immutable and post-freeze setters deterministically reject mutation by throwing `std::logic_error`; empty component/instance keys throw `std::invalid_argument` to avoid accidental wildcards. (files: `src/log/SemanticLogger.cpp`).
- Integrated semantic policy into backend bridge by consulting `LogManager::shouldEmit(...)` in `Logger::emitSemantic(...)`, mapping semantic levels to legacy levels, then formatting via `LogManager::formatRecord(...)` (Text or Json using the existing `formatText`/`formatJsonV1`) and emitting through the existing backend sinks; legacy numeric `Logger::setLogLevel(...)` remains the final gate. (file: `src/log/Logger.cpp`).
- Added focused Round 7 unit test `tests/unit/log/SemanticFilterRound7Test.cpp` and registered it in `tests/unit/log/CMakeLists.txt`, and added the required report `docs/logging/round-07-startup-filter-configuration-report.md`.

### Testing

- Built and ran tests with standard and ASan builds: `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build --parallel 2`, and `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON` then built both; all builds completed successfully. (see report for exact commands).
- Ran focused ctest for Round 2..7 and full test suites: `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test" --output-on-failure` and then full `ctest`; both runs passed and all Round 7 focused checks succeeded. The ASan test run also passed (100% tests passed, 0 failed out of the configured set).
- Verified JSON v1 formatting still emits mandatory fields and omits absent optional fields rather than null, Text format still uses the existing `formatText`, and sink-taking overloads and no-argument object loggers continue to behave correctly through the updated `Logger::semanticSink()` path. (tests: `SemanticFilterRound7Test`, `SemanticBackendRound6Test`, existing round tests).
- Note about repository state: `origin` remote was not usable in this environment (`'origin' does not appear to be a git repository`) and there was no local `master` branch to check out; I confirmed the working checkout already contains the merged Round 6 changes and proceeded from a clean working tree and created branch `codex/implement-logging-roadmap-round-7` for this PR (documented in the included report).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aa355c254832cade57ac387384de1)