### PR TITLE
Semantic logging migration 04 — core runtime

### DIFF
--- a/docs/logging/semantic-migration-04-core-runtime-report.md
+++ b/docs/logging/semantic-migration-04-core-runtime-report.md
@@ -1,0 +1,207 @@
+# Semantic logging migration 04 — core runtime report
+
+## Implementation summary
+
+This is a clean Migration 4 PR from current `master` after the already-merged PR #151, PR #154, PR #155, and PR #156. It does not duplicate those migrations. It migrates suitable core runtime lifecycle call sites in `EventLoop`, `TimerEventReceiver`, `DescriptorEventReceiver`, and the epoll/poll/select mux backend constructor announcements to semantic logging. It does not migrate HTTP, WebSocket, MQTT, DB, apps, examples, MiniGateway, or previous socket-stream migration files.
+
+## Exact changed files
+
+- `src/core/EventLoop.h`
+- `src/core/EventLoop.cpp`
+- `src/core/DescriptorEventReceiver.h`
+- `src/core/DescriptorEventReceiver.cpp`
+- `src/core/TimerEventReceiver.h`
+- `src/core/TimerEventReceiver.cpp`
+- `src/core/multiplexer/epoll/EventMultiplexer.cpp`
+- `src/core/multiplexer/poll/EventMultiplexer.cpp`
+- `src/core/multiplexer/select/EventMultiplexer.cpp`
+- `tests/unit/log/CMakeLists.txt`
+- `tests/unit/log/CoreRuntimeMigration04Test.cpp`
+- `docs/logging/semantic-migration-04-core-runtime-report.md`
+
+## Base verification result
+
+`git fetch origin` could not run because this workspace has no `origin` remote. The current base commit is `2c69151 Merge pull request #156 from SNodeC/codex/start-semantic-logging-migration-03`, which includes the prerequisite merged PRs in the visible history. All requested prerequisite files were present:
+
+- `docs/logging/semantic-production-threshold-repair-report.md`
+- `tests/unit/log/SemanticProductionThresholdRepairTest.cpp`
+- `docs/logging/semantic-migration-01-socketconnection-hpp-report.md`
+- `tests/unit/log/SocketConnectionMigration01Test.cpp`
+- `docs/logging/semantic-migration-02-socketconnector-acceptor-report.md`
+- `tests/unit/log/SocketConnectorAcceptorMigration02Test.cpp`
+- `docs/logging/semantic-migration-03-socketserver-client-report.md`
+- `tests/unit/log/SocketServerClientMigration03Test.cpp`
+- `docs/logging/round-08-controlled-subsystem-migration-report.md`
+- `tests/unit/log/ControlledMigrationRound8Test.cpp`
+- `docs/logging/round-09-compatibility-sanitizer-overhead-report.md`
+- `tests/unit/log/SemanticCompatibilityRound9Test.cpp`
+- `tests/unit/log/SemanticOverheadRound9Test.cpp`
+
+## Initial inventory command/result
+
+Command run exactly as requested:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" \
+  src/core \
+  -g '*.h' -g '*.hpp' -g '*.cpp' \
+  -g '!src/core/socket/stream/SocketConnection.h' \
+  -g '!src/core/socket/stream/SocketConnection.cpp' \
+  -g '!src/core/socket/stream/SocketConnection.hpp' \
+  -g '!src/core/socket/stream/SocketConnector.h' \
+  -g '!src/core/socket/stream/SocketAcceptor.h' \
+  -g '!src/core/socket/stream/SocketServer.h' \
+  -g '!src/core/socket/stream/SocketClient.h' \
+  -g '!src/core/socket/stream/SocketContext.cpp'
+```
+
+Complete initial inventory:
+
+- `src/core/DynamicLoader.cpp`: 14 `LOG(TRACE)` call sites.
+- `src/core/multiplexer/poll/EventMultiplexer.cpp:166`: `LOG(DEBUG)`.
+- `src/core/multiplexer/epoll/EventMultiplexer.cpp:90`: `LOG(DEBUG)`.
+- `src/core/multiplexer/select/EventMultiplexer.cpp:71`: `LOG(DEBUG)`.
+- `src/core/TimerEventReceiver.cpp:88`: `LOG(WARNING)`.
+- `src/core/TimerEventReceiver.cpp:104`: `LOG(TRACE)`.
+- `src/core/DescriptorEventReceiver.cpp:102`: `LOG(TRACE)`.
+- `src/core/DescriptorEventReceiver.cpp:104`: `LOG(WARNING)`.
+- `src/core/DescriptorEventReceiver.cpp:114`: `LOG(TRACE)`.
+- `src/core/DescriptorEventReceiver.cpp:116`: `LOG(WARNING)`.
+- `src/core/DescriptorEventReceiver.cpp:126`: `LOG(WARNING)`.
+- `src/core/DescriptorEventReceiver.cpp:129`: `LOG(WARNING)`.
+- `src/core/DescriptorEventReceiver.cpp:140`: `LOG(WARNING)`.
+- `src/core/DescriptorEventReceiver.cpp:143`: `LOG(WARNING)`.
+- `src/core/EventLoop.cpp:122`: `LOG(TRACE)`.
+- `src/core/EventLoop.cpp:176`: `PLOG(FATAL)`.
+- `src/core/EventLoop.cpp:210`: `LOG(TRACE)`.
+- `src/core/EventLoop.cpp:218`: `LOG(TRACE)`.
+- `src/core/EventLoop.cpp:221`: `LOG(TRACE)`.
+- `src/core/EventLoop.cpp:224`: `LOG(TRACE)`.
+- `src/core/EventLoop.cpp:227`: `PLOG(FATAL)`.
+- `src/core/EventLoop.cpp:261`: `LOG(TRACE)`.
+- `src/core/EventLoop.cpp:270`: `LOG(TRACE)`.
+- `src/core/EventLoop.cpp:287`: `LOG(TRACE)`.
+- `src/core/EventLoop.cpp:291`: `LOG(TRACE)`.
+- `src/core/EventLoop.cpp:293`: `LOG(TRACE)`.
+- `src/core/EventLoop.cpp:297`: `LOG(TRACE)`.
+- Remaining initial matches were under socket-stream TLS helpers, socket-stream writer, `SocketAcceptor.hpp`, and `SocketConnector.hpp`; these are deferred as socket-stream/TLS prior-migration or separate-scope work.
+
+## Inventory classification table
+
+| Class | Files | Initial production macro call sites | Decision |
+| --- | --- | ---: | --- |
+| A. EventLoop / runtime lifecycle | `src/core/EventLoop.cpp` | 13 | Migrated |
+| B. Timer | `src/core/TimerEventReceiver.cpp` | 2 | Migrated |
+| C. Descriptor / eventreceiver | `src/core/DescriptorEventReceiver.cpp` | 8 | Migrated |
+| D. pipe | `src/core/pipe/**` | 0 | No call sites |
+| E. mux backends | epoll/poll/select `EventMultiplexer.cpp` | 3 | Migrated |
+| F. other `src/core` out of Migration 4 scope | `DynamicLoader.cpp`, socket-stream/TLS files, prior socket stream templates | Many | Deferred |
+
+## Ownership discovery summary
+
+Command run:
+
+```sh
+rg -n "\blog\(\)|logger::|BoundaryLogger|LogScopeOwner|semantic|LOG_SCOPE|scope" \
+  src/core \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Existing semantic owners were found only in prior socket-stream migration files (`SocketConnection`, `SocketContext`, `SocketConnector`, `SocketAcceptor`, `SocketServer`, `SocketClient`). No owner existed for EventLoop, descriptor receivers, timer receivers, or mux backend constructors.
+
+## Stop/split decision and reason
+
+The allowed Migration 4 scope contained 26 production macro call sites, below the stop/split threshold of 35. The PR proceeds without splitting. Out-of-scope socket-stream/TLS and `DynamicLoader` matches are documented as deferred and were not used in the threshold decision.
+
+## Post-migration inventory command/result
+
+The same inventory command was rerun. All migrated Migration 4 files are absent from the post-migration results. Remaining results are deferred `LOG`/`PLOG` call sites in socket-stream/TLS or socket-stream template files and `src/core/DynamicLoader.cpp`; there were no remaining `VLOG` matches.
+
+## Migrated call-site table
+
+| File | Count | Mapping |
+| --- | ---: | --- |
+| `src/core/EventLoop.cpp` | 11 `LOG(TRACE)`, 2 `PLOG(FATAL)` | `log().trace(...)`, `log().sysError(LogLevel::Critical, errnum, ...)` |
+| `src/core/DescriptorEventReceiver.cpp` | 2 `LOG(TRACE)`, 6 `LOG(WARNING)` | `log().trace(...)`, `log().warn(...)` |
+| `src/core/TimerEventReceiver.cpp` | 1 `LOG(WARNING)`, 1 `LOG(TRACE)` | `log().warn(...)`, `log().trace(...)` |
+| `src/core/multiplexer/epoll/EventMultiplexer.cpp` | 1 `LOG(DEBUG)` | `muxLog().debug(...)` |
+| `src/core/multiplexer/poll/EventMultiplexer.cpp` | 1 `LOG(DEBUG)` | `muxLog().debug(...)` |
+| `src/core/multiplexer/select/EventMultiplexer.cpp` | 1 `LOG(DEBUG)` | `muxLog().debug(...)` |
+
+## Deferred call-site table
+
+| Area | Reason |
+| --- | --- |
+| `src/core/DynamicLoader.cpp` | Dynamic loader is not part of the requested core runtime layer (`EventLoop`, timer, descriptor/eventreceiver, pipe, mux). It needs a separate ownership decision. |
+| `src/core/socket/stream/tls/**` | TLS socket-stream logging is outside Migration 4 and should not be mixed with core runtime migration. |
+| `src/core/socket/stream/SocketWriter.cpp` | Socket-stream writer is outside this migration and prior socket-stream owner migrations should not be duplicated. |
+| `src/core/socket/stream/SocketAcceptor.hpp` and `SocketConnector.hpp` | Socket stream acceptor/connector implementation templates are prior migration/separate scope and intentionally not modified here. |
+
+## Semantic owner(s) used or added
+
+- Added minimal `LogScopeOwner` ownership to `core::EventLoop` with `Framework`, `System`, component `core.event-loop`.
+- Added minimal object-owned semantic logging to `DescriptorEventReceiver` with `Framework`, `System`, component `core.eventreceiver`, and receiver name as instance.
+- Added minimal object-owned semantic logging to `TimerEventReceiver` with `Framework`, `System`, component `core.timer`, and receiver name as instance.
+- Added file-local mux backend semantic owners with `Framework`, `System`, component `core.mux`, and backend instance (`epoll`, `poll`, `select`).
+- `LogBoundary::Subsystem` does not exist in this codebase, so `LogBoundary::System` is the closest existing boundary for core-runtime subsystem messages. No new enum values were added.
+
+## Severity mapping
+
+- `LOG(TRACE)` -> `trace`
+- `LOG(DEBUG)` -> `debug`
+- `LOG(WARNING)` -> `warn`
+- `PLOG(FATAL)` -> `sysError(LogLevel::Critical, errnum, ...)`
+
+## PLOG/sysError errno handling
+
+Two `PLOG(FATAL)` sites in `EventLoop.cpp` were migrated to `sysError(LogLevel::Critical, errnum, ...)`. Each captures `errno` into `const int errnum` immediately before semantic logging in the failure branch/case, preserving the errno code and generic-category text in semantic records.
+
+## VLOG result
+
+No `VLOG` call sites were migrated. No `VLOG` matches remain in the migration inventory.
+
+## Message/identity preservation notes
+
+The migration preserves lifecycle messages, signal names/numbers, mux backend names, receiver names, and timer dispatch delta values. Existing textual prefixes were kept where they contain useful operational identity; semantic scope adds structured component and instance metadata without deleting technical payload.
+
+## Filter/backend/format compatibility
+
+`CoreRuntimeMigration04Test` validates enabled emission, framework/system/component scope, `LogManager` filtering, `Logger::setLogLevel` backend filtering, JSON format selection, `sysError` errno code/text preservation, sink overload compatibility, and suppressed formatting avoiding `ExpensiveValue` evaluation after PR #151.
+
+## Production-scope confirmations
+
+- This PR changes only allowed Migration 4 files.
+- This PR does not modify `SemanticLogger.*`.
+- This PR does not modify `LogScopeOwner.*`.
+- This PR does not modify `Logger.*`.
+- This PR does not modify `ConfigInstance.cpp`.
+- This PR does not modify previous socket-stream migration files.
+- This PR does not modify previous migration tests.
+- This PR does not change `LOG`/`PLOG`/`VLOG` macro definitions.
+- This PR does not change `LogManager` precedence.
+- This PR does not change `LogManager` freeze behavior.
+- This PR does not change JSON v1 schema.
+- This PR does not start Round 10.
+
+## Build commands run
+
+- `git diff --check`
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2`
+- `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`
+- `cmake --build cmake-build-asan --parallel 2 --target CoreRuntimeMigration04Test`
+
+## Test commands run
+
+- `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test|SemanticProductionThresholdRepairTest|SocketConnectionMigration01Test|SocketConnectorAcceptorMigration02Test|SocketServerClientMigration03Test|CoreRuntimeMigration04Test" --output-on-failure`
+- `ctest --test-dir cmake-build --output-on-failure`
+- `ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan -R CoreRuntimeMigration04Test --output-on-failure`
+
+## ASan result or exact reason not run
+
+A focused ASan build and `CoreRuntimeMigration04Test` run passed. Full ASan was not run because the full non-ASan build already took many minutes in this environment and a full ASan build/test of all apps and component tests would materially exceed the practical runtime for this PR; the migration-specific ASan target was built and executed instead.
+
+## Known follow-ups
+
+- Consider a separate, explicitly-scoped migration for `DynamicLoader` ownership.
+- Consider a separate TLS/socket-stream migration for the remaining TLS and socket-stream template call sites.

--- a/src/core/DescriptorEventReceiver.cpp
+++ b/src/core/DescriptorEventReceiver.cpp
@@ -48,6 +48,7 @@
 #include "log/Logger.h"
 
 #include <climits>
+#include <utility>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -77,12 +78,22 @@ namespace core {
                                                      const utils::Timeval& timeout)
         : EventReceiver(name)
         , descriptorEventPublisher(descriptorEventPublisher)
+        , logScope(logger::LogOrigin::Framework, logger::LogBoundary::System, "core.eventreceiver", name)
         , maxInactivity(timeout)
         , initialTimeout(timeout) {
     }
 
     int DescriptorEventReceiver::getRegisteredFd() const {
         return observedFd;
+    }
+
+    logger::BoundaryLogger DescriptorEventReceiver::log() const {
+        return logScope.logger(logger::Logger::semanticSink());
+    }
+
+    logger::BoundaryLogger
+    DescriptorEventReceiver::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
+        return logScope.logger(std::move(sink), threshold, std::move(clock));
     }
 
     bool DescriptorEventReceiver::isEnabled() const {
@@ -99,9 +110,9 @@ namespace core {
 
             enabled = true;
             descriptorEventPublisher.enable(this);
-            LOG(TRACE) << getName() << ": Enabled";
+            log().trace("{}: Enabled", getName());
         } else {
-            LOG(WARNING) << getName() << ": Double enable";
+            log().warn("{}: Double enable", getName());
         }
 
         return enabled;
@@ -111,9 +122,9 @@ namespace core {
         if (enabled) {
             enabled = false;
             descriptorEventPublisher.disable(this);
-            LOG(TRACE) << getName() << ": Disabled";
+            log().trace("{}: Disabled", getName());
         } else {
-            LOG(WARNING) << getName() << ": Double disable";
+            log().warn("{}: Double disable", getName());
         }
     }
 
@@ -123,10 +134,10 @@ namespace core {
                 suspended = true;
                 descriptorEventPublisher.suspend(this);
             } else {
-                LOG(WARNING) << getName() << ": Double suspend";
+                log().warn("{}: Double suspend", getName());
             }
         } else {
-            LOG(WARNING) << getName() << ": Suspend while not enabled";
+            log().warn("{}: Suspend while not enabled", getName());
         }
     }
 
@@ -137,10 +148,10 @@ namespace core {
                 lastTriggered = utils::Timeval::currentTime();
                 descriptorEventPublisher.resume(this);
             } else {
-                LOG(WARNING) << getName() << ": Double resume";
+                log().warn("{}: Double resume", getName());
             }
         } else {
-            LOG(WARNING) << getName() << ": Resume while not enabled";
+            log().warn("{}: Resume while not enabled", getName());
         }
     }
 

--- a/src/core/DescriptorEventReceiver.h
+++ b/src/core/DescriptorEventReceiver.h
@@ -43,6 +43,7 @@
 #define CORE_DESCRIPTOREVENTRECEIVER_H
 
 #include "core/EventReceiver.h" // IWYU pragma: export
+#include "log/LogScopeOwner.h"
 
 namespace core {
     class DescriptorEventPublisher;
@@ -97,6 +98,11 @@ namespace core {
         bool isEnabled() const;
         bool isSuspended() const;
 
+        logger::BoundaryLogger log() const;
+        logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
+                                   logger::LogLevel threshold = logger::LogLevel::Trace,
+                                   logger::BoundaryLogger::Clock clock = {}) const;
+
     protected:
         bool enable(int fd);
         void disable();
@@ -122,6 +128,7 @@ namespace core {
         virtual void signalEvent(int signum) = 0;
 
         DescriptorEventPublisher& descriptorEventPublisher;
+        logger::LogScopeOwner logScope;
 
         int observedFd = -1;
 

--- a/src/core/EventLoop.cpp
+++ b/src/core/EventLoop.cpp
@@ -50,7 +50,9 @@
 #include "utils/Timeval.h"
 #include "utils/system/signal.h"
 
+#include <cerrno>
 #include <chrono>
+#include <utility>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -71,7 +73,8 @@ namespace core {
     }
 
     EventLoop::EventLoop()
-        : eventMultiplexer(::EventMultiplexer()) {
+        : eventMultiplexer(::EventMultiplexer())
+        , logScope(logger::LogOrigin::Framework, logger::LogBoundary::System, "core.event-loop") {
     }
 
     EventLoop& EventLoop::instance() {
@@ -86,6 +89,15 @@ namespace core {
 
     EventMultiplexer& EventLoop::getEventMultiplexer() {
         return eventMultiplexer;
+    }
+
+    logger::BoundaryLogger EventLoop::log() const {
+        return logScope.logger(logger::Logger::semanticSink());
+    }
+
+    logger::BoundaryLogger
+    EventLoop::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
+        return logScope.logger(std::move(sink), threshold, std::move(clock));
     }
 
     State EventLoop::getEventLoopState() {
@@ -119,7 +131,7 @@ namespace core {
         if (utils::Config::init(argc, argv)) {
             eventLoopState = State::INITIALIZED;
 
-            LOG(TRACE) << "SNode.C: Starting ... HELLO";
+            EventLoop::instance().log().trace("SNode.C: Starting ... HELLO");
         }
 
         sigaction(SIGPIPE, &oldPipeAct, nullptr);
@@ -173,7 +185,11 @@ namespace core {
             EventLoop::instance().eventMultiplexer.clearEventQueue();
             free();
 
-            PLOG(FATAL) << "Core: not initialized: No events will be processed\nCall SNodeC::init(argc, argv) before SNodeC::tick().";
+            const int errnum = errno;
+            EventLoop::instance().log().sysError(
+                logger::LogLevel::Critical,
+                errnum,
+                "Core: not initialized: No events will be processed\nCall SNodeC::init(argc, argv) before SNodeC::tick().");
         }
 
         return tickStatus;
@@ -207,7 +223,7 @@ namespace core {
                 eventLoopState = State::RUNNING;
                 core::TickStatus tickStatus = TickStatus::SUCCESS;
 
-                LOG(TRACE) << "Core::EventLoop: started";
+                EventLoop::instance().log().trace("Core::EventLoop: started");
 
                 do {
                     tickStatus = EventLoop::instance()._tick(timeOut);
@@ -215,16 +231,17 @@ namespace core {
 
                 switch (tickStatus) {
                     case TickStatus::SUCCESS:
-                        LOG(TRACE) << "Core::EventLoop: Stopped";
+                        EventLoop::instance().log().trace("Core::EventLoop: Stopped");
                         break;
                     case TickStatus::NOOBSERVER:
-                        LOG(TRACE) << "Core::EventLoop: No Observer";
+                        EventLoop::instance().log().trace("Core::EventLoop: No Observer");
                         break;
                     case TickStatus::INTERRUPTED:
-                        LOG(TRACE) << "Core::EventLoop: Interrupted";
+                        EventLoop::instance().log().trace("Core::EventLoop: Interrupted");
                         break;
                     case TickStatus::TRACE:
-                        PLOG(FATAL) << "Core::EventLoop: _tick()";
+                        const int errnum = errno;
+                        EventLoop::instance().log().sysError(logger::LogLevel::Critical, errnum, "Core::EventLoop: _tick()");
                         break;
                 }
             } else {
@@ -258,7 +275,7 @@ namespace core {
         }
 
         if (stopsig != 0) {
-            LOG(TRACE) << "Core: Sending signal " << signal << " to all DescriptorEventReceivers";
+            EventLoop::instance().log().trace("Core: Sending signal {} to all DescriptorEventReceivers", signal);
 
             EventLoop::instance().eventMultiplexer.signal(stopsig);
         }
@@ -267,7 +284,7 @@ namespace core {
 
         utils::Timeval timeout = 2;
 
-        LOG(TRACE) << "Core: Terminate all stalled DescriptorEventReceivers";
+        EventLoop::instance().log().trace("Core: Terminate all stalled DescriptorEventReceivers");
 
         EventLoop::instance().eventMultiplexer.terminate();
 
@@ -284,18 +301,18 @@ namespace core {
             timeout -= seconds.count();
         } while (timeout > 0 && (tickStatus == TickStatus::SUCCESS));
 
-        LOG(TRACE) << "Core: Shutdown config system";
+        EventLoop::instance().log().trace("Core: Shutdown config system");
 
         utils::Config::terminate();
 
-        LOG(TRACE) << "Core: All resources released";
+        EventLoop::instance().log().trace("Core: All resources released");
 
-        LOG(TRACE) << "SNode.C: Ended ... BYE";
+        EventLoop::instance().log().trace("SNode.C: Ended ... BYE");
     }
 
     void EventLoop::stoponsig(int sig) {
-        LOG(TRACE) << "Core: Received signal '" << utils::system::strsignal(sig) << "' (SIG" << utils::system::sigabbrev_np(sig) << " = "
-                   << sig << ")";
+        EventLoop::instance().log().trace(
+            "Core: Received signal '{}' (SIG{} = {})", utils::system::strsignal(sig), utils::system::sigabbrev_np(sig), sig);
         stopsig = sig;
         stop();
     }

--- a/src/core/EventLoop.h
+++ b/src/core/EventLoop.h
@@ -44,6 +44,7 @@
 
 #include "core/State.h" // IWYU pragma: export
 #include "core/TickStatus.h"
+#include "log/LogScopeOwner.h"
 
 namespace core {
     class EventMultiplexer;
@@ -75,6 +76,11 @@ namespace core {
         static unsigned long getTickCounter();
         EventMultiplexer& getEventMultiplexer();
 
+        logger::BoundaryLogger log() const;
+        logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
+                                   logger::LogLevel threshold = logger::LogLevel::Trace,
+                                   logger::BoundaryLogger::Clock clock = {}) const;
+
         static core::State getEventLoopState();
 
     private:
@@ -89,6 +95,7 @@ namespace core {
         static void stoponsig(int sig);
 
         core::EventMultiplexer& eventMultiplexer;
+        logger::LogScopeOwner logScope;
 
         static int stopsig;
 

--- a/src/core/TimerEventReceiver.cpp
+++ b/src/core/TimerEventReceiver.cpp
@@ -50,6 +50,8 @@
 
 #include "log/Logger.h"
 
+#include <utility>
+
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace core {
@@ -57,6 +59,7 @@ namespace core {
     TimerEventReceiver::TimerEventReceiver(const std::string& name, const utils::Timeval& delay)
         : EventReceiver(name)
         , timerEventPublisher(EventLoop::instance().getEventMultiplexer().getTimerEventPublisher())
+        , logScope(logger::LogOrigin::Framework, logger::LogBoundary::System, "core.timer", name)
         , absoluteTimeout(utils::Timeval::currentTime() + delay)
         , delay(delay) {
     }
@@ -73,6 +76,15 @@ namespace core {
         }
     }
 
+    logger::BoundaryLogger TimerEventReceiver::log() const {
+        return logScope.logger(logger::Logger::semanticSink());
+    }
+
+    logger::BoundaryLogger
+    TimerEventReceiver::log(logger::BoundaryLogger::Sink sink, logger::LogLevel threshold, logger::BoundaryLogger::Clock clock) const {
+        return logScope.logger(std::move(sink), threshold, std::move(clock));
+    }
+
     utils::Timeval TimerEventReceiver::getTimeoutAbsolut() const {
         return absoluteTimeout;
     }
@@ -85,7 +97,7 @@ namespace core {
         if (core::eventLoopState() != core::State::STOPPING) {
             timerEventPublisher.insert(this);
         } else {
-            LOG(WARNING) << "TimerEventReceiver - Enable after signal: Not enabled";
+            log().warn("TimerEventReceiver - Enable after signal: Not enabled");
             delete this;
         }
     }
@@ -101,7 +113,7 @@ namespace core {
     }
 
     void TimerEventReceiver::onEvent(const utils::Timeval& currentTime) {
-        LOG(TRACE) << "TimerEventReceiver: Dispatch delta = " << (currentTime - getTimeoutAbsolut()).getMsd() << " ms";
+        log().trace("TimerEventReceiver: Dispatch delta = {} ms", (currentTime - getTimeoutAbsolut()).getMsd());
 
         dispatchEvent();
     }

--- a/src/core/TimerEventReceiver.h
+++ b/src/core/TimerEventReceiver.h
@@ -43,6 +43,7 @@
 #define CORE_TIMEREVENTRECEIVER_H
 
 #include "core/EventReceiver.h"
+#include "log/LogScopeOwner.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
@@ -74,6 +75,11 @@ namespace core {
         utils::Timeval getTimeoutAbsolut() const;
         utils::Timeval getTimeoutRelative(const utils::Timeval& currentTime) const;
 
+        logger::BoundaryLogger log() const;
+        logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
+                                   logger::LogLevel threshold = logger::LogLevel::Trace,
+                                   logger::BoundaryLogger::Clock clock = {}) const;
+
         void enable();
         void update();
         void cancel();
@@ -87,6 +93,7 @@ namespace core {
         void setTimer(Timer* timer);
 
         TimerEventPublisher& timerEventPublisher;
+        logger::LogScopeOwner logScope;
 
         Timer* timer = nullptr;
         utils::Timeval absoluteTimeout;

--- a/src/core/multiplexer/epoll/EventMultiplexer.cpp
+++ b/src/core/multiplexer/epoll/EventMultiplexer.cpp
@@ -45,6 +45,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/LogScopeOwner.h"
 #include "log/Logger.h"
 #include "utils/Timeval.h"
 
@@ -60,6 +61,17 @@ core::EventMultiplexer& EventMultiplexer() {
 }
 
 namespace core::multiplexer::epoll {
+
+    namespace {
+        const logger::LogScopeOwner& muxLogScope() {
+            static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::System, "core.mux", "epoll");
+            return scope;
+        }
+
+        logger::BoundaryLogger muxLog() {
+            return muxLogScope().logger(logger::Logger::semanticSink());
+        }
+    } // namespace
 
     EventMultiplexer::EventMultiplexer()
         : core::EventMultiplexer(new core::multiplexer::epoll::DescriptorEventPublisher("READ", //
@@ -87,7 +99,7 @@ namespace core::multiplexer::epoll {
         event.data.ptr = descriptorEventPublishers[core::EventMultiplexer::DISP_TYPE::EX];
         core::system::epoll_ctl(epfd, EPOLL_CTL_ADD, epfds[core::EventMultiplexer::DISP_TYPE::EX], &event);
 
-        LOG(DEBUG) << "Core::multiplexer: epoll";
+        muxLog().debug("Core::multiplexer: epoll");
     }
 
     int EventMultiplexer::monitorDescriptors(utils::Timeval& tickTimeout, const sigset_t& sigMask) {

--- a/src/core/multiplexer/poll/EventMultiplexer.cpp
+++ b/src/core/multiplexer/poll/EventMultiplexer.cpp
@@ -46,6 +46,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/LogScopeOwner.h"
 #include "log/Logger.h"
 #include "utils/Timeval.h"
 
@@ -65,6 +66,17 @@ core::EventMultiplexer& EventMultiplexer() {
 }
 
 namespace core::multiplexer::poll {
+
+    namespace {
+        const logger::LogScopeOwner& muxLogScope() {
+            static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::System, "core.mux", "poll");
+            return scope;
+        }
+
+        logger::BoundaryLogger muxLog() {
+            return muxLogScope().logger(logger::Logger::semanticSink());
+        }
+    } // namespace
 
     PollFdsManager::PollFdsManager() {
         pollfds.resize(1, {-1, 0, 0});
@@ -163,7 +175,7 @@ namespace core::multiplexer::poll {
                                                                                        pollFdsManager,
                                                                                        POLLPRI,
                                                                                        POLLPRI)) {
-        LOG(DEBUG) << "Core::multiplexer: poll";
+        muxLog().debug("Core::multiplexer: poll");
     }
 
     int EventMultiplexer::monitorDescriptors(utils::Timeval& tickTimeOut, const sigset_t& sigMask) {

--- a/src/core/multiplexer/select/EventMultiplexer.cpp
+++ b/src/core/multiplexer/select/EventMultiplexer.cpp
@@ -44,6 +44,7 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #include "core/system/select.h"
+#include "log/LogScopeOwner.h"
 #include "log/Logger.h"
 #include "utils/Timeval.h"
 
@@ -61,6 +62,17 @@ core::EventMultiplexer& EventMultiplexer() {
 
 namespace core::multiplexer::select {
 
+    namespace {
+        const logger::LogScopeOwner& muxLogScope() {
+            static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::System, "core.mux", "select");
+            return scope;
+        }
+
+        logger::BoundaryLogger muxLog() {
+            return muxLogScope().logger(logger::Logger::semanticSink());
+        }
+    } // namespace
+
     EventMultiplexer::EventMultiplexer()
         : core::EventMultiplexer(new core::multiplexer::select::DescriptorEventPublisher("READ", //
                                                                                          fdSets[core::EventMultiplexer::DISP_TYPE::RD]),
@@ -68,7 +80,7 @@ namespace core::multiplexer::select {
                                                                                          fdSets[core::EventMultiplexer::DISP_TYPE::WR]),
                                  new core::multiplexer::select::DescriptorEventPublisher("EXCEPT", //
                                                                                          fdSets[core::EventMultiplexer::DISP_TYPE::EX])) {
-        LOG(DEBUG) << "Core::multiplexer: select";
+        muxLog().debug("Core::multiplexer: select");
     }
 
     int EventMultiplexer::monitorDescriptors(utils::Timeval& tickTimeOut, const sigset_t& sigMask) {

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -64,3 +64,9 @@ target_include_directories(SocketServerClientMigration03Test PRIVATE ${PROJECT_S
 target_compile_features(SocketServerClientMigration03Test PRIVATE cxx_std_20)
 target_link_libraries(SocketServerClientMigration03Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
 set_tests_properties(SocketServerClientMigration03Test PROPERTIES LABELS "unit;log;migration03")
+
+snodec_add_test(CoreRuntimeMigration04Test CoreRuntimeMigration04Test.cpp)
+target_include_directories(CoreRuntimeMigration04Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(CoreRuntimeMigration04Test PRIVATE cxx_std_20)
+target_link_libraries(CoreRuntimeMigration04Test PRIVATE snodec-test-support snodec::core)
+set_tests_properties(CoreRuntimeMigration04Test PROPERTIES LABELS "unit;log;migration04")

--- a/tests/unit/log/CoreRuntimeMigration04Test.cpp
+++ b/tests/unit/log/CoreRuntimeMigration04Test.cpp
@@ -1,0 +1,149 @@
+#include "core/EventLoop.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "tests/support/TestResult.h"
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace {
+    struct ExpensiveValue {
+        int* evaluations;
+    };
+
+    std::ostream& operator<<(std::ostream& out, const ExpensiveValue& value) {
+        ++*value.evaluations;
+        return out << "expensive";
+    }
+
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() {
+                return std::string("MIGRATION04TICK");
+            });
+            logger::Logger::logToFile(logFile);
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto enabledPath = tempLogPath("snodec-migration04-enabled.log");
+    {
+        LoggerStateGuard guard(enabledPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        core::EventLoop::instance().log().trace("core runtime semantic owner emitted");
+    }
+    const auto enabledLog = readFile(enabledPath);
+    result.expectTrue(enabledLog.find("core runtime semantic owner emitted") != std::string::npos,
+                      "core runtime semantic owner emits when enabled");
+    result.expectTrue(enabledLog.find(" framework system core.event-loop ") != std::string::npos,
+                      "emitted records carry framework core-runtime component scope");
+
+    const auto managerFilterPath = tempLogPath("snodec-migration04-manager-filter.log");
+    {
+        LoggerStateGuard guard(managerFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        core::EventLoop::instance().log().debug("core runtime suppressed by manager");
+    }
+    result.expectTrue(readFile(managerFilterPath).find("suppressed by manager") == std::string::npos,
+                      "LogManager filtering suppresses migrated core runtime semantic calls");
+
+    const auto backendFilterPath = tempLogPath("snodec-migration04-backend-filter.log");
+    {
+        LoggerStateGuard guard(backendFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        logger::Logger::setLogLevel(3);
+        core::EventLoop::instance().log().debug("core runtime suppressed by backend");
+    }
+    result.expectTrue(readFile(backendFilterPath).find("suppressed by backend") == std::string::npos,
+                      "Logger::setLogLevel backend filtering suppresses output");
+
+    const auto jsonPath = tempLogPath("snodec-migration04-json.log");
+    {
+        LoggerStateGuard guard(jsonPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        core::EventLoop::instance().log().debug("core runtime json format respected");
+    }
+    const auto jsonLog = readFile(jsonPath);
+    result.expectTrue(jsonLog.find("{\"v\":1") != std::string::npos &&
+                          jsonLog.find("\"message\":\"core runtime json format respected\"") != std::string::npos &&
+                          jsonLog.find("\"origin\":\"framework\"") != std::string::npos &&
+                          jsonLog.find("\"component\":\"core.event-loop\"") != std::string::npos,
+                      "JSON format selection is respected");
+
+    std::vector<logger::LogRecord> sysErrorRecords;
+    core::EventLoop::instance()
+        .log([&](logger::LogRecord record) {
+            sysErrorRecords.push_back(std::move(record));
+        })
+        .sysError(logger::LogLevel::Error, EACCES, "core runtime preserved errno");
+    result.expectTrue(sysErrorRecords.size() == 1 && sysErrorRecords[0].message == "core runtime preserved errno" &&
+                          sysErrorRecords[0].error && sysErrorRecords[0].error->code == EACCES &&
+                          sysErrorRecords[0].error->text.find("Permission") != std::string::npos,
+                      "sysError errno code/text is preserved");
+
+    std::vector<logger::LogRecord> sinkRecords;
+    core::EventLoop::instance()
+        .log([&](logger::LogRecord record) {
+            sinkRecords.push_back(std::move(record));
+        })
+        .info("sink overload still works");
+    result.expectTrue(sinkRecords.size() == 1 && sinkRecords[0].message == "sink overload still works" &&
+                          sinkRecords[0].component == "core.event-loop",
+                      "sink-taking overload remains compatible");
+
+    const auto suppressedPath = tempLogPath("snodec-migration04-suppressed.log");
+    {
+        LoggerStateGuard guard(suppressedPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+
+        int evaluations = 0;
+        core::EventLoop::instance().log().debug("{}", ExpensiveValue{&evaluations});
+        result.expectEqual(0, evaluations, "suppressed production formatting does not evaluate ExpensiveValue after PR #151");
+    }
+    result.expectTrue(readFile(suppressedPath).empty(), "suppressed production formatting emits no backend output");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation

- Migrate low-level core runtime logging in a conservative, inventory-driven way to the new semantic logging API while preserving existing low-level diagnostic payloads and semantics.
- This PR focuses only on the core runtime layer (`EventLoop`, timer, descriptor/eventreceiver, and mux backends) and builds on already-merged logging repairs and socket-stream migrations (PR #151, #154, #155, #156). 
- The goal is to add object-owned semantic owners where safe and replace selected `LOG`/`PLOG` call sites with semantic `BoundaryLogger` calls without changing logging infrastructure, macro definitions, or global filter precedence.

### Description

- Added minimal `logger::LogScopeOwner` ownership and `log()` accessors to `EventLoop`, `DescriptorEventReceiver`, and `TimerEventReceiver`, and added file-local `core.mux` scope owners for `epoll`/`poll`/`select` backends. 
- Replaced selected production `LOG(...)` and `PLOG(...)` sites in the allowed Migration 4 scope with semantic `log().trace/debug/info/warn/error/critical` and `log().sysError(...)` calls while preserving message payloads and capturing `errno` immediately before `sysError` where required. 
- Migrated mux backend constructor debug announcements to semantic logging via file-local owners, and kept all socket-stream/TLS and other out-of-scope `LOG`/`PLOG` call sites explicitly deferred. 
- Added the required migration report `docs/logging/semantic-migration-04-core-runtime-report.md` and a focused test `tests/unit/log/CoreRuntimeMigration04Test.cpp` plus CMake registration in `tests/unit/log/CMakeLists.txt` to validate owners, scope metadata, filtering, JSON formatting, `sysError` errno preservation, sink overloads, and suppressed expensive formatting.

### Testing

- Built the project (`cmake` + `cmake --build`) with tests enabled and ran the focused logging tests including the new `CoreRuntimeMigration04Test`, and all focused logging tests passed. 
- Ran the full test suite (`ctest --test-dir cmake-build --output-on-failure`) and observed all unit/component tests pass in this environment. 
- Performed a focused ASan build and executed `CoreRuntimeMigration04Test` under ASan, which passed; a full ASan run was not performed due to environment runtime constraints but the migration-specific ASan target was validated. 
- Note: `git fetch origin` could not be executed in this workspace because no `origin` remote is available, and base verification used the local history and presence of the prerequisite files instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b9df29600832c8e0e0a9b4d609562)