### PR TITLE
Logging roadmap round 09 — compatibility and sanitizer gates

### DIFF
--- a/docs/logging/round-09-compatibility-sanitizer-overhead-report.md
+++ b/docs/logging/round-09-compatibility-sanitizer-overhead-report.md
@@ -1,0 +1,175 @@
+# Logging roadmap round 09 — compatibility, sanitizer, and overhead gates
+
+Round 9 is a gate-hardening round.
+
+Round 9 does not perform additional production call-site migration.
+
+Round 9 does not change LOG/PLOG/VLOG macro definitions.
+
+Round 9 does not change startup semantic policy.
+
+Round 9 does not change JSON v1.
+
+Round 9 does not add runtime reload, signals, admin endpoints, or mutable atomic runtime thresholds.
+
+Round 10 remains the book integration round.
+
+## Base verification
+
+The Codex environment had no usable `origin` remote: `git fetch origin` failed with `fatal: 'origin' does not appear to be a git repository`. The local checkout had no `master` branch; it started from the `work` branch at `a5f4478 Merge pull request #149 from SNodeC/codex/implement-logging-roadmap-round-8-migration`. The working tree was clean before Round 9 edits, and Round 8 was confirmed present before work continued by checking:
+
+- `docs/logging/round-08-controlled-subsystem-migration-report.md`
+- `tests/unit/log/ControlledMigrationRound8Test.cpp`
+- `git log --oneline -n 10`, which showed the Round 8 merge commit.
+
+A fresh branch named `codex/implement-logging-roadmap-round-9` was created from that checked-out Round 8 commit.
+
+## Implementation summary
+
+Round 9 adds deterministic compatibility and overhead gates around the semantic logging foundation. It does not add logging architecture, does not change production logging code, and does not migrate additional production call sites. The new tests cover legacy macro behavior, semantic API behavior, startup/freeze policy compatibility, Text/JSON formatter compatibility, `sysError`/errno preservation, borrowed `string_view` lifetime safety, Round 8 migrated SocketConnection/SocketContext call-site compatibility, and suppression/overhead invariants.
+
+## Exact files changed
+
+- `tests/unit/log/SemanticCompatibilityRound9Test.cpp` — new focused Round 9 compatibility test.
+- `tests/unit/log/SemanticOverheadRound9Test.cpp` — new focused Round 9 overhead/suppression test.
+- `tests/unit/log/CMakeLists.txt` — registers the two Round 9 tests.
+- `docs/logging/round-09-compatibility-sanitizer-overhead-report.md` — this report.
+
+No production source files were changed.
+
+## Exact build commands run
+
+```sh
+git fetch origin
+# failed because there is no usable origin remote in this Codex environment
+
+git checkout master
+# failed because this checkout has no local master branch
+
+git status --short
+test -f docs/logging/round-08-controlled-subsystem-migration-report.md
+test -f tests/unit/log/ControlledMigrationRound8Test.cpp
+git log --oneline -n 10
+git checkout -b codex/implement-logging-roadmap-round-9
+
+cmake -S . -B cmake-build \
+  -DSNODEC_BUILD_TESTS=ON \
+  -DSNODEC_BUILD_APPS=ON
+cmake --build cmake-build --parallel 2
+
+cmake -S . -B cmake-build-asan \
+  -DSNODEC_BUILD_TESTS=ON \
+  -DSNODEC_BUILD_APPS=ON \
+  -DSNODEC_ENABLE_ASAN=ON
+cmake --build cmake-build-asan --parallel 2
+```
+
+The first normal configure initially failed because `nlohmann-json3-dev` was not installed while apps were enabled. The missing package was installed with:
+
+```sh
+apt-get update && apt-get install -y nlohmann-json3-dev
+```
+
+The normal build and ASan build then completed successfully. Configure emitted non-blocking environment warnings for missing Doxygen, include-what-you-use, BlueZ/libbluetooth, libmagic, and libmariadb.
+
+## Exact test and check commands run
+
+```sh
+git diff --check
+
+ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test" --output-on-failure
+
+ctest --test-dir cmake-build --output-on-failure
+
+ASAN=$(gcc -print-file-name=libasan.so)
+LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure
+```
+
+Results:
+
+- `git diff --check` passed.
+- Focused Round 2–9 logging ctest passed: 9/9 tests passed.
+- Full normal ctest passed: 116/116 tests passed, with 0 failures; the suite reports many network/component tests as skipped in this environment.
+- ASan full ctest passed: 116/116 tests passed, with 0 failures; the suite reports the same environment skips.
+
+## Sanitizer commands and results
+
+ASan was run with the project-supported `SNODEC_ENABLE_ASAN` option:
+
+```sh
+cmake -S . -B cmake-build-asan \
+  -DSNODEC_BUILD_TESTS=ON \
+  -DSNODEC_BUILD_APPS=ON \
+  -DSNODEC_ENABLE_ASAN=ON
+cmake --build cmake-build-asan --parallel 2
+ASAN=$(gcc -print-file-name=libasan.so)
+LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure
+```
+
+ASan result: build passed and full ctest passed with no ASan-reported failures. The ASan validation includes `ControlledMigrationRound8Test`, `SemanticCompatibilityRound9Test`, and `SemanticOverheadRound9Test`.
+
+UBSan result: UBSan was not run because the project exposes `SNODEC_ENABLE_ASAN` but no existing UBSan CMake option was found by `rg -n "UBSAN|ASAN|SANIT" CMakeLists.txt cmake src tests`. Round 9 intentionally did not invent a new global sanitizer flag or otherwise disrupt normal build behavior.
+
+## Legacy macro compatibility audit result
+
+The required audit command was run:
+
+```sh
+rg -n "\\b(LOG|PLOG|VLOG)\\s*\\(" src tests | tee /tmp/round9-legacy-macro-audit.txt
+```
+
+The audit found 1242 legacy macro call-site matches across `src` and `tests`. Legacy macros remain defined, legacy macro call sites still compile, Round 9 did not migrate additional production call sites, and remaining `LOG`/`PLOG`/`VLOG` call sites are intentionally left for future controlled migrations.
+
+## Compatibility results
+
+- Legacy macro compatibility: `SemanticCompatibilityRound9Test` verifies `LOG(INFO)`, `PLOG(ERROR)`, `VLOG(level)`, and numeric `Logger::setLogLevel(...)` behavior.
+- Semantic API compatibility: default backend-backed semantic sinks and sink-taking semantic overloads are covered.
+- LogManager compatibility: semantic filters remain independent from legacy macros; freeze behavior remains immutable; repeated frozen `effectiveLevel(scope)` lookups are stable.
+- Text/JSON compatibility: Text format selection still uses `formatText(record)`, Json format selection still uses `formatJsonV1(record)`, JSON v1 mandatory fields are present, and absent optional fields are omitted rather than emitted as `null`.
+- `sysError`/errno compatibility: semantic `sysError` preserves errno code and text; Round 8 migrated write-error logging also preserves errno code/text.
+- Borrowed `string_view` lifetime result: tests cover copied scope fields when original component/instance strings are mutated or destroyed before logger emission.
+- Round 8 migrated call-site compatibility: tests cover the migrated `SocketConnection` switch log, migrated `SocketContext` framework EOF log, and migrated `SocketContext` sysError log.
+
+## Overhead/suppression gate result
+
+`SemanticOverheadRound9Test` adds deterministic, non-timing gates for:
+
+- BoundaryLogger threshold suppression not invoking the supplied sink.
+- `LogLevel::Off` not invoking the supplied sink.
+- LogManager semantic suppression preventing backend output.
+- `Logger::setLogLevel` backend suppression preventing backend output.
+- Suppressed stream emission not evaluating an expensive insertion operand.
+- Suppressed default backend path emitting no formatted output.
+- Repeated frozen `effectiveLevel(scope)` lookups remaining stable.
+- No heap-use-after-free when original scope strings are mutated/destroyed before logger emission.
+
+No timing-based hard CI gate was introduced. No optional microbenchmark was added or run.
+
+## General SNode.C and mqttsuite review note
+
+Round 9 validation built the broad SNode.C tree with apps enabled, including MQTT-related targets present in this repository, and full ctest was run in both normal and ASan configurations. No MQTT-specific source changes or migrations were made. A deeper mqttsuite-specific review is deliberately deferred because Round 9's hard non-goals prohibit touching protocol/application/MQTT layers.
+
+## Confirmations
+
+- No production migration was done.
+- Macro definitions were not changed.
+- CLI behavior was not changed.
+- LogManager policy semantics were not changed.
+- JSON v1 schema was not changed.
+- No protocol/application/MQTT/HTTP/WebSocket/DB/MiniGateway migration was done.
+- No runtime reload, signals, admin endpoints, mutable atomic runtime thresholds, logging inheritance, logging mixin base, or `LogSuperClass` was added.
+- Round 10 remains the book integration round.
+
+## Deliberate deferrals
+
+- No book/manuscript material was edited.
+- No new production logging call sites were migrated.
+- No runtime reconfiguration or reload feature was added.
+- No new public hooks were added solely to count formatter calls.
+- UBSan support remains deferred until the project has an agreed, non-disruptive sanitizer option.
+
+## Known non-blocking follow-ups
+
+- Add a project-supported UBSan or ASan+UBSan CMake option in a dedicated build-system round if desired.
+- Add non-gating logging microbenchmarks if reviewers want repeatable local performance observations.
+- Continue controlled production call-site migrations only in future roadmap rounds.

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -33,3 +33,13 @@ snodec_add_test(ControlledMigrationRound8Test ControlledMigrationRound8Test.cpp)
 target_include_directories(ControlledMigrationRound8Test PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(ControlledMigrationRound8Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
 set_tests_properties(ControlledMigrationRound8Test PROPERTIES LABELS "unit;log;round8")
+
+snodec_add_test(SemanticCompatibilityRound9Test SemanticCompatibilityRound9Test.cpp)
+target_include_directories(SemanticCompatibilityRound9Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(SemanticCompatibilityRound9Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
+set_tests_properties(SemanticCompatibilityRound9Test PROPERTIES LABELS "unit;log;round9")
+
+snodec_add_test(SemanticOverheadRound9Test SemanticOverheadRound9Test.cpp)
+target_include_directories(SemanticOverheadRound9Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(SemanticOverheadRound9Test PRIVATE snodec-test-support snodec::logger)
+set_tests_properties(SemanticOverheadRound9Test PROPERTIES LABELS "unit;log;round9")

--- a/tests/unit/log/SemanticCompatibilityRound9Test.cpp
+++ b/tests/unit/log/SemanticCompatibilityRound9Test.cpp
@@ -1,0 +1,222 @@
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "tests/support/TestResult.h"
+
+#include <cerrno>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace {
+    std::chrono::system_clock::time_point fixedTimestamp() {
+        using namespace std::chrono;
+        return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
+    }
+
+    class StateGuard {
+    public:
+        explicit StateGuard(const std::string& logFile) : savedErrno(errno) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() { return std::string("ROUND9TICK000"); });
+            logger::Logger::logToFile(logFile);
+        }
+        ~StateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = savedErrno;
+        }
+
+    private:
+        int savedErrno;
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+
+    logger::LogScope scope(std::string_view component = "round9.component", std::string_view instance = "round9-instance") {
+        return {logger::LogOrigin::Framework, logger::LogBoundary::System, component, instance, logger::LogRole::Server, "round9-connection"};
+    }
+
+    logger::LogRecord record(logger::LogLevel level, std::string message) {
+        logger::LogRecordOptions options;
+        options.ts = fixedTimestamp();
+        return logger::materialize(scope(), level, std::move(message), std::move(options));
+    }
+
+    class TestSocketConnection : public core::socket::stream::SocketConnection {
+    public:
+        explicit TestSocketConnection(const std::string& instanceName) : SocketConnection(9, instanceName, nullptr) {}
+        ~TestSocketConnection() override = default;
+        using core::socket::stream::SocketConnection::setSocketContext;
+        int getFd() const override { return 9; }
+        void sendToPeer(const char*, std::size_t) override {}
+        bool streamToPeer(core::pipe::Source*) override { return false; }
+        void streamEof() override {}
+        std::size_t readFromPeer(char*, std::size_t) override { return 0; }
+        void shutdownRead() override {}
+        void shutdownWrite() override {}
+        const core::socket::SocketAddress& getBindAddress() const override { return unusableAddress(); }
+        const core::socket::SocketAddress& getLocalAddress() const override { return unusableAddress(); }
+        const core::socket::SocketAddress& getRemoteAddress() const override { return unusableAddress(); }
+        void close() override {}
+        void setTimeout(const utils::Timeval&) override {}
+        void setReadTimeout(const utils::Timeval&) override {}
+        void setWriteTimeout(const utils::Timeval&) override {}
+        std::size_t getTotalSent() const override { return 0; }
+        std::size_t getTotalQueued() const override { return 0; }
+        std::size_t getTotalRead() const override { return 0; }
+        std::size_t getTotalProcessed() const override { return 0; }
+    private:
+        static const core::socket::SocketAddress& unusableAddress() { return *static_cast<const core::socket::SocketAddress*>(nullptr); }
+    };
+
+    class TestSocketContext : public core::socket::stream::SocketContext {
+    public:
+        explicit TestSocketContext(core::socket::stream::SocketConnection* socketConnection) : SocketContext(socketConnection) {}
+        ~TestSocketContext() override = default;
+        void exposeReadError(int errnum) { onReadError(errnum); }
+        void exposeWriteError(int errnum) { onWriteError(errnum); }
+    private:
+        std::size_t onReceivedFromPeer() override { return 0; }
+        bool onSignal(int) override { return false; }
+        void onConnected() override {}
+        void onDisconnected() override {}
+    };
+}
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto legacyPath = tempLogPath("snodec-round9-legacy.log");
+    {
+        StateGuard guard(legacyPath.string());
+        LOG(INFO) << "round9 legacy info";
+        errno = EACCES;
+        PLOG(ERROR) << "round9 legacy plog";
+        VLOG(1) << "round9 verbose hidden";
+        logger::Logger::setVerboseLevel(1);
+        VLOG(1) << "round9 verbose visible";
+        logger::Logger::setLogLevel(3);
+        LOG(INFO) << "round9 numeric info hidden";
+        LOG(WARNING) << "round9 numeric warning visible";
+    }
+    const auto legacyLog = readFile(legacyPath);
+    result.expectTrue(legacyLog.find("round9 legacy info") != std::string::npos, "LOG(INFO) emits through legacy backend");
+    result.expectTrue(legacyLog.find("round9 legacy plog") != std::string::npos && legacyLog.find("Permission denied") != std::string::npos,
+                      "PLOG(ERROR) preserves errno text through legacy backend");
+    result.expectTrue(legacyLog.find("round9 verbose hidden") == std::string::npos && legacyLog.find("round9 verbose visible") != std::string::npos,
+                      "VLOG respects Logger::setVerboseLevel");
+    result.expectTrue(legacyLog.find("round9 numeric info hidden") == std::string::npos && legacyLog.find("round9 numeric warning visible") != std::string::npos,
+                      "Logger::setLogLevel numeric thresholds remain compatible");
+
+    const auto independencePath = tempLogPath("snodec-round9-independent.log");
+    {
+        StateGuard guard(independencePath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Off);
+        logger::LogManager::freeze();
+        LOG(ERROR) << "legacy unaffected by semantic off";
+        logger::Logger::emitSemantic(record(logger::LogLevel::Error, "semantic filtered by off"));
+    }
+    const auto independenceLog = readFile(independencePath);
+    result.expectTrue(independenceLog.find("legacy unaffected by semantic off") != std::string::npos && independenceLog.find("semantic filtered by off") == std::string::npos,
+                      "LogManager filtering remains independent from legacy macros");
+
+    const auto semanticPath = tempLogPath("snodec-round9-semantic.log");
+    {
+        StateGuard guard(semanticPath.string());
+        logger::BoundaryLogger::createForTest(scope(), logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedTimestamp).info("default semantic backend");
+    }
+    result.expectTrue(readFile(semanticPath).find("default semantic backend") != std::string::npos, "default no-argument semantic sink emits through backend");
+
+    std::vector<logger::LogRecord> captured;
+    logger::BoundaryLogger::createForTest(scope(), [&](logger::LogRecord capturedRecord) { captured.push_back(std::move(capturedRecord)); }, logger::LogLevel::Trace, fixedTimestamp)
+        .info("captured only");
+    result.expectEqual(1, static_cast<int>(captured.size()), "sink-taking semantic overload captures records");
+
+    bool froze = false;
+    logger::LogManager::init();
+    logger::LogManager::setGlobalLevel(logger::LogLevel::Warn);
+    logger::LogManager::freeze();
+    try { logger::LogManager::setGlobalLevel(logger::LogLevel::Trace); } catch (const std::logic_error&) { froze = true; }
+    result.expectTrue(froze && logger::LogManager::effectiveLevel(scope()) == logger::LogLevel::Warn, "LogManager freeze remains immutable");
+    logger::LogManager::init();
+
+    const auto text = logger::formatText(record(logger::LogLevel::Info, "text format message"));
+    result.expectTrue(logger::LogManager::formatRecord(record(logger::LogLevel::Info, "text format message")) == text, "Text format uses formatText");
+    logger::LogManager::setFormat(logger::LogManager::Format::Json);
+    const auto jsonRecord = record(logger::LogLevel::Info, "json format message");
+    const auto json = logger::LogManager::formatRecord(jsonRecord);
+    result.expectTrue(json == logger::formatJsonV1(jsonRecord), "Json format uses formatJsonV1");
+    result.expectTrue(json.find("\"v\":1") != std::string::npos && json.find("\"ts\":") != std::string::npos && json.find("\"level\":\"info\"") != std::string::npos &&
+                          json.find("\"origin\":\"framework\"") != std::string::npos && json.find("\"boundary\":\"system\"") != std::string::npos &&
+                          json.find("\"component\":\"round9.component\"") != std::string::npos && json.find("\"message\":\"json format message\"") != std::string::npos,
+                      "JSON v1 mandatory fields are present");
+    const auto sparseJson = logger::formatJsonV1(logger::materialize(scope("round9.sparse", ""), logger::LogLevel::Info, "sparse", {std::nullopt, std::nullopt, std::nullopt, fixedTimestamp()}));
+    result.expectTrue(sparseJson.find("\"instance\"") == std::string::npos && sparseJson.find("\"event\"") == std::string::npos && sparseJson.find("null") == std::string::npos,
+                      "JSON v1 optional fields are omitted when absent");
+    logger::LogManager::init();
+
+    std::vector<logger::LogRecord> errors;
+    logger::BoundaryLogger::createForTest(scope(), [&](logger::LogRecord errorRecord) { errors.push_back(std::move(errorRecord)); }, logger::LogLevel::Trace, fixedTimestamp)
+        .sysError(logger::LogLevel::Error, EACCES, "semantic sysError");
+    result.expectTrue(errors.size() == 1 && errors[0].error && errors[0].error->code == EACCES && errors[0].error->text.find("Permission denied") != std::string::npos,
+                      "sysError preserves errno code and error text");
+
+    std::vector<logger::LogRecord> borrowed;
+    std::string component = "borrowed.component";
+    auto borrowedLogger = logger::BoundaryLogger::createForTest(scope(component, "borrowed-instance"), [&](logger::LogRecord borrowedRecord) { borrowed.push_back(std::move(borrowedRecord)); }, logger::LogLevel::Trace, fixedTimestamp);
+    component.assign("mutated.component");
+    borrowedLogger.info("borrowed safe");
+    result.expectTrue(borrowed.size() == 1 && borrowed[0].component == "borrowed.component", "borrowed LogScope string_views are copied before sink use");
+
+    const auto migratedPath = tempLogPath("snodec-round9-migrated.log");
+    {
+        StateGuard guard(migratedPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        TestSocketConnection connection("round9-instance");
+        auto* first = new TestSocketContext(&connection);
+        auto* second = new TestSocketContext(&connection);
+        connection.setSocketContext(first);
+        connection.setSocketContext(second);
+        TestSocketContext context(&connection);
+        context.exposeReadError(0);
+        context.exposeWriteError(EACCES);
+        delete first;
+        delete second;
+    }
+    const auto migratedLog = readFile(migratedPath);
+    result.expectTrue(migratedLog.find("SocketContext: switch") != std::string::npos, "Round 8 SocketConnection migrated call emits semantically");
+    result.expectTrue(migratedLog.find("SocketContext: EOF received") != std::string::npos && migratedLog.find("\"origin\":\"framework\"") != std::string::npos,
+                      "Round 8 SocketContext frameworkLog call emits with framework origin");
+    result.expectTrue(migratedLog.find("SocketContext: onWriteError") != std::string::npos && migratedLog.find("\"code\":13") != std::string::npos &&
+                          migratedLog.find("Permission denied") != std::string::npos,
+                      "Round 8 migrated sysError call preserves errno code/text");
+
+    return result.processResult();
+}

--- a/tests/unit/log/SemanticOverheadRound9Test.cpp
+++ b/tests/unit/log/SemanticOverheadRound9Test.cpp
@@ -1,0 +1,135 @@
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "tests/support/TestResult.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <optional>
+#include <ostream>
+#include <vector>
+
+namespace {
+    struct ExpensiveValue {
+        int* evaluations;
+    };
+
+    std::ostream& operator<<(std::ostream& out, const ExpensiveValue& value) {
+        ++*value.evaluations;
+        return out << "expensive";
+    }
+
+    class StateGuard {
+    public:
+        explicit StateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() { return std::string("ROUND9OVERHD"); });
+            logger::Logger::logToFile(logFile);
+        }
+        ~StateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+
+    logger::LogScope scope(std::string_view component = "round9.overhead", std::string_view instance = "round9-overhead") {
+        return {logger::LogOrigin::Framework, logger::LogBoundary::System, component, instance, logger::LogRole::Server, "round9-overhead-connection"};
+    }
+
+    std::chrono::system_clock::time_point fixedTimestamp() {
+        using namespace std::chrono;
+        return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
+    }
+}
+
+int main() {
+    tests::support::TestResult result;
+
+    int sinkCalls = 0;
+    auto suppressed = logger::BoundaryLogger::createForTest(scope(), [&](logger::LogRecord) { ++sinkCalls; }, logger::LogLevel::Error, fixedTimestamp);
+    suppressed.info("suppressed by threshold");
+    result.expectEqual(0, sinkCalls, "BoundaryLogger threshold suppression does not invoke sink");
+    suppressed.emit(logger::LogLevel::Off, "suppressed off");
+    result.expectEqual(0, sinkCalls, "LogLevel::Off does not invoke sink");
+
+    const auto semanticSuppressedPath = tempLogPath("snodec-round9-overhead-semantic.log");
+    {
+        StateGuard guard(semanticSuppressedPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Off);
+        logger::LogManager::freeze();
+        logger::BoundaryLogger::createForTest(scope(), logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedTimestamp).error("suppressed by LogManager");
+    }
+    result.expectTrue(readFile(semanticSuppressedPath).find("suppressed by LogManager") == std::string::npos, "LogManager semantic suppression prevents backend output");
+
+    const auto backendSuppressedPath = tempLogPath("snodec-round9-overhead-backend.log");
+    {
+        StateGuard guard(backendSuppressedPath.string());
+        logger::Logger::setLogLevel(2);
+        logger::BoundaryLogger::createForTest(scope(), logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedTimestamp).info("suppressed by backend threshold");
+    }
+    result.expectTrue(readFile(backendSuppressedPath).find("suppressed by backend threshold") == std::string::npos, "Logger::setLogLevel backend suppression prevents backend output");
+
+    int expensiveEvaluations = 0;
+    suppressed.info() << ExpensiveValue{&expensiveEvaluations};
+    result.expectEqual(0, expensiveEvaluations, "suppressed stream path does not evaluate expensive insertion");
+
+    const auto formatGatePath = tempLogPath("snodec-round9-overhead-format-gate.log");
+    {
+        StateGuard guard(formatGatePath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Off);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        logger::BoundaryLogger::createForTest(scope(), logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedTimestamp).error("format gate message");
+    }
+    const auto gatedLog = readFile(formatGatePath);
+    result.expectTrue(gatedLog.find("format gate message") == std::string::npos && gatedLog.find("{\"v\":1") == std::string::npos,
+                      "suppressed default backend path emits no formatted text");
+
+    logger::LogManager::init();
+    logger::LogManager::setComponentLevel("round9.overhead", logger::LogLevel::Warn);
+    logger::LogManager::freeze();
+    const auto first = logger::LogManager::effectiveLevel(scope());
+    bool stable = true;
+    for (int i = 0; i < 16; ++i) {
+        stable = stable && logger::LogManager::effectiveLevel(scope()) == first;
+    }
+    result.expectTrue(stable && first == logger::LogLevel::Warn, "repeated effectiveLevel lookups after freeze are stable");
+    logger::LogManager::init();
+
+    std::vector<logger::LogRecord> records;
+    std::optional<logger::BoundaryLogger> lifetimeLogger;
+    {
+        std::string component = "lifetime.component";
+        std::string instance = "lifetime-instance";
+        lifetimeLogger.emplace(logger::BoundaryLogger::createForTest(scope(component, instance), [&](logger::LogRecord record) { records.push_back(std::move(record)); }, logger::LogLevel::Trace, fixedTimestamp));
+        component.assign("changed");
+        instance.assign("changed");
+    }
+    lifetimeLogger->info("lifetime safe");
+    result.expectTrue(records.size() == 1 && records[0].component == "lifetime.component" && records[0].instance && *records[0].instance == "lifetime-instance",
+                      "original scope strings may be mutated/destroyed before logger emission");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation
- Round 9 is a gate-hardening pass to prove compatibility and safety of the semantic logging foundation without introducing new production migrations or architecture changes. 
- The changes aim to validate legacy macro compatibility, semantic API compatibility, Text/JSON formatter compatibility, `sysError`/`errno` preservation, borrowed `string_view` lifetime safety, sanitizer validation, and deterministic low-overhead suppression invariants.

### Description
- Add deterministic compatibility coverage in `tests/unit/log/SemanticCompatibilityRound9Test.cpp` validating legacy `LOG`/`PLOG`/`VLOG` behavior, semantic sink/back-end interaction, `LogManager` freeze/filter semantics, text/json formatting, JSON v1 field rules, `sysError` errno preservation, borrowed-scope safety, and Round 8 migrated Socket call-site compatibility. 
- Add deterministic overhead/suppression gates in `tests/unit/log/SemanticOverheadRound9Test.cpp` covering `BoundaryLogger` threshold suppression, `LogLevel::Off`, semantic/backend suppression, suppressed stream insertion avoidance, format-gate behavior, frozen `effectiveLevel` stability, and scope lifetime safety. 
- Register both tests in `tests/unit/log/CMakeLists.txt` and add the validation report `docs/logging/round-09-compatibility-sanitizer-overhead-report.md`; no production source files or macro definitions were changed. 

### Testing
- Built the project with `-DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and ran focused logging tests `ctest -R

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4abeb37eac832c904126c95f109d05)