### PR TITLE
Logging roadmap round 08 — controlled socket-stream migration

### DIFF
--- a/docs/logging/round-08-controlled-subsystem-migration-report.md
+++ b/docs/logging/round-08-controlled-subsystem-migration-report.md
@@ -1,0 +1,209 @@
+# Logging roadmap round 08 — controlled socket-stream subsystem migration
+
+## Implementation summary
+
+Round 8 performs only a controlled core socket-stream subsystem migration.
+
+Round 8 migrates a small, reviewable subset of existing production logging call sites from legacy `LOG`/`PLOG` macros to existing object-owned semantic loggers in `SocketConnection` and `SocketContext`.
+
+Round 8 does not migrate protocol-specific subsystems.
+
+Round 8 does not change LOG/PLOG/VLOG macro definitions.
+
+Round 8 does not change startup semantic policy.
+
+Round 8 does not add runtime reload, signals, admin endpoints, or mutable atomic runtime thresholds.
+
+The Codex environment had no usable `origin` remote: `git fetch origin` failed with `fatal: 'origin' does not appear to be a git repository`. The local checkout had no `master` branch, but the checked-out commit was `b946e5c Merge pull request #148 from SNodeC/codex/implement-startup-only-semantic-filters`, which contains merged Round 7. The working tree was clean before the Round 8 branch was created from that commit.
+
+## Exact files changed
+
+- `src/core/socket/stream/SocketConnection.cpp`
+- `src/core/socket/stream/SocketContext.cpp`
+- `tests/unit/log/ControlledMigrationRound8Test.cpp`
+- `tests/unit/log/CMakeLists.txt`
+- `docs/logging/round-08-controlled-subsystem-migration-report.md`
+
+## Exact build commands run
+
+```sh
+git fetch origin
+```
+
+Failed because no usable `origin` remote exists in this environment.
+
+```sh
+git checkout master
+```
+
+Failed because no local `master` branch exists in this environment.
+
+```sh
+git status --short
+git checkout -b codex/implement-logging-roadmap-round-8
+cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON
+cmake --build cmake-build --parallel 2
+cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON
+cmake --build cmake-build-asan --parallel 2
+```
+
+The first non-ASan configure attempt initially failed because `nlohmann-json3-dev` was missing. I installed it with:
+
+```sh
+apt-get update && apt-get install -y nlohmann-json3-dev
+```
+
+Then the required non-ASan configure/build succeeded.
+
+## Exact test commands run
+
+```sh
+git diff --check
+ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test" --output-on-failure
+ctest --test-dir cmake-build --output-on-failure
+ASAN=$(gcc -print-file-name=libasan.so)
+LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure
+```
+
+Focused tests initially failed while the Round 8 assertions expected older `origin=...` text labels. The production code was unchanged; the test assertions were corrected to match the current semantic text output (`framework connection ...`, `framework context ...`), and the focused test command then passed.
+
+## Sanitizer result
+
+ASan configure, build, and test run succeeded with:
+
+```sh
+cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON
+cmake --build cmake-build-asan --parallel 2
+ASAN=$(gcc -print-file-name=libasan.so)
+LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure
+```
+
+The linker emitted libasan warnings about `tmpnam_r`, `tmpnam`, and `tempnam`; no ASan test failures were reported.
+
+## Migration scope
+
+Round 8 only touches the core socket-stream production files below:
+
+- `src/core/socket/stream/SocketConnection.cpp`
+- `src/core/socket/stream/SocketContext.cpp`
+
+No HTTP, WebSocket, MQTT, DB, application example, MiniGateway, OAuth, `apps/`, `src/iot/`, `src/web/`, `src/db/`, or protocol-family wrapper production code was migrated.
+
+## Candidate inventory summary
+
+Before editing, the allowed files were inventoried with:
+
+```sh
+rg -n "\b(P?LOG|VLOG)\s*\(" src/core/socket/stream/SocketConnection.cpp src/core/socket/stream/SocketConnection.hpp src/core/socket/stream/SocketContext.cpp src/core/socket/stream/SocketConnector.hpp src/core/socket/stream/SocketAcceptor.hpp src/core/socket/stream/SocketServer.h src/core/socket/stream/SocketClient.h src/core/socket/stream/SocketConnector.h src/core/socket/stream/SocketAcceptor.h
+```
+
+Summary:
+
+- `SocketConnection.cpp`: 3 legacy `LOG` candidates; all 3 migrated.
+- `SocketContext.cpp`: 8 legacy `LOG`/`PLOG` candidates; all 8 migrated.
+- `SocketConnection.hpp`: many template/lifecycle candidates, including `PLOG`, deferred to avoid a broad template migration in Round 8.
+- `SocketConnector.hpp` and `SocketAcceptor.hpp`: many endpoint lifecycle and syscall candidates, deferred to keep Round 8 deliberately small.
+- `SocketServer.h` and `SocketClient.h`: many endpoint callback candidates, deferred to keep Round 8 deliberately small.
+- No `VLOG(...)` candidates were found in the inventoried allowed files.
+
+## Migrated call-site table
+
+| File | Old call form | New call form | Reason migrated | Semantic owner used | origin/boundary/component/instance/role/connection expectation | errno preserved? |
+| --- | --- | --- | --- | --- | --- | --- |
+| `src/core/socket/stream/SocketConnection.cpp` | `LOG(DEBUG) << connectionName << ": SocketContext created successful"` | `log().debug("SocketContext created successful")` | Direct connection lifecycle diagnostic with existing connection owner | `SocketConnection::log()` | framework / connection / `core.socket.stream` / instance when present / no role / connection present | not applicable |
+| `src/core/socket/stream/SocketConnection.cpp` | `LOG(ERROR) << connectionName << ": SocketContext failed to create"` | `log().error("SocketContext failed to create")` | Direct connection lifecycle diagnostic with existing connection owner | `SocketConnection::log()` | framework / connection / `core.socket.stream` / instance when present / no role / connection present | not applicable |
+| `src/core/socket/stream/SocketConnection.cpp` | `LOG(DEBUG) << connectionName << " SocketContext: switch"` | `log().debug("SocketContext: switch")` | Direct context-switch diagnostic with existing connection owner | `SocketConnection::log()` | framework / connection / `core.socket.stream` / instance when present / no role / connection present | not applicable |
+| `src/core/socket/stream/SocketContext.cpp` | `PLOG(DEBUG) << socketConnection->getConnectionName() << " SocketContext: onWriteError"` | `frameworkLog().sysError(logger::LogLevel::Debug, errnum, "SocketContext: onWriteError")` | Framework-internal write-error diagnostic with errno payload | `SocketContext::frameworkLog()` | framework / context / `core.socket.context` / instance when present / no role / connection present | yes |
+| `src/core/socket/stream/SocketContext.cpp` | `LOG(DEBUG) << socketConnection->getConnectionName() << " SocketContext: EOF received"` | `frameworkLog().debug("SocketContext: EOF received")` | Framework-internal EOF read diagnostic | `SocketContext::frameworkLog()` | framework / context / `core.socket.context` / instance when present / no role / connection present | not applicable |
+| `src/core/socket/stream/SocketContext.cpp` | `PLOG(DEBUG) << socketConnection->getConnectionName() << " SocketContext: onReadError"` | `frameworkLog().sysError(logger::LogLevel::Debug, errnum, "SocketContext: onReadError")` | Framework-internal read-error diagnostic with errno payload | `SocketContext::frameworkLog()` | framework / context / `core.socket.context` / instance when present / no role / connection present | yes |
+| `src/core/socket/stream/SocketContext.cpp` | `LOG(DEBUG) << socketConnection->getConnectionName() << " SocketContext: detached"` | `frameworkLog().debug("SocketContext: detached")` | Framework-internal detach lifecycle diagnostic | `SocketContext::frameworkLog()` | framework / context / `core.socket.context` / instance when present / no role / connection present | not applicable |
+| `src/core/socket/stream/SocketContext.cpp` | `LOG(DEBUG) << "     Online Since: " << getOnlineSince()` | `frameworkLog().debug("     Online Since: {}", getOnlineSince())` | Framework-internal detach summary detail | `SocketContext::frameworkLog()` | framework / context / `core.socket.context` / instance when present / no role / connection present | not applicable |
+| `src/core/socket/stream/SocketContext.cpp` | `LOG(DEBUG) << "  Online Duration: " << getOnlineDuration()` | `frameworkLog().debug("  Online Duration: {}", getOnlineDuration())` | Framework-internal detach summary detail | `SocketContext::frameworkLog()` | framework / context / `core.socket.context` / instance when present / no role / connection present | not applicable |
+| `src/core/socket/stream/SocketContext.cpp` | `LOG(DEBUG) << "       Total Sent: " << getTotalQueued()` | `frameworkLog().debug("       Total Sent: {}", getTotalQueued())` | Framework-internal detach summary detail | `SocketContext::frameworkLog()` | framework / context / `core.socket.context` / instance when present / no role / connection present | not applicable |
+| `src/core/socket/stream/SocketContext.cpp` | `LOG(DEBUG) << "  Total Processed: " << getTotalProcessed()` | `frameworkLog().debug("  Total Processed: {}", getTotalProcessed())` | Framework-internal detach summary detail | `SocketContext::frameworkLog()` | framework / context / `core.socket.context` / instance when present / no role / connection present | not applicable |
+
+Migrated production call-site count: 11.
+
+## Deferred call-site table
+
+| File | Candidate call form | Deferral reason |
+| --- | --- | --- |
+| `src/core/socket/stream/SocketConnection.hpp` | Template constructor address-discovery `LOG`/`PLOG` calls | Template helper path requires a separate review to avoid broad constructor/template churn and to preserve errno at syscall boundaries. |
+| `src/core/socket/stream/SocketConnection.hpp` | Read/write shutdown, timeout, signal, and disconnect `LOG`/`PLOG` calls | Suitable but deferred to keep Round 8 below a broad production migration and within a small reviewable slice. |
+| `src/core/socket/stream/SocketConnector.hpp` | Connector open/bind/connect/getsockopt `LOG`/`PLOG` calls | Endpoint migration is suitable but includes many syscall/error paths; deferred to keep Round 8 focused. |
+| `src/core/socket/stream/SocketAcceptor.hpp` | Acceptor open/bind/listen/accept `LOG`/`PLOG` calls | Endpoint migration is suitable but includes many syscall/error paths; deferred to keep Round 8 focused. |
+| `src/core/socket/stream/SocketServer.h` | Default endpoint callback and listen retry `LOG` calls | Suitable endpoint call sites, but deferred because Round 8 already migrated 11 connection/context call sites. |
+| `src/core/socket/stream/SocketClient.h` | Default endpoint callback and reconnect retry `LOG` calls | Suitable endpoint call sites, but deferred because Round 8 already migrated 11 connection/context call sites. |
+
+No `VLOG(...)` candidates were found in the inventoried allowed files; verbose migration remains deferred as a general policy item.
+
+## Semantic owners used
+
+- `SocketConnection` call sites use the existing `SocketConnection::log()` owner.
+- `SocketContext` framework-internal call sites use the existing `SocketContext::frameworkLog()` owner.
+- No `BoundaryLogger` is stored in production objects.
+- No new `LogScopeOwner` members were added.
+
+## Severity mapping result
+
+- `LOG(DEBUG)` migrated to `.debug(...)`.
+- `LOG(ERROR)` migrated to `.error(...)`.
+- `PLOG(DEBUG)` migrated to `.sysError(logger::LogLevel::Debug, errnum, ...)`.
+- No `LOG(TRACE)`, `LOG(INFO)`, `LOG(WARNING)`, `LOG(FATAL)`, or `VLOG(...)` call sites were migrated in this slice.
+
+## PLOG/sysError result
+
+Two `PLOG(DEBUG)` call sites in `SocketContext` were migrated to semantic `sysError` calls. The existing `errnum` parameter is used directly, so errno code and text are preserved without relying on later global `errno` state. The production methods still assign `errno = errnum` before logging, preserving legacy side effects.
+
+## VLOG deferral result
+
+No `VLOG(...)` candidates were found in the allowed files. No verbose-level migration was performed.
+
+## Identity-prefix cleanup result
+
+Connection-name prefixes were removed only where semantic scope already carries connection identity:
+
+- `SocketConnection::log()` carries the connection boundary and connection identity.
+- `SocketContext::frameworkLog()` carries context boundary, instance identity when present, and connection identity.
+
+Other message text was preserved where it described the event or metric.
+
+## LogManager filter compatibility result
+
+`ControlledMigrationRound8Test` verifies a migrated `SocketContext` debug call is suppressed when `LogManager` global level is `Error`.
+
+## Logger::setLogLevel backend-gate compatibility result
+
+`ControlledMigrationRound8Test` verifies a migrated semantic debug call is suppressed by `Logger::setLogLevel(3)` even when `LogManager` permits trace/debug records.
+
+## Text/Json format compatibility result
+
+`ControlledMigrationRound8Test` verifies a migrated semantic call reaches the text backend with semantic fields and reaches JSON output when `LogManager::Format::Json` is selected.
+
+## Legacy macro compatibility result
+
+Legacy `LOG`, `PLOG`, and `VLOG` macro definitions were not changed. Existing Round 2 through Round 7 semantic logging tests still pass, including the Round 7 legacy macro compatibility coverage.
+
+## Confirmation of non-goals
+
+- Macro definitions were not changed.
+- No broad production migration was done.
+- HTTP, WebSocket, MQTT, DB, apps, MiniGateway, OAuth examples, and protocol-specific subsystems were not migrated.
+- Startup semantic policy was not changed.
+- No runtime reload, signals, admin endpoints, or mutable atomic runtime thresholds were added.
+- JSON schema and format selection behavior were not changed.
+- No `LogSuperClass`, logging inheritance, or logging mixin base was added.
+
+## Deliberate deferrals
+
+- `SocketConnection.hpp` template call sites remain for a follow-up because they include syscall/PLOG paths and broader lifecycle flow.
+- `SocketConnector.hpp` and `SocketAcceptor.hpp` endpoint syscall paths remain for a follow-up so errno handling can be reviewed carefully.
+- `SocketServer.h` and `SocketClient.h` default callback logs remain for a follow-up endpoint-specific round.
+- A broader SNode.C and mqttsuite review was not folded into this production migration because Round 8 explicitly forbids protocol-specific migration and must remain small.
+
+## Known non-blocking follow-ups
+
+- Continue controlled migration in `SocketConnection.hpp` with focused tests around shutdown/read/write paths.
+- Continue endpoint migration in `SocketConnector.hpp` and `SocketAcceptor.hpp`, especially syscall `PLOG` sites with explicit errno preservation.
+- Consider endpoint default callback logs in `SocketServer.h` and `SocketClient.h` once endpoint role assertions are added for migrated production calls.
+- Keep verbose-level migration as a separate policy decision if `VLOG(...)` candidates are encountered later.

--- a/src/core/socket/stream/SocketConnection.cpp
+++ b/src/core/socket/stream/SocketConnection.cpp
@@ -80,10 +80,10 @@ namespace core::socket::stream {
         SocketContext* socketContext = socketContextFactory->create(this);
 
         if (socketContext != nullptr) {
-            LOG(DEBUG) << connectionName << ": SocketContext created successful";
+            log().debug("SocketContext created successful");
             setSocketContext(socketContext);
         } else {
-            LOG(ERROR) << connectionName << ": SocketContext failed to create";
+            log().error("SocketContext failed to create");
             close();
         }
     }
@@ -94,7 +94,7 @@ namespace core::socket::stream {
 
             socketContext->attach();
         } else {
-            LOG(DEBUG) << connectionName << " SocketContext: switch";
+            log().debug("SocketContext: switch");
 
             newSocketContext = socketContext;
         }

--- a/src/core/socket/stream/SocketContext.cpp
+++ b/src/core/socket/stream/SocketContext.cpp
@@ -164,7 +164,7 @@ namespace core::socket::stream {
     void SocketContext::onWriteError(int errnum) {
         errno = errnum;
 
-        PLOG(DEBUG) << socketConnection->getConnectionName() << " SocketContext: onWriteError";
+        frameworkLog().sysError(logger::LogLevel::Debug, errnum, "SocketContext: onWriteError");
         shutdownRead();
     }
 
@@ -172,9 +172,9 @@ namespace core::socket::stream {
         errno = errnum;
 
         if (errno == 0) {
-            LOG(DEBUG) << socketConnection->getConnectionName() << " SocketContext: EOF received";
+            frameworkLog().debug("SocketContext: EOF received");
         } else {
-            PLOG(DEBUG) << socketConnection->getConnectionName() << " SocketContext: onReadError";
+            frameworkLog().sysError(logger::LogLevel::Debug, errnum, "SocketContext: onReadError");
         }
         shutdownWrite();
     }
@@ -189,11 +189,11 @@ namespace core::socket::stream {
     void SocketContext::detach() {
         onDisconnected();
 
-        LOG(DEBUG) << socketConnection->getConnectionName() << " SocketContext: detached";
-        LOG(DEBUG) << "     Online Since: " << getOnlineSince();
-        LOG(DEBUG) << "  Online Duration: " << getOnlineDuration();
-        LOG(DEBUG) << "       Total Sent: " << getTotalQueued();
-        LOG(DEBUG) << "  Total Processed: " << getTotalProcessed();
+        frameworkLog().debug("SocketContext: detached");
+        frameworkLog().debug("     Online Since: {}", getOnlineSince());
+        frameworkLog().debug("  Online Duration: {}", getOnlineDuration());
+        frameworkLog().debug("       Total Sent: {}", getTotalQueued());
+        frameworkLog().debug("  Total Processed: {}", getTotalProcessed());
 
         delete this;
     }

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -28,3 +28,8 @@ snodec_add_test(SemanticFilterRound7Test SemanticFilterRound7Test.cpp)
 target_include_directories(SemanticFilterRound7Test PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(SemanticFilterRound7Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
 set_tests_properties(SemanticFilterRound7Test PROPERTIES LABELS "unit;log;round7")
+
+snodec_add_test(ControlledMigrationRound8Test ControlledMigrationRound8Test.cpp)
+target_include_directories(ControlledMigrationRound8Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(ControlledMigrationRound8Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
+set_tests_properties(ControlledMigrationRound8Test PROPERTIES LABELS "unit;log;round8")

--- a/tests/unit/log/ControlledMigrationRound8Test.cpp
+++ b/tests/unit/log/ControlledMigrationRound8Test.cpp
@@ -1,0 +1,198 @@
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "tests/support/TestResult.h"
+
+#include <cerrno>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace {
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() { return std::string("ROUND8TICK000"); });
+            logger::Logger::logToFile(logFile);
+        }
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+
+    class TestSocketConnection : public core::socket::stream::SocketConnection {
+    public:
+        explicit TestSocketConnection(const std::string& instanceName)
+            : SocketConnection(8, instanceName, nullptr) {}
+        ~TestSocketConnection() override = default;
+
+        using core::socket::stream::SocketConnection::setSocketContext;
+
+        int getFd() const override { return 8; }
+        void sendToPeer(const char*, std::size_t) override {}
+        bool streamToPeer(core::pipe::Source*) override { return false; }
+        void streamEof() override {}
+        std::size_t readFromPeer(char*, std::size_t) override { return 0; }
+        void shutdownRead() override { shutdownReadCalled = true; }
+        void shutdownWrite() override { shutdownWriteCalled = true; }
+        const core::socket::SocketAddress& getBindAddress() const override { return unusableAddress(); }
+        const core::socket::SocketAddress& getLocalAddress() const override { return unusableAddress(); }
+        const core::socket::SocketAddress& getRemoteAddress() const override { return unusableAddress(); }
+        void close() override { closeCalled = true; }
+        void setTimeout(const utils::Timeval&) override {}
+        void setReadTimeout(const utils::Timeval&) override {}
+        void setWriteTimeout(const utils::Timeval&) override {}
+        std::size_t getTotalSent() const override { return 0; }
+        std::size_t getTotalQueued() const override { return 0; }
+        std::size_t getTotalRead() const override { return 0; }
+        std::size_t getTotalProcessed() const override { return 0; }
+
+        bool shutdownReadCalled = false;
+        bool shutdownWriteCalled = false;
+        bool closeCalled = false;
+
+    private:
+        static const core::socket::SocketAddress& unusableAddress() { return *static_cast<const core::socket::SocketAddress*>(nullptr); }
+    };
+
+    class TestSocketContext : public core::socket::stream::SocketContext {
+    public:
+        explicit TestSocketContext(core::socket::stream::SocketConnection* socketConnection)
+            : SocketContext(socketConnection) {}
+        ~TestSocketContext() override = default;
+
+        void exposeReadError(int errnum) { onReadError(errnum); }
+        void exposeWriteError(int errnum) { onWriteError(errnum); }
+
+    private:
+        std::size_t onReceivedFromPeer() override { return 0; }
+        bool onSignal(int) override { return false; }
+        void onConnected() override {}
+        void onDisconnected() override {}
+    };
+}
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto connectionPath = tempLogPath("snodec-round8-connection.log");
+    {
+        LoggerStateGuard guard(connectionPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::freeze();
+        TestSocketConnection connection("round8-instance");
+        auto* first = new TestSocketContext(&connection);
+        auto* second = new TestSocketContext(&connection);
+        connection.setSocketContext(first);
+        connection.setSocketContext(second);
+        delete first;
+        delete second;
+    }
+    const auto connectionLog = readFile(connectionPath);
+    result.expectTrue(connectionLog.find("SocketContext: switch") != std::string::npos, "migrated SocketConnection call emits through semantic backend");
+    result.expectTrue(connectionLog.find(" framework connection core.socket.stream ") != std::string::npos,
+                      "migrated SocketConnection call carries framework connection scope");
+
+    const auto contextPath = tempLogPath("snodec-round8-context.log");
+    {
+        LoggerStateGuard guard(contextPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::freeze();
+        TestSocketConnection connection("round8-instance");
+        TestSocketContext context(&connection);
+        context.exposeReadError(0);
+    }
+    const auto contextLog = readFile(contextPath);
+    result.expectTrue(contextLog.find("SocketContext: EOF received") != std::string::npos, "migrated SocketContext call emits through semantic backend");
+    result.expectTrue(contextLog.find(" framework context core.socket.context ") != std::string::npos,
+                      "migrated SocketContext framework-internal call emits with framework origin");
+
+    const auto filterPath = tempLogPath("snodec-round8-filter.log");
+    {
+        LoggerStateGuard guard(filterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        TestSocketConnection connection("round8-instance");
+        TestSocketContext context(&connection);
+        context.exposeReadError(0);
+    }
+    result.expectTrue(readFile(filterPath).find("SocketContext: EOF received") == std::string::npos, "migrated call respects LogManager filtering");
+
+    const auto gatePath = tempLogPath("snodec-round8-backend-gate.log");
+    {
+        LoggerStateGuard guard(gatePath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        logger::Logger::setLogLevel(3);
+        TestSocketConnection connection("round8-instance");
+        TestSocketContext context(&connection);
+        context.exposeReadError(0);
+    }
+    result.expectTrue(readFile(gatePath).find("SocketContext: EOF received") == std::string::npos, "migrated call respects Logger::setLogLevel backend gate");
+
+    const auto jsonPath = tempLogPath("snodec-round8-json.log");
+    {
+        LoggerStateGuard guard(jsonPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        TestSocketConnection connection("round8-instance");
+        TestSocketContext context(&connection);
+        context.exposeReadError(0);
+    }
+    const auto jsonLog = readFile(jsonPath);
+    result.expectTrue(jsonLog.find("{\"v\":1") != std::string::npos && jsonLog.find("\"message\":\"SocketContext: EOF received\"") != std::string::npos,
+                      "migrated call respects Json format selection");
+
+    const auto sysErrorPath = tempLogPath("snodec-round8-syserror.log");
+    {
+        LoggerStateGuard guard(sysErrorPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        TestSocketConnection connection("round8-instance");
+        TestSocketContext context(&connection);
+        context.exposeWriteError(EACCES);
+    }
+    const auto sysErrorLog = readFile(sysErrorPath);
+    result.expectTrue(sysErrorLog.find("SocketContext: onWriteError") != std::string::npos && sysErrorLog.find("\"code\":13") != std::string::npos &&
+                          sysErrorLog.find("Permission denied") != std::string::npos,
+                      "migrated PLOG-equivalent preserves errno code and text");
+
+    TestSocketConnection sinkConnection("round8-sink");
+    std::vector<logger::LogRecord> records;
+    sinkConnection.log([&](logger::LogRecord record) { records.push_back(std::move(record)); }).debug("sink overload still works");
+    result.expectEqual(1, static_cast<int>(records.size()), "sink-taking overload remains compatible");
+    result.expectTrue(records[0].message == "sink overload still works", "sink-taking overload captures message");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation
- Begin a small, controlled production migration from legacy `LOG`/`PLOG` macros to object-owned semantic logging in the core socket-stream subsystem as specified by Round 8 contract. 
- Only migrate reviewable call sites where Round 4/5 semantic owners already exist, preserve semantics (severity, errno, identity) and avoid broad template/protocol changes.

### Description
- Replaced 11 legacy production call sites in the allowed core socket-stream area with semantic logging: 3 in `src/core/socket/stream/SocketConnection.cpp` now use `log().debug(...)` / `log().error(...)`, and 8 in `src/core/socket/stream/SocketContext.cpp` now use `frameworkLog().debug(...)` and errno-preserving `frameworkLog().sysError(...)` where appropriate. 
- Preserved severity mapping, captured `errnum` immediately for `sysError(...)` so errno code/text are preserved, and removed identity prefixes only where the semantic scope already carries connection/instance identity. 
- Added a focused Round 8 unit test `tests/unit/log/ControlledMigrationRound8Test.cpp` and registered it in `tests/unit/log/CMakeLists.txt`. 
- Added migration report `docs/logging/round-08-controlled-subsystem-migration-report.md` containing inventory, migrated/deferred tables, validation commands, and non-goal confirmations. 
- No legacy macro definitions were changed; no new `LogScopeOwner` members or global runtime configuration were added.

### Testing
- Built with `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build --parallel 2` and ran focused unit tests with `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test" --output-on-failure`, which passed after a minor test assertion adjustment to match current semantic textual output. 
- Ran full test suite with `ctest --test-dir cmake-build --output-on-failure` and an ASan build (`cmake -S . -B cmake-build-asan -DSNODEC_ENABLE_ASAN=ON` + `LD_PRELOAD=$(gcc -print-file-name=libasan.so) ctest --test-dir cmake-build-asan --output-on-failure`); all tests passed and ASan run produced linker warnings about `tmpnam*` but no ASan failures. 
- Note: the Codex environment had no usable `origin` remote (`git fetch origin` failed) and no local `master` branch, so the Round 8 branch `codex/implement-logging-roadmap-round-8` was created from the checked-out commit (which already contains merged Round 7) after confirming the tree was clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ab2ab9b9c832cbad2e0389bebd9cc)