### PR TITLE
Semantic logging repair — production threshold wiring

### DIFF
--- a/docs/logging/semantic-production-threshold-repair-report.md
+++ b/docs/logging/semantic-production-threshold-repair-report.md
@@ -1,0 +1,135 @@
+# Semantic logging repair — production threshold wiring and hygiene
+
+## Summary of the defect
+
+Production semantic no-arg loggers were constructing `BoundaryLogger` instances through sink-taking overloads that defaulted the local threshold to `LogLevel::Trace`. Output filtering remained correct because `Logger::emitSemantic()` still applies `LogManager::shouldEmit(record)`, but suppressed format-style calls had already formatted their message and materialized a `LogRecord` before that final policy gate.
+
+This repair fixes production threshold wiring so no-arg semantic loggers use `LogManager::effectiveLevel(scope)`.
+
+This repair ensures format-style semantic calls check `BoundaryLogger::enabled(level)` before formatting.
+
+This repair ensures `sysError` checks `BoundaryLogger::enabled(level)` before formatting or building error payloads.
+
+## Root cause
+
+The no-arg production APIs called their sink-taking overloads with `Logger::semanticSink()` and relied on the explicit-threshold overload default of `LogLevel::Trace`. That default is appropriate for custom sink/testing compatibility, but it is not appropriate for backend-backed production no-arg loggers that should use the frozen startup semantic policy as their local threshold.
+
+## Branch and precondition notes
+
+The requested `origin` remote was not usable in this environment: `git fetch origin` failed with `fatal: 'origin' does not appear to be a git repository`. The checkout was clean before changes, and Round 9 / PR #150 was confirmed present by the required files and `git log --oneline -n 12`, including `9a6f335 Merge pull request #150 from SNodeC/codex/implement-logging-roadmap-round-9`.
+
+## Exact files changed
+
+- `src/log/SemanticLogger.h`
+- `src/log/SemanticLogger.cpp`
+- `src/log/LogScopeOwner.h`
+- `src/log/LogScopeOwner.cpp`
+- `src/net/config/ConfigInstance.cpp`
+- `src/core/socket/stream/SocketConnection.cpp`
+- `src/core/socket/stream/SocketContext.cpp`
+- `src/core/socket/stream/SocketServer.h`
+- `src/core/socket/stream/SocketClient.h`
+- `src/core/socket/stream/SocketConnector.h`
+- `src/core/socket/stream/SocketAcceptor.h`
+- `tests/unit/log/SemanticProductionThresholdRepairTest.cpp`
+- `tests/unit/log/CMakeLists.txt`
+- `docs/logging/semantic-production-threshold-repair-report.md`
+
+## Exact production loggers repaired
+
+- `ConfigInstance::log()`
+- `SocketConnection::log()`
+- `SocketContext::log()`
+- `SocketContext::frameworkLog()`
+- `SocketServer::log()`
+- `SocketClient::log()`
+- `SocketConnector::log()`
+- `SocketAcceptor::log()`
+
+## LogScopeOwner helper
+
+A `LogScopeOwner::logger(BoundaryLogger::Sink sink, BoundaryLogger::Clock clock = {}) const` helper was added. It resolves `LogManager::effectiveLevel(scope())` and delegates to the preserved explicit-threshold overload.
+
+The explicit-threshold overload remains available and still honors caller-provided thresholds for custom sink and test paths.
+
+## Format-style suppression fix
+
+`BoundaryLogger::emitFormatted()` now checks `enabled(level)` before collecting arguments and formatting the message. This avoids expensive formatting when the local semantic threshold suppresses the call.
+
+## sysError suppression fix
+
+Both `sysError(LogLevel, int, ...)` and `sysError(LogLevel, std::error_code, ...)` now check `enabled(level)` before formatting or constructing `LogError` payloads.
+
+## Stale comment cleanup
+
+Comments that said startup semantic filter configuration was deferred to Round 7 were updated to state that the production default logger uses the frozen startup semantic policy as its local threshold.
+
+## License header cleanup
+
+The standard project dual LGPL/MIT header was added to:
+
+- `src/log/SemanticLogger.h`
+- `src/log/SemanticLogger.cpp`
+- `src/log/LogScopeOwner.h`
+- `src/log/LogScopeOwner.cpp`
+
+## clang-format result
+
+`clang-format -i` completed successfully for the semantic logging files and all changed production/test C++ files.
+
+## Tests added
+
+Added `tests/unit/log/SemanticProductionThresholdRepairTest.cpp` and registered `SemanticProductionThresholdRepairTest` in `tests/unit/log/CMakeLists.txt`.
+
+The test covers:
+
+- suppressed production no-arg `SocketConnection::log().debug("{}", ExpensiveValue)` does not evaluate formatting and emits no backend output;
+- enabled production no-arg `SocketConnection::log().debug("{}", ExpensiveValue)` evaluates formatting once, emits backend output, and preserves semantic scope;
+- suppressed production no-arg `SocketContext::frameworkLog().debug("{}", ExpensiveValue)` does not evaluate formatting and emits no backend output;
+- disabled `sysError` does not format or call the sink;
+- enabled `sysError` preserves errno code, errno text, and message;
+- explicit-threshold custom sink overloads remain compatible even when `LogManager` global level is higher.
+
+## Exact build commands run
+
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2`
+- `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`
+- `cmake --build cmake-build-asan --parallel 2`
+
+## Exact test commands run
+
+- `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test|SemanticProductionThresholdRepairTest" --output-on-failure`
+- `ctest --test-dir cmake-build --output-on-failure`
+- `ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan --output-on-failure`
+
+## ASan result
+
+ASan build and test run passed. The ASan `ctest` command reported 100% tests passed, 0 failed out of 117. The same environment-level skipped component tests remained skipped under ASan.
+
+## Non-goal confirmations
+
+This repair does not migrate additional `LOG`/`PLOG`/`VLOG` production call sites.
+
+This repair does not change `LOG`/`PLOG`/`VLOG` macro definitions.
+
+This repair does not change the JSON v1 schema.
+
+This repair does not start Round 10 book integration.
+
+LogManager precedence was unchanged.
+
+LogManager freeze behavior was unchanged.
+
+Logger::semanticSink still applies final LogManager filtering through `Logger::emitSemantic()`.
+
+No new production call-site migration was done.
+
+Migration 1 was not started.
+
+Round 10 was not started.
+
+## Known follow-ups
+
+- Continue the planned post-roadmap migration work only in a separate future PR.
+- Keep future production no-arg semantic logger APIs wired through `LogManager::effectiveLevel(scope)` at construction time.

--- a/src/core/socket/stream/SocketAcceptor.h
+++ b/src/core/socket/stream/SocketAcceptor.h
@@ -97,8 +97,8 @@ namespace core::socket::stream {
         logger::BoundaryLogger log() const {
             // Round 6 backend-backed default semantic logger.
             // The sink-taking overload remains available for tests and custom capture.
-            // Startup semantic filter configuration is deferred to Round 7.
-            return log(logger::Logger::semanticSink());
+            // Production default logger uses the frozen startup semantic policy as its local threshold.
+            return logScope.logger(logger::Logger::semanticSink());
         }
 
         logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
@@ -129,7 +129,6 @@ namespace core::socket::stream {
         std::function<void(core::eventreceiver::AcceptEventReceiver*)> onInitState;
 
         std::function<void(const SocketAddress&, core::socket::State)> onStatus = nullptr;
-
 
         static logger::LogScopeOwner makeLogScope(const std::string& instanceName) {
             return logger::LogScopeOwner(logger::LogOrigin::Framework,

--- a/src/core/socket/stream/SocketClient.h
+++ b/src/core/socket/stream/SocketClient.h
@@ -57,7 +57,7 @@
 #include "utils/Random.h"
 
 #include <algorithm>
-#include <functional>  // IWYU pragma: export
+#include <functional> // IWYU pragma: export
 #include <optional>
 #include <type_traits> // IWYU pragma: export
 
@@ -301,12 +301,11 @@ namespace core::socket::stream {
             return connect(remoteAddress, onStatus);
         }
 
-
         logger::BoundaryLogger log() const {
             // Round 6 backend-backed default semantic logger.
             // The sink-taking overload remains available for tests and custom capture.
-            // Startup semantic filter configuration is deferred to Round 7.
-            return log(logger::Logger::semanticSink());
+            // Production default logger uses the frozen startup semantic policy as its local threshold.
+            return logScope.logger(logger::Logger::semanticSink());
         }
 
         logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
@@ -367,7 +366,6 @@ namespace core::socket::stream {
         }
 
     private:
-
         static logger::LogScopeOwner makeLogScope(const std::string& instanceName) {
             return logger::LogScopeOwner(logger::LogOrigin::Framework,
                                          logger::LogBoundary::Instance,

--- a/src/core/socket/stream/SocketConnection.cpp
+++ b/src/core/socket/stream/SocketConnection.cpp
@@ -123,11 +123,12 @@ namespace core::socket::stream {
     logger::BoundaryLogger SocketConnection::log() const {
         // Round 6 backend-backed default semantic logger.
         // The sink-taking overload remains available for tests and custom capture.
-        // Startup semantic filter configuration is deferred to Round 7.
-        return log(logger::Logger::semanticSink());
+        // Production default logger uses the frozen startup semantic policy as its local threshold.
+        return logScope.logger(logger::Logger::semanticSink());
     }
 
-    logger::BoundaryLogger SocketConnection::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
+    logger::BoundaryLogger
+    SocketConnection::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
         return logScope.logger(std::move(sink), threshold, std::move(clock));
     }
 

--- a/src/core/socket/stream/SocketConnector.h
+++ b/src/core/socket/stream/SocketConnector.h
@@ -92,8 +92,8 @@ namespace core::socket::stream {
         logger::BoundaryLogger log() const {
             // Round 6 backend-backed default semantic logger.
             // The sink-taking overload remains available for tests and custom capture.
-            // Startup semantic filter configuration is deferred to Round 7.
-            return log(logger::Logger::semanticSink());
+            // Production default logger uses the frozen startup semantic policy as its local threshold.
+            return logScope.logger(logger::Logger::semanticSink());
         }
 
         logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
@@ -125,7 +125,6 @@ namespace core::socket::stream {
         std::function<void(core::eventreceiver::ConnectEventReceiver*)> onInitState;
 
         std::function<void(const SocketAddress&, core::socket::State)> onStatus;
-
 
         static logger::LogScopeOwner makeLogScope(const std::string& instanceName) {
             return logger::LogScopeOwner(logger::LogOrigin::Framework,

--- a/src/core/socket/stream/SocketContext.cpp
+++ b/src/core/socket/stream/SocketContext.cpp
@@ -64,13 +64,15 @@ namespace core::socket::stream {
         , applicationLogScope(logger::LogOrigin::Application,
                               logger::LogBoundary::Context,
                               "core.socket.context",
-                              socketConnection->getInstanceName().empty() ? std::nullopt : std::optional<std::string>(socketConnection->getInstanceName()),
+                              socketConnection->getInstanceName().empty() ? std::nullopt
+                                                                          : std::optional<std::string>(socketConnection->getInstanceName()),
                               std::nullopt,
                               socketConnection->getConnectionName())
         , frameworkLogScope(logger::LogOrigin::Framework,
                             logger::LogBoundary::Context,
                             "core.socket.context",
-                            socketConnection->getInstanceName().empty() ? std::nullopt : std::optional<std::string>(socketConnection->getInstanceName()),
+                            socketConnection->getInstanceName().empty() ? std::nullopt
+                                                                        : std::optional<std::string>(socketConnection->getInstanceName()),
                             std::nullopt,
                             socketConnection->getConnectionName())
         , onlineSinceTimePoint(std::chrono::system_clock::now()) {
@@ -83,22 +85,24 @@ namespace core::socket::stream {
     logger::BoundaryLogger SocketContext::log() const {
         // Round 6 backend-backed default semantic logger.
         // The sink-taking overload remains available for tests and custom capture.
-        // Startup semantic filter configuration is deferred to Round 7.
-        return log(logger::Logger::semanticSink());
+        // Production default logger uses the frozen startup semantic policy as its local threshold.
+        return applicationLogScope.logger(logger::Logger::semanticSink());
     }
 
-    logger::BoundaryLogger SocketContext::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
+    logger::BoundaryLogger
+    SocketContext::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
         return applicationLogScope.logger(std::move(sink), threshold, std::move(clock));
     }
 
     logger::BoundaryLogger SocketContext::frameworkLog() const {
         // Round 6 backend-backed default semantic logger.
         // The sink-taking overload remains available for tests and custom capture.
-        // Startup semantic filter configuration is deferred to Round 7.
-        return frameworkLog(logger::Logger::semanticSink());
+        // Production default logger uses the frozen startup semantic policy as its local threshold.
+        return frameworkLogScope.logger(logger::Logger::semanticSink());
     }
 
-    logger::BoundaryLogger SocketContext::frameworkLog(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
+    logger::BoundaryLogger
+    SocketContext::frameworkLog(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
         return frameworkLogScope.logger(std::move(sink), threshold, std::move(clock));
     }
 

--- a/src/core/socket/stream/SocketServer.h
+++ b/src/core/socket/stream/SocketServer.h
@@ -57,7 +57,7 @@
 #include "utils/Random.h"
 
 #include <algorithm>
-#include <functional>  // IWYU pragma: export
+#include <functional> // IWYU pragma: export
 #include <optional>
 #include <type_traits> // IWYU pragma: export
 
@@ -268,12 +268,11 @@ namespace core::socket::stream {
             return listen(localAddress, onStatus);
         }
 
-
         logger::BoundaryLogger log() const {
             // Round 6 backend-backed default semantic logger.
             // The sink-taking overload remains available for tests and custom capture.
-            // Startup semantic filter configuration is deferred to Round 7.
-            return log(logger::Logger::semanticSink());
+            // Production default logger uses the frozen startup semantic policy as its local threshold.
+            return logScope.logger(logger::Logger::semanticSink());
         }
 
         logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
@@ -334,7 +333,6 @@ namespace core::socket::stream {
         }
 
     private:
-
         static logger::LogScopeOwner makeLogScope(const std::string& instanceName) {
             return logger::LogScopeOwner(logger::LogOrigin::Framework,
                                          logger::LogBoundary::Instance,

--- a/src/log/LogScopeOwner.cpp
+++ b/src/log/LogScopeOwner.cpp
@@ -1,3 +1,44 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #include "log/LogScopeOwner.h"
 
 #include <utility>
@@ -30,10 +71,16 @@ namespace logger {
         return viewLogScope(ownedScope);
     }
 
+    BoundaryLogger LogScopeOwner::logger(BoundaryLogger::Sink sink, BoundaryLogger::Clock clock) const {
+        return logger(std::move(sink), LogManager::effectiveLevel(scope()), std::move(clock));
+    }
+
     BoundaryLogger LogScopeOwner::logger(BoundaryLogger::Sink sink, LogLevel threshold, BoundaryLogger::Clock clock) const {
         return BoundaryLogger(ownedScope, std::move(sink), threshold, std::move(clock));
     }
 
-    LogScopeOwner::LogScopeOwner(OwnedLogScope scope) : ownedScope(std::move(scope)) {}
+    LogScopeOwner::LogScopeOwner(OwnedLogScope scope)
+        : ownedScope(std::move(scope)) {
+    }
 
 } // namespace logger

--- a/src/log/LogScopeOwner.h
+++ b/src/log/LogScopeOwner.h
@@ -1,3 +1,44 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #ifndef LOGGER_LOGSCOPEOWNER_H
 #define LOGGER_LOGSCOPEOWNER_H
 
@@ -24,7 +65,8 @@ namespace logger {
 
         LogScope scope() const noexcept;
 
-        BoundaryLogger logger(BoundaryLogger::Sink sink, LogLevel threshold = LogLevel::Trace, BoundaryLogger::Clock clock = {}) const;
+        BoundaryLogger logger(BoundaryLogger::Sink sink, BoundaryLogger::Clock clock = {}) const;
+        BoundaryLogger logger(BoundaryLogger::Sink sink, LogLevel threshold, BoundaryLogger::Clock clock = {}) const;
 
     private:
         explicit LogScopeOwner(OwnedLogScope scope);

--- a/src/log/SemanticLogger.cpp
+++ b/src/log/SemanticLogger.cpp
@@ -1,306 +1,445 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #include "log/SemanticLogger.h"
 
 #include <iomanip>
 #include <map>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <utility>
 
 namespace logger {
-namespace {
-    int rank(LogLevel level) { return static_cast<int>(level); }
-    std::string escapeJson(const std::string& value) {
-        std::ostringstream out;
-        for (const unsigned char ch : value) {
-            switch (ch) {
-                case '"': out << "\\\""; break;
-                case '\\': out << "\\\\"; break;
-                case '\b': out << "\\b"; break;
-                case '\f': out << "\\f"; break;
-                case '\n': out << "\\n"; break;
-                case '\r': out << "\\r"; break;
-                case '\t': out << "\\t"; break;
-                default:
-                    if (ch < 0x20) {
-                        out << "\\u00" << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(ch) << std::dec;
-                    } else {
-                        out << static_cast<char>(ch);
-                    }
-                    break;
+    namespace {
+        int rank(LogLevel level) {
+            return static_cast<int>(level);
+        }
+        std::string escapeJson(const std::string& value) {
+            std::ostringstream out;
+            for (const unsigned char ch : value) {
+                switch (ch) {
+                    case '"':
+                        out << "\\\"";
+                        break;
+                    case '\\':
+                        out << "\\\\";
+                        break;
+                    case '\b':
+                        out << "\\b";
+                        break;
+                    case '\f':
+                        out << "\\f";
+                        break;
+                    case '\n':
+                        out << "\\n";
+                        break;
+                    case '\r':
+                        out << "\\r";
+                        break;
+                    case '\t':
+                        out << "\\t";
+                        break;
+                    default:
+                        if (ch < 0x20) {
+                            out << "\\u00" << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(ch) << std::dec;
+                        } else {
+                            out << static_cast<char>(ch);
+                        }
+                        break;
+                }
+            }
+            return out.str();
+        }
+        void appendField(std::ostringstream& out, bool& first, std::string_view name, const std::string& value) {
+            out << (first ? "" : ",") << "\"" << name << "\":\"" << escapeJson(value) << "\"";
+            first = false;
+        }
+        void appendInt(std::ostringstream& out, bool& first, std::string_view name, int value) {
+            out << (first ? "" : ",") << "\"" << name << "\":" << value;
+            first = false;
+        }
+
+        struct SemanticPolicy {
+            LogLevel globalLevel = LogLevel::Trace;
+            std::map<LogOrigin, LogLevel> originLevels;
+            std::map<LogBoundary, LogLevel> boundaryLevels;
+            std::map<std::string, LogLevel> componentLevels;
+            std::map<std::string, LogLevel> instanceLevels;
+            LogManager::Format format = LogManager::Format::Text;
+            bool frozen = false;
+        };
+
+        SemanticPolicy& policy() {
+            static SemanticPolicy current;
+            return current;
+        }
+
+        void ensureMutable() {
+            if (policy().frozen) {
+                throw std::logic_error("logger::LogManager semantic policy is frozen");
             }
         }
+
+        void ensureNonEmptyKey(const std::string& key, const char* name) {
+            if (key.empty()) {
+                throw std::invalid_argument(std::string("logger::LogManager ") + name + " key must not be empty");
+            }
+        }
+
+    } // namespace
+
+    LogRecord materialize(const LogScope& scope, LogLevel level, std::string message, LogRecordOptions options) {
+        LogRecord record;
+        record.v = 1;
+        record.ts = options.ts;
+        record.level = level;
+        record.origin = scope.origin;
+        record.boundary = scope.boundary;
+        record.component = std::string(scope.component);
+        if (!scope.instance.empty())
+            record.instance = std::string(scope.instance);
+        if (knownLogRole(scope.role))
+            record.role = scope.role;
+        if (!scope.connection.empty())
+            record.connection = std::string(scope.connection);
+        if (options.event && !options.event->empty())
+            record.event = std::string(*options.event);
+        record.message = std::move(message);
+        record.error = std::move(options.error);
+        record.source = std::move(options.source);
+        return record;
+    }
+
+    void LogManager::init() {
+        policy() = SemanticPolicy{};
+    }
+
+    void LogManager::setGlobalLevel(LogLevel level) {
+        ensureMutable();
+        policy().globalLevel = level;
+    }
+
+    void LogManager::setOriginLevel(LogOrigin origin, LogLevel level) {
+        ensureMutable();
+        policy().originLevels[origin] = level;
+    }
+
+    void LogManager::setBoundaryLevel(LogBoundary boundary, LogLevel level) {
+        ensureMutable();
+        policy().boundaryLevels[boundary] = level;
+    }
+
+    void LogManager::setComponentLevel(std::string component, LogLevel level) {
+        ensureMutable();
+        ensureNonEmptyKey(component, "component");
+        policy().componentLevels[std::move(component)] = level;
+    }
+
+    void LogManager::setInstanceLevel(std::string instance, LogLevel level) {
+        ensureMutable();
+        ensureNonEmptyKey(instance, "instance");
+        policy().instanceLevels[std::move(instance)] = level;
+    }
+
+    void LogManager::setFormat(Format format) {
+        ensureMutable();
+        policy().format = format;
+    }
+
+    void LogManager::freeze() {
+        policy().frozen = true;
+    }
+
+    bool LogManager::isFrozen() {
+        return policy().frozen;
+    }
+
+    LogLevel LogManager::effectiveLevel(const LogScope& scope) {
+        const auto& current = policy();
+        if (!scope.instance.empty()) {
+            if (const auto it = current.instanceLevels.find(std::string(scope.instance)); it != current.instanceLevels.end())
+                return it->second;
+        }
+        if (!scope.component.empty()) {
+            if (const auto it = current.componentLevels.find(std::string(scope.component)); it != current.componentLevels.end())
+                return it->second;
+        }
+        if (const auto it = current.boundaryLevels.find(scope.boundary); it != current.boundaryLevels.end())
+            return it->second;
+        if (const auto it = current.originLevels.find(scope.origin); it != current.originLevels.end())
+            return it->second;
+        return current.globalLevel;
+    }
+
+    LogLevel LogManager::effectiveLevel(const LogRecord& record) {
+        LogScope scope{record.origin,
+                       record.boundary,
+                       record.component,
+                       record.instance ? std::string_view(*record.instance) : std::string_view(),
+                       record.role.value_or(LogRole::Unknown),
+                       record.connection ? std::string_view(*record.connection) : std::string_view()};
+        return effectiveLevel(scope);
+    }
+
+    bool LogManager::shouldEmit(const LogRecord& record) {
+        const LogLevel threshold = effectiveLevel(record);
+        return record.level != LogLevel::Off && threshold != LogLevel::Off && rank(record.level) >= rank(threshold);
+    }
+
+    LogManager::Format LogManager::format() {
+        return policy().format;
+    }
+
+    std::string LogManager::formatRecord(const LogRecord& record) {
+        return format() == Format::Json ? formatJsonV1(record) : formatText(record);
+    }
+
+    std::string toString(LogLevel level) {
+        switch (level) {
+            case LogLevel::Trace:
+                return "trace";
+            case LogLevel::Debug:
+                return "debug";
+            case LogLevel::Info:
+                return "info";
+            case LogLevel::Warn:
+                return "warn";
+            case LogLevel::Error:
+                return "error";
+            case LogLevel::Critical:
+                return "critical";
+            case LogLevel::Off:
+                return "off";
+        }
+        return "off";
+    }
+    std::string toString(LogOrigin origin) {
+        return origin == LogOrigin::Framework ? "framework" : "application";
+    }
+    std::string toString(LogBoundary boundary) {
+        switch (boundary) {
+            case LogBoundary::Application:
+                return "application";
+            case LogBoundary::Configuration:
+                return "configuration";
+            case LogBoundary::Instance:
+                return "instance";
+            case LogBoundary::Connection:
+                return "connection";
+            case LogBoundary::Context:
+                return "context";
+            case LogBoundary::System:
+                return "system";
+        }
+        return "system";
+    }
+    std::optional<std::string_view> toString(LogRole role) {
+        if (role == LogRole::Server)
+            return "server";
+        if (role == LogRole::Client)
+            return "client";
+        return std::nullopt;
+    }
+
+    std::string formatTimestamp(std::chrono::system_clock::time_point ts) {
+        const auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(ts.time_since_epoch()) % 1000;
+        const auto time = std::chrono::system_clock::to_time_t(ts);
+        std::tm tm{};
+        gmtime_r(&time, &tm);
+        std::ostringstream out;
+        out << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S") << '.' << std::setw(3) << std::setfill('0') << millis.count() << 'Z';
         return out.str();
     }
-    void appendField(std::ostringstream& out, bool& first, std::string_view name, const std::string& value) {
-        out << (first ? "" : ",") << "\"" << name << "\":\"" << escapeJson(value) << "\"";
-        first = false;
-    }
-    void appendInt(std::ostringstream& out, bool& first, std::string_view name, int value) {
-        out << (first ? "" : ",") << "\"" << name << "\":" << value;
-        first = false;
-    }
 
-    struct SemanticPolicy {
-        LogLevel globalLevel = LogLevel::Trace;
-        std::map<LogOrigin, LogLevel> originLevels;
-        std::map<LogBoundary, LogLevel> boundaryLevels;
-        std::map<std::string, LogLevel> componentLevels;
-        std::map<std::string, LogLevel> instanceLevels;
-        LogManager::Format format = LogManager::Format::Text;
-        bool frozen = false;
-    };
-
-    SemanticPolicy& policy() {
-        static SemanticPolicy current;
-        return current;
-    }
-
-    void ensureMutable() {
-        if (policy().frozen) {
-            throw std::logic_error("logger::LogManager semantic policy is frozen");
+    std::string formatJsonV1(const LogRecord& record) {
+        std::ostringstream out;
+        bool first = true;
+        out << "{";
+        appendInt(out, first, "v", record.v);
+        appendField(out, first, "ts", formatTimestamp(record.ts));
+        appendField(out, first, "level", toString(record.level));
+        appendField(out, first, "origin", toString(record.origin));
+        appendField(out, first, "boundary", toString(record.boundary));
+        appendField(out, first, "component", record.component);
+        if (record.instance)
+            appendField(out, first, "instance", *record.instance);
+        if (record.role)
+            if (auto role = toString(*record.role))
+                appendField(out, first, "role", std::string(*role));
+        if (record.connection)
+            appendField(out, first, "connection", *record.connection);
+        if (record.event)
+            appendField(out, first, "event", *record.event);
+        appendField(out, first, "message", record.message);
+        if (record.error) {
+            out << (first ? "" : ",") << "\"error\":{";
+            bool errorFirst = true;
+            appendInt(out, errorFirst, "code", record.error->code);
+            appendField(out, errorFirst, "text", record.error->text);
+            out << "}";
+            first = false;
         }
-    }
-
-    void ensureNonEmptyKey(const std::string& key, const char* name) {
-        if (key.empty()) {
-            throw std::invalid_argument(std::string("logger::LogManager ") + name + " key must not be empty");
+        if (record.source) {
+            out << (first ? "" : ",") << "\"source\":{";
+            bool sourceFirst = true;
+            appendField(out, sourceFirst, "file", record.source->file);
+            appendInt(out, sourceFirst, "line", record.source->line);
+            appendField(out, sourceFirst, "func", record.source->func);
+            out << "}";
+            first = false;
         }
-    }
-
-}
-
-LogRecord materialize(const LogScope& scope, LogLevel level, std::string message, LogRecordOptions options) {
-    LogRecord record;
-    record.v = 1;
-    record.ts = options.ts;
-    record.level = level;
-    record.origin = scope.origin;
-    record.boundary = scope.boundary;
-    record.component = std::string(scope.component);
-    if (!scope.instance.empty()) record.instance = std::string(scope.instance);
-    if (knownLogRole(scope.role)) record.role = scope.role;
-    if (!scope.connection.empty()) record.connection = std::string(scope.connection);
-    if (options.event && !options.event->empty()) record.event = std::string(*options.event);
-    record.message = std::move(message);
-    record.error = std::move(options.error);
-    record.source = std::move(options.source);
-    return record;
-}
-
-
-void LogManager::init() {
-    policy() = SemanticPolicy{};
-}
-
-void LogManager::setGlobalLevel(LogLevel level) {
-    ensureMutable();
-    policy().globalLevel = level;
-}
-
-void LogManager::setOriginLevel(LogOrigin origin, LogLevel level) {
-    ensureMutable();
-    policy().originLevels[origin] = level;
-}
-
-void LogManager::setBoundaryLevel(LogBoundary boundary, LogLevel level) {
-    ensureMutable();
-    policy().boundaryLevels[boundary] = level;
-}
-
-void LogManager::setComponentLevel(std::string component, LogLevel level) {
-    ensureMutable();
-    ensureNonEmptyKey(component, "component");
-    policy().componentLevels[std::move(component)] = level;
-}
-
-void LogManager::setInstanceLevel(std::string instance, LogLevel level) {
-    ensureMutable();
-    ensureNonEmptyKey(instance, "instance");
-    policy().instanceLevels[std::move(instance)] = level;
-}
-
-void LogManager::setFormat(Format format) {
-    ensureMutable();
-    policy().format = format;
-}
-
-void LogManager::freeze() {
-    policy().frozen = true;
-}
-
-bool LogManager::isFrozen() {
-    return policy().frozen;
-}
-
-LogLevel LogManager::effectiveLevel(const LogScope& scope) {
-    const auto& current = policy();
-    if (!scope.instance.empty()) {
-        if (const auto it = current.instanceLevels.find(std::string(scope.instance)); it != current.instanceLevels.end()) return it->second;
-    }
-    if (!scope.component.empty()) {
-        if (const auto it = current.componentLevels.find(std::string(scope.component)); it != current.componentLevels.end()) return it->second;
-    }
-    if (const auto it = current.boundaryLevels.find(scope.boundary); it != current.boundaryLevels.end()) return it->second;
-    if (const auto it = current.originLevels.find(scope.origin); it != current.originLevels.end()) return it->second;
-    return current.globalLevel;
-}
-
-LogLevel LogManager::effectiveLevel(const LogRecord& record) {
-    LogScope scope{record.origin,
-                   record.boundary,
-                   record.component,
-                   record.instance ? std::string_view(*record.instance) : std::string_view(),
-                   record.role.value_or(LogRole::Unknown),
-                   record.connection ? std::string_view(*record.connection) : std::string_view()};
-    return effectiveLevel(scope);
-}
-
-bool LogManager::shouldEmit(const LogRecord& record) {
-    const LogLevel threshold = effectiveLevel(record);
-    return record.level != LogLevel::Off && threshold != LogLevel::Off && rank(record.level) >= rank(threshold);
-}
-
-LogManager::Format LogManager::format() {
-    return policy().format;
-}
-
-std::string LogManager::formatRecord(const LogRecord& record) {
-    return format() == Format::Json ? formatJsonV1(record) : formatText(record);
-}
-
-std::string toString(LogLevel level) {
-    switch (level) {
-        case LogLevel::Trace: return "trace";
-        case LogLevel::Debug: return "debug";
-        case LogLevel::Info: return "info";
-        case LogLevel::Warn: return "warn";
-        case LogLevel::Error: return "error";
-        case LogLevel::Critical: return "critical";
-        case LogLevel::Off: return "off";
-    }
-    return "off";
-}
-std::string toString(LogOrigin origin) { return origin == LogOrigin::Framework ? "framework" : "application"; }
-std::string toString(LogBoundary boundary) {
-    switch (boundary) {
-        case LogBoundary::Application: return "application";
-        case LogBoundary::Configuration: return "configuration";
-        case LogBoundary::Instance: return "instance";
-        case LogBoundary::Connection: return "connection";
-        case LogBoundary::Context: return "context";
-        case LogBoundary::System: return "system";
-    }
-    return "system";
-}
-std::optional<std::string_view> toString(LogRole role) {
-    if (role == LogRole::Server) return "server";
-    if (role == LogRole::Client) return "client";
-    return std::nullopt;
-}
-
-std::string formatTimestamp(std::chrono::system_clock::time_point ts) {
-    const auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(ts.time_since_epoch()) % 1000;
-    const auto time = std::chrono::system_clock::to_time_t(ts);
-    std::tm tm{};
-    gmtime_r(&time, &tm);
-    std::ostringstream out;
-    out << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S") << '.' << std::setw(3) << std::setfill('0') << millis.count() << 'Z';
-    return out.str();
-}
-
-std::string formatJsonV1(const LogRecord& record) {
-    std::ostringstream out;
-    bool first = true;
-    out << "{";
-    appendInt(out, first, "v", record.v);
-    appendField(out, first, "ts", formatTimestamp(record.ts));
-    appendField(out, first, "level", toString(record.level));
-    appendField(out, first, "origin", toString(record.origin));
-    appendField(out, first, "boundary", toString(record.boundary));
-    appendField(out, first, "component", record.component);
-    if (record.instance) appendField(out, first, "instance", *record.instance);
-    if (record.role) if (auto role = toString(*record.role)) appendField(out, first, "role", std::string(*role));
-    if (record.connection) appendField(out, first, "connection", *record.connection);
-    if (record.event) appendField(out, first, "event", *record.event);
-    appendField(out, first, "message", record.message);
-    if (record.error) {
-        out << (first ? "" : ",") << "\"error\":{";
-        bool errorFirst = true;
-        appendInt(out, errorFirst, "code", record.error->code);
-        appendField(out, errorFirst, "text", record.error->text);
         out << "}";
-        first = false;
+        return out.str();
     }
-    if (record.source) {
-        out << (first ? "" : ",") << "\"source\":{";
-        bool sourceFirst = true;
-        appendField(out, sourceFirst, "file", record.source->file);
-        appendInt(out, sourceFirst, "line", record.source->line);
-        appendField(out, sourceFirst, "func", record.source->func);
-        out << "}";
-        first = false;
+
+    std::string formatText(const LogRecord& record) {
+        std::ostringstream out;
+        out << formatTimestamp(record.ts) << ' ' << toString(record.level) << ' ' << toString(record.origin) << ' '
+            << toString(record.boundary) << ' ' << record.component;
+        if (record.instance)
+            out << " instance=" << *record.instance;
+        if (record.role)
+            if (auto role = toString(*record.role))
+                out << " role=" << *role;
+        if (record.connection)
+            out << " connection=" << *record.connection;
+        out << " - " << record.message;
+        if (record.error)
+            out << " error=" << record.error->code << ':' << record.error->text;
+        return out.str();
     }
-    out << "}";
-    return out.str();
-}
 
-std::string formatText(const LogRecord& record) {
-    std::ostringstream out;
-    out << formatTimestamp(record.ts) << ' ' << toString(record.level) << ' ' << toString(record.origin) << ' ' << toString(record.boundary) << ' '
-        << record.component;
-    if (record.instance) out << " instance=" << *record.instance;
-    if (record.role) if (auto role = toString(*record.role)) out << " role=" << *role;
-    if (record.connection) out << " connection=" << *record.connection;
-    out << " - " << record.message;
-    if (record.error) out << " error=" << record.error->code << ':' << record.error->text;
-    return out.str();
-}
-
-LogStream::LogStream(const BoundaryLogger* logger, LogLevel level) : logger(logger), level(level), enabled(logger != nullptr && logger->enabled(level)), flushed(false) {}
-LogStream::LogStream(LogStream&& other) noexcept : logger(other.logger), level(other.level), enabled(other.enabled), flushed(other.flushed), stream(std::move(other.stream)) { other.flushed = true; }
-LogStream& LogStream::operator=(LogStream&& other) noexcept {
-    if (this != &other) {
-        if (!flushed && enabled && logger != nullptr) logger->emit(level, stream.str());
-        logger = other.logger; level = other.level; enabled = other.enabled; flushed = other.flushed; stream = std::move(other.stream); other.flushed = true;
+    LogStream::LogStream(const BoundaryLogger* logger, LogLevel level)
+        : logger(logger)
+        , level(level)
+        , enabled(logger != nullptr && logger->enabled(level))
+        , flushed(false) {
     }
-    return *this;
-}
-LogStream::~LogStream() { if (!flushed && enabled && logger != nullptr) logger->emit(level, stream.str()); }
-
-bool knownLogRole(LogRole role) noexcept { return role == LogRole::Server || role == LogRole::Client; }
-
-OwnedLogScope copyLogScope(LogScope scope) {
-    OwnedLogScope owned{scope.origin, scope.boundary, std::string(scope.component), std::nullopt, std::nullopt, std::nullopt};
-    if (!scope.instance.empty()) owned.instance = std::string(scope.instance);
-    if (knownLogRole(scope.role)) owned.role = scope.role;
-    if (!scope.connection.empty()) owned.connection = std::string(scope.connection);
-    return owned;
-}
-
-LogScope viewLogScope(const OwnedLogScope& scope) noexcept {
-    return LogScope{scope.origin,
-                    scope.boundary,
-                    scope.component,
-                    scope.instance ? std::string_view(*scope.instance) : std::string_view(),
-                    scope.role.value_or(LogRole::Unknown),
-                    scope.connection ? std::string_view(*scope.connection) : std::string_view()};
-}
-
-BoundaryLogger BoundaryLogger::createForTest(LogScope scope, Sink sink, LogLevel threshold, Clock clock) { return BoundaryLogger(copyLogScope(scope), std::move(sink), threshold, std::move(clock)); }
-BoundaryLogger::BoundaryLogger(OwnedLogScope scope, Sink sink, LogLevel threshold, Clock clock) : scope(std::move(scope)), sink(std::move(sink)), threshold(threshold), clock(std::move(clock)) {}
-bool BoundaryLogger::enabled(LogLevel level) const noexcept { return level != LogLevel::Off && rank(level) >= rank(threshold) && threshold != LogLevel::Off; }
-LogStream BoundaryLogger::trace() const { return {this, LogLevel::Trace}; }
-LogStream BoundaryLogger::debug() const { return {this, LogLevel::Debug}; }
-LogStream BoundaryLogger::info() const { return {this, LogLevel::Info}; }
-LogStream BoundaryLogger::warn() const { return {this, LogLevel::Warn}; }
-LogStream BoundaryLogger::error() const { return {this, LogLevel::Error}; }
-LogStream BoundaryLogger::critical() const { return {this, LogLevel::Critical}; }
-void BoundaryLogger::emit(LogLevel level, std::string message, LogRecordOptions options) const {
-    if (!enabled(level) || !sink) return;
-    if (options.ts == std::chrono::system_clock::time_point{}) {
-        options.ts = clock ? clock() : std::chrono::system_clock::now();
+    LogStream::LogStream(LogStream&& other) noexcept
+        : logger(other.logger)
+        , level(other.level)
+        , enabled(other.enabled)
+        , flushed(other.flushed)
+        , stream(std::move(other.stream)) {
+        other.flushed = true;
     }
-    sink(materialize(viewLogScope(scope), level, std::move(message), std::move(options)));
-}
+    LogStream& LogStream::operator=(LogStream&& other) noexcept {
+        if (this != &other) {
+            if (!flushed && enabled && logger != nullptr)
+                logger->emit(level, stream.str());
+            logger = other.logger;
+            level = other.level;
+            enabled = other.enabled;
+            flushed = other.flushed;
+            stream = std::move(other.stream);
+            other.flushed = true;
+        }
+        return *this;
+    }
+    LogStream::~LogStream() {
+        if (!flushed && enabled && logger != nullptr)
+            logger->emit(level, stream.str());
+    }
+
+    bool knownLogRole(LogRole role) noexcept {
+        return role == LogRole::Server || role == LogRole::Client;
+    }
+
+    OwnedLogScope copyLogScope(LogScope scope) {
+        OwnedLogScope owned{scope.origin, scope.boundary, std::string(scope.component), std::nullopt, std::nullopt, std::nullopt};
+        if (!scope.instance.empty())
+            owned.instance = std::string(scope.instance);
+        if (knownLogRole(scope.role))
+            owned.role = scope.role;
+        if (!scope.connection.empty())
+            owned.connection = std::string(scope.connection);
+        return owned;
+    }
+
+    LogScope viewLogScope(const OwnedLogScope& scope) noexcept {
+        return LogScope{scope.origin,
+                        scope.boundary,
+                        scope.component,
+                        scope.instance ? std::string_view(*scope.instance) : std::string_view(),
+                        scope.role.value_or(LogRole::Unknown),
+                        scope.connection ? std::string_view(*scope.connection) : std::string_view()};
+    }
+
+    BoundaryLogger BoundaryLogger::createForTest(LogScope scope, Sink sink, LogLevel threshold, Clock clock) {
+        return BoundaryLogger(copyLogScope(scope), std::move(sink), threshold, std::move(clock));
+    }
+    BoundaryLogger::BoundaryLogger(OwnedLogScope scope, Sink sink, LogLevel threshold, Clock clock)
+        : scope(std::move(scope))
+        , sink(std::move(sink))
+        , threshold(threshold)
+        , clock(std::move(clock)) {
+    }
+    bool BoundaryLogger::enabled(LogLevel level) const noexcept {
+        return level != LogLevel::Off && rank(level) >= rank(threshold) && threshold != LogLevel::Off;
+    }
+    LogStream BoundaryLogger::trace() const {
+        return {this, LogLevel::Trace};
+    }
+    LogStream BoundaryLogger::debug() const {
+        return {this, LogLevel::Debug};
+    }
+    LogStream BoundaryLogger::info() const {
+        return {this, LogLevel::Info};
+    }
+    LogStream BoundaryLogger::warn() const {
+        return {this, LogLevel::Warn};
+    }
+    LogStream BoundaryLogger::error() const {
+        return {this, LogLevel::Error};
+    }
+    LogStream BoundaryLogger::critical() const {
+        return {this, LogLevel::Critical};
+    }
+    void BoundaryLogger::emit(LogLevel level, std::string message, LogRecordOptions options) const {
+        if (!enabled(level) || !sink)
+            return;
+        if (options.ts == std::chrono::system_clock::time_point{}) {
+            options.ts = clock ? clock() : std::chrono::system_clock::now();
+        }
+        sink(materialize(viewLogScope(scope), level, std::move(message), std::move(options)));
+    }
 
 } // namespace logger

--- a/src/log/SemanticLogger.h
+++ b/src/log/SemanticLogger.h
@@ -1,3 +1,44 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #ifndef LOGGER_SEMANTICLOGGER_H
 #define LOGGER_SEMANTICLOGGER_H
 
@@ -155,20 +196,36 @@ namespace logger {
         LogStream critical() const;
 
         template <class... Args>
-        void trace(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Trace, format, std::forward<Args>(args)...); }
+        void trace(std::string_view format, Args&&... args) const {
+            emitFormatted(LogLevel::Trace, format, std::forward<Args>(args)...);
+        }
         template <class... Args>
-        void debug(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Debug, format, std::forward<Args>(args)...); }
+        void debug(std::string_view format, Args&&... args) const {
+            emitFormatted(LogLevel::Debug, format, std::forward<Args>(args)...);
+        }
         template <class... Args>
-        void info(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Info, format, std::forward<Args>(args)...); }
+        void info(std::string_view format, Args&&... args) const {
+            emitFormatted(LogLevel::Info, format, std::forward<Args>(args)...);
+        }
         template <class... Args>
-        void warn(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Warn, format, std::forward<Args>(args)...); }
+        void warn(std::string_view format, Args&&... args) const {
+            emitFormatted(LogLevel::Warn, format, std::forward<Args>(args)...);
+        }
         template <class... Args>
-        void error(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Error, format, std::forward<Args>(args)...); }
+        void error(std::string_view format, Args&&... args) const {
+            emitFormatted(LogLevel::Error, format, std::forward<Args>(args)...);
+        }
         template <class... Args>
-        void critical(std::string_view format, Args&&... args) const { emitFormatted(LogLevel::Critical, format, std::forward<Args>(args)...); }
+        void critical(std::string_view format, Args&&... args) const {
+            emitFormatted(LogLevel::Critical, format, std::forward<Args>(args)...);
+        }
 
         template <class... Args>
         void sysError(LogLevel level, int errnum, std::string_view format, Args&&... args) const {
+            if (!enabled(level)) {
+                return;
+            }
+
             LogRecordOptions options;
             options.error = LogError{errnum, std::error_code(errnum, std::generic_category()).message()};
             emit(level, formatMessage(format, std::forward<Args>(args)...), std::move(options));
@@ -176,6 +233,10 @@ namespace logger {
 
         template <class... Args>
         void sysError(LogLevel level, std::error_code errorCode, std::string_view format, Args&&... args) const {
+            if (!enabled(level)) {
+                return;
+            }
+
             LogRecordOptions options;
             options.error = LogError{errorCode.value(), errorCode.message()};
             emit(level, formatMessage(format, std::forward<Args>(args)...), std::move(options));
@@ -188,10 +249,16 @@ namespace logger {
 
         template <class... Args>
         void emitFormatted(LogLevel level, std::string_view format, Args&&... args) const {
+            if (!enabled(level)) {
+                return;
+            }
+
             emit(level, formatMessage(format, std::forward<Args>(args)...));
         }
 
-        static std::vector<std::string> collectArgs() { return {}; }
+        static std::vector<std::string> collectArgs() {
+            return {};
+        }
         template <class T, class... Args>
         static std::vector<std::string> collectArgs(T&& value, Args&&... args) {
             std::ostringstream out;

--- a/src/net/config/ConfigInstance.cpp
+++ b/src/net/config/ConfigInstance.cpp
@@ -58,7 +58,7 @@ namespace {
     logger::LogRole toLogRole(net::config::ConfigInstance::Role role) {
         return role == net::config::ConfigInstance::Role::SERVER ? logger::LogRole::Server : logger::LogRole::Client;
     }
-}
+} // namespace
 
 namespace net::config {
 
@@ -121,11 +121,12 @@ namespace net::config {
     logger::BoundaryLogger ConfigInstance::log() const {
         // Round 6 backend-backed default semantic logger.
         // The sink-taking overload remains available for tests and custom capture.
-        // Startup semantic filter configuration is deferred to Round 7.
-        return log(logger::Logger::semanticSink());
+        // Production default logger uses the frozen startup semantic policy as its local threshold.
+        return logScope.logger(logger::Logger::semanticSink());
     }
 
-    logger::BoundaryLogger ConfigInstance::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
+    logger::BoundaryLogger
+    ConfigInstance::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
         return logScope.logger(std::move(sink), threshold, std::move(clock));
     }
 

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -43,3 +43,8 @@ snodec_add_test(SemanticOverheadRound9Test SemanticOverheadRound9Test.cpp)
 target_include_directories(SemanticOverheadRound9Test PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(SemanticOverheadRound9Test PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(SemanticOverheadRound9Test PROPERTIES LABELS "unit;log;round9")
+
+snodec_add_test(SemanticProductionThresholdRepairTest SemanticProductionThresholdRepairTest.cpp)
+target_include_directories(SemanticProductionThresholdRepairTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(SemanticProductionThresholdRepairTest PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
+set_tests_properties(SemanticProductionThresholdRepairTest PROPERTIES LABELS "unit;log;repair")

--- a/tests/unit/log/SemanticProductionThresholdRepairTest.cpp
+++ b/tests/unit/log/SemanticProductionThresholdRepairTest.cpp
@@ -1,0 +1,251 @@
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContext.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "tests/support/TestResult.h"
+
+#include <cerrno>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace {
+    struct ExpensiveValue {
+        int* evaluations;
+    };
+
+    std::ostream& operator<<(std::ostream& out, const ExpensiveValue& value) {
+        ++*value.evaluations;
+        return out << "expensive";
+    }
+
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() {
+                return std::string("REPAIRTICK");
+            });
+            logger::Logger::logToFile(logFile);
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+
+    logger::LogScope testScope() {
+        return {logger::LogOrigin::Framework,
+                logger::LogBoundary::System,
+                "repair.test",
+                "repair-instance",
+                logger::LogRole::Server,
+                "repair-connection"};
+    }
+
+    std::chrono::system_clock::time_point fixedTimestamp() {
+        using namespace std::chrono;
+        return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
+    }
+
+    class TestSocketConnection : public core::socket::stream::SocketConnection {
+    public:
+        explicit TestSocketConnection(const std::string& instanceName)
+            : SocketConnection(9, instanceName, nullptr) {
+        }
+        ~TestSocketConnection() override = default;
+
+        int getFd() const override {
+            return 9;
+        }
+        void sendToPeer(const char*, std::size_t) override {
+        }
+        bool streamToPeer(core::pipe::Source*) override {
+            return false;
+        }
+        void streamEof() override {
+        }
+        std::size_t readFromPeer(char*, std::size_t) override {
+            return 0;
+        }
+        void shutdownRead() override {
+        }
+        void shutdownWrite() override {
+        }
+        const core::socket::SocketAddress& getBindAddress() const override {
+            return unusableAddress();
+        }
+        const core::socket::SocketAddress& getLocalAddress() const override {
+            return unusableAddress();
+        }
+        const core::socket::SocketAddress& getRemoteAddress() const override {
+            return unusableAddress();
+        }
+        void close() override {
+        }
+        void setTimeout(const utils::Timeval&) override {
+        }
+        void setReadTimeout(const utils::Timeval&) override {
+        }
+        void setWriteTimeout(const utils::Timeval&) override {
+        }
+        std::size_t getTotalSent() const override {
+            return 0;
+        }
+        std::size_t getTotalQueued() const override {
+            return 0;
+        }
+        std::size_t getTotalRead() const override {
+            return 0;
+        }
+        std::size_t getTotalProcessed() const override {
+            return 0;
+        }
+
+    private:
+        static const core::socket::SocketAddress& unusableAddress() {
+            return *static_cast<const core::socket::SocketAddress*>(nullptr);
+        }
+    };
+
+    class TestSocketContext : public core::socket::stream::SocketContext {
+    public:
+        explicit TestSocketContext(core::socket::stream::SocketConnection* socketConnection)
+            : SocketContext(socketConnection) {
+        }
+        ~TestSocketContext() override = default;
+
+    private:
+        std::size_t onReceivedFromPeer() override {
+            return 0;
+        }
+        bool onSignal(int) override {
+            return false;
+        }
+        void onConnected() override {
+        }
+        void onDisconnected() override {
+        }
+    };
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto suppressedConnectionPath = tempLogPath("snodec-semantic-repair-connection-suppressed.log");
+    {
+        LoggerStateGuard guard(suppressedConnectionPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        TestSocketConnection connection("repair-instance");
+        int evaluations = 0;
+        connection.log().debug("{}", ExpensiveValue{&evaluations});
+        result.expectEqual(0, evaluations, "production SocketConnection::log debug formatting is skipped when globally suppressed");
+    }
+    result.expectTrue(readFile(suppressedConnectionPath).empty(),
+                      "production SocketConnection::log suppressed debug emits no backend output");
+
+    const auto enabledConnectionPath = tempLogPath("snodec-semantic-repair-connection-enabled.log");
+    {
+        LoggerStateGuard guard(enabledConnectionPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::freeze();
+        TestSocketConnection connection("repair-instance");
+        int evaluations = 0;
+        connection.log().debug("{}", ExpensiveValue{&evaluations});
+        result.expectEqual(1, evaluations, "production SocketConnection::log debug formatting runs when enabled");
+    }
+    const auto enabledConnectionLog = readFile(enabledConnectionPath);
+    result.expectTrue(enabledConnectionLog.find("expensive") != std::string::npos,
+                      "enabled SocketConnection::log writes formatted message");
+    result.expectTrue(enabledConnectionLog.find(" framework connection core.socket.stream ") != std::string::npos,
+                      "enabled SocketConnection::log preserves framework connection scope");
+
+    const auto suppressedContextPath = tempLogPath("snodec-semantic-repair-context-suppressed.log");
+    {
+        LoggerStateGuard guard(suppressedContextPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        TestSocketConnection connection("repair-instance");
+        TestSocketContext context(&connection);
+        int evaluations = 0;
+        context.frameworkLog().debug("{}", ExpensiveValue{&evaluations});
+        result.expectEqual(0, evaluations, "production SocketContext::frameworkLog debug formatting is skipped when globally suppressed");
+    }
+    result.expectTrue(readFile(suppressedContextPath).empty(),
+                      "production SocketContext::frameworkLog suppressed debug emits no backend output");
+
+    int disabledSysErrorEvaluations = 0;
+    int disabledSysErrorSinkCalls = 0;
+    auto disabledSysErrorLogger = logger::BoundaryLogger::createForTest(
+        testScope(),
+        [&](logger::LogRecord) {
+            ++disabledSysErrorSinkCalls;
+        },
+        logger::LogLevel::Error,
+        fixedTimestamp);
+    disabledSysErrorLogger.sysError(logger::LogLevel::Debug, EACCES, "{}", ExpensiveValue{&disabledSysErrorEvaluations});
+    result.expectEqual(0, disabledSysErrorEvaluations, "disabled int sysError does not format message");
+    result.expectEqual(0, disabledSysErrorSinkCalls, "disabled int sysError does not call sink");
+
+    std::vector<logger::LogRecord> sysErrorRecords;
+    auto enabledSysErrorLogger = logger::BoundaryLogger::createForTest(
+        testScope(),
+        [&](logger::LogRecord record) {
+            sysErrorRecords.push_back(std::move(record));
+        },
+        logger::LogLevel::Debug,
+        fixedTimestamp);
+    int enabledSysErrorEvaluations = 0;
+    enabledSysErrorLogger.sysError(logger::LogLevel::Debug, EACCES, "{}", ExpensiveValue{&enabledSysErrorEvaluations});
+    result.expectEqual(1, enabledSysErrorEvaluations, "enabled int sysError formats message");
+    result.expectTrue(sysErrorRecords.size() == 1 && sysErrorRecords[0].message == "expensive" && sysErrorRecords[0].error &&
+                          sysErrorRecords[0].error->code == EACCES &&
+                          sysErrorRecords[0].error->text.find("Permission") != std::string::npos,
+                      "enabled int sysError preserves message, errno code, and errno text");
+
+    std::vector<logger::LogRecord> explicitThresholdRecords;
+    logger::LogManager::init();
+    logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+    logger::LogManager::freeze();
+    TestSocketConnection explicitConnection("repair-instance");
+    explicitConnection
+        .log(
+            [&](logger::LogRecord record) {
+                explicitThresholdRecords.push_back(std::move(record));
+            },
+            logger::LogLevel::Trace)
+        .debug("explicit threshold still emits");
+    result.expectTrue(explicitThresholdRecords.size() == 1 && explicitThresholdRecords[0].message == "explicit threshold still emits",
+                      "explicit custom-sink threshold overload remains independent of LogManager global level");
+    logger::LogManager::init();
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation
- Fix a production performance defect where no-arg semantic loggers were constructed with the default `LogLevel::Trace`, causing disabled-path formatting to execute in production instead of being cheaply suppressed.
- Ensure format-style semantic logging and `sysError(...)` overloads do not construct formatted messages or error payloads when the local `BoundaryLogger` threshold disables the level.
- Address hygiene issues in the newly added semantic logging files by adding the standard project license header and enforcing `clang-format` cleanliness.

### Description
- Added a `LogScopeOwner::logger(BoundaryLogger::Sink sink, BoundaryLogger::Clock clock = {}) const` helper that resolves `LogManager::effectiveLevel(scope())` and preserved the explicit-threshold overload that accepts `LogLevel threshold` for tests/custom sinks.
- Rewired production no-arg semantic logger call paths to use the helper (thereby using `LogManager::effectiveLevel(scope)`), repairing these production APIs: `ConfigInstance::log()`, `SocketConnection::log()`, `SocketContext::log()`, `SocketContext::frameworkLog()`, `SocketServer::log()`, `SocketClient::log()`, `SocketConnector::log()`, and `SocketAcceptor::log()`.
- Changed `BoundaryLogger` so `emitFormatted(...)` and both `sysError(...)` overloads short-circuit with `if (!enabled(level)) return;` before formatting or constructing `LogError` payloads, preserving `Logger::emitSemantic()` final `LogManager::shouldEmit(record)` gate.
- Hygiene: added the standard dual LGPL/MIT license header to `src/log/{SemanticLogger,LogScopeOwner}.{h,cpp}` and ran `clang-format -i` on all touched files; added `tests/unit/log/SemanticProductionThresholdRepairTest.cpp` and registered it in `tests/unit/log/CMakeLists.txt`; updated short stale comments to reflect that production default loggers use the frozen startup semantic policy.

### Testing
- Built the project and ran the unit test selection that includes the new test with `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` then `cmake --build cmake-build --parallel 2`; the build succeeded.
- Executed `ctest` for the logging rounds plus the new `SemanticProductionThresholdRepairTest` and all targeted tests passed, including `SemanticProductionThresholdRepairTest` (100% passed for the invoked test set).
- Performed ASan build and test (`-DSNODEC_ENABLE_ASAN=ON`) and the ASan test run passed with no failures (ASan reported 100% tests passed for the run performed).
- Ran `clang-format -i` on the modified semantic logging and touched files and verified `git diff --check` produced no formatting or whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b3894d498832cb54d015a7941447c)