### PR TITLE
Semantic logging migration 05 — net physical sockets

### DIFF
--- a/docs/logging/semantic-migration-05-net-physical-sockets-report.md
+++ b/docs/logging/semantic-migration-05-net-physical-sockets-report.md
@@ -1,0 +1,220 @@
+# Semantic logging migration 05 — net physical sockets
+
+## Implementation summary
+
+This is a clean Migration 05 PR from current master after merged PR #151, #154, #155, #156, and #157. It does not duplicate any previous PR and does not start Round 10.
+
+The migration covers the manageable net physical-socket inventory under `src/net` only. It adds a minimal semantic owner to the Unix-domain physical socket boundary and migrates the Unix-domain lock-file lifecycle `LOG`/`PLOG` sites plus IPv4/IPv6 address-info trace dumps. Config and TLS matches remain deferred.
+
+## Exact changed files
+
+- `src/net/in/SocketAddrInfo.cpp`
+- `src/net/in6/SocketAddrInfo.cpp`
+- `src/net/un/phy/PhysicalSocket.h`
+- `src/net/un/phy/PhysicalSocket.hpp`
+- `tests/unit/log/CMakeLists.txt`
+- `tests/unit/log/NetPhysicalSocketMigration05Test.cpp`
+- `docs/logging/semantic-migration-05-net-physical-sockets-report.md`
+
+## Base verification result
+
+`git fetch origin` could not run because this container has no `origin` remote. The local base HEAD was the current merged line containing PR #151, #154, #155, #156, and #157 merge commits. The required prerequisite files for production threshold repair, migrations 01-04, Round 8, and Round 9 were present.
+
+## Initial inventory command/result
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" \
+  src/net \
+  -g '*.h' -g '*.hpp' -g '*.cpp' \
+  -g '!src/net/config/ConfigInstance.cpp' \
+  -g '!src/net/config/ConfigInstance.h'
+```
+
+Result:
+
+```text
+src/net/in6/SocketAddrInfo.cpp:129:            LOG(TRACE) << formatted.str();
+src/net/un/phy/PhysicalSocket.hpp:82:                LOG(DEBUG) << "Remove sun path: " << Super::getBindAddress().getSunPath();
+src/net/un/phy/PhysicalSocket.hpp:84:                PLOG(ERROR) << "Remove sun path: " << Super::getBindAddress().getSunPath();
+src/net/un/phy/PhysicalSocket.hpp:88:                LOG(DEBUG) << "Remove lock from file: " << Super::getBindAddress().getSunPath().append(".lock");
+src/net/un/phy/PhysicalSocket.hpp:90:                PLOG(ERROR) << "Remove lock from file: " << Super::getBindAddress().getSunPath().append(".lock");
+src/net/un/phy/PhysicalSocket.hpp:94:                LOG(DEBUG) << "Remove lock file: " << Super::getBindAddress().getSunPath().append(".lock");
+src/net/un/phy/PhysicalSocket.hpp:96:                PLOG(ERROR) << "Remove lock file: " << Super::getBindAddress().getSunPath().append(".lock");
+src/net/un/phy/PhysicalSocket.hpp:108:                LOG(DEBUG) << "Opening lock file: " << bindAddress.getSunPath().append(".lock").data();
+src/net/un/phy/PhysicalSocket.hpp:110:                    LOG(DEBUG) << "Locking lock file: " << bindAddress.getSunPath().append(".lock").data();
+src/net/un/phy/PhysicalSocket.hpp:113:                            LOG(WARNING) << "Removed stalled sun_path: " << bindAddress.getSunPath().data();
+src/net/un/phy/PhysicalSocket.hpp:115:                            PLOG(ERROR) << "Removed stalled sun path: " << bindAddress.getSunPath().data();
+src/net/un/phy/PhysicalSocket.hpp:119:                    PLOG(ERROR) << "Locking lock file " << bindAddress.getSunPath().append(".lock").data();
+src/net/un/phy/PhysicalSocket.hpp:125:                PLOG(ERROR) << "Opening lock file: " << bindAddress.getSunPath().append(".lock").data();
+src/net/in/SocketAddrInfo.cpp:136:            LOG(TRACE) << formatted.str();
+src/net/config/ConfigPhysicalSocket.cpp:86:                           LOG(ERROR) << err.what();
+src/net/config/stream/tls/ConfigSocketServer.hpp:103:                LOG(TRACE) << getInstanceName() << " SSL/TLS: SSL_CTX (M) sni for '" << sni << "' from master certificate installed";
+src/net/config/stream/tls/ConfigSocketServer.hpp:140:                        LOG(TRACE) << getInstanceName() << " SSL/TLS: SSL_CTX (E) sni for '" << domain << "' explicitly installed";
+src/net/config/stream/tls/ConfigSocketServer.hpp:145:                            LOG(TRACE) << getInstanceName() << " SSL/TLS: SSL_CTX (S) sni for '" << san << "' from SAN installed";
+src/net/config/stream/tls/ConfigSocketServer.hpp:148:                        LOG(WARNING) << getInstanceName() << " SSL/TLS: Can not create SNI_SSL_CTX for domain '" << domain << "'";
+src/net/config/stream/tls/ConfigSocketServer.hpp:152:            LOG(TRACE) << getInstanceName() << " SSL/TLS: SNI list result:";
+src/net/config/stream/tls/ConfigSocketServer.hpp:154:                LOG(TRACE) << "  " << sni;
+src/net/config/stream/tls/ConfigSocketServer.hpp:163:        LOG(TRACE) << getInstanceName() << " SSL/TLS SNI: Lookup for sni='" << serverNameIndication << "' in sni certificates";
+src/net/config/stream/tls/ConfigSocketServer.hpp:169:                LOG(TRACE) << getInstanceName() << " SSL/TLS SNI:  .. " << sniPair.first.c_str();
+src/net/config/stream/tls/ConfigSocketServer.hpp:174:            LOG(TRACE) << getInstanceName() << " SSL/TLS SNI: found for " << serverNameIndication << " -> '" << sniPairIt->first << "'";
+src/net/config/stream/tls/ConfigSocketServer.hpp:177:            LOG(WARNING) << getInstanceName() << " SSL/TL SNI: not found for " << serverNameIndication;
+```
+
+## Inventory classification table
+
+| Class | Count | Files | Decision |
+| --- | ---: | --- | --- |
+| A. generic physical socket helpers | 0 | n/a | none |
+| B. IPv4 / in | 1 | `src/net/in/SocketAddrInfo.cpp` | migrated |
+| C. IPv6 / in6 | 1 | `src/net/in6/SocketAddrInfo.cpp` | migrated |
+| D. Unix domain / un | 13 | `src/net/un/phy/PhysicalSocket.hpp` | migrated |
+| E. Bluetooth RFCOMM / rc | 0 | n/a | none |
+| F. Bluetooth L2CAP / l2 | 0 | n/a | none |
+| G. address/address-info helpers | 2 | `src/net/in*/SocketAddrInfo.cpp` | migrated with `net.address` scope |
+| H. TLS or encryption-related matches | 10 | `src/net/config/stream/tls/ConfigSocketServer.hpp` | deferred as TLS/config |
+| I. config/other out-of-scope net matches | 1 | `src/net/config/ConfigPhysicalSocket.cpp` | deferred as config |
+
+## Ownership discovery summary
+
+Command:
+
+```sh
+rg -n "\blog\(\)|logger::|BoundaryLogger|LogScopeOwner|semantic|scope|Instance|connectionName|getInstanceName" \
+  src/net \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Result summary: existing semantic ownership is concentrated in `net::config::ConfigInstance`, with a `Configuration` boundary owner and `log()` overloads. Physical socket classes did not have an object-owned semantic logger before this migration. The Unix-domain physical socket has a narrow transport boundary, a stable component identity, and no required broad API churn, so this PR adds a minimal local owner there only.
+
+## Stop/split decision and reason
+
+The allowed physical-socket scope contained 15 production macro call sites, which is below the 35-call-site stop/split threshold. No split was required.
+
+## Post-migration inventory command/result
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" \
+  src/net \
+  -g '*.h' -g '*.hpp' -g '*.cpp' \
+  -g '!src/net/config/ConfigInstance.cpp' \
+  -g '!src/net/config/ConfigInstance.h'
+```
+
+Result:
+
+```text
+src/net/config/ConfigPhysicalSocket.cpp:86:                           LOG(ERROR) << err.what();
+src/net/config/stream/tls/ConfigSocketServer.hpp:103:                LOG(TRACE) << getInstanceName() << " SSL/TLS: SSL_CTX (M) sni for '" << sni << "' from master certificate installed";
+src/net/config/stream/tls/ConfigSocketServer.hpp:140:                        LOG(TRACE) << getInstanceName() << " SSL/TLS: SSL_CTX (E) sni for '" << domain << "' explicitly installed";
+src/net/config/stream/tls/ConfigSocketServer.hpp:145:                            LOG(TRACE) << getInstanceName() << " SSL/TLS: SSL_CTX (S) sni for '" << san << "' from SAN installed";
+src/net/config/stream/tls/ConfigSocketServer.hpp:148:                        LOG(WARNING) << getInstanceName() << " SSL/TLS: Can not create SNI_SSL_CTX for domain '" << domain << "'";
+src/net/config/stream/tls/ConfigSocketServer.hpp:152:            LOG(TRACE) << getInstanceName() << " SSL/TLS: SNI list result:";
+src/net/config/stream/tls/ConfigSocketServer.hpp:154:                LOG(TRACE) << "  " << sni;
+src/net/config/stream/tls/ConfigSocketServer.hpp:163:        LOG(TRACE) << getInstanceName() << " SSL/TLS SNI: Lookup for sni='" << serverNameIndication << "' in sni certificates";
+src/net/config/stream/tls/ConfigSocketServer.hpp:169:                LOG(TRACE) << getInstanceName() << " SSL/TLS SNI:  .. " << sniPair.first.c_str();
+src/net/config/stream/tls/ConfigSocketServer.hpp:174:            LOG(TRACE) << getInstanceName() << " SSL/TLS SNI: found for " << serverNameIndication << " -> '" << sniPairIt->first << "'";
+src/net/config/stream/tls/ConfigSocketServer.hpp:177:            LOG(WARNING) << getInstanceName() << " SSL/TL SNI: not found for " << serverNameIndication;
+```
+
+All suitable LOG/PLOG call sites in the Migration 5 net physical-socket scope were migrated. Remaining LOG/PLOG sites are config/TLS and are deferred. No VLOG sites were found.
+
+## Migrated call-site table
+
+| File | Old severity | New semantic call | Notes |
+| --- | --- | --- | --- |
+| `src/net/in/SocketAddrInfo.cpp` | `LOG(TRACE)` | `net.address` `trace` | preserves formatted address-info payload |
+| `src/net/in6/SocketAddrInfo.cpp` | `LOG(TRACE)` | `net.address` `trace` | preserves formatted address-info payload |
+| `src/net/un/phy/PhysicalSocket.hpp` | `LOG(DEBUG)` x5 | `net.un` `debug` | preserves Unix socket path/lock-file lifecycle text |
+| `src/net/un/phy/PhysicalSocket.hpp` | `LOG(WARNING)` x1 | `net.un` `warn` | preserves stalled `sun_path` removal detail |
+| `src/net/un/phy/PhysicalSocket.hpp` | `PLOG(ERROR)` x7 | `net.un` `sysError(Error, errnum, ...)` | captures `errno` immediately after failing syscall |
+
+## Deferred call-site table
+
+| File | Call sites | Reason |
+| --- | ---: | --- |
+| `src/net/config/ConfigPhysicalSocket.cpp` | 1 | config-layer callback logging; out of default Migration 5 physical-socket production scope |
+| `src/net/config/stream/tls/ConfigSocketServer.hpp` | 10 | TLS/SNI configuration logging; explicitly out of scope |
+
+## Semantic owner(s) used or added
+
+- Added `logger::LogScopeOwner` inside `net::un::phy::PhysicalSocket`, with `LogOrigin::Framework`, `LogBoundary::System`, and component `net.un`.
+- Added public `log()` and sink-taking `log(...)` overloads to that physical socket class only.
+- Used static local `LogScopeOwner` instances in IPv4/IPv6 address-info helpers with component `net.address`.
+
+## Severity mapping
+
+- `LOG(TRACE)` -> `trace`
+- `LOG(DEBUG)` -> `debug`
+- `LOG(WARNING)` -> `warn`
+- `PLOG(ERROR)` -> `sysError(logger::LogLevel::Error, errnum, ...)`
+
+No `LOG(INFO)`, `LOG(FATAL)`, or `VLOG` sites were present in migrated scope.
+
+## PLOG/sysError errno handling
+
+Each migrated `PLOG(ERROR)` branch captures `const int errnum = errno;` immediately after the failing syscall branch and before semantic formatting/logging. The semantic `sysError` call preserves errno code and text.
+
+## VLOG result
+
+No `VLOG` call sites were found. No VLOG migration was performed.
+
+## Message/identity preservation notes
+
+The migration keeps Unix domain socket path and lock-file lifecycle details, including remove/open/lock/stalled-path messages. Address-info logs retain the full formatted address-info diagnostic dump. Manual prefixes were not removed unless semantic component scope supplied the transport identity.
+
+## Filter/backend/format compatibility
+
+`NetPhysicalSocketMigration05Test` verifies the new net physical-socket owner emits when enabled, carries framework/system/`net.un` scope, respects `LogManager` filtering, respects backend `Logger::setLogLevel` filtering, respects JSON format selection, preserves `sysError` errno code/text, keeps the sink-taking overload compatible, and does not evaluate `ExpensiveValue` when production formatting is suppressed.
+
+## Production-scope confirmations
+
+- This PR changes only allowed Migration 5 files.
+- This PR does not modify `SemanticLogger.*`.
+- This PR does not modify `LogScopeOwner.*`.
+- This PR does not modify `Logger.*`.
+- This PR does not modify `ConfigInstance.cpp`.
+- This PR does not modify previous socket-stream migration files.
+- This PR does not modify previous core-runtime migration files.
+- This PR does not modify previous migration tests.
+- This PR does not change LOG/PLOG/VLOG macro definitions.
+- This PR does not change LogManager precedence.
+- This PR does not change LogManager freeze behavior.
+- This PR does not change JSON v1 schema.
+- This PR does not start Round 10.
+
+## Build commands run
+
+```sh
+cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON
+cmake --build cmake-build --parallel 2
+```
+
+## Test commands run
+
+```sh
+ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test|SemanticProductionThresholdRepairTest|SocketConnectionMigration01Test|SocketConnectorAcceptorMigration02Test|SocketServerClientMigration03Test|CoreRuntimeMigration04Test|NetPhysicalSocketMigration05Test" --output-on-failure
+ctest --test-dir cmake-build --output-on-failure
+```
+
+Both commands passed. The full suite reported 122 tests with skipped component tests controlled by the existing test gating.
+
+## ASan result
+
+Full ASan was not run because it requires rebuilding and running the entire large app/test tree; instead the required minimum ASan validation was run for the new Migration 05 test:
+
+```sh
+cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON
+cmake --build cmake-build-asan --target NetPhysicalSocketMigration05Test --parallel 2
+ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan -R NetPhysicalSocketMigration05Test --output-on-failure
+```
+
+The ASan-focused `NetPhysicalSocketMigration05Test` passed.
+
+## Known follow-ups
+
+- A future config/TLS-specific semantic migration should handle the deferred config/TLS call sites.
+- Bluetooth RFCOMM/L2CAP had no current macro call sites in this inventory, but future logging additions there should use the same semantic owner policy.

--- a/src/net/in/SocketAddrInfo.cpp
+++ b/src/net/in/SocketAddrInfo.cpp
@@ -43,6 +43,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/LogScopeOwner.h"
 #include "log/Logger.h"
 
 #include <cstring>
@@ -133,7 +134,8 @@ namespace net::in {
                       << "                  sin_addr:     " << hostBfr << "\n"
                       << "                  sin_port:     " << servBfr;
 
-            LOG(TRACE) << formatted.str();
+            static const logger::LogScopeOwner logScope(logger::LogOrigin::Framework, logger::LogBoundary::System, "net.address");
+            logScope.logger(logger::Logger::semanticSink()).trace("{}", formatted.str());
         }
     }
 

--- a/src/net/in6/SocketAddrInfo.cpp
+++ b/src/net/in6/SocketAddrInfo.cpp
@@ -43,6 +43,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/LogScopeOwner.h"
 #include "log/Logger.h"
 
 #include <cstring>
@@ -126,7 +127,8 @@ namespace net::in6 {
                       << "                  sin_addr:     " << hostBfr << "\n"
                       << "                  sin_port:     " << servBfr;
 
-            LOG(TRACE) << formatted.str();
+            static const logger::LogScopeOwner logScope(logger::LogOrigin::Framework, logger::LogBoundary::System, "net.address");
+            logScope.logger(logger::Logger::semanticSink()).trace("{}", formatted.str());
         }
     }
 

--- a/src/net/un/phy/PhysicalSocket.h
+++ b/src/net/un/phy/PhysicalSocket.h
@@ -42,6 +42,7 @@
 #ifndef NET_UN_PHY_PHYSICALSOCKET_H
 #define NET_UN_PHY_PHYSICALSOCKET_H
 
+#include "log/LogScopeOwner.h"
 #include "net/phy/PhysicalSocket.h"
 #include "net/un/SocketAddress.h" // IWYU pragma: export
 
@@ -58,6 +59,7 @@ namespace net::un::phy {
         using Super::Super;
 
         PhysicalSocket(int type, int protocol);
+        PhysicalSocket(int fd, const SocketAddress& bindAddress);
         PhysicalSocket(PhysicalSocket&& physicalSocket) noexcept;
 
         PhysicalSocket& operator=(PhysicalSocket&& physicalSocket) noexcept;
@@ -66,7 +68,13 @@ namespace net::un::phy {
 
         int bind(SocketAddress& bindAddress);
 
+        logger::BoundaryLogger log() const;
+        logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
+                                   logger::LogLevel threshold = logger::LogLevel::Trace,
+                                   logger::BoundaryLogger::Clock clock = {}) const;
+
     private:
+        logger::LogScopeOwner logScope;
         int lockFd = -1;
     };
 

--- a/src/net/un/phy/PhysicalSocket.hpp
+++ b/src/net/un/phy/PhysicalSocket.hpp
@@ -58,18 +58,27 @@ namespace net::un::phy {
 
     template <template <typename SocketAddress> typename PhysicalPeerSocket>
     PhysicalSocket<PhysicalPeerSocket>::PhysicalSocket(int type, int protocol)
-        : Super(PF_UNIX, type, protocol) {
+        : Super(PF_UNIX, type, protocol)
+        , logScope(logger::LogOrigin::Framework, logger::LogBoundary::System, "net.un") {
+    }
+
+    template <template <typename SocketAddress> typename PhysicalPeerSocket>
+    PhysicalSocket<PhysicalPeerSocket>::PhysicalSocket(int fd, const SocketAddress& bindAddress)
+        : Super(fd, bindAddress)
+        , logScope(logger::LogOrigin::Framework, logger::LogBoundary::System, "net.un") {
     }
 
     template <template <typename SocketAddress> typename PhysicalPeerSocket>
     PhysicalSocket<PhysicalPeerSocket>::PhysicalSocket(PhysicalSocket&& physicalSocket) noexcept
         : Super(std::move(physicalSocket))
+        , logScope(std::move(physicalSocket.logScope))
         , lockFd(std::exchange(physicalSocket.lockFd, -1)) {
     }
 
     template <template <typename SocketAddress> typename PhysicalPeerSocket>
     PhysicalSocket<PhysicalPeerSocket>& PhysicalSocket<PhysicalPeerSocket>::operator=(PhysicalSocket&& physicalSocket) noexcept {
         Super::operator=(std::move(physicalSocket));
+        logScope = std::move(physicalSocket.logScope);
         lockFd = std::exchange(physicalSocket.lockFd, -1);
 
         return *this;
@@ -79,21 +88,26 @@ namespace net::un::phy {
     PhysicalSocket<PhysicalPeerSocket>::~PhysicalSocket() {
         if (lockFd >= 0) {
             if (std::remove(Super::getBindAddress().getSunPath().data()) == 0) {
-                LOG(DEBUG) << "Remove sun path: " << Super::getBindAddress().getSunPath();
+                log().debug("Remove sun path: {}", Super::getBindAddress().getSunPath());
             } else {
-                PLOG(ERROR) << "Remove sun path: " << Super::getBindAddress().getSunPath();
+                const int errnum = errno;
+                log().sysError(logger::LogLevel::Error, errnum, "Remove sun path: {}", Super::getBindAddress().getSunPath());
             }
 
             if (core::system::flock(lockFd, LOCK_UN) == 0) {
-                LOG(DEBUG) << "Remove lock from file: " << Super::getBindAddress().getSunPath().append(".lock");
+                log().debug("Remove lock from file: {}", Super::getBindAddress().getSunPath().append(".lock"));
             } else {
-                PLOG(ERROR) << "Remove lock from file: " << Super::getBindAddress().getSunPath().append(".lock");
+                const int errnum = errno;
+                log().sysError(
+                    logger::LogLevel::Error, errnum, "Remove lock from file: {}", Super::getBindAddress().getSunPath().append(".lock"));
             }
 
             if (std::remove(Super::bindAddress.getSunPath().append(".lock").data()) == 0) {
-                LOG(DEBUG) << "Remove lock file: " << Super::getBindAddress().getSunPath().append(".lock");
+                log().debug("Remove lock file: {}", Super::getBindAddress().getSunPath().append(".lock"));
             } else {
-                PLOG(ERROR) << "Remove lock file: " << Super::getBindAddress().getSunPath().append(".lock");
+                const int errnum = errno;
+                log().sysError(
+                    logger::LogLevel::Error, errnum, "Remove lock file: {}", Super::getBindAddress().getSunPath().append(".lock"));
             }
 
             core::system::close(lockFd);
@@ -102,27 +116,42 @@ namespace net::un::phy {
     }
 
     template <template <typename SocketAddress> typename PhysicalPeerSocket>
+    logger::BoundaryLogger PhysicalSocket<PhysicalPeerSocket>::log() const {
+        return logScope.logger(logger::Logger::semanticSink());
+    }
+
+    template <template <typename SocketAddress> typename PhysicalPeerSocket>
+    logger::BoundaryLogger PhysicalSocket<PhysicalPeerSocket>::log(logger::BoundaryLogger::Sink sink,
+                                                                   logger::LogLevel threshold,
+                                                                   logger::BoundaryLogger::Clock clock) const {
+        return logScope.logger(std::move(sink), threshold, std::move(clock));
+    }
+
+    template <template <typename SocketAddress> typename PhysicalPeerSocket>
     int PhysicalSocket<PhysicalPeerSocket>::bind(SocketAddress& bindAddress) {
         if (!bindAddress.getSunPath().empty() && !bindAddress.getSunPath().starts_with('\0')) {
             if ((lockFd = open(bindAddress.getSunPath().append(".lock").data(), O_RDONLY | O_CREAT, 0600)) >= 0) {
-                LOG(DEBUG) << "Opening lock file: " << bindAddress.getSunPath().append(".lock").data();
+                log().debug("Opening lock file: {}", bindAddress.getSunPath().append(".lock"));
                 if (core::system::flock(lockFd, LOCK_EX | LOCK_NB) == 0) {
-                    LOG(DEBUG) << "Locking lock file: " << bindAddress.getSunPath().append(".lock").data();
+                    log().debug("Locking lock file: {}", bindAddress.getSunPath().append(".lock"));
                     if (std::filesystem::exists(bindAddress.getSunPath().data())) {
                         if (std::remove(bindAddress.getSunPath().data()) == 0) {
-                            LOG(WARNING) << "Removed stalled sun_path: " << bindAddress.getSunPath().data();
+                            log().warn("Removed stalled sun_path: {}", bindAddress.getSunPath());
                         } else {
-                            PLOG(ERROR) << "Removed stalled sun path: " << bindAddress.getSunPath().data();
+                            const int errnum = errno;
+                            log().sysError(logger::LogLevel::Error, errnum, "Removed stalled sun path: {}", bindAddress.getSunPath());
                         }
                     }
                 } else {
-                    PLOG(ERROR) << "Locking lock file " << bindAddress.getSunPath().append(".lock").data();
+                    const int errnum = errno;
+                    log().sysError(logger::LogLevel::Error, errnum, "Locking lock file {}", bindAddress.getSunPath().append(".lock"));
 
                     core::system::close(lockFd);
                     lockFd = -1;
                 }
             } else {
-                PLOG(ERROR) << "Opening lock file: " << bindAddress.getSunPath().append(".lock").data();
+                const int errnum = errno;
+                log().sysError(logger::LogLevel::Error, errnum, "Opening lock file: {}", bindAddress.getSunPath().append(".lock"));
             }
         }
 

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -70,3 +70,9 @@ target_include_directories(CoreRuntimeMigration04Test PRIVATE ${PROJECT_SOURCE_D
 target_compile_features(CoreRuntimeMigration04Test PRIVATE cxx_std_20)
 target_link_libraries(CoreRuntimeMigration04Test PRIVATE snodec-test-support snodec::core)
 set_tests_properties(CoreRuntimeMigration04Test PROPERTIES LABELS "unit;log;migration04")
+
+snodec_add_test(NetPhysicalSocketMigration05Test NetPhysicalSocketMigration05Test.cpp)
+target_include_directories(NetPhysicalSocketMigration05Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(NetPhysicalSocketMigration05Test PRIVATE cxx_std_20)
+target_link_libraries(NetPhysicalSocketMigration05Test PRIVATE snodec-test-support snodec::net-un-phy-stream snodec::core-socket-stream)
+set_tests_properties(NetPhysicalSocketMigration05Test PROPERTIES LABELS "unit;log;migration05")

--- a/tests/unit/log/NetPhysicalSocketMigration05Test.cpp
+++ b/tests/unit/log/NetPhysicalSocketMigration05Test.cpp
@@ -1,0 +1,156 @@
+#include "log/Logger.h"
+#include "net/un/phy/stream/PhysicalSocketClient.h"
+#include "tests/support/TestResult.h"
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+    struct ExpensiveValue {
+        int* evaluations;
+    };
+
+    std::ostream& operator<<(std::ostream& out, const ExpensiveValue& value) {
+        ++*value.evaluations;
+        return out << "expensive";
+    }
+
+    using TestUnixPhysicalSocket = net::un::phy::stream::PhysicalSocketClient;
+
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() {
+                return std::string("MIGRATION05TICK");
+            });
+            logger::Logger::logToFile(logFile);
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto enabledPath = tempLogPath("snodec-migration05-enabled.log");
+    {
+        LoggerStateGuard guard(enabledPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        TestUnixPhysicalSocket owner;
+        owner.log().debug("net physical socket semantic owner emitted");
+    }
+    const auto enabledLog = readFile(enabledPath);
+    result.expectTrue(enabledLog.find("net physical socket semantic owner emitted") != std::string::npos,
+                      "net physical-socket semantic owner emits when enabled");
+    result.expectTrue(enabledLog.find(" framework system net.un ") != std::string::npos,
+                      "emitted records carry framework net physical-socket component scope");
+
+    const auto managerFilterPath = tempLogPath("snodec-migration05-manager-filter.log");
+    {
+        LoggerStateGuard guard(managerFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        TestUnixPhysicalSocket owner;
+        owner.log().debug("net physical socket suppressed by manager");
+    }
+    result.expectTrue(readFile(managerFilterPath).find("suppressed by manager") == std::string::npos,
+                      "LogManager filtering suppresses migrated net semantic calls");
+
+    const auto backendFilterPath = tempLogPath("snodec-migration05-backend-filter.log");
+    {
+        LoggerStateGuard guard(backendFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        logger::Logger::setLogLevel(3);
+        TestUnixPhysicalSocket owner;
+        owner.log().debug("net physical socket suppressed by backend");
+    }
+    result.expectTrue(readFile(backendFilterPath).find("suppressed by backend") == std::string::npos,
+                      "Logger::setLogLevel backend filtering suppresses output");
+
+    const auto jsonPath = tempLogPath("snodec-migration05-json.log");
+    {
+        LoggerStateGuard guard(jsonPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        TestUnixPhysicalSocket owner;
+        owner.log().debug("net physical socket json format respected");
+    }
+    const auto jsonLog = readFile(jsonPath);
+    result.expectTrue(jsonLog.find("{\"v\":1") != std::string::npos &&
+                          jsonLog.find("\"message\":\"net physical socket json format respected\"") != std::string::npos &&
+                          jsonLog.find("\"origin\":\"framework\"") != std::string::npos &&
+                          jsonLog.find("\"component\":\"net.un\"") != std::string::npos,
+                      "JSON format selection is respected");
+
+    std::vector<logger::LogRecord> sysErrorRecords;
+    TestUnixPhysicalSocket sysErrorOwner;
+    sysErrorOwner
+        .log([&](logger::LogRecord record) {
+            sysErrorRecords.push_back(std::move(record));
+        })
+        .sysError(logger::LogLevel::Error, EACCES, "net physical socket preserved errno");
+    result.expectTrue(sysErrorRecords.size() == 1 && sysErrorRecords[0].message == "net physical socket preserved errno" &&
+                          sysErrorRecords[0].error && sysErrorRecords[0].error->code == EACCES &&
+                          sysErrorRecords[0].error->text.find("Permission") != std::string::npos,
+                      "sysError errno code/text is preserved");
+
+    std::vector<logger::LogRecord> sinkRecords;
+    TestUnixPhysicalSocket sinkOwner;
+    sinkOwner
+        .log([&](logger::LogRecord record) {
+            sinkRecords.push_back(std::move(record));
+        })
+        .info("sink overload still works");
+    result.expectTrue(sinkRecords.size() == 1 && sinkRecords[0].message == "sink overload still works" &&
+                          sinkRecords[0].component == "net.un",
+                      "sink-taking overload remains compatible");
+
+    const auto suppressedPath = tempLogPath("snodec-migration05-suppressed.log");
+    {
+        LoggerStateGuard guard(suppressedPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+
+        int evaluations = 0;
+        TestUnixPhysicalSocket owner;
+        owner.log().debug("{}", ExpensiveValue{&evaluations});
+        result.expectEqual(0, evaluations, "suppressed production formatting does not evaluate ExpensiveValue after PR #151");
+    }
+    result.expectTrue(readFile(suppressedPath).empty(), "suppressed production formatting emits no backend output");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation

- Migrate low-level LOG/PLOG call sites in the net physical-socket layer under `src/net` to the semantic logging API while preserving detailed socket diagnostics (paths, ports, fd/state, errno text/code).
- Add a minimal, local semantic owner for the Unix-domain physical socket boundary so migrated calls are emitted with an unambiguous framework/component identity without broad API churn.
- Keep config/TLS and unrelated subsystems out of scope and defer their LOG sites to a future migration to avoid cross-cutting changes.

### Description

- Added a `logger::LogScopeOwner` to the Unix-domain physical socket class and exposed `log()` and sink-taking `log(...)` overloads so instances can emit semantic logs with component scope `net.un` (`LogOrigin::Framework`, `LogBoundary::System`).
- Replaced `LOG(DEBUG|WARNING)` and `PLOG(ERROR)` sites in the Unix-domain physical socket lifecycle with semantic `debug`/`warn`/`sysError(...)`, capturing `errno` immediately where `PLOG` was used to preserve errno code/text.
- Converted `LOG(TRACE)` dumps in IPv4 and IPv6 `SocketAddrInfo` helpers to semantic `trace` under a static `LogScopeOwner` using component `net.address`, preserving the full formatted diagnostic payload.
- Added the required Migration 05 unit test `tests/unit/log/NetPhysicalSocketMigration05Test.cpp` and registered it in `tests/unit/log/CMakeLists.txt` to validate owner emission, scope, manager/backend filtering, JSON format, `sysError` errno preservation, sink overload compatibility, and suppression of expensive formatting when filtered.
- Added the migration report `docs/logging/semantic-migration-05-net-physical-sockets-report.md` documenting inventory, classification, migrated/deferred call sites, ownership decisions, commands run, and validation results.

Changed production files (subset):
- `src/net/un/phy/PhysicalSocket.h`
- `src/net/un/phy/PhysicalSocket.hpp`
- `src/net/in/SocketAddrInfo.cpp`
- `src/net/in6/SocketAddrInfo.cpp`
Added test and registration:
- `tests/unit/log/NetPhysicalSocketMigration05Test.cpp`
- `tests/unit/log/CMakeLists.txt` (test registration)
Added report:
- `docs/logging/semantic-migration-05-net-physical-sockets-report.md`

### Testing

- Ran `clang-format` on touched C++ files and `git diff --check` for style/whitespace checks; no issues were reported.
- Built project and ran the focused suite and full test runs; all relevant tests passed:
  - `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build` succeeded.
  - Focused migration/logging tests including `NetPhysicalSocketMigration05Test` passed.
  - Full `ctest --test-dir cmake-build --output-on-failure` run completed with tests passing (observed run reported 122 tests with the expected skipped component tests).
- Per-PR ASan validation: built ASan variant and ran `NetPhysicalSocketMigration05Test` under ASan; the ASan-focused test passed.
- Note: `git fetch origin` could not be executed in this environment (no `origin` remote), but the branch was created from the local master that already included the merged prerequisites; this is recorded in the included migration report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ba9a6eeb8832ca2c38ead47b599ef)