### PR TITLE
Semantic logging migration 03 — SocketServer and SocketClient

### DIFF
--- a/docs/logging/semantic-migration-03-socketserver-client-report.md
+++ b/docs/logging/semantic-migration-03-socketserver-client-report.md
@@ -1,0 +1,184 @@
+# Semantic logging migration 03 — SocketServer and SocketClient
+
+## Implementation summary
+
+This is a clean Migration 03 PR from the current base branch after PR #151, PR #154, and PR #155 were present in history. PR #151 already provides the production-threshold repair; PR #154 already completed Migration 1 for `SocketConnection.hpp`; PR #155 already completed Migration 2 for `SocketConnector.h` and `SocketAcceptor.h`. This PR does not implement or duplicate PR #151, PR #154, or PR #155.
+
+Migration 03 converts scoped legacy `LOG` macro call sites in `SocketServer.h` and `SocketClient.h` to the existing object-owned semantic logger. It also adds one focused unit test for the SocketServer/SocketClient owner path.
+
+## Exact changed files
+
+- `docs/logging/semantic-migration-03-socketserver-client-report.md`
+- `src/core/socket/stream/SocketClient.h`
+- `src/core/socket/stream/SocketServer.h`
+- `tests/unit/log/CMakeLists.txt`
+- `tests/unit/log/SocketServerClientMigration03Test.cpp`
+
+## Base verification result
+
+The requested `git fetch origin` step could not be completed because this checkout has no `origin` remote configured. The local base branch was the provided clean `work` checkout, whose latest commit is merge commit `2615d0a Merge pull request #155 from SNodeC/codex/create-semantic-logging-migration-02`, with PR #151, PR #154, PR #155, Round 8, and Round 9 visible in the recent log and required files present.
+
+Verified required files:
+
+- `docs/logging/semantic-production-threshold-repair-report.md`
+- `tests/unit/log/SemanticProductionThresholdRepairTest.cpp`
+- `docs/logging/semantic-migration-01-socketconnection-hpp-report.md`
+- `tests/unit/log/SocketConnectionMigration01Test.cpp`
+- `docs/logging/semantic-migration-02-socketconnector-acceptor-report.md`
+- `tests/unit/log/SocketConnectorAcceptorMigration02Test.cpp`
+- `docs/logging/round-08-controlled-subsystem-migration-report.md`
+- `tests/unit/log/ControlledMigrationRound8Test.cpp`
+- `docs/logging/round-09-compatibility-sanitizer-overhead-report.md`
+- `tests/unit/log/SemanticCompatibilityRound9Test.cpp`
+- `tests/unit/log/SemanticOverheadRound9Test.cpp`
+
+## Initial inventory command/result
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" src/core/socket/stream/SocketServer.h src/core/socket/stream/SocketClient.h
+```
+
+Result:
+
+```text
+src/core/socket/stream/SocketClient.h:134:                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnConnect";
+src/core/socket/stream/SocketClient.h:136:                      LOG(DEBUG) << "  Local: " << socketConnection->getLocalAddress().toString();
+src/core/socket/stream/SocketClient.h:137:                      LOG(DEBUG) << "   Peer: " << socketConnection->getRemoteAddress().toString();
+src/core/socket/stream/SocketClient.h:144:                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnConnected";
+src/core/socket/stream/SocketClient.h:146:                      LOG(DEBUG) << "  Local: " << socketConnection->getLocalAddress().toString();
+src/core/socket/stream/SocketClient.h:147:                      LOG(DEBUG) << "   Peer: " << socketConnection->getRemoteAddress().toString();
+src/core/socket/stream/SocketClient.h:154:                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnDisconnect";
+src/core/socket/stream/SocketClient.h:156:                      LOG(DEBUG) << "            Local: " << socketConnection->getLocalAddress().toString();
+src/core/socket/stream/SocketClient.h:157:                      LOG(DEBUG) << "             Peer: " << socketConnection->getRemoteAddress().toString();
+src/core/socket/stream/SocketClient.h:159:                      LOG(DEBUG) << "     Online Since: " << socketConnection->getOnlineSince();
+src/core/socket/stream/SocketClient.h:160:                      LOG(DEBUG) << "  Online Duration: " << socketConnection->getOnlineDuration();
+src/core/socket/stream/SocketClient.h:162:                      LOG(DEBUG) << "     Total Queued: " << socketConnection->getTotalQueued();
+src/core/socket/stream/SocketClient.h:163:                      LOG(DEBUG) << "       Total Sent: " << socketConnection->getTotalSent();
+src/core/socket/stream/SocketClient.h:164:                      LOG(DEBUG) << "      Write Delta: " << socketConnection->getTotalQueued() - socketConnection->getTotalSent();
+src/core/socket/stream/SocketClient.h:165:                      LOG(DEBUG) << "       Total Read: " << socketConnection->getTotalRead();
+src/core/socket/stream/SocketClient.h:166:                      LOG(DEBUG) << "  Total Processed: " << socketConnection->getTotalProcessed();
+src/core/socket/stream/SocketClient.h:167:                      LOG(DEBUG) << "       Read Delta: " << socketConnection->getTotalRead() - socketConnection->getTotalProcessed();
+src/core/socket/stream/SocketClient.h:197:                        LOG(DEBUG) << config->getInstanceName() << ": Initiating connect";
+src/core/socket/stream/SocketClient.h:211:                                        LOG(INFO)
+src/core/socket/stream/SocketClient.h:223:                                                    LOG(INFO) << config->getInstanceName() << ": Reconnect disabled during wait";
+src/core/socket/stream/SocketClient.h:251:                                        LOG(INFO)
+src/core/socket/stream/SocketClient.h:269:                                                    LOG(INFO) << config->getInstanceName() << ": Retry connect disabled during wait";
+src/core/socket/stream/SocketClient.h:277:                        LOG(FATAL) << config->getInstanceName() << " required";
+src/core/socket/stream/SocketServer.h:128:                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnConnect";
+src/core/socket/stream/SocketServer.h:130:                      LOG(DEBUG) << "  Local: " << socketConnection->getLocalAddress().toString();
+src/core/socket/stream/SocketServer.h:131:                      LOG(DEBUG) << "   Peer: " << socketConnection->getRemoteAddress().toString();
+src/core/socket/stream/SocketServer.h:138:                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnConnected";
+src/core/socket/stream/SocketServer.h:140:                      LOG(DEBUG) << "  Local: " << socketConnection->getLocalAddress().toString();
+src/core/socket/stream/SocketServer.h:141:                      LOG(DEBUG) << "   Peer: " << socketConnection->getRemoteAddress().toString();
+src/core/socket/stream/SocketServer.h:148:                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnDisconnect";
+src/core/socket/stream/SocketServer.h:150:                      LOG(DEBUG) << "            Local: " << socketConnection->getLocalAddress().toString();
+src/core/socket/stream/SocketServer.h:151:                      LOG(DEBUG) << "             Peer: " << socketConnection->getRemoteAddress().toString();
+src/core/socket/stream/SocketServer.h:153:                      LOG(DEBUG) << "     Online Since: " << socketConnection->getOnlineSince();
+src/core/socket/stream/SocketServer.h:154:                      LOG(DEBUG) << "  Online Duration: " << socketConnection->getOnlineDuration();
+src/core/socket/stream/SocketServer.h:156:                      LOG(DEBUG) << "     Total Queued: " << socketConnection->getTotalQueued();
+src/core/socket/stream/SocketServer.h:157:                      LOG(DEBUG) << "       Total Sent: " << socketConnection->getTotalSent();
+src/core/socket/stream/SocketServer.h:158:                      LOG(DEBUG) << "      Write Delta: " << socketConnection->getTotalQueued() - socketConnection->getTotalSent();
+src/core/socket/stream/SocketServer.h:159:                      LOG(DEBUG) << "       Total Read: " << socketConnection->getTotalRead();
+src/core/socket/stream/SocketServer.h:160:                      LOG(DEBUG) << "  Total Processed: " << socketConnection->getTotalProcessed();
+src/core/socket/stream/SocketServer.h:161:                      LOG(DEBUG) << "       Read Delta: " << socketConnection->getTotalRead() - socketConnection->getTotalProcessed();
+src/core/socket/stream/SocketServer.h:191:                        LOG(DEBUG) << config->getInstanceName() << ": Initiating listen";
+src/core/socket/stream/SocketServer.h:222:                                        LOG(INFO)
+src/core/socket/stream/SocketServer.h:236:                                                    LOG(INFO) << config->getInstanceName() << ": Retry listen disabled during wait";
+src/core/socket/stream/SocketServer.h:244:                        LOG(FATAL) << config->getInstanceName() << " required";
+```
+
+## Post-migration inventory command/result
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" src/core/socket/stream/SocketServer.h src/core/socket/stream/SocketClient.h
+```
+
+Result: no matches.
+
+## Migrated call-site table
+
+| File | Legacy call sites | Semantic result |
+| --- | ---: | --- |
+| `src/core/socket/stream/SocketServer.h` | 22 `LOG` calls | Converted to captured `this->log()` owner calls using `debug`, `info`, and `critical`. |
+| `src/core/socket/stream/SocketClient.h` | 23 `LOG` calls | Converted to captured `this->log()` owner calls using `debug`, `info`, and `critical`. |
+
+## Deferred call-site table
+
+| File | Deferred call sites | Reason |
+| --- | ---: | --- |
+| `src/core/socket/stream/SocketServer.h` | 0 | No scoped `LOG`, `PLOG`, or `VLOG` call sites remain. |
+| `src/core/socket/stream/SocketClient.h` | 0 | No scoped `LOG`, `PLOG`, or `VLOG` call sites remain. |
+
+## Semantic owner used
+
+All migrated production calls use the existing object-owned semantic logger exposed by `this->log()`. Lambdas capture `log = this->log()` at owner construction or flow start so nested callbacks retain the existing SocketServer/SocketClient semantic scope. No new `BoundaryLogger`, `LogScopeOwner`, inheritance, mixin, constructor parameter, or logging infrastructure was added.
+
+## Severity mapping
+
+- `LOG(DEBUG)` -> `log.debug(...)`
+- `LOG(INFO)` -> `log.info(...)`
+- `LOG(FATAL)` -> `log.critical(...)`
+
+No `TRACE`, `WARNING`, or `ERROR` call sites were present in the scoped inventory.
+
+## PLOG/sysError errno handling
+
+No `PLOG` call sites were present in the scoped inventory, so no production errno conversion was required. The new unit test exercises `sysError` through the SocketServer semantic owner path and verifies errno code/text preservation.
+
+## VLOG result
+
+No `VLOG` call sites were present in the scoped inventory. No verbose-level behavior was migrated or changed.
+
+## Identity-prefix cleanup result
+
+Manual instance-name prefixes such as `config->getInstanceName() << ": ..."` were removed when the semantic owner already carries the instance identity. Connection names and socket endpoint values were retained because they describe the connected stream peer/local details rather than the SocketServer/SocketClient owner identity.
+
+## Filter/backend/format compatibility
+
+`SocketServerClientMigration03Test` covers enabled server/client owner emission, framework/instance/core.socket.stream scope, server/client role fields, LogManager filtering, backend `Logger::setLogLevel` filtering, JSON format selection, `sysError` errno code/text preservation, sink-taking overload compatibility, and suppressed expensive formatting after PR #151.
+
+## Production-scope confirmations
+
+This PR changes only SocketServer.h, SocketClient.h, tests/unit/log/CMakeLists.txt, SocketServerClientMigration03Test.cpp, and this report, or fewer files if no header changes are needed.
+This PR does not modify SemanticLogger.*.
+This PR does not modify LogScopeOwner.*.
+This PR does not modify Logger.*.
+This PR does not modify ConfigInstance.cpp.
+This PR does not modify SocketConnection.*.
+This PR does not modify SocketConnection.hpp.
+This PR does not modify SocketContext.cpp.
+This PR does not modify SocketConnector.h.
+This PR does not modify SocketAcceptor.h.
+This PR does not modify SemanticProductionThresholdRepairTest.cpp.
+This PR does not modify SocketConnectionMigration01Test.cpp.
+This PR does not modify SocketConnectorAcceptorMigration02Test.cpp.
+This PR does not change LOG/PLOG/VLOG macro definitions.
+This PR does not change LogManager precedence.
+This PR does not change LogManager freeze behavior.
+This PR does not change JSON v1 schema.
+This PR does not start Round 10.
+
+## Build commands run
+
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2`
+- `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`
+- `cmake --build cmake-build-asan --target SocketServerClientMigration03Test --parallel 2`
+
+## Test commands run
+
+- `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test|SemanticProductionThresholdRepairTest|SocketConnectionMigration01Test|SocketConnectorAcceptorMigration02Test|SocketServerClientMigration03Test" --output-on-failure`
+- `ctest --test-dir cmake-build --output-on-failure`
+- `ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan -R SocketServerClientMigration03Test --output-on-failure`
+
+## ASan result or exact reason not run
+
+A focused ASan build and run of `SocketServerClientMigration03Test` passed. A full ASan suite was not run because the non-ASan full suite already built all targets and the focused ASan run covered the new Migration 03 owner test while keeping validation time practical in this container.
+
+## Known follow-ups
+
+- Continue subsequent semantic logging migrations in separate PRs only; this PR does not start Migration 4 or Round 10.

--- a/src/core/socket/stream/SocketClient.h
+++ b/src/core/socket/stream/SocketClient.h
@@ -130,41 +130,41 @@ namespace core::socket::stream {
             , sharedContext(std::make_shared<Context>(
                   this->config,
                   std::make_shared<SocketContextFactory>(std::forward<Args>(args)...),
-                  [onConnect](SocketConnection* socketConnection) { // onConnect
-                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnConnect";
+                  [onConnect, log = this->log()](SocketConnection* socketConnection) { // onConnect
+                      log.debug("{}: OnConnect", socketConnection->getConnectionName());
 
-                      LOG(DEBUG) << "  Local: " << socketConnection->getLocalAddress().toString();
-                      LOG(DEBUG) << "   Peer: " << socketConnection->getRemoteAddress().toString();
+                      log.debug("Local: {}", socketConnection->getLocalAddress().toString());
+                      log.debug("Peer: {}", socketConnection->getRemoteAddress().toString());
 
                       if (onConnect) {
                           onConnect(socketConnection);
                       }
                   },
-                  [onConnected](SocketConnection* socketConnection) { // onConnected
-                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnConnected";
+                  [onConnected, log = this->log()](SocketConnection* socketConnection) { // onConnected
+                      log.debug("{}: OnConnected", socketConnection->getConnectionName());
 
-                      LOG(DEBUG) << "  Local: " << socketConnection->getLocalAddress().toString();
-                      LOG(DEBUG) << "   Peer: " << socketConnection->getRemoteAddress().toString();
+                      log.debug("Local: {}", socketConnection->getLocalAddress().toString());
+                      log.debug("Peer: {}", socketConnection->getRemoteAddress().toString());
 
                       if (onConnected) {
                           onConnected(socketConnection);
                       }
                   },
-                  [onDisconnect](SocketConnection* socketConnection) { // onDisconnect
-                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnDisconnect";
+                  [onDisconnect, log = this->log()](SocketConnection* socketConnection) { // onDisconnect
+                      log.debug("{}: OnDisconnect", socketConnection->getConnectionName());
 
-                      LOG(DEBUG) << "            Local: " << socketConnection->getLocalAddress().toString();
-                      LOG(DEBUG) << "             Peer: " << socketConnection->getRemoteAddress().toString();
+                      log.debug("Local: {}", socketConnection->getLocalAddress().toString());
+                      log.debug("Peer: {}", socketConnection->getRemoteAddress().toString());
 
-                      LOG(DEBUG) << "     Online Since: " << socketConnection->getOnlineSince();
-                      LOG(DEBUG) << "  Online Duration: " << socketConnection->getOnlineDuration();
+                      log.debug("Online Since: {}", socketConnection->getOnlineSince());
+                      log.debug("Online Duration: {}", socketConnection->getOnlineDuration());
 
-                      LOG(DEBUG) << "     Total Queued: " << socketConnection->getTotalQueued();
-                      LOG(DEBUG) << "       Total Sent: " << socketConnection->getTotalSent();
-                      LOG(DEBUG) << "      Write Delta: " << socketConnection->getTotalQueued() - socketConnection->getTotalSent();
-                      LOG(DEBUG) << "       Total Read: " << socketConnection->getTotalRead();
-                      LOG(DEBUG) << "  Total Processed: " << socketConnection->getTotalProcessed();
-                      LOG(DEBUG) << "       Read Delta: " << socketConnection->getTotalRead() - socketConnection->getTotalProcessed();
+                      log.debug("Total Queued: {}", socketConnection->getTotalQueued());
+                      log.debug("Total Sent: {}", socketConnection->getTotalSent());
+                      log.debug("Write Delta: {}", socketConnection->getTotalQueued() - socketConnection->getTotalSent());
+                      log.debug("Total Read: {}", socketConnection->getTotalRead());
+                      log.debug("Total Processed: {}", socketConnection->getTotalProcessed());
+                      log.debug("Read Delta: {}", socketConnection->getTotalRead() - socketConnection->getTotalProcessed());
 
                       if (onDisconnect) {
                           onDisconnect(socketConnection);
@@ -192,27 +192,26 @@ namespace core::socket::stream {
                                         unsigned int tries,
                                         double retryTimeoutScale) const {
             sharedContext->flowController.startFlow(
-                [config = this->config, sharedContext = this->sharedContext, onStatus, tries, retryTimeoutScale] {
+                [config = this->config, sharedContext = this->sharedContext, log = this->log(), onStatus, tries, retryTimeoutScale] {
                     if (config->Instance::getParent() != nullptr || !config->Instance::getRequired()) {
-                        LOG(DEBUG) << config->getInstanceName() << ": Initiating connect";
+                        log.debug("Initiating connect");
 
                         if (core::SNodeC::state() == core::State::RUNNING || core::SNodeC::state() == core::State::INITIALIZED) {
                             new SocketConnector(
                                 sharedContext->socketContextFactory,
                                 sharedContext->onConnect,
                                 sharedContext->onConnected,
-                                [config, sharedContext, onStatus](SocketConnection* socketConnection) {
+                                [config, sharedContext, log, onStatus](SocketConnection* socketConnection) {
                                     sharedContext->onDisconnect(socketConnection);
 
                                     if (config->getReconnect() && sharedContext->flowController.isReconnectEnabled() &&
                                         core::eventLoopState() == core::State::RUNNING) {
                                         double relativeReconnectTimeout = config->getReconnectTime();
 
-                                        LOG(INFO)
-                                            << config->getInstanceName() << ": Reconnect in " << relativeReconnectTimeout << " seconds";
+                                        log.info("Reconnect in {} seconds", relativeReconnectTimeout);
 
                                         sharedContext->flowController.armReconnectTimer(
-                                            relativeReconnectTimeout, [config, sharedContext, /*generation,*/ onStatus]() {
+                                            relativeReconnectTimeout, [config, sharedContext, log, /*generation,*/ onStatus]() {
                                                 if (!sharedContext->flowController.isReconnectEnabled()) {
                                                     return;
                                                 }
@@ -220,7 +219,7 @@ namespace core::socket::stream {
                                                     sharedContext->flowController.reportFlowReconnect();
                                                     SocketClient(config, sharedContext).realConnect(onStatus, 0, config->getRetryBase());
                                                 } else {
-                                                    LOG(INFO) << config->getInstanceName() << ": Reconnect disabled during wait";
+                                                    log.info("Reconnect disabled during wait");
                                                 }
                                             });
                                     }
@@ -228,8 +227,8 @@ namespace core::socket::stream {
                                 [sharedContext](core::eventreceiver::ConnectEventReceiver* connectEventReceiver) {
                                     sharedContext->flowController.observeConnectEventReceiver(connectEventReceiver);
                                 },
-                                [config, sharedContext, onStatus, tries, retryTimeoutScale](const SocketAddress& socketAddress,
-                                                                                            core::socket::State state) {
+                                [config, sharedContext, log, onStatus, tries, retryTimeoutScale](const SocketAddress& socketAddress,
+                                                                                                 core::socket::State state) {
                                     const bool retryFlag = (state & core::socket::State::NO_RETRY) == 0;
                                     state &= ~core::socket::State::NO_RETRY;
                                     onStatus(socketAddress, state);
@@ -248,13 +247,13 @@ namespace core::socket::stream {
                                             utils::Random::getInRange(-config->getRetryJitter(), config->getRetryJitter()) *
                                             relativeRetryTimeout / 100.;
 
-                                        LOG(INFO)
-                                            << config->getInstanceName() << ": Retry connect in " << relativeRetryTimeout << " seconds";
+                                        log.info("Retry connect in {} seconds", relativeRetryTimeout);
 
                                         sharedContext->flowController.armRetryTimer(
                                             relativeRetryTimeout,
                                             [config,
                                              sharedContext,
+                                             log,
                                              /*generation,*/ onStatus,
                                              tries,
                                              retryTimeoutScale]() {
@@ -266,7 +265,7 @@ namespace core::socket::stream {
                                                     SocketClient(config, sharedContext)
                                                         .realConnect(onStatus, tries + 1, retryTimeoutScale * config->getRetryBase());
                                                 } else {
-                                                    LOG(INFO) << config->getInstanceName() << ": Retry connect disabled during wait";
+                                                    log.info("Retry connect disabled during wait");
                                                 }
                                             });
                                     }
@@ -274,7 +273,7 @@ namespace core::socket::stream {
                                 config);
                         }
                     } else {
-                        LOG(FATAL) << config->getInstanceName() << " required";
+                        log.critical("{} required", config->getInstanceName());
                     }
                 });
 

--- a/src/core/socket/stream/SocketServer.h
+++ b/src/core/socket/stream/SocketServer.h
@@ -124,41 +124,41 @@ namespace core::socket::stream {
             , sharedContext(std::make_shared<Context>(
                   this->config,
                   std::make_shared<SocketContextFactory>(std::forward<Args>(args)...),
-                  [onConnect](SocketConnection* socketConnection) { // onConnect
-                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnConnect";
+                  [onConnect, log = this->log()](SocketConnection* socketConnection) { // onConnect
+                      log.debug("{}: OnConnect", socketConnection->getConnectionName());
 
-                      LOG(DEBUG) << "  Local: " << socketConnection->getLocalAddress().toString();
-                      LOG(DEBUG) << "   Peer: " << socketConnection->getRemoteAddress().toString();
+                      log.debug("Local: {}", socketConnection->getLocalAddress().toString());
+                      log.debug("Peer: {}", socketConnection->getRemoteAddress().toString());
 
                       if (onConnect) {
                           onConnect(socketConnection);
                       }
                   },
-                  [onConnected](SocketConnection* socketConnection) { // onConnected
-                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnConnected";
+                  [onConnected, log = this->log()](SocketConnection* socketConnection) { // onConnected
+                      log.debug("{}: OnConnected", socketConnection->getConnectionName());
 
-                      LOG(DEBUG) << "  Local: " << socketConnection->getLocalAddress().toString();
-                      LOG(DEBUG) << "   Peer: " << socketConnection->getRemoteAddress().toString();
+                      log.debug("Local: {}", socketConnection->getLocalAddress().toString());
+                      log.debug("Peer: {}", socketConnection->getRemoteAddress().toString());
 
                       if (onConnected) {
                           onConnected(socketConnection);
                       }
                   },
-                  [onDisconnect](SocketConnection* socketConnection) { // onDisconnect
-                      LOG(DEBUG) << socketConnection->getConnectionName() << ": OnDisconnect";
+                  [onDisconnect, log = this->log()](SocketConnection* socketConnection) { // onDisconnect
+                      log.debug("{}: OnDisconnect", socketConnection->getConnectionName());
 
-                      LOG(DEBUG) << "            Local: " << socketConnection->getLocalAddress().toString();
-                      LOG(DEBUG) << "             Peer: " << socketConnection->getRemoteAddress().toString();
+                      log.debug("Local: {}", socketConnection->getLocalAddress().toString());
+                      log.debug("Peer: {}", socketConnection->getRemoteAddress().toString());
 
-                      LOG(DEBUG) << "     Online Since: " << socketConnection->getOnlineSince();
-                      LOG(DEBUG) << "  Online Duration: " << socketConnection->getOnlineDuration();
+                      log.debug("Online Since: {}", socketConnection->getOnlineSince());
+                      log.debug("Online Duration: {}", socketConnection->getOnlineDuration());
 
-                      LOG(DEBUG) << "     Total Queued: " << socketConnection->getTotalQueued();
-                      LOG(DEBUG) << "       Total Sent: " << socketConnection->getTotalSent();
-                      LOG(DEBUG) << "      Write Delta: " << socketConnection->getTotalQueued() - socketConnection->getTotalSent();
-                      LOG(DEBUG) << "       Total Read: " << socketConnection->getTotalRead();
-                      LOG(DEBUG) << "  Total Processed: " << socketConnection->getTotalProcessed();
-                      LOG(DEBUG) << "       Read Delta: " << socketConnection->getTotalRead() - socketConnection->getTotalProcessed();
+                      log.debug("Total Queued: {}", socketConnection->getTotalQueued());
+                      log.debug("Total Sent: {}", socketConnection->getTotalSent());
+                      log.debug("Write Delta: {}", socketConnection->getTotalQueued() - socketConnection->getTotalSent());
+                      log.debug("Total Read: {}", socketConnection->getTotalRead());
+                      log.debug("Total Processed: {}", socketConnection->getTotalProcessed());
+                      log.debug("Read Delta: {}", socketConnection->getTotalRead() - socketConnection->getTotalProcessed());
 
                       if (onDisconnect) {
                           onDisconnect(socketConnection);
@@ -186,9 +186,9 @@ namespace core::socket::stream {
                                        unsigned int tries,
                                        double retryTimeoutScale) const {
             sharedContext->flowController.startFlow(
-                [config = this->config, sharedContext = this->sharedContext, onStatus, tries, retryTimeoutScale] {
+                [config = this->config, sharedContext = this->sharedContext, log = this->log(), onStatus, tries, retryTimeoutScale] {
                     if (config->Instance::getParent() != nullptr || !config->Instance::getRequired()) {
-                        LOG(DEBUG) << config->getInstanceName() << ": Initiating listen";
+                        log.debug("Initiating listen");
 
                         if (core::SNodeC::state() == core::State::RUNNING || core::SNodeC::state() == core::State::INITIALIZED) {
                             new SocketAcceptor(
@@ -199,8 +199,8 @@ namespace core::socket::stream {
                                 [sharedContext](core::eventreceiver::AcceptEventReceiver* acceptEventReceiver) {
                                     sharedContext->flowController.observeAcceptEventReceiver(acceptEventReceiver);
                                 },
-                                [config, sharedContext, onStatus, tries, retryTimeoutScale](const SocketAddress& socketAddress,
-                                                                                            core::socket::State state) {
+                                [config, sharedContext, log, onStatus, tries, retryTimeoutScale](const SocketAddress& socketAddress,
+                                                                                                 core::socket::State state) {
                                     const bool retryFlag = (state & core::socket::State::NO_RETRY) == 0;
                                     state &= ~core::socket::State::NO_RETRY;
                                     onStatus(socketAddress, state);
@@ -219,12 +219,11 @@ namespace core::socket::stream {
                                             utils::Random::getInRange(-config->getRetryJitter(), config->getRetryJitter()) *
                                             relativeRetryTimeout / 100.;
 
-                                        LOG(INFO)
-                                            << config->getInstanceName() << ": Retry listen in " << relativeRetryTimeout << " seconds";
+                                        log.info("Retry listen in {} seconds", relativeRetryTimeout);
 
                                         sharedContext->flowController.armRetryTimer(
                                             relativeRetryTimeout,
-                                            [config, sharedContext, /*generation,*/ onStatus, tries, retryTimeoutScale]() {
+                                            [config, sharedContext, log, /*generation,*/ onStatus, tries, retryTimeoutScale]() {
                                                 if (!sharedContext->flowController.isRetryEnabled()) {
                                                     return;
                                                 }
@@ -233,7 +232,7 @@ namespace core::socket::stream {
                                                     SocketServer(config, sharedContext)
                                                         .realListen(onStatus, tries + 1, retryTimeoutScale * config->getRetryBase());
                                                 } else {
-                                                    LOG(INFO) << config->getInstanceName() << ": Retry listen disabled during wait";
+                                                    log.info("Retry listen disabled during wait");
                                                 }
                                             });
                                     }
@@ -241,7 +240,7 @@ namespace core::socket::stream {
                                 config);
                         }
                     } else {
-                        LOG(FATAL) << config->getInstanceName() << " required";
+                        log.critical("{} required", config->getInstanceName());
                     }
                 });
 

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -58,3 +58,9 @@ snodec_add_test(SocketConnectorAcceptorMigration02Test SocketConnectorAcceptorMi
 target_include_directories(SocketConnectorAcceptorMigration02Test PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(SocketConnectorAcceptorMigration02Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
 set_tests_properties(SocketConnectorAcceptorMigration02Test PROPERTIES LABELS "unit;log;migration02")
+
+snodec_add_test(SocketServerClientMigration03Test SocketServerClientMigration03Test.cpp)
+target_include_directories(SocketServerClientMigration03Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(SocketServerClientMigration03Test PRIVATE cxx_std_20)
+target_link_libraries(SocketServerClientMigration03Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
+set_tests_properties(SocketServerClientMigration03Test PROPERTIES LABELS "unit;log;migration03")

--- a/tests/unit/log/SocketServerClientMigration03Test.cpp
+++ b/tests/unit/log/SocketServerClientMigration03Test.cpp
@@ -1,0 +1,246 @@
+#include "core/eventreceiver/AcceptEventReceiver.h"
+#include "core/eventreceiver/ConnectEventReceiver.h"
+#include "core/socket/Socket.hpp"
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketClient.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "core/socket/stream/SocketServer.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "net/config/ConfigInstance.h"
+#include "tests/support/TestResult.h"
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace {
+    struct ExpensiveValue {
+        int* evaluations;
+    };
+
+    std::ostream& operator<<(std::ostream& out, const ExpensiveValue& value) {
+        ++*value.evaluations;
+        return out << "expensive";
+    }
+
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() {
+                return std::string("MIGRATION03TICK");
+            });
+            logger::Logger::logToFile(logFile);
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+
+    class TestConfigInstance : public net::config::ConfigInstance {
+    public:
+        explicit TestConfigInstance(const std::string& instanceName)
+            : ConfigInstance(instanceName, Role::SERVER) {
+        }
+        ~TestConfigInstance() override = default;
+    };
+
+    class TestSocketAddress : public core::socket::SocketAddress {
+    public:
+        std::string toString(bool = true) const override {
+            return "migration03-address";
+        }
+    };
+
+    class TestSocketConnection {
+    public:
+        std::string getConnectionName() const {
+            return "migration03-connection";
+        }
+
+        const TestSocketAddress& getLocalAddress() const {
+            return address;
+        }
+
+        const TestSocketAddress& getRemoteAddress() const {
+            return address;
+        }
+
+        std::string getOnlineSince() const {
+            return "migration03-online-since";
+        }
+
+        double getOnlineDuration() const {
+            return 1.0;
+        }
+
+        std::size_t getTotalQueued() const {
+            return 2;
+        }
+
+        std::size_t getTotalSent() const {
+            return 1;
+        }
+
+        std::size_t getTotalRead() const {
+            return 4;
+        }
+
+        std::size_t getTotalProcessed() const {
+            return 3;
+        }
+
+    private:
+        TestSocketAddress address;
+    };
+
+    class TestSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection*) override {
+            return nullptr;
+        }
+    };
+
+    class TestAcceptEventReceiver : public core::eventreceiver::AcceptEventReceiver {
+    public:
+        using Config = TestConfigInstance;
+        using SocketAddress = TestSocketAddress;
+        using SocketConnection = TestSocketConnection;
+    };
+
+    class TestConnectEventReceiver : public core::eventreceiver::ConnectEventReceiver {
+    public:
+        using Config = TestConfigInstance;
+        using SocketAddress = TestSocketAddress;
+        using SocketConnection = TestSocketConnection;
+    };
+
+    using TestSocketServer = core::socket::stream::SocketServer<TestAcceptEventReceiver, TestSocketContextFactory>;
+    using TestSocketClient = core::socket::stream::SocketClient<TestConnectEventReceiver, TestSocketContextFactory>;
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto enabledPath = tempLogPath("snodec-migration03-enabled.log");
+    {
+        LoggerStateGuard guard(enabledPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::freeze();
+        TestSocketServer("migration03-server").log().debug("server semantic owner emitted");
+        TestSocketClient("migration03-client").log().info("client semantic owner emitted");
+    }
+    const auto enabledLog = readFile(enabledPath);
+    result.expectTrue(enabledLog.find("server semantic owner emitted") != std::string::npos,
+                      "SocketServer semantic owner emits when enabled");
+    result.expectTrue(enabledLog.find("client semantic owner emitted") != std::string::npos,
+                      "SocketClient semantic owner emits when enabled");
+    result.expectTrue(enabledLog.find(" framework instance core.socket.stream instance=migration03-server role=server ") !=
+                          std::string::npos,
+                      "server emitted records carry framework instance core.socket.stream scope and server role");
+    result.expectTrue(enabledLog.find(" framework instance core.socket.stream instance=migration03-client role=client ") !=
+                          std::string::npos,
+                      "client emitted records carry framework instance core.socket.stream scope and client role");
+
+    const auto managerFilterPath = tempLogPath("snodec-migration03-manager-filter.log");
+    {
+        LoggerStateGuard guard(managerFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        TestSocketServer("migration03-server").log().debug("server suppressed by manager");
+        TestSocketClient("migration03-client").log().warn("client suppressed by manager");
+    }
+    result.expectTrue(readFile(managerFilterPath).find("suppressed by manager") == std::string::npos,
+                      "LogManager filtering suppresses server/client semantic calls");
+
+    const auto backendFilterPath = tempLogPath("snodec-migration03-backend-filter.log");
+    {
+        LoggerStateGuard guard(backendFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        logger::Logger::setLogLevel(3);
+        TestSocketServer("migration03-server").log().debug("server suppressed by backend");
+        TestSocketClient("migration03-client").log().debug("client suppressed by backend");
+    }
+    result.expectTrue(readFile(backendFilterPath).find("suppressed by backend") == std::string::npos,
+                      "Logger::setLogLevel backend filtering still suppresses output");
+
+    const auto jsonPath = tempLogPath("snodec-migration03-json.log");
+    {
+        LoggerStateGuard guard(jsonPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        TestSocketClient("migration03-client").log().debug("client json format respected");
+    }
+    const auto jsonLog = readFile(jsonPath);
+    result.expectTrue(jsonLog.find("{\"v\":1") != std::string::npos &&
+                          jsonLog.find("\"message\":\"client json format respected\"") != std::string::npos &&
+                          jsonLog.find("\"role\":\"client\"") != std::string::npos,
+                      "JSON format selection is respected");
+
+    std::vector<logger::LogRecord> sysErrorRecords;
+    TestSocketServer("migration03-server")
+        .log([&](logger::LogRecord record) {
+            sysErrorRecords.push_back(std::move(record));
+        })
+        .sysError(logger::LogLevel::Error, EACCES, "server preserved errno");
+    result.expectTrue(sysErrorRecords.size() == 1 && sysErrorRecords[0].message == "server preserved errno" && sysErrorRecords[0].error &&
+                          sysErrorRecords[0].error->code == EACCES &&
+                          sysErrorRecords[0].error->text.find("Permission") != std::string::npos,
+                      "sysError errno code/text preservation through the owner path");
+
+    std::vector<logger::LogRecord> sinkRecords;
+    TestSocketClient("migration03-client")
+        .log([&](logger::LogRecord record) {
+            sinkRecords.push_back(std::move(record));
+        })
+        .info("sink overload still works");
+    result.expectTrue(sinkRecords.size() == 1 && sinkRecords[0].message == "sink overload still works" && sinkRecords[0].role &&
+                          *sinkRecords[0].role == logger::LogRole::Client,
+                      "sink-taking overload remains compatible");
+
+    const auto suppressedPath = tempLogPath("snodec-migration03-suppressed.log");
+    {
+        LoggerStateGuard guard(suppressedPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+
+        int evaluations = 0;
+        TestSocketServer("migration03-server").log().debug("{}", ExpensiveValue{&evaluations});
+        result.expectEqual(0, evaluations, "suppressed production formatting does not evaluate ExpensiveValue after PR #151");
+    }
+    result.expectTrue(readFile(suppressedPath).empty(), "suppressed production formatting emits no backend output");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation
- Migrate legacy `LOG` call sites in the Socket stream owners to the object-owned semantic logger so logging uses the scoped semantic owner and obeys production thresholds introduced by prior repairs.
- Keep the change limited to the SocketServer/SocketClient owner scope and provide an audit/report and focused unit test to validate owner behavior and backward-compatible semantics.
- Build on the production-threshold repair and earlier migrations (Round 6 owner model / Migrations 01–02) without changing logging infrastructure or APIs.

### Description
- Replaced scoped `LOG(...)` calls in `src/core/socket/stream/SocketServer.h` and `src/core/socket/stream/SocketClient.h` by capturing the existing owner logger (`log = this->log()`) in callbacks and using `log.<level>(...)` (e.g. `LOG(DEBUG)` -> `log.debug(...)`, `LOG(INFO)` -> `log.info(...)`, `LOG(FATAL)` -> `log.critical(...)`).
- Captured `log = this->log()` in nested lambdas and in `startFlow` closures so callbacks retain the `core.socket.stream`/instance/role semantic scope, and removed manual instance-name prefixes where the semantic owner already provides that identity.
- Added a focused unit test `tests/unit/log/SocketServerClientMigration03Test.cpp` and registered it in `tests/unit/log/CMakeLists.txt` to verify owner emission, scope/role fields, manager/backend/format filtering, `sysError` errno preservation, sink overload compatibility, and suppressed expensive formatting behavior.
- Added the migration report `docs/logging/semantic-migration-03-socketserver-client-report.md` documenting inventory, mapping, deferred sites (none), and validation; applied `clang-format` to the touched C++ files; no other production files or logging infra were modified.

### Testing
- Initial inventory with `rg` found multiple `LOG(...)` sites in both headers and post-migration `rg` shows no `LOG/PLOG/VLOG` matches in the two scoped headers.
- Performed a non-ASan build: `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build --parallel 2`, and ran focused logging tests with `ctest` including `SocketServerClientMigration03Test`; the focused and full `ctest` runs passed.
- Performed a focused ASan build/run for the migration test: `cmake -S . -B cmake-build-asan -DSNODEC_ENABLE_ASAN=ON` then built and ran `SocketServerClientMigration03Test` under ASan; the focused ASan migration test passed.
- `git diff --name-only` / changed-file check contains only the allowed files: the two headers, the new test, the test CMakeLists entry, and the migration report. All automated checks mentioned above passed (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b8918beb4832c8190f4a3baddcb6f)