### PR TITLE
Semantic logging migration 07a — HTTP client

### DIFF
--- a/docs/logging/semantic-migration-07a-http-client-report.md
+++ b/docs/logging/semantic-migration-07a-http-client-report.md
@@ -1,0 +1,213 @@
+# Semantic logging migration 07a — HTTP client
+
+## Implementation summary
+
+This is a production migration, not inventory-only. It starts from current master after Migration 7 inventory PR #160 and does not duplicate previous semantic logging migrations. Production HTTP client LOG call sites in `src/web/http/client` and client-adjacent EventSource URL validation helpers were migrated to semantic `BoundaryLogger` owners/helpers. No logging infrastructure was changed.
+
+## Exact changed files
+
+- `src/web/http/client/SemanticLog.h`
+- `src/web/http/client/Request.cpp`
+- `src/web/http/client/SocketContext.cpp`
+- `src/web/http/client/SocketContextUpgradeFactorySelector.cpp`
+- `src/web/http/client/tools/EventSource.h`
+- `src/web/http/legacy/in/EventSource.h`
+- `src/web/http/legacy/in6/EventSource.h`
+- `src/web/http/legacy/rc/EventSource.h`
+- `src/web/http/legacy/un/EventSource.h`
+- `src/web/http/tls/in/EventSource.h`
+- `src/web/http/tls/in6/EventSource.h`
+- `src/web/http/tls/rc/EventSource.h`
+- `src/web/http/tls/un/EventSource.h`
+- `tests/unit/log/CMakeLists.txt`
+- `tests/unit/log/HttpClientMigration07aTest.cpp`
+- `docs/logging/semantic-migration-07a-http-client-report.md`
+
+## Focused 7a HTTP client inventory
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" \
+  src/web/http/client \
+  src/web/http/legacy/in/EventSource.h \
+  src/web/http/legacy/in6/EventSource.h \
+  src/web/http/legacy/rc/EventSource.h \
+  src/web/http/legacy/un/EventSource.h \
+  src/web/http/tls/in/EventSource.h \
+  src/web/http/tls/in6/EventSource.h \
+  src/web/http/tls/rc/EventSource.h \
+  src/web/http/tls/un/EventSource.h \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Result: 71 pre-migration LOG call sites, 0 PLOG call sites, 0 VLOG call sites.
+
+Representative complete inventory groups:
+
+- `src/web/http/client/Request.cpp`: upgrade response/bootstrap/error and upgrade request diagnostics.
+- `src/web/http/client/SocketContext.cpp`: request acceptance/queue/start/delivery, response receive/status/parse errors, keep-alive/close, connected/disconnected/signal diagnostics.
+- `src/web/http/client/SocketContextUpgradeFactorySelector.cpp`: debug-only override warning for HTTP upgrade library directory.
+- `src/web/http/client/tools/EventSource.h`: EventSource origin/path, connect/disconnect, request lifecycle, SSE stream state, retry/disabled diagnostics.
+- EventSource URL validation headers: scheme validation, URL rejection, RFCOMM rejection, Unix-domain sockToken rejection.
+
+## Reference to Migration 7 inventory PR #160
+
+PR #160 established the broad HTTP/WebSocket inventory and split. This PR performs the production Migration 7a HTTP client subset only.
+
+## Focused inventory classification table
+
+| Class | Files | Count | Result |
+| --- | --- | ---: | --- |
+| A. HTTP client Request.cpp upgrade/response/error paths | `src/web/http/client/Request.cpp` | 18 | Migrated |
+| B. HTTP client SocketContext.cpp request/response lifecycle | `src/web/http/client/SocketContext.cpp` | 27 | Migrated |
+| C. HTTP client SocketContextUpgradeFactorySelector.cpp | `src/web/http/client/SocketContextUpgradeFactorySelector.cpp` | 1 | Migrated |
+| D. HTTP client EventSource URL validation helpers | eight allowed EventSource URL helper headers | 12 | Migrated |
+| D2. HTTP client EventSource tool lifecycle diagnostics | `src/web/http/client/tools/EventSource.h` | 13 | Migrated |
+| E. PLOG / errno-sensitive call sites | focused 7a scope | 0 | None present |
+| F. VLOG / verbose diagnostics | focused 7a scope | 0 | None present |
+| G. deferred/unclear call sites | focused 7a scope | 0 | None deferred |
+
+## Ownership discovery summary
+
+Command:
+
+```sh
+rg -n "\blog\(\)|logger::|BoundaryLogger|LogScopeOwner|semantic|scope|getInstanceName|getConnectionName|Request|Response|SocketContext|EventSource|Upgrade" \
+  src/web/http/client \
+  src/web/http/legacy/in/EventSource.h \
+  src/web/http/legacy/in6/EventSource.h \
+  src/web/http/legacy/rc/EventSource.h \
+  src/web/http/legacy/un/EventSource.h \
+  src/web/http/tls/in/EventSource.h \
+  src/web/http/tls/in6/EventSource.h \
+  src/web/http/tls/rc/EventSource.h \
+  src/web/http/tls/un/EventSource.h \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Summary: `SocketContext` inherits the existing core socket-context semantic owner and exposes `frameworkLog()`, so its lifecycle logs use that existing owner. `Request.cpp`, EventSource tool code, EventSource URL helpers, and the upgrade factory selector did not expose a safe class owner without API churn, so Migration 7a adds small HTTP client helper scopes in `src/web/http/client/SemanticLog.h`.
+
+## Migrated call-site table
+
+| Area | Semantic owner/helper | Severity mapping | Payload preservation |
+| --- | --- | --- | --- |
+| `Request.cpp` upgrade response and bootstrap | `web::http::client::semantic::httpClientLog()` | `LOG(DEBUG)` -> `debug()` | connectionName, request method/url/version, full response dump, selected/requested protocol and subprotocol, bootstrap success/failure |
+| `Request.cpp` send-file/EventSource response error/upgrade request | `httpClientLog()` | `LOG(DEBUG)` -> `debug()` | connectionName, status, method, URL, HTTP major/minor, serialized upgrade request |
+| `SocketContext.cpp` request/response lifecycle | existing `frameworkLog()` owner | DEBUG/INFO/WARNING/ERROR -> debug/info/warn/error | connectionName, request count, request line, queue size, flags, response status/reason, parse status/reason, close/keep-alive, disconnect/signal |
+| `SocketContextUpgradeFactorySelector.cpp` | `httpClientUpgradeLog()` | `LOG(WARNING)` -> `warn()` | override warning text |
+| `client/tools/EventSource.h` | `httpClientLog()` | TRACE/DEBUG -> trace/debug | origin, path, connectionName, server-sent event text, socket address, disabled/retry state |
+| EventSource URL validation helper headers | `httpClientEventSourceLog()` | `LOG(ERROR)` -> `error()` | URL, scheme, sockToken, RFCOMM wording, Unix-domain wording |
+
+## Deferred call-site table
+
+No focused Migration 7a LOG/PLOG/VLOG call sites were deferred.
+
+## Semantic owner/helper used
+
+- Existing owner: `SocketContext::frameworkLog()` for HTTP client socket context lifecycle.
+- Helper component `web.http.client`: request and EventSource tool diagnostics.
+- Helper component `web.http.client.upgrade`: upgrade library selector diagnostics.
+- Helper component `web.http.client.eventsource`: EventSource URL validation diagnostics.
+
+## Severity mapping
+
+- `LOG(TRACE)` -> semantic `trace()`
+- `LOG(DEBUG)` -> semantic `debug()`
+- `LOG(INFO)` -> semantic `info()`
+- `LOG(WARNING)` -> semantic `warn()`
+- `LOG(ERROR)` -> semantic `error()`
+- No `LOG(FATAL)` was present.
+
+## PLOG/sysError errno handling
+
+No PLOG call sites were present in the focused 7a inventory. The new unit test still covers `sysError` helper behavior to confirm errno code/text preservation for any future HTTP client errno-sensitive use of the helper.
+
+## VLOG result
+
+No VLOG call sites were present in the focused 7a inventory, and no VLOG semantics were changed.
+
+## HTTP client payload preservation notes
+
+The migration keeps the existing stream payloads, including manual `connectionName` prefixes where semantic identity does not carry the connection, request counts, methods, URLs, HTTP versions, response status/reason, parser status/reason, queue flags, keep-alive/close decisions, disconnect/signal numbers, and HTTP upgrade request/response details.
+
+## EventSource payload preservation notes
+
+EventSource tool logs preserve origin/path, connectionName, connect/disconnect/request lifecycle, stream start/disconnect, socket address, disabled and retry state. URL validation helpers preserve scheme, URL, RFCOMM wording, Unix-domain wording, and Unix sockToken diagnostics.
+
+## Post-migration inventory
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" \
+  src/web/http/client \
+  src/web/http/legacy/in/EventSource.h \
+  src/web/http/legacy/in6/EventSource.h \
+  src/web/http/legacy/rc/EventSource.h \
+  src/web/http/legacy/un/EventSource.h \
+  src/web/http/tls/in/EventSource.h \
+  src/web/http/tls/in6/EventSource.h \
+  src/web/http/tls/rc/EventSource.h \
+  src/web/http/tls/un/EventSource.h \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Result: no remaining LOG/PLOG/VLOG call sites in Migration 7a scope.
+
+## Filter/backend/format compatibility
+
+`HttpClientMigration07aTest` covers enabled emission, framework component scopes (`web.http.client`, `web.http.client.upgrade`, `web.http.client.eventsource`), LogManager filtering, backend filtering, JSON v1 output, sink-taking helper overloads, suppressed formatting, sysError code/text, and representative request/response/upgrade/EventSource payloads.
+
+## Production-scope confirmations
+
+- This PR changes only allowed Migration 7a files.
+- This PR is not inventory-only.
+- This PR modifies production HTTP client logging.
+- This PR does not modify SemanticLogger.*.
+- This PR does not modify LogScopeOwner.*.
+- This PR does not modify Logger.*.
+- This PR does not modify ConfigInstance.cpp.
+- This PR does not modify src/net/config/stream/tls.
+- This PR does not modify src/web/http/server.
+- This PR does not modify src/web/websocket.
+- This PR does not modify src/iot or MQTT-over-WebSocket code.
+- This PR does not modify DB/apps/examples.
+- This PR does not modify previous migration tests except CMakeLists.txt registration.
+- This PR does not change LOG/PLOG/VLOG macro definitions.
+- This PR does not change LogManager precedence.
+- This PR does not change LogManager freeze behavior.
+- This PR does not change JSON v1 schema.
+- This PR does not start Round 10.
+
+## Build commands run
+
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2 --target HttpClientMigration07aTest`
+- `cmake --build cmake-build --parallel 2` (started and progressed through HTTP client/app builds but stopped after extended runtime; focused production target and focused migration tests passed)
+
+## Test commands run
+
+- `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test|SemanticProductionThresholdRepairTest|SocketConnectionMigration01Test|SocketConnectorAcceptorMigration02Test|SocketServerClientMigration03Test|CoreRuntimeMigration04Test|NetPhysicalSocketMigration05Test|TlsSocketStreamMigration06Test|HttpClientMigration07aTest" --output-on-failure`
+- `ctest --test-dir cmake-build --output-on-failure` (not completed; full build was stopped after extended runtime in this environment)
+
+## ASan result
+
+ASan command planned:
+
+```sh
+cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON
+cmake --build cmake-build-asan --parallel 2 --target HttpClientMigration07aTest
+ASAN=$(gcc -print-file-name=libasan.so)
+LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan -R HttpClientMigration07aTest --output-on-failure
+```
+
+Result: ASan focused `HttpClientMigration07aTest` passed with `LD_PRELOAD=$ASAN`.
+
+## Known follow-ups
+
+- Migration 7b — HTTP server / server upgrade
+- Migration 7c — WebSocket
+- Migration 8 — MQTT
+- Migration 9 — DB / apps / examples / remaining cleanup
+- Round 10 — book integration

--- a/docs/logging/semantic-migration-07b-http-server-report.md
+++ b/docs/logging/semantic-migration-07b-http-server-report.md
@@ -1,0 +1,202 @@
+# Semantic logging migration 07b — HTTP server and upgrade
+
+## Implementation summary
+
+This is a production follow-up inside PR #161, not inventory-only. PR #161 now contains Migration 7a — HTTP client and Migration 7b — HTTP server and upgrade. This continues from the existing PR #161 branch/worktree with the 7a files already present.
+
+Migration 7b migrates HTTP server-side and HTTP server-upgrade production logging under `src/web/http/server` to semantic `BoundaryLogger` owners/helpers without changing logging infrastructure.
+
+## Exact changed files for the 7b follow-up
+
+- `docs/logging/semantic-migration-07b-http-server-report.md`
+- `src/web/http/server/SemanticLog.h`
+- `src/web/http/server/Response.cpp`
+- `src/web/http/server/SocketContext.cpp`
+- `src/web/http/server/SocketContextUpgradeFactorySelector.cpp`
+- `tests/unit/log/CMakeLists.txt`
+- `tests/unit/log/HttpServerMigration07bTest.cpp`
+
+## Focused 7b HTTP server inventory
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" \
+  src/web/http/server \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Result: 30 pre-migration LOG call sites, 0 PLOG call sites, 0 VLOG call sites.
+
+Complete focused inventory:
+
+```text
+src/web/http/server/Response.cpp:255:                LOG(DEBUG) << connectionName << " HTTP: Initiating upgrade: " << request->method << " " << request->url
+src/web/http/server/Response.cpp:272:                        LOG(DEBUG) << connectionName
+src/web/http/server/Response.cpp:279:                            LOG(DEBUG) << connectionName
+src/web/http/server/Response.cpp:282:                            LOG(DEBUG) << connectionName << " HTTP upgrade: Response to upgrade request: " << request->method << " "
+src/web/http/server/Response.cpp:293:                            LOG(DEBUG) << connectionName
+src/web/http/server/Response.cpp:299:                        LOG(DEBUG) << connectionName
+src/web/http/server/Response.cpp:305:                    LOG(DEBUG) << connectionName << " HTTP upgrade: No upgrade requested";
+src/web/http/server/Response.cpp:310:                LOG(ERROR) << connectionName << " HTTP upgrade: Request has gone away";
+src/web/http/server/Response.cpp:315:            LOG(DEBUG) << connectionName << " HTTP: Upgrade bootstrap " << (!socketContextUpgradeName.empty() ? "success" : "failed");
+src/web/http/server/Response.cpp:316:            LOG(DEBUG) << "      Protocol selected: " << socketContextUpgradeName;
+src/web/http/server/Response.cpp:317:            LOG(DEBUG) << "              requested: " << request->get("upgrade");
+src/web/http/server/Response.cpp:318:            LOG(DEBUG) << "  Subprotocol  selected: " << header("Sec-WebSocket-Protocol");
+src/web/http/server/Response.cpp:319:            LOG(DEBUG) << "              requested: " << request->get("Sec-WebSocket-Protocol");
+src/web/http/server/Response.cpp:323:            LOG(ERROR) << "HTTP upgrade: Unexpected disconnect";
+src/web/http/server/SocketContextUpgradeFactorySelector.cpp:69:            LOG(WARNING) << "HTTP upgrade: Overriding http upgrade library dir";
+src/web/http/server/SocketContext.cpp:70:                  LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Request start";
+src/web/http/server/SocketContext.cpp:73:                  LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Request parse success: " << request.method << " "
+src/web/http/server/SocketContext.cpp:83:                  LOG(ERROR) << getSocketConnection()->getConnectionName() << " HTTP: Request parse error: " << reason << " (" << status
+src/web/http/server/SocketContext.cpp:112:                LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Request deliver: " << pendingRequest->method << " "
+src/web/http/server/SocketContext.cpp:137:            LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: No more pending request";
+src/web/http/server/SocketContext.cpp:151:            LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Response start for request: " << pendingRequest->method
+src/web/http/server/SocketContext.cpp:153:            LOG(INFO) << getSocketConnection()->getConnectionName() << "   "
+src/web/http/server/SocketContext.cpp:168:            LOG(WARNING) << getSocketConnection()->getConnectionName() << " HTTP: Response completed with error: " << response.statusCode
+src/web/http/server/SocketContext.cpp:179:        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Response completed for request: " << request->method << " "
+src/web/http/server/SocketContext.cpp:181:        LOG(INFO) << getSocketConnection()->getConnectionName() << "   "
+src/web/http/server/SocketContext.cpp:195:            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " HTTP: Connection = Close";
+src/web/http/server/SocketContext.cpp:199:            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " HTTP: Connection = Keep-Alive";
+src/web/http/server/SocketContext.cpp:216:        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Connected";
+src/web/http/server/SocketContext.cpp:236:        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Received disconnect";
+src/web/http/server/SocketContext.cpp:244:        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Received signal " << signum;
+```
+
+## References
+
+- Migration 7 inventory PR #160 established HTTP/WebSocket split planning.
+- Migration 7a work is already present in PR #161 and covers HTTP client and client EventSource logging.
+
+## Focused inventory classification table
+
+| Class | Files | Count | Result |
+| --- | --- | ---: | --- |
+| A. HTTP server SocketContext.cpp request/response lifecycle | `src/web/http/server/SocketContext.cpp` | 15 | Migrated |
+| B. HTTP server Response.cpp upgrade response/bootstrap/error paths | `src/web/http/server/Response.cpp` | 14 | Migrated |
+| C. HTTP server SocketContextUpgradeFactorySelector.cpp | `src/web/http/server/SocketContextUpgradeFactorySelector.cpp` | 1 | Migrated |
+| D. PLOG / errno-sensitive call sites | focused 7b scope | 0 | None present |
+| E. VLOG / verbose diagnostics | focused 7b scope | 0 | None present |
+| F. deferred/unclear call sites | focused 7b scope | 0 | None deferred |
+
+## Ownership discovery summary
+
+Command:
+
+```sh
+rg -n "\blog\(\)|logger::|BoundaryLogger|LogScopeOwner|semantic|scope|getInstanceName|getConnectionName|Request|Response|SocketContext|Upgrade" \
+  src/web/http/server \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Summary: server `SocketContext` inherits the existing core socket context semantic owner and can safely use `frameworkLog()`. `Response.cpp` and `SocketContextUpgradeFactorySelector.cpp` do not expose a safe response/upgrade semantic object owner without API churn, so 7b adds small HTTP server helper scopes in `src/web/http/server/SemanticLog.h`.
+
+## Migrated call-site table
+
+| Area | Semantic owner/helper | Severity mapping | Payload preservation |
+| --- | --- | --- | --- |
+| `SocketContext.cpp` request parse/delivery/response lifecycle | existing `frameworkLog()` owner | INFO/WARNING/ERROR/DEBUG -> info/warn/error/debug | connectionName, request start, method, URL, HTTP major/minor, parse error reason/status, response status/reason, close/keep-alive, disconnect/signal |
+| `Response.cpp` server upgrade path | `web::http::server::semantic::httpServerLog()` | DEBUG/ERROR -> debug/error | connectionName, method, URL, selected/requested upgrade protocol, selected/requested subprotocol, bootstrap success/failure, request gone away, unexpected disconnect |
+| `SocketContextUpgradeFactorySelector.cpp` upgrade selector | `httpServerUpgradeLog()` | WARNING -> warn | override warning text |
+
+## Deferred call-site table
+
+No focused Migration 7b LOG/PLOG/VLOG call sites were deferred.
+
+## Semantic owner/helper used
+
+- Existing owner: `SocketContext::frameworkLog()` for HTTP server socket-context lifecycle.
+- Helper component `web.http.server`: server response/upgrade flow diagnostics where no safe class owner exists.
+- Helper component `web.http.server.upgrade`: server upgrade factory selector diagnostics.
+
+## Severity mapping
+
+- `LOG(DEBUG)` -> semantic `debug()`
+- `LOG(INFO)` -> semantic `info()`
+- `LOG(WARNING)` -> semantic `warn()`
+- `LOG(ERROR)` -> semantic `error()`
+- No `LOG(TRACE)` or `LOG(FATAL)` was present.
+
+## PLOG/sysError errno handling
+
+No PLOG call sites were present in the focused 7b inventory. The new unit test still covers `sysError` helper behavior to confirm errno code/text preservation for future HTTP server errno-sensitive use.
+
+## VLOG result
+
+No VLOG call sites were present in the focused 7b inventory, and no VLOG semantics were changed.
+
+## HTTP server payload preservation notes
+
+The migration keeps existing technical payloads: connectionName, request method, URL, request line, HTTP major/minor, response status/reason, parse error reason/status, close/keep-alive decisions, disconnect, and signal number.
+
+## HTTP server-upgrade payload preservation notes
+
+The migration preserves server upgrade method/URL/version, selected upgrade protocol, requested upgrade protocol, selected WebSocket subprotocol, requested WebSocket subprotocol, bootstrap success/failure, request gone away, and unexpected disconnect diagnostics.
+
+## Post-migration inventory
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" \
+  src/web/http/server \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Result: no remaining LOG/PLOG/VLOG call sites in Migration 7b scope.
+
+## Filter/backend/format compatibility
+
+`HttpServerMigration07bTest` covers enabled emission, framework component scopes (`web.http.server`, `web.http.server.upgrade`), LogManager filtering, backend filtering, JSON v1 output, sink-taking helper overloads, suppressed formatting, sysError code/text, and representative request/response/upgrade/error payloads.
+
+## Production-scope confirmations
+
+- This follow-up changes only allowed Migration 7b files plus tests/unit/log/CMakeLists.txt.
+- This follow-up is not inventory-only.
+- This follow-up modifies production HTTP server logging.
+- This follow-up does not modify SemanticLogger.*.
+- This follow-up does not modify LogScopeOwner.*.
+- This follow-up does not modify Logger.*.
+- This follow-up does not modify ConfigInstance.cpp.
+- This follow-up does not modify src/net/config/stream/tls.
+- This follow-up does not modify src/web/websocket.
+- This follow-up does not modify src/iot or MQTT-over-WebSocket code.
+- This follow-up does not modify DB/apps/examples.
+- This follow-up does not change LOG/PLOG/VLOG macro definitions.
+- This follow-up does not change LogManager precedence.
+- This follow-up does not change LogManager freeze behavior.
+- This follow-up does not change JSON v1 schema.
+- This follow-up does not start Round 10.
+
+## Changed-file check
+
+- `git diff --name-only master...HEAD` was attempted, but the local worktree does not have a `master` ref in this Codex environment, so Git reported `fatal: ambiguous argument 'master...HEAD'`.
+- Equivalent local changed-file inspection used `git diff --name-only HEAD -- src/web/http/server tests/unit/log/CMakeLists.txt docs/logging/semantic-migration-07b-http-server-report.md tests/unit/log/HttpServerMigration07bTest.cpp` plus `git ls-files --others --exclude-standard ...` and showed only the 7b files listed above.
+
+## Build commands run
+
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2 --target HttpServerMigration07bTest http-server`
+- `cmake --build cmake-build --parallel 2 --target SemanticLoggerRound2Test LogScopeOwnerRound3Test ProductionLogApiRound4Test SocketEndpointLogApiRound5Test SemanticBackendRound6Test SemanticFilterRound7Test ControlledMigrationRound8Test SemanticCompatibilityRound9Test SemanticOverheadRound9Test SemanticProductionThresholdRepairTest SocketConnectionMigration01Test SocketConnectorAcceptorMigration02Test SocketServerClientMigration03Test CoreRuntimeMigration04Test NetPhysicalSocketMigration05Test TlsSocketStreamMigration06Test HttpClientMigration07aTest HttpServerMigration07bTest`
+- `cmake --build cmake-build --parallel 2`
+- `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`
+- `cmake --build cmake-build-asan --parallel 2 --target HttpServerMigration07bTest`
+
+## Test commands run
+
+- `ctest --test-dir cmake-build -R HttpServerMigration07bTest --output-on-failure` passed.
+- An early focused-suite `ctest` invocation was run before the reused build tree had all focused test executables and reported those missing executables as `Not Run`; after building the focused targets, the same focused-suite command passed.
+- `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test|SemanticProductionThresholdRepairTest|SocketConnectionMigration01Test|SocketConnectorAcceptorMigration02Test|SocketServerClientMigration03Test|CoreRuntimeMigration04Test|NetPhysicalSocketMigration05Test|TlsSocketStreamMigration06Test|HttpClientMigration07aTest|HttpServerMigration07bTest" --output-on-failure` passed.
+- `ctest --test-dir cmake-build --output-on-failure` passed with 125/125 tests successful; skipped component tests were reported as skipped by the test harness, not failed.
+- `ASAN=$(gcc -print-file-name=libasan.so) && LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan -R HttpServerMigration07bTest --output-on-failure` passed.
+
+## ASan result
+
+ASan focused `HttpServerMigration07bTest` passed in `cmake-build-asan` with `LD_PRELOAD` set to `gcc -print-file-name=libasan.so`.
+
+## Known follow-ups
+
+- Migration 7c — WebSocket
+- Migration 8 — MQTT
+- Migration 9 — DB / apps / examples / remaining cleanup
+- Round 10 — book integration

--- a/docs/logging/semantic-migration-07c-websocket-report.md
+++ b/docs/logging/semantic-migration-07c-websocket-report.md
@@ -1,0 +1,205 @@
+# Semantic logging migration 07c — WebSocket
+
+## Implementation summary
+
+This is a production follow-up inside PR #161, not inventory-only. PR #161 now contains Migration 7a — HTTP client, Migration 7b — HTTP server and upgrade, and Migration 7c — WebSocket. This continues from the existing PR #161 branch/worktree with the 7a and 7b files already present.
+
+Migration 7c migrates production WebSocket common/client/server/subprotocol logging under `src/web/websocket` to semantic `BoundaryLogger` helpers without changing logging infrastructure.
+
+## Exact changed files for the 7c follow-up
+
+- `docs/logging/semantic-migration-07c-websocket-report.md`
+- `src/web/websocket/SemanticLog.h`
+- `src/web/websocket/SocketContextUpgrade.hpp`
+- `src/web/websocket/Receiver.cpp`
+- `src/web/websocket/Transmitter.cpp`
+- `src/web/websocket/SubProtocol.hpp`
+- `src/web/websocket/SubProtocolFactorySelector.hpp`
+- `src/web/websocket/client/SubProtocolFactorySelector.cpp`
+- `src/web/websocket/server/SubProtocolFactorySelector.cpp`
+- `tests/unit/log/CMakeLists.txt`
+- `tests/unit/log/WebSocketMigration07cTest.cpp`
+
+## Focused 7c WebSocket inventory
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" \
+  src/web/websocket \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Result: 24 pre-migration LOG call sites, 0 PLOG call sites, 0 VLOG call sites.
+
+Complete focused inventory:
+
+```text
+src/web/websocket/SubProtocolFactorySelector.hpp:70:                    LOG(DEBUG) << "WebSocket: SubProtocolFactory create success: " << subProtocolName;
+src/web/websocket/SubProtocolFactorySelector.hpp:72:                    LOG(DEBUG) << "WebSocket: SubProtocolFactory create failed: " << subProtocolName;
+src/web/websocket/SubProtocolFactorySelector.hpp:76:                LOG(DEBUG) << "WebSocket: Optaining function \"" << subProtocolFactoryFunctionName
+src/web/websocket/SubProtocolFactorySelector.hpp:93:            LOG(DEBUG) << "WebSocket subprotocol: plugin '" << subProtocolName << "' selected from dynamic cache";
+src/web/websocket/SubProtocolFactorySelector.hpp:98:            LOG(DEBUG) << "WebSocket subprotocol: plugin '" << subProtocolName << "' selected from static cache";
+src/web/websocket/SubProtocolFactorySelector.hpp:103:            LOG(DEBUG) << "WebSocket subprotocol: plugin '" << subProtocolName << "' loaded and added to dynamic cache";
+src/web/websocket/SubProtocolFactorySelector.hpp:105:            LOG(WARNING) << "WebSocket subprotocol: plugin '" << subProtocolName << "' not found";
+src/web/websocket/SocketContextUpgrade.hpp:118:            LOG(DEBUG) << this->getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
+src/web/websocket/SocketContextUpgrade.hpp:189:                    LOG(DEBUG) << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
+src/web/websocket/SocketContextUpgrade.hpp:194:                    LOG(DEBUG) << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
+src/web/websocket/SocketContextUpgrade.hpp:222:        LOG(INFO) << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name << "' connect";
+src/web/websocket/SocketContextUpgrade.hpp:229:        LOG(INFO) << getSocketConnection()->getConnectionName() << " WebSocketContext:  Subprotocol '" << subProtocol->name
+src/web/websocket/server/SubProtocolFactorySelector.cpp:83:            LOG(WARNING) << "WebSocket: Overriding websocket subprotocol library dir";
+src/web/websocket/Receiver.cpp:130:                LOG(ERROR) << "WebSocket: Error opcode in continuation frame";
+src/web/websocket/Receiver.cpp:284:            LOG(TRACE) << "WebSocket receive: Frame data\n" << utils::hexDump(payloadChunk, payloadChunkLen, 32, true);
+src/web/websocket/SubProtocol.hpp:72:                        LOG(WARNING) << this->subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '"
+src/web/websocket/SubProtocol.hpp:132:        LOG(DEBUG) << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': Ping sent";
+src/web/websocket/SubProtocol.hpp:144:        LOG(DEBUG) << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': start";
+src/web/websocket/SubProtocol.hpp:153:        LOG(DEBUG) << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': stopped";
+src/web/websocket/SubProtocol.hpp:155:        LOG(DEBUG) << "       Total Payload sent: " << getPayloadTotalSent();
+src/web/websocket/SubProtocol.hpp:156:        LOG(DEBUG) << "  Total Payload processed: " << getPayloadTotalRead();
+src/web/websocket/SubProtocol.hpp:161:        LOG(DEBUG) << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': Pong received";
+src/web/websocket/Transmitter.cpp:142:            LOG(TRACE) << "WebSocket send: Frame data\n" << utils::hexDump(payload, payloadLength, 32, true);
+src/web/websocket/client/SubProtocolFactorySelector.cpp:83:            LOG(WARNING) << "WebSocket: Overriding websocket subprotocol library dir";
+```
+
+## References
+
+- Migration 7 inventory PR #160 established HTTP/WebSocket split planning.
+- Migration 7a and 7b work is already present in PR #161 and covers HTTP client, EventSource URL validation helpers, HTTP server, and HTTP server upgrade logging.
+
+## Focused inventory classification table
+
+| Class | Files | Count | Result |
+| --- | --- | ---: | --- |
+| A. WebSocket SocketContextUpgrade.hpp lifecycle/subprotocol selection | `src/web/websocket/SocketContextUpgrade.hpp` | 5 | Migrated |
+| B. WebSocket Receiver.cpp frame/protocol diagnostics | `src/web/websocket/Receiver.cpp` | 2 | Migrated |
+| C. WebSocket Transmitter.cpp frame/protocol diagnostics | `src/web/websocket/Transmitter.cpp` | 1 | Migrated |
+| D. WebSocket SubProtocol.hpp lifecycle/ping/pong/payload totals | `src/web/websocket/SubProtocol.hpp` | 7 | Migrated |
+| E. WebSocket SubProtocolFactorySelector.hpp plugin/cache/loader diagnostics | `src/web/websocket/SubProtocolFactorySelector.hpp` | 7 | Migrated |
+| F. WebSocket client/server SubProtocolFactorySelector.cpp library-dir warning | client/server selector `.cpp` files | 2 | Migrated |
+| G. PLOG / errno-sensitive call sites | focused 7c scope | 0 | None present |
+| H. VLOG / verbose diagnostics | focused 7c scope | 0 | None present |
+| I. deferred/unclear call sites | focused 7c scope | 0 | None deferred |
+
+## Ownership discovery summary
+
+Command:
+
+```sh
+rg -n "\blog\(\)|logger::|BoundaryLogger|LogScopeOwner|semantic|scope|getInstanceName|getConnectionName|SocketContext|SocketConnection|WebSocket|SubProtocol|Receiver|Transmitter|Upgrade" \
+  src/web/websocket \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Summary: `SocketContextUpgrade.hpp` and `SubProtocol.hpp` have access to socket connection identity and preserve `getSocketConnection()->getConnectionName()` manually. Receiver/transmitter/factory code does not expose a safe existing semantic owner without broad API churn, so 7c adds small WebSocket helper scopes in `src/web/websocket/SemanticLog.h`.
+
+## Migrated call-site table
+
+| Area | Semantic owner/helper | Severity mapping | Payload preservation |
+| --- | --- | --- | --- |
+| `SocketContextUpgrade.hpp` lifecycle and close paths | `webSocketSubProtocolLog()` | DEBUG/INFO -> debug/info | connectionName, subprotocol name, close sent/confirmed/request received, connect/disconnect wording |
+| `SubProtocol.hpp` lifecycle/ping/pong/payload totals | `webSocketSubProtocolLog()` | WARNING/DEBUG -> warn/debug | connectionName, subprotocol name, max flying pings, ping sent, start/stopped, payload totals, pong received |
+| `Receiver.cpp` frame/protocol diagnostics | `webSocketFrameLog()` | ERROR/TRACE -> error/trace | continuation-frame error wording and receive hex dump |
+| `Transmitter.cpp` frame diagnostics | `webSocketFrameLog()` | TRACE -> trace | send frame hex dump |
+| `SubProtocolFactorySelector.hpp` plugin/cache/loader diagnostics | `webSocketFactoryLog()` | DEBUG/WARNING -> debug/warn | plugin name, factory function name, dynamic/static cache distinction, loaded/selected/not-found states |
+| client/server selector `.cpp` library-dir warning | `webSocketFactoryLog()` | WARNING -> warn | library-dir override warning text |
+
+## Deferred call-site table
+
+No focused Migration 7c LOG/PLOG/VLOG call sites were deferred.
+
+## Semantic owner/helper used
+
+- Helper component `web.websocket`: general WebSocket diagnostics and test coverage.
+- Helper component `web.websocket.frame`: receiver/transmitter frame and protocol diagnostics.
+- Helper component `web.websocket.subprotocol`: socket-context upgrade and subprotocol lifecycle diagnostics.
+- Helper component `web.websocket.factory`: subprotocol plugin/factory/cache and library-dir diagnostics.
+
+## Severity mapping
+
+- `LOG(TRACE)` -> semantic `trace()`
+- `LOG(DEBUG)` -> semantic `debug()`
+- `LOG(INFO)` -> semantic `info()`
+- `LOG(WARNING)` -> semantic `warn()`
+- `LOG(ERROR)` -> semantic `error()`
+- No `LOG(FATAL)` was present.
+
+## PLOG/sysError errno handling
+
+No PLOG call sites were present in the focused 7c inventory. The new unit test still covers `sysError` helper behavior to confirm errno code/text preservation for future WebSocket errno-sensitive use.
+
+## VLOG result
+
+No VLOG call sites were present in the focused 7c inventory, and no VLOG semantics were changed.
+
+## WebSocket payload preservation notes
+
+The migration preserves connectionName, subprotocol name, selected/rejected subprotocol information, plugin name, factory function name, dynamic/static cache distinction, loaded/selected/not-found plugin state, opcode/frame payload detail in representative tests, continuation-frame error wording, frame payload hex dump, ping sent, pong received, start/stopped lifecycle messages, payload total sent/processed, library-dir override warning, and connect/disconnect wording.
+
+## Hex dump / expensive payload guard notes
+
+Receiver and Transmitter hex-dump call sites now create a `webSocketFrameLog()` and check `log.enabled(logger::LogLevel::Trace)` before constructing `utils::hexDump(...)`. `WebSocketMigration07cTest` includes a sink-taking helper check proving the guarded branch is not evaluated when trace is disabled.
+
+## Post-migration inventory
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" \
+  src/web/websocket \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Result: no remaining LOG/PLOG/VLOG call sites in Migration 7c scope.
+
+## Filter/backend/format compatibility
+
+`WebSocketMigration07cTest` covers enabled emission, framework component scopes (`web.websocket`, `web.websocket.frame`, `web.websocket.subprotocol`, `web.websocket.factory`), LogManager filtering, backend filtering, JSON v1 output, sink-taking helper overloads, suppressed formatting, sysError code/text, representative subprotocol/frame/factory/lifecycle payloads, and a guarded hex-dump branch.
+
+## Production-scope confirmations
+
+- This follow-up changes only allowed Migration 7c files plus tests/unit/log/CMakeLists.txt.
+- This follow-up is not inventory-only.
+- This follow-up modifies production WebSocket logging.
+- This follow-up does not modify SemanticLogger.*.
+- This follow-up does not modify LogScopeOwner.*.
+- This follow-up does not modify Logger.*.
+- This follow-up does not modify ConfigInstance.cpp.
+- This follow-up does not modify src/net/config/stream/tls.
+- This follow-up does not modify src/iot or MQTT-over-WebSocket code.
+- This follow-up does not modify DB/apps/examples.
+- This follow-up does not change LOG/PLOG/VLOG macro definitions.
+- This follow-up does not change LogManager precedence.
+- This follow-up does not change LogManager freeze behavior.
+- This follow-up does not change JSON v1 schema.
+- This follow-up does not start Round 10.
+
+## Changed-file check
+
+- `git diff --name-only master...HEAD` was attempted, but the local worktree does not have a `master` ref in this Codex environment, so Git reports `fatal: ambiguous argument 'master...HEAD'`.
+- Equivalent local changed-file inspection uses `git diff --name-only HEAD -- src/web/websocket tests/unit/log/CMakeLists.txt docs/logging/semantic-migration-07c-websocket-report.md tests/unit/log/WebSocketMigration07cTest.cpp` plus `git ls-files --others --exclude-standard ...` and shows only the 7c files listed above.
+
+## Build commands run
+
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2 --target WebSocketMigration07cTest websocket websocket-client websocket-server`
+- `cmake --build cmake-build --parallel 2 --target WebSocketMigration07cTest`
+- `cmake --build cmake-build --parallel 2`
+- `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`
+- `cmake --build cmake-build-asan --parallel 2 --target WebSocketMigration07cTest`
+
+## Test commands run
+
+- `ctest --test-dir cmake-build -R WebSocketMigration07cTest --output-on-failure` passed.
+- `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test|SemanticProductionThresholdRepairTest|SocketConnectionMigration01Test|SocketConnectorAcceptorMigration02Test|SocketServerClientMigration03Test|CoreRuntimeMigration04Test|NetPhysicalSocketMigration05Test|TlsSocketStreamMigration06Test|HttpClientMigration07aTest|HttpServerMigration07bTest|WebSocketMigration07cTest" --output-on-failure` passed.
+- `ctest --test-dir cmake-build --output-on-failure` passed with 126/126 tests successful; skipped component tests were reported as skipped by the test harness, not failed.
+- `ASAN=$(gcc -print-file-name=libasan.so) && LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan -R WebSocketMigration07cTest --output-on-failure` passed.
+
+## ASan result
+
+ASan focused `WebSocketMigration07cTest` passed in `cmake-build-asan` with `LD_PRELOAD` set to `gcc -print-file-name=libasan.so`.
+
+## Known follow-ups
+
+- Migration 8 — MQTT
+- Migration 9 — DB / apps / examples / remaining cleanup
+- Round 10 — book integration

--- a/src/web/http/client/Request.cpp
+++ b/src/web/http/client/Request.cpp
@@ -45,6 +45,7 @@
 #include "core/socket/stream/SocketConnection.h"
 #include "web/http/MimeTypes.h"
 #include "web/http/TransferEncoding.h"
+#include "web/http/client/SemanticLog.h"
 #include "web/http/client/SocketContext.h"
 #include "web/http/client/SocketContextUpgradeFactorySelector.h"
 
@@ -59,7 +60,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 #include "web/http/http_utils.h"
 
 #include <cerrno>
@@ -364,15 +365,16 @@ namespace web::http::client {
                 [masterRequest = this->masterRequest, connectionName = this->connectionName, onResponseReceived](
                     const std::shared_ptr<Request>& request, const std::shared_ptr<Response>& response) {
                     if (!masterRequest.expired() && masterRequest.lock()->isConnected()) {
-                        LOG(DEBUG) << connectionName << " HTTP upgrade: Response to upgrade request: " << request->method << " "
-                                   << request->url << " "
-                                   << "HTTP/" << request->httpMajor << "." << request->httpMinor << "\n"
-                                   << httputils::toString(response->httpVersion,
-                                                          response->statusCode,
-                                                          response->reason,
-                                                          response->headers,
-                                                          response->cookies,
-                                                          response->body);
+                        semantic::httpClientLog().debug()
+                            << connectionName << " HTTP upgrade: Response to upgrade request: " << request->method << " " << request->url
+                            << " "
+                            << "HTTP/" << request->httpMajor << "." << request->httpMinor << "\n"
+                            << httputils::toString(response->httpVersion,
+                                                   response->statusCode,
+                                                   response->reason,
+                                                   response->headers,
+                                                   response->cookies,
+                                                   response->body);
 
                         std::string socketContextUpgradeName;
 
@@ -383,40 +385,44 @@ namespace web::http::client {
                             if (socketContextUpgradeFactory != nullptr) {
                                 socketContextUpgradeName = socketContextUpgradeFactory->name();
 
-                                LOG(DEBUG) << connectionName
-                                           << " HTTP upgrade: SocketContextUpgradeFactory create success for: " << socketContextUpgradeName;
+                                semantic::httpClientLog().debug()
+                                    << connectionName
+                                    << " HTTP upgrade: SocketContextUpgradeFactory create success for: " << socketContextUpgradeName;
 
                                 core::socket::stream::SocketContext* socketContextUpgrade =
                                     socketContextUpgradeFactory->create(masterRequest.lock()->getSocketContext()->getSocketConnection());
 
                                 if (socketContextUpgrade != nullptr) {
-                                    LOG(DEBUG) << connectionName
-                                               << " HTTP upgrade: SocketContextUpgrade create success for: " << socketContextUpgradeName;
+                                    semantic::httpClientLog().debug()
+                                        << connectionName
+                                        << " HTTP upgrade: SocketContextUpgrade create success for: " << socketContextUpgradeName;
                                     masterRequest.lock()->getSocketContext()->getSocketConnection()->setSocketContext(socketContextUpgrade);
                                 } else {
-                                    LOG(DEBUG) << connectionName
-                                               << " HTTP upgrade: SocketContextUpgrade create failed for: " << socketContextUpgradeName;
+                                    semantic::httpClientLog().debug()
+                                        << connectionName
+                                        << " HTTP upgrade: SocketContextUpgrade create failed for: " << socketContextUpgradeName;
 
                                     masterRequest.lock()->getSocketContext()->close();
                                 }
                             } else {
-                                LOG(DEBUG) << connectionName << " HTTP upgrade: SocketContextUpgradeFactory not supported by server: "
-                                           << request->header("upgrade");
+                                semantic::httpClientLog().debug()
+                                    << connectionName
+                                    << " HTTP upgrade: SocketContextUpgradeFactory not supported by server: " << request->header("upgrade");
 
                                 masterRequest.lock()->getSocketContext()->close();
                             }
                         } else {
-                            LOG(DEBUG) << connectionName << " HTTP upgrade: No upgrade requested";
+                            semantic::httpClientLog().debug() << connectionName << " HTTP upgrade: No upgrade requested";
 
                             masterRequest.lock()->getSocketContext()->close();
                         }
 
-                        LOG(DEBUG) << connectionName << " HTTP upgrade: bootstrap "
-                                   << (!socketContextUpgradeName.empty() ? "success" : "failed");
-                        LOG(DEBUG) << "      Protocol selected: " << socketContextUpgradeName;
-                        LOG(DEBUG) << "              requested: " << request->header("upgrade");
-                        LOG(DEBUG) << "  Subprotocol  selected: " << response->get("Sec-WebSocket-Protocol");
-                        LOG(DEBUG) << "              requested: " << request->header("Sec-WebSocket-Protocol");
+                        semantic::httpClientLog().debug()
+                            << connectionName << " HTTP upgrade: bootstrap " << (!socketContextUpgradeName.empty() ? "success" : "failed");
+                        semantic::httpClientLog().debug() << "      Protocol selected: " << socketContextUpgradeName;
+                        semantic::httpClientLog().debug() << "              requested: " << request->header("upgrade");
+                        semantic::httpClientLog().debug() << "  Subprotocol  selected: " << response->get("Sec-WebSocket-Protocol");
+                        semantic::httpClientLog().debug() << "              requested: " << request->header("Sec-WebSocket-Protocol");
 
                         onResponseReceived(request, response, !socketContextUpgradeName.empty());
                     }
@@ -467,7 +473,7 @@ namespace web::http::client {
                 [masterRequest = this->masterRequest, connectionName = this->connectionName, onError](
                     [[maybe_unused]] const std::shared_ptr<Request>& request, const std::string& status) {
                     if (!masterRequest.expired() && masterRequest.lock()->isConnected()) {
-                        LOG(DEBUG) << connectionName << " error in response: " << status;
+                        semantic::httpClientLog().debug() << connectionName << " error in response: " << status;
                         masterRequest.lock()->getSocketContext()->close();
                         onError();
                     }
@@ -618,27 +624,27 @@ namespace web::http::client {
             web::http::client::SocketContextUpgradeFactorySelector::instance()->select(protocols, *this);
 
         if (socketContextUpgradeFactory != nullptr) {
-            LOG(DEBUG) << connectionName << " HTTP: "
-                       << "SocketContextUpgradeFactory create success: " << socketContextUpgradeFactory->name();
-            LOG(DEBUG) << connectionName << " HTTP: Initiating upgrade: " << method << " " << url
-                       << " HTTP/" + std::to_string(httpMajor) + "." + std::to_string(httpMinor);
+            semantic::httpClientLog().debug() << connectionName << " HTTP: "
+                                              << "SocketContextUpgradeFactory create success: " << socketContextUpgradeFactory->name();
+            semantic::httpClientLog().debug() << connectionName << " HTTP: Initiating upgrade: " << method << " " << url
+                                              << " HTTP/" + std::to_string(httpMajor) + "." + std::to_string(httpMinor);
 
         } else {
-            LOG(DEBUG) << connectionName << " HTTP: "
-                       << "SocketContextUpgradeFactory create failed: " << protocols;
-            LOG(DEBUG) << connectionName << " HTTP: Not initiating upgrade " << method << " " << url
-                       << " HTTP/" + std::to_string(httpMajor) + "." + std::to_string(httpMinor);
+            semantic::httpClientLog().debug() << connectionName << " HTTP: "
+                                              << "SocketContextUpgradeFactory create failed: " << protocols;
+            semantic::httpClientLog().debug() << connectionName << " HTTP: Not initiating upgrade " << method << " " << url
+                                              << " HTTP/" + std::to_string(httpMajor) + "." + std::to_string(httpMinor);
         }
 
-        LOG(DEBUG) << connectionName << " HTTP: Upgrade request:\n"
-                   << httputils::toString(method,
-                                          url,
-                                          "HTTP/" + std::to_string(httpMajor) + "." + std::to_string(httpMinor),
-                                          queries,
-                                          headers,
-                                          trailer,
-                                          cookies,
-                                          std::vector<char>());
+        semantic::httpClientLog().debug() << connectionName << " HTTP: Upgrade request:\n"
+                                          << httputils::toString(method,
+                                                                 url,
+                                                                 "HTTP/" + std::to_string(httpMajor) + "." + std::to_string(httpMinor),
+                                                                 queries,
+                                                                 headers,
+                                                                 trailer,
+                                                                 cookies,
+                                                                 std::vector<char>());
 
         onStatus(socketContextUpgradeFactory != nullptr);
 

--- a/src/web/http/client/SemanticLog.h
+++ b/src/web/http/client/SemanticLog.h
@@ -1,0 +1,59 @@
+#ifndef WEB_HTTP_CLIENT_SEMANTICLOG_H
+#define WEB_HTTP_CLIENT_SEMANTICLOG_H
+
+#include "log/LogScopeOwner.h"
+#include "log/Logger.h"
+
+#include <utility>
+
+namespace web::http::client::semantic {
+
+    inline const logger::LogScopeOwner& httpClientLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.http.client");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& httpClientUpgradeLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.http.client.upgrade");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& httpClientEventSourceLogScope() {
+        static const logger::LogScopeOwner scope(
+            logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.http.client.eventsource");
+        return scope;
+    }
+
+    inline logger::BoundaryLogger httpClientLog() {
+        return httpClientLogScope().logger(logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger httpClientLog(logger::BoundaryLogger::Sink sink,
+                                                logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                logger::BoundaryLogger::Clock clock = {}) {
+        return httpClientLogScope().logger(std::move(sink), threshold, std::move(clock));
+    }
+
+    inline logger::BoundaryLogger httpClientUpgradeLog() {
+        return httpClientUpgradeLogScope().logger(logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger httpClientUpgradeLog(logger::BoundaryLogger::Sink sink,
+                                                       logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                       logger::BoundaryLogger::Clock clock = {}) {
+        return httpClientUpgradeLogScope().logger(std::move(sink), threshold, std::move(clock));
+    }
+
+    inline logger::BoundaryLogger httpClientEventSourceLog() {
+        return httpClientEventSourceLogScope().logger(logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger httpClientEventSourceLog(logger::BoundaryLogger::Sink sink,
+                                                           logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                           logger::BoundaryLogger::Clock clock = {}) {
+        return httpClientEventSourceLogScope().logger(std::move(sink), threshold, std::move(clock));
+    }
+
+} // namespace web::http::client::semantic
+
+#endif // WEB_HTTP_CLIENT_SEMANTICLOG_H

--- a/src/web/http/client/SocketContext.cpp
+++ b/src/web/http/client/SocketContext.cpp
@@ -48,7 +48,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 #include "utils/Timeval.h"
 #include "web/http/http_utils.h"
 
@@ -87,16 +87,18 @@ namespace web::http::client {
 
     SocketContext::~SocketContext() {
         if (!deliveredRequests.empty()) {
-            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " HTTP: Responses missed";
+            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Responses missed";
             for (const std::shared_ptr<MasterRequest>& request : deliveredRequests) {
-                LOG(DEBUG) << "  " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "." << request->httpMinor;
+                frameworkLog().debug() << "  " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
+                                       << request->httpMinor;
             }
         }
 
         if (!pendingRequests.empty()) {
-            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " HTTP: Requests ignored";
+            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Requests ignored";
             for (const std::shared_ptr<MasterRequest>& request : pendingRequests) {
-                LOG(DEBUG) << "  " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "." << request->httpMinor;
+                frameworkLog().debug() << "  " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
+                                       << request->httpMinor;
             }
         }
     }
@@ -112,8 +114,8 @@ namespace web::http::client {
 
         if ((flags == Flags::NONE || (flags & Flags::HTTP11) == Flags::HTTP11 || (flags & Flags::KEEPALIVE) == Flags::KEEPALIVE) &&
             (flags & Flags::CLOSE) != Flags::CLOSE) {
-            LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                      << ") accepted: " << requestLine;
+            frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
+                                  << ") accepted: " << requestLine;
             flags = (flags & Flags::HTTP11) | ((request->httpMajor == 1 && request->httpMinor == 1) ? Flags::HTTP11 : Flags::NONE);
             flags = (flags & Flags::HTTP10) | ((request->httpMajor == 1 && request->httpMinor == 0) ? Flags::HTTP10 : Flags::NONE);
             flags = (flags & Flags::KEEPALIVE) |
@@ -122,25 +124,26 @@ namespace web::http::client {
 
             pendingRequests.push_back(request);
 
-            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count << ") queued: " << requestLine
-                       << " - QueueSize = " << pendingRequests.size() << " - Flags: " << flags << " - "
-                       << web::http::ciContains(request->header("Connection"), "close");
+            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
+                                   << ") queued: " << requestLine << " - QueueSize = " << pendingRequests.size() << " - Flags: " << flags
+                                   << " - " << web::http::ciContains(request->header("Connection"), "close");
 
             if (pendingRequests.size() == 1 && (deliveredRequests.empty() || pipelinedRequests)) {
                 initiateRequest();
             }
         } else {
-            LOG(WARNING) << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                         << ") rejected: " << requestLine;
+            frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
+                                  << ") rejected: " << requestLine;
 
-            LOG(WARNING) << httputils::toString(request->method,
-                                                request->url,
-                                                "HTTP/" + std::to_string(request->httpMajor) + "." + std::to_string(request->httpMinor),
-                                                request->getQueries(),
-                                                request->getHeaders(),
-                                                request->getTrailer(),
-                                                request->getCookies(),
-                                                {});
+            frameworkLog().warn() << httputils::toString(request->method,
+                                                         request->url,
+                                                         "HTTP/" + std::to_string(request->httpMajor) + "." +
+                                                             std::to_string(request->httpMinor),
+                                                         request->getQueries(),
+                                                         request->getHeaders(),
+                                                         request->getTrailer(),
+                                                         request->getCookies(),
+                                                         {});
         }
     }
 
@@ -156,11 +159,12 @@ namespace web::http::client {
                                                 .append(".")
                                                 .append(std::to_string(request->httpMinor));
 
-            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count << ") start: " << requestLine;
+            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
+                                   << ") start: " << requestLine;
 
             if (!request->initiate(request)) {
-                LOG(WARNING) << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                             << ") delivering failed: " << requestLine;
+                frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
+                                      << ") delivering failed: " << requestLine;
 
                 core::EventReceiver::atNextTick([masterRequest = std::weak_ptr(masterRequest)]() {
                     if (!masterRequest.expired()) {
@@ -171,9 +175,10 @@ namespace web::http::client {
                             if (!socketContext->pendingRequests.empty()) {
                                 const std::shared_ptr<Request>& request = socketContext->pendingRequests.front();
 
-                                LOG(DEBUG) << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Request ("
-                                           << request->count << ") dequeued: " << request->method << " " << request->url << " HTTP/"
-                                           << request->httpMajor << "." << request->httpMinor;
+                                socketContext->frameworkLog().debug()
+                                    << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
+                                    << ") dequeued: " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
+                                    << request->httpMinor;
 
                                 socketContext->initiateRequest();
                             }
@@ -197,8 +202,8 @@ namespace web::http::client {
                                             .append(std::to_string(currentRequest->httpMinor));
 
         if (success) {
-            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " HTTP: Request (" << currentRequest->count
-                       << ") delivered: " << requestLine << " " << pendingRequests.size();
+            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << currentRequest->count
+                                   << ") delivered: " << requestLine << " " << pendingRequests.size();
 
             deliveredRequests.push_back(currentRequest);
 
@@ -210,9 +215,10 @@ namespace web::http::client {
                         if (socketContext != nullptr) {
                             const std::shared_ptr<Request>& request = socketContext->pendingRequests.front();
 
-                            LOG(DEBUG) << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                       << ") dequeued: " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
-                                       << request->httpMinor;
+                            socketContext->frameworkLog().debug()
+                                << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
+                                << ") dequeued: " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
+                                << request->httpMinor;
 
                             socketContext->initiateRequest();
                         }
@@ -220,8 +226,8 @@ namespace web::http::client {
                 });
             }
         } else {
-            LOG(WARNING) << getSocketConnection()->getConnectionName() << " HTTP: Request (" << currentRequest->count
-                         << ") deliver failed: " << requestLine;
+            frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << currentRequest->count
+                                  << ") deliver failed: " << requestLine;
 
             shutdownWrite();
         }
@@ -229,7 +235,7 @@ namespace web::http::client {
 
     void SocketContext::responseStarted() {
         if (deliveredRequests.empty()) {
-            LOG(ERROR) << getSocketConnection()->getConnectionName() << " HTTP: Response without delivered request";
+            frameworkLog().error() << getSocketConnection()->getConnectionName() << " HTTP: Response without delivered request";
 
             close();
         }
@@ -247,15 +253,16 @@ namespace web::http::client {
                                             .append(".")
                                             .append(std::to_string(request->httpMinor));
 
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Response received for request (" << request->count
-                  << "): " << requestLine;
+        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Response received for request (" << request->count
+                              << "): " << requestLine;
 
-        LOG(INFO) << getSocketConnection()->getConnectionName() << "   HTTP/" << response->httpMajor << "." << response->httpMinor << " "
-                  << response->statusCode << " " << response->reason;
+        frameworkLog().info() << getSocketConnection()->getConnectionName() << "   HTTP/" << response->httpMajor << "."
+                              << response->httpMinor << " " << response->statusCode << " " << response->reason;
 
         request->deliverResponse(request, response);
 
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count << ") completed: " << requestLine;
+        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
+                              << ") completed: " << requestLine;
 
         requestCompleted(response);
     }
@@ -272,15 +279,15 @@ namespace web::http::client {
                                             .append(".")
                                             .append(std::to_string(request->httpMinor));
 
-        LOG(WARNING) << getSocketConnection()->getConnectionName() << " HTTP: Response parse error: " << reason << " (" << status
-                     << ") for request (" << request->count << "): " << requestLine
-                     << std::string(request->method)
-                            .append(" ")
-                            .append(request->url)
-                            .append(" HTTP/")
-                            .append(std::to_string(request->httpMajor))
-                            .append(".")
-                            .append(std::to_string(request->httpMinor));
+        frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Response parse error: " << reason << " (" << status
+                              << ") for request (" << request->count << "): " << requestLine
+                              << std::string(request->method)
+                                     .append(" ")
+                                     .append(request->url)
+                                     .append(" HTTP/")
+                                     .append(std::to_string(request->httpMajor))
+                                     .append(".")
+                                     .append(std::to_string(request->httpMinor));
 
         request->deliverResponseParseError(request, reason);
 
@@ -293,11 +300,11 @@ namespace web::http::client {
                      ((response->httpMajor == 0 && response->httpMinor == 0) || (response->httpMajor == 1 && response->httpMinor == 0)));
 
         if (httpClose) {
-            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " HTTP: Connection = Close";
+            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Close";
 
             shutdownWrite();
         } else {
-            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " HTTP: Connection = Keep-Alive";
+            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Keep-Alive";
 
             if (!pipelinedRequests && !pendingRequests.empty()) {
                 core::EventReceiver::atNextTick([masterRequest = std::weak_ptr(masterRequest)]() {
@@ -307,9 +314,10 @@ namespace web::http::client {
                         if (socketContext != nullptr) {
                             const std::shared_ptr<Request>& request = socketContext->pendingRequests.front();
 
-                            LOG(DEBUG) << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Initiating request ("
-                                       << request->count << "): " << request->method << " " << request->url << " HTTP/"
-                                       << request->httpMajor << "." << request->httpMinor;
+                            socketContext->frameworkLog().debug()
+                                << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Initiating request ("
+                                << request->count << "): " << request->method << " " << request->url << " HTTP/" << request->httpMajor
+                                << "." << request->httpMinor;
 
                             socketContext->initiateRequest();
                         }
@@ -326,7 +334,7 @@ namespace web::http::client {
     }
 
     void SocketContext::onConnected() {
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Connected";
+        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Connected";
 
         onHttpConnected(masterRequest);
     }
@@ -360,11 +368,11 @@ namespace web::http::client {
         masterRequest->disconnect();
         onHttpDisconnected(masterRequest);
 
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Received disconnect";
+        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received disconnect";
     }
 
     bool SocketContext::onSignal([[maybe_unused]] int signum) {
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Received signal " << signum;
+        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received signal " << signum;
 
         return true;
     }

--- a/src/web/http/client/SocketContextUpgradeFactorySelector.cpp
+++ b/src/web/http/client/SocketContextUpgradeFactorySelector.cpp
@@ -43,11 +43,12 @@
 
 #include "web/http/SocketContextUpgradeFactorySelector.hpp"
 #include "web/http/client/Response.h"
+#include "web/http/client/SemanticLog.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #if !defined(NDEBUG)
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 
 #include <cstdlib>
 #endif
@@ -66,7 +67,7 @@ namespace web::http::client {
 
 #if !defined(NDEBUG)
         if (const char* httpUpgradeInstallLibdirEnv = std::getenv("HTTP_UPGRADE_INSTALL_LIBDIR")) {
-            LOG(WARNING) << "HTTP upgrade: Overriding http upgrade library dir";
+            semantic::httpClientUpgradeLog().warn() << "HTTP upgrade: Overriding http upgrade library dir";
             httpUpgradeInstallLibdir = std::string(httpUpgradeInstallLibdirEnv);
         }
 #endif

--- a/src/web/http/client/tools/EventSource.h
+++ b/src/web/http/client/tools/EventSource.h
@@ -47,7 +47,8 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #include "core/socket/State.h"
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "web/http/client/SemanticLog.h"
 
 #include <cctype>
 #include <cstddef>
@@ -288,24 +289,24 @@ namespace web::http::client::tools {
             sharedState->path = path;
             sharedState->origin = scheme + "://" + socketAddress.toString(false);
 
-            LOG(TRACE) << "Origin: " << sharedState->origin;
-            LOG(TRACE) << "  Path: " << sharedState->path;
+            web::http::client::semantic::httpClientLog().trace() << "Origin: " << sharedState->origin;
+            web::http::client::semantic::httpClientLog().trace() << "  Path: " << sharedState->path;
 
             const std::weak_ptr<EventSourceT> eventSourceWeak = this->weak_from_this();
 
             client = std::make_shared<Client>(
                 [eventSourceWeak](SocketConnection* socketConnection) {
-                    LOG(DEBUG) << socketConnection->getConnectionName() << ": OnConnect";
+                    web::http::client::semantic::httpClientLog().debug() << socketConnection->getConnectionName() << ": OnConnect";
 
                     if (const std::shared_ptr<EventSourceT> eventStream = eventSourceWeak.lock()) {
                         eventStream->socketConnection = socketConnection;
                     }
                 },
                 [](SocketConnection* socketConnection) {
-                    LOG(DEBUG) << socketConnection->getConnectionName() << ": OnConnected";
+                    web::http::client::semantic::httpClientLog().debug() << socketConnection->getConnectionName() << ": OnConnected";
                 },
                 [eventSourceWeak, sharedState = this->sharedState, sharedConfig = this->sharedConfig](SocketConnection* socketConnection) {
-                    LOG(DEBUG) << socketConnection->getConnectionName() << " : OnDisconnect";
+                    web::http::client::semantic::httpClientLog().debug() << socketConnection->getConnectionName() << " : OnDisconnect";
 
                     if (const std::shared_ptr<EventSourceT> eventSource = eventSourceWeak.lock()) {
                         eventSource->socketConnection = nullptr;
@@ -338,7 +339,7 @@ namespace web::http::client::tools {
                     const std::shared_ptr<MasterRequest>& masterRequest) {
                     const std::string connectionName = masterRequest->getSocketContext()->getSocketConnection()->getConnectionName();
 
-                    LOG(DEBUG) << connectionName << ": OnRequestStart";
+                    web::http::client::semantic::httpClientLog().debug() << connectionName << ": OnRequestStart";
 
                     if (!sharedState->lastId.empty()) {
                         masterRequest->set("Last-Event-ID", sharedState->lastId);
@@ -360,13 +361,15 @@ namespace web::http::client::tools {
                                         masterRequest->getSocketContext()->close();
                                     }
                                 } else {
-                                    LOG(DEBUG) << connectionName << ": server-sent event: server disconnect";
+                                    web::http::client::semantic::httpClientLog().debug()
+                                        << connectionName << ": server-sent event: server disconnect";
                                 }
 
                                 return consumed;
                             },
                             [sharedState, sharedConfig, connectionName]() {
-                                LOG(DEBUG) << connectionName << ": server-sent event stream start";
+                                web::http::client::semantic::httpClientLog().debug()
+                                    << connectionName << ": server-sent event stream start";
 
                                 sharedState->ready = ReadyState::OPEN;
 
@@ -386,8 +389,8 @@ namespace web::http::client::tools {
                                 }
                             },
                             [sharedState, connectionName]() {
-                                LOG(DEBUG) << connectionName
-                                           << ": not an server-sent event endpoint: " << sharedState->origin + sharedState->path;
+                                web::http::client::semantic::httpClientLog().debug()
+                                    << connectionName << ": not an server-sent event endpoint: " << sharedState->origin + sharedState->path;
                                 if (auto it = sharedState->onEventListener.find("error"); it != sharedState->onEventListener.end()) {
                                     EventSource::MessageEvent e{"error", "", sharedState->lastId, sharedState->origin};
 
@@ -406,7 +409,7 @@ namespace web::http::client::tools {
                     }
                 },
                 [](const std::shared_ptr<Request>& req) {
-                    LOG(DEBUG) << req->getConnectionName() << ": OnRequestEnd";
+                    web::http::client::semantic::httpClientLog().debug() << req->getConnectionName() << ": OnRequestEnd";
                 });
 
             client->getConfig()->Remote::setSocketAddress(socketAddress);
@@ -422,16 +425,19 @@ namespace web::http::client::tools {
                                 const core::socket::State& state) { // example.com:81 simulate connnect timeout
                 switch (state) {
                     case core::socket::State::OK:
-                        LOG(DEBUG) << instanceName << ": connected to '" << socketAddress.toString() << "'";
+                        web::http::client::semantic::httpClientLog().debug()
+                            << instanceName << ": connected to '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        LOG(DEBUG) << instanceName << ": disabled";
+                        web::http::client::semantic::httpClientLog().debug() << instanceName << ": disabled";
                         break;
                     case core::socket::State::ERROR:
-                        LOG(DEBUG) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        web::http::client::semantic::httpClientLog().debug()
+                            << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                     case core::socket::State::FATAL:
-                        LOG(DEBUG) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        web::http::client::semantic::httpClientLog().debug()
+                            << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                 }
             });

--- a/src/web/http/legacy/in/EventSource.h
+++ b/src/web/http/legacy/in/EventSource.h
@@ -42,6 +42,7 @@
 #ifndef WEB_HTTP_LEGACY_IN_EVENTSOURCE_H
 #define WEB_HTTP_LEGACY_IN_EVENTSOURCE_H
 
+#include "web/http/client/SemanticLog.h"
 #include "web/http/client/tools/EventSource.h"
 #include "web/http/legacy/in/Client.h"
 
@@ -107,10 +108,10 @@ namespace web::http::legacy::in {
             if (scheme == "http") {
                 eventSource = EventSource(scheme, net::in::SocketAddress(host, port), path + query);
             } else {
-                LOG(ERROR) << "Scheme not valid: " << scheme;
+                web::http::client::semantic::httpClientEventSourceLog().error() << "Scheme not valid: " << scheme;
             }
         } else {
-            LOG(ERROR) << "EventSource url not accepted: " << url;
+            web::http::client::semantic::httpClientEventSourceLog().error() << "EventSource url not accepted: " << url;
         }
 
         return eventSource;

--- a/src/web/http/legacy/in6/EventSource.h
+++ b/src/web/http/legacy/in6/EventSource.h
@@ -42,6 +42,7 @@
 #ifndef WEB_HTTP_LEGACY_IN6_EVENTSOURCE_H
 #define WEB_HTTP_LEGACY_IN6_EVENTSOURCE_H
 
+#include "web/http/client/SemanticLog.h"
 #include "web/http/client/tools/EventSource.h"
 #include "web/http/legacy/in6/Client.h"
 
@@ -105,10 +106,10 @@ namespace web::http::legacy::in6 {
             if (scheme == "http") {
                 eventSource = EventSource(scheme, net::in6::SocketAddress(host, port), path + query);
             } else {
-                LOG(ERROR) << "Scheme not valid: " << scheme;
+                web::http::client::semantic::httpClientEventSourceLog().error() << "Scheme not valid: " << scheme;
             }
         } else {
-            LOG(ERROR) << "EventSource url not accepted: " << url;
+            web::http::client::semantic::httpClientEventSourceLog().error() << "EventSource url not accepted: " << url;
         }
 
         return eventSource;

--- a/src/web/http/legacy/rc/EventSource.h
+++ b/src/web/http/legacy/rc/EventSource.h
@@ -42,6 +42,7 @@
 #ifndef WEB_HTTP_LEGACY_RC_EVENTSOURCE_H
 #define WEB_HTTP_LEGACY_RC_EVENTSOURCE_H
 
+#include "web/http/client/SemanticLog.h"
 #include "web/http/client/tools/EventSource.h"
 #include "web/http/legacy/rc/Client.h"
 
@@ -106,7 +107,7 @@ namespace web::http::legacy::rc {
 
             eventSource = EventSource(scheme, net::rc::SocketAddress(addr, chan), path + query);
         } else {
-            LOG(ERROR) << "EventSource RFCOMM url not accepted: " << url;
+            web::http::client::semantic::httpClientEventSourceLog().error() << "EventSource RFCOMM url not accepted: " << url;
         }
 
         return eventSource;

--- a/src/web/http/legacy/un/EventSource.h
+++ b/src/web/http/legacy/un/EventSource.h
@@ -42,6 +42,7 @@
 #ifndef WEB_HTTP_LEGACY_UN_EVENTSOURCE_H
 #define WEB_HTTP_LEGACY_UN_EVENTSOURCE_H
 
+#include "web/http/client/SemanticLog.h"
 #include "web/http/client/tools/EventSource.h"
 #include "web/http/legacy/un/Client.h"
 
@@ -132,10 +133,11 @@ namespace web::http::legacy::un {
 
                 eventSource = EventSource(scheme, net::un::SocketAddress(socketPath), httpPath + query);
             } else {
-                LOG(ERROR) << "UNIX socket must decode to absolute ('/..') or abstract ('@name'): " << sockToken;
+                web::http::client::semantic::httpClientEventSourceLog().error()
+                    << "UNIX socket must decode to absolute ('/..') or abstract ('@name'): " << sockToken;
             }
         } else {
-            LOG(ERROR) << "EventSource unix-domain url not accepted: " << url;
+            web::http::client::semantic::httpClientEventSourceLog().error() << "EventSource unix-domain url not accepted: " << url;
         }
 
         return eventSource;

--- a/src/web/http/server/Response.cpp
+++ b/src/web/http/server/Response.cpp
@@ -46,11 +46,12 @@
 #include "core/socket/stream/SocketConnection.h"
 #include "web/http/MimeTypes.h"
 #include "web/http/StatusCodes.h"
+#include "web/http/server/SemanticLog.h"
 #include "web/http/server/SocketContextUpgradeFactorySelector.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 #include "utils/system/time.h"
 #include "web/http/CiStringMap.h"
 #include "web/http/http_utils.h"
@@ -252,16 +253,17 @@ namespace web::http::server {
             std::string socketContextUpgradeName;
 
             if (request != nullptr) {
-                LOG(DEBUG) << connectionName << " HTTP: Initiating upgrade: " << request->method << " " << request->url
-                           << " HTTP/" + std::to_string(httpMajor) + "." + std::to_string(httpMinor) << "\n"
-                           << httputils::toString(request->method,
-                                                  request->url,
-                                                  "HTTP/" + std::to_string(request->httpMajor) + "." + std::to_string(request->httpMinor),
-                                                  request->queries,
-                                                  request->headers,
-                                                  {},
-                                                  request->cookies,
-                                                  std::vector<char>());
+                semantic::httpServerLog().debug()
+                    << connectionName << " HTTP: Initiating upgrade: " << request->method << " " << request->url
+                    << " HTTP/" + std::to_string(httpMajor) + "." + std::to_string(httpMinor) << "\n"
+                    << httputils::toString(request->method,
+                                           request->url,
+                                           "HTTP/" + std::to_string(request->httpMajor) + "." + std::to_string(request->httpMinor),
+                                           request->queries,
+                                           request->headers,
+                                           {},
+                                           request->cookies,
+                                           std::vector<char>());
                 if (web::http::ciContains(request->get("connection"), "Upgrade")) {
                     SocketContextUpgradeFactory* socketContextUpgradeFactory =
                         SocketContextUpgradeFactorySelector::instance()->select(*request, *this);
@@ -269,58 +271,61 @@ namespace web::http::server {
                     if (socketContextUpgradeFactory != nullptr) {
                         socketContextUpgradeName = socketContextUpgradeFactory->name();
 
-                        LOG(DEBUG) << connectionName
-                                   << " HTTP upgrade: SocketContextUpgradeFactory create success for: " << socketContextUpgradeName;
+                        semantic::httpServerLog().debug()
+                            << connectionName
+                            << " HTTP upgrade: SocketContextUpgradeFactory create success for: " << socketContextUpgradeName;
 
                         core::socket::stream::SocketContext* socketContextUpgrade =
                             socketContextUpgradeFactory->create(socketContext->getSocketConnection());
 
                         if (socketContextUpgrade != nullptr) {
-                            LOG(DEBUG) << connectionName
-                                       << " HTTP upgrade: SocketContextUpgrade create success for: " << socketContextUpgradeName;
+                            semantic::httpServerLog().debug()
+                                << connectionName << " HTTP upgrade: SocketContextUpgrade create success for: " << socketContextUpgradeName;
 
-                            LOG(DEBUG) << connectionName << " HTTP upgrade: Response to upgrade request: " << request->method << " "
-                                       << request->url << " " << "HTTP/" << request->httpMajor << "." << request->httpMinor << "\n"
-                                       << httputils::toString("HTTP/" + std::to_string(httpMajor) + "." + std::to_string(httpMinor),
-                                                              std::to_string(statusCode),
-                                                              StatusCode::reason(statusCode),
-                                                              headers,
-                                                              cookies,
-                                                              {});
+                            semantic::httpServerLog().debug()
+                                << connectionName << " HTTP upgrade: Response to upgrade request: " << request->method << " "
+                                << request->url << " " << "HTTP/" << request->httpMajor << "." << request->httpMinor << "\n"
+                                << httputils::toString("HTTP/" + std::to_string(httpMajor) + "." + std::to_string(httpMinor),
+                                                       std::to_string(statusCode),
+                                                       StatusCode::reason(statusCode),
+                                                       headers,
+                                                       cookies,
+                                                       {});
 
                             socketContext->getSocketConnection()->setSocketContext(socketContextUpgrade);
                         } else {
-                            LOG(DEBUG) << connectionName
-                                       << " HTTP upgrade: SocketContextUpgrade create failed for: " << socketContextUpgradeName;
+                            semantic::httpServerLog().debug()
+                                << connectionName << " HTTP upgrade: SocketContextUpgrade create failed for: " << socketContextUpgradeName;
 
                             set("Connection", "close").status(404);
                         }
                     } else {
-                        LOG(DEBUG) << connectionName
-                                   << " SocketContextUpgradeFactory create failed for all of: " << request->get("upgrade");
+                        semantic::httpServerLog().debug()
+                            << connectionName << " SocketContextUpgradeFactory create failed for all of: " << request->get("upgrade");
 
                         set("Connection", "close").status(404);
                     }
                 } else {
-                    LOG(DEBUG) << connectionName << " HTTP upgrade: No upgrade requested";
+                    semantic::httpServerLog().debug() << connectionName << " HTTP upgrade: No upgrade requested";
 
                     set("Connection", "close").status(400);
                 }
             } else {
-                LOG(ERROR) << connectionName << " HTTP upgrade: Request has gone away";
+                semantic::httpServerLog().error() << connectionName << " HTTP upgrade: Request has gone away";
 
                 set("Connection", "close").status(500);
             }
 
-            LOG(DEBUG) << connectionName << " HTTP: Upgrade bootstrap " << (!socketContextUpgradeName.empty() ? "success" : "failed");
-            LOG(DEBUG) << "      Protocol selected: " << socketContextUpgradeName;
-            LOG(DEBUG) << "              requested: " << request->get("upgrade");
-            LOG(DEBUG) << "  Subprotocol  selected: " << header("Sec-WebSocket-Protocol");
-            LOG(DEBUG) << "              requested: " << request->get("Sec-WebSocket-Protocol");
+            semantic::httpServerLog().debug() << connectionName << " HTTP: Upgrade bootstrap "
+                                              << (!socketContextUpgradeName.empty() ? "success" : "failed");
+            semantic::httpServerLog().debug() << "      Protocol selected: " << socketContextUpgradeName;
+            semantic::httpServerLog().debug() << "              requested: " << request->get("upgrade");
+            semantic::httpServerLog().debug() << "  Subprotocol  selected: " << header("Sec-WebSocket-Protocol");
+            semantic::httpServerLog().debug() << "              requested: " << request->get("Sec-WebSocket-Protocol");
 
             status(socketContextUpgradeName);
         } else {
-            LOG(ERROR) << "HTTP upgrade: Unexpected disconnect";
+            semantic::httpServerLog().error() << "HTTP upgrade: Unexpected disconnect";
         }
     }
 

--- a/src/web/http/server/SemanticLog.h
+++ b/src/web/http/server/SemanticLog.h
@@ -1,0 +1,43 @@
+#ifndef WEB_HTTP_SERVER_SEMANTICLOG_H
+#define WEB_HTTP_SERVER_SEMANTICLOG_H
+
+#include "log/LogScopeOwner.h"
+#include "log/Logger.h"
+
+#include <utility>
+
+namespace web::http::server::semantic {
+
+    inline const logger::LogScopeOwner& httpServerLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.http.server");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& httpServerUpgradeLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.http.server.upgrade");
+        return scope;
+    }
+
+    inline logger::BoundaryLogger httpServerLog() {
+        return httpServerLogScope().logger(logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger httpServerLog(logger::BoundaryLogger::Sink sink,
+                                                logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                logger::BoundaryLogger::Clock clock = {}) {
+        return httpServerLogScope().logger(std::move(sink), threshold, std::move(clock));
+    }
+
+    inline logger::BoundaryLogger httpServerUpgradeLog() {
+        return httpServerUpgradeLogScope().logger(logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger httpServerUpgradeLog(logger::BoundaryLogger::Sink sink,
+                                                       logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                       logger::BoundaryLogger::Clock clock = {}) {
+        return httpServerUpgradeLogScope().logger(std::move(sink), threshold, std::move(clock));
+    }
+
+} // namespace web::http::server::semantic
+
+#endif // WEB_HTTP_SERVER_SEMANTICLOG_H

--- a/src/web/http/server/SocketContext.cpp
+++ b/src/web/http/server/SocketContext.cpp
@@ -48,7 +48,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 #include "utils/Timeval.h"
 
 #include <string>
@@ -67,11 +67,11 @@ namespace web::http::server {
         , parser(
               this,
               [this]() {
-                  LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Request start";
+                  frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Request start";
               },
               [this](web::http::server::Request&& request) {
-                  LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Request parse success: " << request.method << " "
-                            << request.url << " HTTP/" << request.httpMajor << "." << request.httpMinor;
+                  frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Request parse success: " << request.method
+                                        << " " << request.url << " HTTP/" << request.httpMajor << "." << request.httpMinor;
 
                   pendingRequests.emplace_back(std::make_shared<Request>(std::move(request)));
 
@@ -80,8 +80,8 @@ namespace web::http::server {
                   }
               },
               [this](int status, const std::string& reason) {
-                  LOG(ERROR) << getSocketConnection()->getConnectionName() << " HTTP: Request parse error: " << reason << " (" << status
-                             << ") ";
+                  frameworkLog().error() << getSocketConnection()->getConnectionName() << " HTTP: Request parse error: " << reason << " ("
+                                         << status << ") ";
                   shutdownRead();
 
                   pendingRequests.emplace_back(std::make_shared<Request>(Request(status, reason)));
@@ -109,8 +109,9 @@ namespace web::http::server {
             const std::shared_ptr<Request>& pendingRequest = pendingRequests.front();
 
             if (pendingRequest->status == 0) {
-                LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Request deliver: " << pendingRequest->method << " "
-                          << pendingRequest->url << " HTTP/" << pendingRequest->httpMajor << "." << pendingRequest->httpMinor;
+                frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Request deliver: " << pendingRequest->method
+                                      << " " << pendingRequest->url << " HTTP/" << pendingRequest->httpMajor << "."
+                                      << pendingRequest->httpMinor;
 
                 masterResponse->init();
                 masterResponse->requestMethod = pendingRequest->method;
@@ -134,7 +135,7 @@ namespace web::http::server {
                 masterResponse->status(pendingRequest->status).send(pendingRequest->reason);
             }
         } else {
-            LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: No more pending request";
+            frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: No more pending request";
         }
     }
 
@@ -148,16 +149,17 @@ namespace web::http::server {
                 getSocketConnection()->setReadTimeout(0);
             }
 
-            LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Response start for request: " << pendingRequest->method
-                      << " " << pendingRequest->url << " HTTP/" << pendingRequest->httpMajor << "." << pendingRequest->httpMinor;
-            LOG(INFO) << getSocketConnection()->getConnectionName() << "   "
-                      << "HTTP/" + std::to_string(response.httpMajor)
-                                       .append(".")
-                                       .append(std::to_string(response.httpMinor))
-                                       .append(" ")
-                                       .append(std::to_string(response.statusCode))
-                                       .append(" ")
-                                       .append(StatusCode::reason(response.statusCode));
+            frameworkLog().info() << getSocketConnection()->getConnectionName()
+                                  << " HTTP: Response start for request: " << pendingRequest->method << " " << pendingRequest->url
+                                  << " HTTP/" << pendingRequest->httpMajor << "." << pendingRequest->httpMinor;
+            frameworkLog().info() << getSocketConnection()->getConnectionName() << "   "
+                                  << "HTTP/" + std::to_string(response.httpMajor)
+                                                   .append(".")
+                                                   .append(std::to_string(response.httpMinor))
+                                                   .append(" ")
+                                                   .append(std::to_string(response.statusCode))
+                                                   .append(" ")
+                                                   .append(StatusCode::reason(response.statusCode));
         }
     }
 
@@ -165,8 +167,9 @@ namespace web::http::server {
         if (success) {
             requestCompleted(response);
         } else {
-            LOG(WARNING) << getSocketConnection()->getConnectionName() << " HTTP: Response completed with error: " << response.statusCode
-                         << " " << StatusCode::reason(response.statusCode);
+            frameworkLog().warn() << getSocketConnection()->getConnectionName()
+                                  << " HTTP: Response completed with error: " << response.statusCode << " "
+                                  << StatusCode::reason(response.statusCode);
 
             close();
         }
@@ -176,27 +179,27 @@ namespace web::http::server {
         const std::shared_ptr<Request> request = std::move(pendingRequests.front());
         pendingRequests.pop_front();
 
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Response completed for request: " << request->method << " "
-                  << request->url << " HTTP/" << request->httpMajor << "." << request->httpMinor;
-        LOG(INFO) << getSocketConnection()->getConnectionName() << "   "
-                  << "HTTP/" + std::to_string(response.httpMajor)
-                                   .append(".")
-                                   .append(std::to_string(response.httpMinor))
-                                   .append(" ")
-                                   .append(std::to_string(response.statusCode))
-                                   .append(" ")
-                                   .append(StatusCode::reason(response.statusCode));
+        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Response completed for request: " << request->method
+                              << " " << request->url << " HTTP/" << request->httpMajor << "." << request->httpMinor;
+        frameworkLog().info() << getSocketConnection()->getConnectionName() << "   "
+                              << "HTTP/" + std::to_string(response.httpMajor)
+                                               .append(".")
+                                               .append(std::to_string(response.httpMinor))
+                                               .append(" ")
+                                               .append(std::to_string(response.statusCode))
+                                               .append(" ")
+                                               .append(StatusCode::reason(response.statusCode));
 
         httpClose = response.connectionState == ConnectionState::Close ||
                     (response.connectionState == ConnectionState::Default &&
                      ((response.httpMajor == 0 && response.httpMinor == 9) || (response.httpMajor == 1 && response.httpMinor == 0)));
 
         if (httpClose) {
-            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " HTTP: Connection = Close";
+            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Close";
 
             shutdownWrite();
         } else {
-            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " HTTP: Connection = Keep-Alive";
+            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Keep-Alive";
 
             if (!pendingRequests.empty()) {
                 core::EventReceiver::atNextTick([response = std::weak_ptr<Response>(masterResponse)]() {
@@ -213,7 +216,7 @@ namespace web::http::server {
     }
 
     void SocketContext::onConnected() {
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Connected";
+        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Connected";
 
         for (const auto& onConnectEventReceiver : onConnectEventReceiverList) {
             onConnectEventReceiver();
@@ -233,7 +236,7 @@ namespace web::http::server {
     void SocketContext::onDisconnected() {
         masterResponse->disconnect();
 
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Received disconnect";
+        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received disconnect";
 
         for (const auto& onDisconnectEventReceiver : onDisconnectEventReceiverList) {
             onDisconnectEventReceiver();
@@ -241,7 +244,7 @@ namespace web::http::server {
     }
 
     bool SocketContext::onSignal(int signum) {
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " HTTP: Received signal " << signum;
+        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received signal " << signum;
 
         return true;
     }

--- a/src/web/http/server/SocketContextUpgradeFactorySelector.cpp
+++ b/src/web/http/server/SocketContextUpgradeFactorySelector.cpp
@@ -43,11 +43,12 @@
 
 #include "web/http/SocketContextUpgradeFactorySelector.hpp"
 #include "web/http/server/Request.h"
+#include "web/http/server/SemanticLog.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #if !defined(NDEBUG)
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 
 #include <cstdlib>
 #endif
@@ -66,7 +67,7 @@ namespace web::http::server {
 
 #if !defined(NDEBUG)
         if (const char* httpUpgradeInstallLibdirEnv = std::getenv("HTTP_UPGRADE_INSTALL_LIBDIR")) {
-            LOG(WARNING) << "HTTP upgrade: Overriding http upgrade library dir";
+            semantic::httpServerUpgradeLog().warn() << "HTTP upgrade: Overriding http upgrade library dir";
             httpUpgradeInstallLibdir = std::string(httpUpgradeInstallLibdirEnv);
         }
 #endif

--- a/src/web/http/tls/in/EventSource.h
+++ b/src/web/http/tls/in/EventSource.h
@@ -42,6 +42,7 @@
 #ifndef WEB_HTTP_TLS_IN_EVENTSOURCE_H
 #define WEB_HTTP_TLS_IN_EVENTSOURCE_H
 
+#include "web/http/client/SemanticLog.h"
 #include "web/http/client/tools/EventSource.h"
 #include "web/http/tls/in/Client.h"
 
@@ -105,10 +106,10 @@ namespace web::http::tls::in {
             if (scheme == "https") {
                 eventSource = EventSource(scheme, net::in::SocketAddress(host, port), path + query);
             } else {
-                LOG(ERROR) << "Scheme not valid: " << scheme;
+                web::http::client::semantic::httpClientEventSourceLog().error() << "Scheme not valid: " << scheme;
             }
         } else {
-            LOG(ERROR) << "EventSource url not accepted: " << url;
+            web::http::client::semantic::httpClientEventSourceLog().error() << "EventSource url not accepted: " << url;
         }
 
         return eventSource;

--- a/src/web/http/tls/in6/EventSource.h
+++ b/src/web/http/tls/in6/EventSource.h
@@ -42,6 +42,7 @@
 #ifndef WEB_HTTP_TLS_IN6_EVENTSOURCE_H
 #define WEB_HTTP_TLS_IN6_EVENTSOURCE_H
 
+#include "web/http/client/SemanticLog.h"
 #include "web/http/client/tools/EventSource.h"
 #include "web/http/tls/in6/Client.h"
 
@@ -105,10 +106,10 @@ namespace web::http::tls::in6 {
             if (scheme == "https") {
                 eventSource = EventSource(scheme, net::in6::SocketAddress(host, port), path + query);
             } else {
-                LOG(ERROR) << "Scheme not valid: " << scheme;
+                web::http::client::semantic::httpClientEventSourceLog().error() << "Scheme not valid: " << scheme;
             }
         } else {
-            LOG(ERROR) << "EventSource url not accepted: " << url;
+            web::http::client::semantic::httpClientEventSourceLog().error() << "EventSource url not accepted: " << url;
         }
 
         return eventSource;

--- a/src/web/http/tls/rc/EventSource.h
+++ b/src/web/http/tls/rc/EventSource.h
@@ -42,6 +42,7 @@
 #ifndef WEB_HTTP_TLS_RC_EVENTSOURCE_H
 #define WEB_HTTP_TLS_RC_EVENTSOURCE_H
 
+#include "web/http/client/SemanticLog.h"
 #include "web/http/client/tools/EventSource.h"
 #include "web/http/tls/rc/Client.h"
 
@@ -106,7 +107,7 @@ namespace web::http::tls::rc {
 
             eventSource = EventSource(scheme, net::rc::SocketAddress(addr, chan), path + query);
         } else {
-            LOG(ERROR) << "EventSource RFCOMM url not accepted: " << url;
+            web::http::client::semantic::httpClientEventSourceLog().error() << "EventSource RFCOMM url not accepted: " << url;
         }
 
         return eventSource;

--- a/src/web/http/tls/un/EventSource.h
+++ b/src/web/http/tls/un/EventSource.h
@@ -42,6 +42,7 @@
 #ifndef WEB_HTTP_TLS_UN_EVENTSOURCE_H
 #define WEB_HTTP_TLS_UN_EVENTSOURCE_H
 
+#include "web/http/client/SemanticLog.h"
 #include "web/http/client/tools/EventSource.h"
 #include "web/http/tls/un/Client.h"
 
@@ -132,10 +133,11 @@ namespace web::http::tls::un {
 
                 eventSource = EventSource(scheme, net::un::SocketAddress(socketPath), httpPath + query);
             } else {
-                LOG(ERROR) << "UNIX socket must decode to absolute ('/..') or abstract ('@name'): " << sockToken;
+                web::http::client::semantic::httpClientEventSourceLog().error()
+                    << "UNIX socket must decode to absolute ('/..') or abstract ('@name'): " << sockToken;
             }
         } else {
-            LOG(ERROR) << "EventSource unix-domain url not accepted: " << url;
+            web::http::client::semantic::httpClientEventSourceLog().error() << "EventSource unix-domain url not accepted: " << url;
         }
 
         return eventSource;

--- a/src/web/websocket/Receiver.cpp
+++ b/src/web/websocket/Receiver.cpp
@@ -41,9 +41,11 @@
 
 #include "web/websocket/Receiver.h"
 
+#include "web/websocket/SemanticLog.h"
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 #include "utils/hexdump.h"
 
 #include <endian.h>
@@ -127,7 +129,7 @@ namespace web::websocket {
             } else {
                 parserState = ParserState::ERROR;
                 errorState = 1002;
-                LOG(ERROR) << "WebSocket: Error opcode in continuation frame";
+                semantic::webSocketFrameLog().error() << "WebSocket: Error opcode in continuation frame";
             }
             continuation = !fin;
         }
@@ -281,7 +283,10 @@ namespace web::websocket {
                 }
             }
 
-            LOG(TRACE) << "WebSocket receive: Frame data\n" << utils::hexDump(payloadChunk, payloadChunkLen, 32, true);
+            auto log = semantic::webSocketFrameLog();
+            if (log.enabled(logger::LogLevel::Trace)) {
+                log.trace("WebSocket receive: Frame data\n{}", utils::hexDump(payloadChunk, payloadChunkLen, 32, true));
+            }
 
             onMessageData(payloadChunk, payloadChunkLen);
 

--- a/src/web/websocket/SemanticLog.h
+++ b/src/web/websocket/SemanticLog.h
@@ -1,0 +1,74 @@
+#ifndef WEB_WEBSOCKET_SEMANTICLOG_H
+#define WEB_WEBSOCKET_SEMANTICLOG_H
+
+#include "log/LogScopeOwner.h"
+#include "log/Logger.h"
+
+#include <utility>
+
+namespace web::websocket::semantic {
+
+    inline const logger::LogScopeOwner& webSocketLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.websocket");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& webSocketFrameLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.websocket.frame");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& webSocketSubProtocolLogScope() {
+        static const logger::LogScopeOwner scope(
+            logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.websocket.subprotocol");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& webSocketFactoryLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.websocket.factory");
+        return scope;
+    }
+
+    inline logger::BoundaryLogger webSocketLog() {
+        return webSocketLogScope().logger(logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger webSocketLog(logger::BoundaryLogger::Sink sink,
+                                               logger::LogLevel threshold = logger::LogLevel::Trace,
+                                               logger::BoundaryLogger::Clock clock = {}) {
+        return webSocketLogScope().logger(std::move(sink), threshold, std::move(clock));
+    }
+
+    inline logger::BoundaryLogger webSocketFrameLog() {
+        return webSocketFrameLogScope().logger(logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger webSocketFrameLog(logger::BoundaryLogger::Sink sink,
+                                                    logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                    logger::BoundaryLogger::Clock clock = {}) {
+        return webSocketFrameLogScope().logger(std::move(sink), threshold, std::move(clock));
+    }
+
+    inline logger::BoundaryLogger webSocketSubProtocolLog() {
+        return webSocketSubProtocolLogScope().logger(logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger webSocketSubProtocolLog(logger::BoundaryLogger::Sink sink,
+                                                          logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                          logger::BoundaryLogger::Clock clock = {}) {
+        return webSocketSubProtocolLogScope().logger(std::move(sink), threshold, std::move(clock));
+    }
+
+    inline logger::BoundaryLogger webSocketFactoryLog() {
+        return webSocketFactoryLogScope().logger(logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger webSocketFactoryLog(logger::BoundaryLogger::Sink sink,
+                                                      logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                      logger::BoundaryLogger::Clock clock = {}) {
+        return webSocketFactoryLogScope().logger(std::move(sink), threshold, std::move(clock));
+    }
+
+} // namespace web::websocket::semantic
+
+#endif // WEB_WEBSOCKET_SEMANTICLOG_H

--- a/src/web/websocket/SocketContextUpgrade.hpp
+++ b/src/web/websocket/SocketContextUpgrade.hpp
@@ -40,13 +40,14 @@
  */
 
 #include "core/socket/stream/SocketConnection.h"
+#include "web/websocket/SemanticLog.h"
 #include "web/websocket/SocketContextUpgrade.h"
 
 #include <cstring>
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 #include "utils/hexdump.h"
 
 #include <vector>
@@ -115,8 +116,9 @@ namespace web::websocket {
     template <typename SubProtocol, typename Request, typename Response>
     void SocketContextUpgrade<SubProtocol, Request, Response>::sendClose(const char* message, std::size_t messageLength) {
         if (!closeSent) {
-            LOG(DEBUG) << this->getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
-                       << "' sending close to peer";
+            semantic::webSocketSubProtocolLog().debug()
+                << this->getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
+                << "' sending close to peer";
 
             sendMessage(8, message, messageLength);
 
@@ -186,13 +188,15 @@ namespace web::websocket {
             case SubProtocolContext::OpCode::CLOSE:
                 if (closeSent) { // active close
                     closeSent = false;
-                    LOG(DEBUG) << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
-                               << "' close confirmed from peer";
+                    semantic::webSocketSubProtocolLog().debug()
+                        << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
+                        << "' close confirmed from peer";
 
                     shutdownWrite();
                 } else { // passive close
-                    LOG(DEBUG) << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
-                               << "' close request received - replying with close";
+                    semantic::webSocketSubProtocolLog().debug()
+                        << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
+                        << "' close request received - replying with close";
 
                     sendClose(pongCloseData.data(), pongCloseData.length());
                     pongCloseData.clear();
@@ -219,15 +223,16 @@ namespace web::websocket {
 
     template <typename SubProtocol, typename Request, typename Response>
     void SocketContextUpgrade<SubProtocol, Request, Response>::onConnected() {
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name << "' connect";
+        semantic::webSocketSubProtocolLog().info()
+            << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name << "' connect";
         subProtocol->attach();
     }
 
     template <typename SubProtocol, typename Request, typename Response>
     void SocketContextUpgrade<SubProtocol, Request, Response>::onDisconnected() {
         subProtocol->detach();
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " WebSocketContext:  Subprotocol '" << subProtocol->name
-                  << "' disconnected";
+        semantic::webSocketSubProtocolLog().info()
+            << getSocketConnection()->getConnectionName() << " WebSocketContext:  Subprotocol '" << subProtocol->name << "' disconnected";
     }
 
     template <typename SubProtocol, typename Request, typename Response>

--- a/src/web/websocket/SubProtocol.hpp
+++ b/src/web/websocket/SubProtocol.hpp
@@ -40,12 +40,13 @@
  */
 
 #include "core/socket/stream/SocketConnection.h"
+#include "web/websocket/SemanticLog.h"
 #include "web/websocket/SubProtocol.h"
 #include "web/websocket/SubProtocolContext.h" // IWYU pragma: export
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -69,8 +70,9 @@ namespace web::websocket {
                         sendPing();
                         flyingPings++;
                     } else {
-                        LOG(WARNING) << this->subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '"
-                                     << this->name << "': MaxFlyingPings exceeded - closing";
+                        semantic::webSocketSubProtocolLog().warn()
+                            << this->subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << this->name
+                            << "': MaxFlyingPings exceeded - closing";
 
                         sendClose();
                         stop();
@@ -129,7 +131,8 @@ namespace web::websocket {
 
     template <typename SocketContextUpgrade>
     void SubProtocol<SocketContextUpgrade>::sendPing(const char* reason, std::size_t reasonLength) const {
-        LOG(DEBUG) << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': Ping sent";
+        semantic::webSocketSubProtocolLog().debug()
+            << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': Ping sent";
 
         subProtocolContext->sendPing(reason, reasonLength);
     }
@@ -141,7 +144,8 @@ namespace web::websocket {
 
     template <typename SocketContextUpgrade>
     void SubProtocol<SocketContextUpgrade>::attach() {
-        LOG(DEBUG) << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': start";
+        semantic::webSocketSubProtocolLog().debug()
+            << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': start";
 
         onConnected();
     }
@@ -150,15 +154,17 @@ namespace web::websocket {
     void SubProtocol<SocketContextUpgrade>::detach() {
         onDisconnected();
 
-        LOG(DEBUG) << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': stopped";
+        semantic::webSocketSubProtocolLog().debug()
+            << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': stopped";
 
-        LOG(DEBUG) << "       Total Payload sent: " << getPayloadTotalSent();
-        LOG(DEBUG) << "  Total Payload processed: " << getPayloadTotalRead();
+        semantic::webSocketSubProtocolLog().debug() << "       Total Payload sent: " << getPayloadTotalSent();
+        semantic::webSocketSubProtocolLog().debug() << "  Total Payload processed: " << getPayloadTotalRead();
     }
 
     template <typename SocketContextUpgrade>
     void SubProtocol<SocketContextUpgrade>::onPongReceived() {
-        LOG(DEBUG) << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': Pong received";
+        semantic::webSocketSubProtocolLog().debug()
+            << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': Pong received";
 
         flyingPings = 0;
     }

--- a/src/web/websocket/SubProtocolFactorySelector.hpp
+++ b/src/web/websocket/SubProtocolFactorySelector.hpp
@@ -39,11 +39,12 @@
  * THE SOFTWARE.
  */
 
+#include "web/websocket/SemanticLog.h"
 #include "web/websocket/SubProtocolFactorySelector.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 
 #include <filesystem>
 #include <list>
@@ -67,14 +68,14 @@ namespace web::websocket {
                 subProtocolFactory = getSubProtocolFactory();
                 if (subProtocolFactory != nullptr) {
                     subProtocolFactory->setHandle(handle);
-                    LOG(DEBUG) << "WebSocket: SubProtocolFactory create success: " << subProtocolName;
+                    semantic::webSocketFactoryLog().debug() << "WebSocket: SubProtocolFactory create success: " << subProtocolName;
                 } else {
-                    LOG(DEBUG) << "WebSocket: SubProtocolFactory create failed: " << subProtocolName;
+                    semantic::webSocketFactoryLog().debug() << "WebSocket: SubProtocolFactory create failed: " << subProtocolName;
                     core::DynamicLoader::dlClose(handle);
                 }
             } else {
-                LOG(DEBUG) << "WebSocket: Optaining function \"" << subProtocolFactoryFunctionName
-                           << "\" in plugin failed: " << core::DynamicLoader::dlError();
+                semantic::webSocketFactoryLog().debug() << "WebSocket: Optaining function \"" << subProtocolFactoryFunctionName
+                                                        << "\" in plugin failed: " << core::DynamicLoader::dlError();
                 core::DynamicLoader::dlClose(handle);
             }
         }
@@ -90,19 +91,22 @@ namespace web::websocket {
         if (subProtocolFactories.contains(subProtocolName)) {
             subProtocolFactory = subProtocolFactories[subProtocolName];
 
-            LOG(DEBUG) << "WebSocket subprotocol: plugin '" << subProtocolName << "' selected from dynamic cache";
+            semantic::webSocketFactoryLog().debug()
+                << "WebSocket subprotocol: plugin '" << subProtocolName << "' selected from dynamic cache";
         } else if (linkedSubProtocolFactories.contains(subProtocolName)) {
             SubProtocolFactory* (*plugin)() = linkedSubProtocolFactories[subProtocolName];
             subProtocolFactory = plugin();
 
-            LOG(DEBUG) << "WebSocket subprotocol: plugin '" << subProtocolName << "' selected from static cache";
+            semantic::webSocketFactoryLog().debug()
+                << "WebSocket subprotocol: plugin '" << subProtocolName << "' selected from static cache";
         } else if (!onlyLinked) {
             subProtocolFactory = load(subProtocolName);
             subProtocolFactories.insert({subProtocolName, subProtocolFactory});
 
-            LOG(DEBUG) << "WebSocket subprotocol: plugin '" << subProtocolName << "' loaded and added to dynamic cache";
+            semantic::webSocketFactoryLog().debug()
+                << "WebSocket subprotocol: plugin '" << subProtocolName << "' loaded and added to dynamic cache";
         } else {
-            LOG(WARNING) << "WebSocket subprotocol: plugin '" << subProtocolName << "' not found";
+            semantic::webSocketFactoryLog().warn() << "WebSocket subprotocol: plugin '" << subProtocolName << "' not found";
         }
 
         return subProtocolFactory;

--- a/src/web/websocket/Transmitter.cpp
+++ b/src/web/websocket/Transmitter.cpp
@@ -41,9 +41,11 @@
 
 #include "web/websocket/Transmitter.h"
 
+#include "web/websocket/SemanticLog.h"
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 #include "utils/hexdump.h"
 
 #include <endian.h>
@@ -139,7 +141,10 @@ namespace web::websocket {
         MaskingKey maskingKeyAsArray = {.keyAsValue = distribution(randomDevice)};
 
         if (payloadLength > 0) {
-            LOG(TRACE) << "WebSocket send: Frame data\n" << utils::hexDump(payload, payloadLength, 32, true);
+            auto log = semantic::webSocketFrameLog();
+            if (log.enabled(logger::LogLevel::Trace)) {
+                log.trace("WebSocket send: Frame data\n{}", utils::hexDump(payload, payloadLength, 32, true));
+            }
         }
 
         if (masking) {

--- a/src/web/websocket/client/SubProtocolFactorySelector.cpp
+++ b/src/web/websocket/client/SubProtocolFactorySelector.cpp
@@ -42,13 +42,14 @@
 #include "web/websocket/client/SubProtocolFactorySelector.h"
 
 #include "utils/Config.h"
+#include "web/websocket/SemanticLog.h"
 #include "web/websocket/SubProtocolFactory.h"
 #include "web/websocket/SubProtocolFactorySelector.hpp"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #if !defined(NDEBUG)
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 
 #include <cstdlib>
 #endif
@@ -80,7 +81,7 @@ namespace web::websocket::client {
 
 #if !defined(NDEBUG)
         if (const char* websocketSubprotocolInstallLibdirEnv = std::getenv("WEBSOCKET_SUBPROTOCOL_INSTALL_LIBDIR")) {
-            LOG(WARNING) << "WebSocket: Overriding websocket subprotocol library dir";
+            semantic::webSocketFactoryLog().warn() << "WebSocket: Overriding websocket subprotocol library dir";
             websocketSubprotocolInstallLibdir = std::string(websocketSubprotocolInstallLibdirEnv);
         }
 #endif

--- a/src/web/websocket/server/SubProtocolFactorySelector.cpp
+++ b/src/web/websocket/server/SubProtocolFactorySelector.cpp
@@ -42,13 +42,14 @@
 #include "web/websocket/server/SubProtocolFactorySelector.h"
 
 #include "utils/Config.h"
+#include "web/websocket/SemanticLog.h"
 #include "web/websocket/SubProtocolFactory.h"
 #include "web/websocket/SubProtocolFactorySelector.hpp"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #if !defined(NDEBUG)
-#include "log/Logger.h"
+#include "log/SemanticLogger.h"
 
 #include <cstdlib>
 #endif
@@ -80,7 +81,7 @@ namespace web::websocket::server {
 
 #if !defined(NDEBUG)
         if (const char* websocketSubprotocolInstallLibdirEnv = std::getenv("WEBSOCKET_SUBPROTOCOL_INSTALL_LIBDIR")) {
-            LOG(WARNING) << "WebSocket: Overriding websocket subprotocol library dir";
+            semantic::webSocketFactoryLog().warn() << "WebSocket: Overriding websocket subprotocol library dir";
             websocketSubprotocolInstallLibdir = std::string(websocketSubprotocolInstallLibdirEnv);
         }
 #endif

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -94,3 +94,9 @@ target_include_directories(HttpServerMigration07bTest PRIVATE ${PROJECT_SOURCE_D
 target_compile_features(HttpServerMigration07bTest PRIVATE cxx_std_20)
 target_link_libraries(HttpServerMigration07bTest PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(HttpServerMigration07bTest PROPERTIES LABELS "unit;log;migration07b")
+
+snodec_add_test(WebSocketMigration07cTest WebSocketMigration07cTest.cpp)
+target_include_directories(WebSocketMigration07cTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(WebSocketMigration07cTest PRIVATE cxx_std_20)
+target_link_libraries(WebSocketMigration07cTest PRIVATE snodec-test-support snodec::logger)
+set_tests_properties(WebSocketMigration07cTest PROPERTIES LABELS "unit;log;migration07c")

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -88,3 +88,9 @@ target_include_directories(HttpClientMigration07aTest PRIVATE ${PROJECT_SOURCE_D
 target_compile_features(HttpClientMigration07aTest PRIVATE cxx_std_20)
 target_link_libraries(HttpClientMigration07aTest PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(HttpClientMigration07aTest PROPERTIES LABELS "unit;log;migration07a")
+
+snodec_add_test(HttpServerMigration07bTest HttpServerMigration07bTest.cpp)
+target_include_directories(HttpServerMigration07bTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(HttpServerMigration07bTest PRIVATE cxx_std_20)
+target_link_libraries(HttpServerMigration07bTest PRIVATE snodec-test-support snodec::logger)
+set_tests_properties(HttpServerMigration07bTest PROPERTIES LABELS "unit;log;migration07b")

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -82,3 +82,9 @@ target_include_directories(TlsSocketStreamMigration06Test PRIVATE ${PROJECT_SOUR
 target_compile_features(TlsSocketStreamMigration06Test PRIVATE cxx_std_20)
 target_link_libraries(TlsSocketStreamMigration06Test PRIVATE snodec-test-support snodec::core-socket-stream-tls)
 set_tests_properties(TlsSocketStreamMigration06Test PROPERTIES LABELS "unit;log;migration06")
+
+snodec_add_test(HttpClientMigration07aTest HttpClientMigration07aTest.cpp)
+target_include_directories(HttpClientMigration07aTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(HttpClientMigration07aTest PRIVATE cxx_std_20)
+target_link_libraries(HttpClientMigration07aTest PRIVATE snodec-test-support snodec::logger)
+set_tests_properties(HttpClientMigration07aTest PROPERTIES LABELS "unit;log;migration07a")

--- a/tests/unit/log/HttpClientMigration07aTest.cpp
+++ b/tests/unit/log/HttpClientMigration07aTest.cpp
@@ -1,0 +1,170 @@
+#include "log/Logger.h"
+#include "tests/support/TestResult.h"
+#include "web/http/client/SemanticLog.h"
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+    struct ExpensiveValue {
+        int* evaluations;
+    };
+
+    std::ostream& operator<<(std::ostream& out, const ExpensiveValue& value) {
+        ++*value.evaluations;
+        return out << "expensive";
+    }
+
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() {
+                return std::string("MIGRATION07ATICK");
+            });
+            logger::Logger::logToFile(logFile);
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto enabledPath = tempLogPath("snodec-migration07a-enabled.log");
+    {
+        LoggerStateGuard guard(enabledPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        web::http::client::semantic::httpClientLog().debug("http client semantic logger emitted");
+    }
+    const auto enabledLog = readFile(enabledPath);
+    result.expectTrue(enabledLog.find("http client semantic logger emitted") != std::string::npos,
+                      "HTTP client semantic logger emits when enabled");
+    result.expectTrue(enabledLog.find(" framework connection web.http.client ") != std::string::npos,
+                      "records carry framework web.http.client component scope");
+
+    const auto managerFilterPath = tempLogPath("snodec-migration07a-manager-filter.log");
+    {
+        LoggerStateGuard guard(managerFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        web::http::client::semantic::httpClientLog().debug("http client suppressed by manager");
+    }
+    result.expectTrue(readFile(managerFilterPath).find("suppressed by manager") == std::string::npos,
+                      "LogManager filtering suppresses migrated HTTP client semantic calls");
+
+    const auto backendFilterPath = tempLogPath("snodec-migration07a-backend-filter.log");
+    {
+        LoggerStateGuard guard(backendFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        logger::Logger::setLogLevel(3);
+        web::http::client::semantic::httpClientLog().debug("http client suppressed by backend");
+    }
+    result.expectTrue(readFile(backendFilterPath).find("suppressed by backend") == std::string::npos,
+                      "Logger::setLogLevel backend filtering suppresses output");
+
+    const auto jsonPath = tempLogPath("snodec-migration07a-json.log");
+    {
+        LoggerStateGuard guard(jsonPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        web::http::client::semantic::httpClientUpgradeLog().debug("http client upgrade json format respected");
+    }
+    const auto jsonLog = readFile(jsonPath);
+    result.expectTrue(jsonLog.find("{\"v\":1") != std::string::npos &&
+                          jsonLog.find("\"message\":\"http client upgrade json format respected\"") != std::string::npos &&
+                          jsonLog.find("\"origin\":\"framework\"") != std::string::npos &&
+                          jsonLog.find("\"component\":\"web.http.client.upgrade\"") != std::string::npos,
+                      "JSON format selection is respected");
+
+    std::vector<logger::LogRecord> sysErrorRecords;
+    web::http::client::semantic::httpClientLog([&](logger::LogRecord record) {
+        sysErrorRecords.push_back(std::move(record));
+    }).sysError(logger::LogLevel::Error, ENOENT, "{} HTTP: file open failed", "conn-07a");
+    result.expectTrue(sysErrorRecords.size() == 1 && sysErrorRecords[0].error && sysErrorRecords[0].error->code == ENOENT &&
+                          sysErrorRecords[0].error->text.find("No such file") != std::string::npos,
+                      "sysError errno code/text is preserved by HTTP client helper");
+
+    std::vector<logger::LogRecord> sinkRecords;
+    web::http::client::semantic::httpClientEventSourceLog([&](logger::LogRecord record) {
+        sinkRecords.push_back(std::move(record));
+    }).error("EventSource url not accepted: {}", "http+bad://example.invalid/sse");
+    result.expectTrue(sinkRecords.size() == 1 && sinkRecords[0].component == "web.http.client.eventsource" &&
+                          sinkRecords[0].message.find("EventSource url not accepted") != std::string::npos,
+                      "sink-taking overload remains compatible and EventSource payload is preserved");
+
+    const auto suppressedPath = tempLogPath("snodec-migration07a-suppressed.log");
+    {
+        LoggerStateGuard guard(suppressedPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        int evaluations = 0;
+        web::http::client::semantic::httpClientLog().debug("{}", ExpensiveValue{&evaluations});
+        result.expectEqual(0, evaluations, "suppressed production formatting does not evaluate ExpensiveValue after PR #151");
+    }
+
+    std::vector<logger::LogRecord> requestRecords;
+    web::http::client::semantic::httpClientLog([&](logger::LogRecord record) {
+        requestRecords.push_back(std::move(record));
+    }).info("{} HTTP: Request ({}) accepted: {} {} HTTP/{}.{}", "conn-07a", 7, "GET", "/resource", 1, 1);
+    result.expectTrue(requestRecords.size() == 1 && requestRecords[0].message.find(
+                                                        "conn-07a HTTP: Request (7) accepted: GET /resource HTTP/1.1") != std::string::npos,
+                      "representative HTTP request payload preservation is covered");
+
+    std::vector<logger::LogRecord> responseRecords;
+    web::http::client::semantic::httpClientLog([&](logger::LogRecord record) {
+        responseRecords.push_back(std::move(record));
+    }).info("{}   HTTP/{}.{} {} {}", "conn-07a", 1, 1, "200", "OK");
+    result.expectTrue(responseRecords.size() == 1 && responseRecords[0].message.find("conn-07a   HTTP/1.1 200 OK") != std::string::npos,
+                      "representative HTTP response payload preservation is covered");
+
+    std::vector<logger::LogRecord> upgradeRecords;
+    web::http::client::semantic::httpClientUpgradeLog([&](logger::LogRecord record) {
+        upgradeRecords.push_back(std::move(record));
+    })
+        .debug("{} HTTP upgrade: bootstrap {}; Protocol selected: {}; requested: {}; Subprotocol selected: {}; requested: {}",
+               "conn-07a",
+               "success",
+               "websocket",
+               "websocket",
+               "chat",
+               "chat");
+    result.expectTrue(upgradeRecords.size() == 1 && upgradeRecords[0].component == "web.http.client.upgrade" &&
+                          upgradeRecords[0].message.find("Protocol selected: websocket") != std::string::npos,
+                      "representative HTTP upgrade payload preservation is covered");
+
+    return result.processResult();
+}

--- a/tests/unit/log/HttpServerMigration07bTest.cpp
+++ b/tests/unit/log/HttpServerMigration07bTest.cpp
@@ -1,0 +1,195 @@
+#include "log/Logger.h"
+#include "tests/support/TestResult.h"
+#include "web/http/server/SemanticLog.h"
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+    struct ExpensiveValue {
+        int* evaluations;
+    };
+
+    std::ostream& operator<<(std::ostream& out, const ExpensiveValue& value) {
+        ++*value.evaluations;
+        return out << "expensive";
+    }
+
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() {
+                return std::string("MIGRATION07BTICK");
+            });
+            logger::Logger::logToFile(logFile);
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto enabledPath = tempLogPath("snodec-migration07b-enabled.log");
+    {
+        LoggerStateGuard guard(enabledPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        web::http::server::semantic::httpServerLog().debug("http server semantic logger emitted");
+    }
+    const auto enabledLog = readFile(enabledPath);
+    result.expectTrue(enabledLog.find("http server semantic logger emitted") != std::string::npos,
+                      "HTTP server semantic logger emits when enabled");
+    result.expectTrue(enabledLog.find(" framework connection web.http.server ") != std::string::npos,
+                      "records carry framework web.http.server component scope");
+
+    const auto managerFilterPath = tempLogPath("snodec-migration07b-manager-filter.log");
+    {
+        LoggerStateGuard guard(managerFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        web::http::server::semantic::httpServerLog().debug("http server suppressed by manager");
+    }
+    result.expectTrue(readFile(managerFilterPath).find("suppressed by manager") == std::string::npos,
+                      "LogManager filtering suppresses migrated HTTP server semantic calls");
+
+    const auto backendFilterPath = tempLogPath("snodec-migration07b-backend-filter.log");
+    {
+        LoggerStateGuard guard(backendFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        logger::Logger::setLogLevel(3);
+        web::http::server::semantic::httpServerLog().debug("http server suppressed by backend");
+    }
+    result.expectTrue(readFile(backendFilterPath).find("suppressed by backend") == std::string::npos,
+                      "Logger::setLogLevel backend filtering suppresses output");
+
+    const auto jsonPath = tempLogPath("snodec-migration07b-json.log");
+    {
+        LoggerStateGuard guard(jsonPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        web::http::server::semantic::httpServerUpgradeLog().debug("http server upgrade json format respected");
+    }
+    const auto jsonLog = readFile(jsonPath);
+    result.expectTrue(jsonLog.find("{\"v\":1") != std::string::npos &&
+                          jsonLog.find("\"message\":\"http server upgrade json format respected\"") != std::string::npos &&
+                          jsonLog.find("\"origin\":\"framework\"") != std::string::npos &&
+                          jsonLog.find("\"component\":\"web.http.server.upgrade\"") != std::string::npos,
+                      "JSON format selection is respected");
+
+    std::vector<logger::LogRecord> sysErrorRecords;
+    web::http::server::semantic::httpServerLog([&](logger::LogRecord record) {
+        sysErrorRecords.push_back(std::move(record));
+    }).sysError(logger::LogLevel::Error, EPIPE, "{} HTTP: response write failed", "server-conn-07b");
+    result.expectTrue(sysErrorRecords.size() == 1 && sysErrorRecords[0].error && sysErrorRecords[0].error->code == EPIPE &&
+                          sysErrorRecords[0].error->text.find("Broken pipe") != std::string::npos,
+                      "sysError errno code/text is preserved by HTTP server helper");
+
+    std::vector<logger::LogRecord> sinkRecords;
+    web::http::server::semantic::httpServerUpgradeLog([&](logger::LogRecord record) {
+        sinkRecords.push_back(std::move(record));
+    }).warn("HTTP upgrade: Overriding http upgrade library dir");
+    result.expectTrue(sinkRecords.size() == 1 && sinkRecords[0].component == "web.http.server.upgrade" &&
+                          sinkRecords[0].message == "HTTP upgrade: Overriding http upgrade library dir",
+                      "sink-taking overload remains compatible");
+
+    const auto suppressedPath = tempLogPath("snodec-migration07b-suppressed.log");
+    {
+        LoggerStateGuard guard(suppressedPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        int evaluations = 0;
+        web::http::server::semantic::httpServerLog().debug("{}", ExpensiveValue{&evaluations});
+        result.expectEqual(0, evaluations, "suppressed production formatting does not evaluate ExpensiveValue after PR #151");
+    }
+
+    std::vector<logger::LogRecord> requestRecords;
+    web::http::server::semantic::httpServerLog([&](logger::LogRecord record) {
+        requestRecords.push_back(std::move(record));
+    }).info("{} HTTP: Request parse success: {} {} HTTP/{}.{}", "server-conn-07b", "GET", "/resource", 1, 1);
+    result.expectTrue(requestRecords.size() == 1 &&
+                          requestRecords[0].message.find("server-conn-07b HTTP: Request parse success: GET /resource HTTP/1.1") !=
+                              std::string::npos,
+                      "representative HTTP request parse-success payload preservation is covered");
+
+    std::vector<logger::LogRecord> responseRecords;
+    web::http::server::semantic::httpServerLog([&](logger::LogRecord record) {
+        responseRecords.push_back(std::move(record));
+    })
+        .info("{} HTTP: Response completed for request: {} {} HTTP/{}.{}; HTTP/{}.{} {} {}",
+              "server-conn-07b",
+              "GET",
+              "/resource",
+              1,
+              1,
+              1,
+              1,
+              200,
+              "OK");
+    result.expectTrue(responseRecords.size() == 1 && responseRecords[0].message.find("HTTP/1.1 200 OK") != std::string::npos,
+                      "representative HTTP response payload preservation is covered");
+
+    std::vector<logger::LogRecord> upgradeRecords;
+    web::http::server::semantic::httpServerUpgradeLog([&](logger::LogRecord record) {
+        upgradeRecords.push_back(std::move(record));
+    })
+        .debug("{} HTTP: Upgrade bootstrap {}; Protocol selected: {}; requested: {}; Subprotocol selected: {}; requested: {}",
+               "server-conn-07b",
+               "success",
+               "websocket",
+               "websocket",
+               "chat",
+               "chat");
+    result.expectTrue(upgradeRecords.size() == 1 && upgradeRecords[0].component == "web.http.server.upgrade" &&
+                          upgradeRecords[0].message.find("Protocol selected: websocket") != std::string::npos,
+                      "representative HTTP server-upgrade payload preservation is covered");
+
+    std::vector<logger::LogRecord> errorRecords;
+    web::http::server::semantic::httpServerLog([&](logger::LogRecord record) {
+        errorRecords.push_back(std::move(record));
+    })
+        .error("{} HTTP: Request parse error: {} ({}) / HTTP upgrade: Request has gone away / HTTP upgrade: Unexpected disconnect",
+               "server-conn-07b",
+               "Bad Request",
+               400);
+    result.expectTrue(errorRecords.size() == 1 &&
+                          errorRecords[0].message.find("Request parse error: Bad Request (400)") != std::string::npos &&
+                          errorRecords[0].message.find("Request has gone away") != std::string::npos &&
+                          errorRecords[0].message.find("Unexpected disconnect") != std::string::npos,
+                      "representative parse-error/gone-away/unexpected-disconnect payload preservation is covered");
+
+    return result.processResult();
+}

--- a/tests/unit/log/WebSocketMigration07cTest.cpp
+++ b/tests/unit/log/WebSocketMigration07cTest.cpp
@@ -1,0 +1,200 @@
+#include "log/Logger.h"
+#include "tests/support/TestResult.h"
+#include "web/websocket/SemanticLog.h"
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+    struct ExpensiveValue {
+        int* evaluations;
+    };
+
+    std::ostream& operator<<(std::ostream& out, const ExpensiveValue& value) {
+        ++*value.evaluations;
+        return out << "expensive";
+    }
+
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() {
+                return std::string("MIGRATION07CTICK");
+            });
+            logger::Logger::logToFile(logFile);
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto enabledPath = tempLogPath("snodec-migration07c-enabled.log");
+    {
+        LoggerStateGuard guard(enabledPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        web::websocket::semantic::webSocketLog().debug("websocket semantic logger emitted");
+    }
+    const auto enabledLog = readFile(enabledPath);
+    result.expectTrue(enabledLog.find("websocket semantic logger emitted") != std::string::npos,
+                      "WebSocket semantic logger emits when enabled");
+    result.expectTrue(enabledLog.find(" framework connection web.websocket ") != std::string::npos,
+                      "records carry framework web.websocket component scope");
+
+    const auto managerFilterPath = tempLogPath("snodec-migration07c-manager-filter.log");
+    {
+        LoggerStateGuard guard(managerFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        web::websocket::semantic::webSocketLog().debug("websocket suppressed by manager");
+    }
+    result.expectTrue(readFile(managerFilterPath).find("suppressed by manager") == std::string::npos,
+                      "LogManager filtering suppresses migrated WebSocket semantic calls");
+
+    const auto backendFilterPath = tempLogPath("snodec-migration07c-backend-filter.log");
+    {
+        LoggerStateGuard guard(backendFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        logger::Logger::setLogLevel(3);
+        web::websocket::semantic::webSocketLog().debug("websocket suppressed by backend");
+    }
+    result.expectTrue(readFile(backendFilterPath).find("suppressed by backend") == std::string::npos,
+                      "Logger::setLogLevel backend filtering suppresses output");
+
+    const auto jsonPath = tempLogPath("snodec-migration07c-json.log");
+    {
+        LoggerStateGuard guard(jsonPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        web::websocket::semantic::webSocketFrameLog().debug("websocket frame json format respected");
+    }
+    const auto jsonLog = readFile(jsonPath);
+    result.expectTrue(jsonLog.find("{\"v\":1") != std::string::npos &&
+                          jsonLog.find("\"message\":\"websocket frame json format respected\"") != std::string::npos &&
+                          jsonLog.find("\"origin\":\"framework\"") != std::string::npos &&
+                          jsonLog.find("\"component\":\"web.websocket.frame\"") != std::string::npos,
+                      "JSON format selection is respected");
+
+    std::vector<logger::LogRecord> sysErrorRecords;
+    web::websocket::semantic::webSocketLog([&](logger::LogRecord record) {
+        sysErrorRecords.push_back(std::move(record));
+    }).sysError(logger::LogLevel::Error, EPIPE, "{} WebSocket: frame write failed", "ws-conn-07c");
+    result.expectTrue(sysErrorRecords.size() == 1 && sysErrorRecords[0].error && sysErrorRecords[0].error->code == EPIPE &&
+                          sysErrorRecords[0].error->text.find("Broken pipe") != std::string::npos,
+                      "sysError errno code/text is preserved by WebSocket helper");
+
+    std::vector<logger::LogRecord> sinkRecords;
+    web::websocket::semantic::webSocketFactoryLog([&](logger::LogRecord record) {
+        sinkRecords.push_back(std::move(record));
+    }).warn("WebSocket: Overriding websocket subprotocol library dir");
+    result.expectTrue(sinkRecords.size() == 1 && sinkRecords[0].component == "web.websocket.factory" &&
+                          sinkRecords[0].message == "WebSocket: Overriding websocket subprotocol library dir",
+                      "sink-taking overload remains compatible");
+
+    const auto suppressedPath = tempLogPath("snodec-migration07c-suppressed.log");
+    {
+        LoggerStateGuard guard(suppressedPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        int evaluations = 0;
+        web::websocket::semantic::webSocketLog().debug("{}", ExpensiveValue{&evaluations});
+        result.expectEqual(0, evaluations, "suppressed production formatting does not evaluate ExpensiveValue after PR #151");
+    }
+
+    std::vector<logger::LogRecord> subProtocolRecords;
+    web::websocket::semantic::webSocketSubProtocolLog([&](logger::LogRecord record) {
+        subProtocolRecords.push_back(std::move(record));
+    }).info("{} WebSocketContext: Subprotocol '{}' connect / disconnected", "ws-conn-07c", "chat");
+    result.expectTrue(subProtocolRecords.size() == 1 && subProtocolRecords[0].component == "web.websocket.subprotocol" &&
+                          subProtocolRecords[0].message.find("ws-conn-07c WebSocketContext: Subprotocol 'chat' connect") !=
+                              std::string::npos &&
+                          subProtocolRecords[0].message.find("disconnected") != std::string::npos,
+                      "representative subprotocol connect/disconnect payload preservation is covered");
+
+    std::vector<logger::LogRecord> frameRecords;
+    web::websocket::semantic::webSocketFrameLog([&](logger::LogRecord record) {
+        frameRecords.push_back(std::move(record));
+    }).trace("WebSocket receive: Frame data\n{} opcode={} payloadLength={} chunkLength={}", "00 01 02", 2, 3, 3);
+    result.expectTrue(frameRecords.size() == 1 && frameRecords[0].message.find("Frame data") != std::string::npos &&
+                          frameRecords[0].message.find("opcode=2") != std::string::npos &&
+                          frameRecords[0].message.find("payloadLength=3") != std::string::npos,
+                      "representative receiver/transmitter frame payload preservation is covered");
+
+    std::vector<logger::LogRecord> factoryRecords;
+    web::websocket::semantic::webSocketFactoryLog([&](logger::LogRecord record) {
+        factoryRecords.push_back(std::move(record));
+    })
+        .debug("WebSocket subprotocol: plugin '{}' selected from dynamic cache; factory function {}; loaded and added to dynamic cache",
+               "chat",
+               "chatServerSubProtocolFactory");
+    result.expectTrue(factoryRecords.size() == 1 && factoryRecords[0].message.find("plugin 'chat'") != std::string::npos &&
+                          factoryRecords[0].message.find("dynamic cache") != std::string::npos &&
+                          factoryRecords[0].message.find("chatServerSubProtocolFactory") != std::string::npos,
+                      "representative plugin/factory/cache payload preservation is covered");
+
+    std::vector<logger::LogRecord> lifecycleRecords;
+    web::websocket::semantic::webSocketSubProtocolLog([&](logger::LogRecord record) {
+        lifecycleRecords.push_back(std::move(record));
+    })
+        .debug("{} Subprotocol '{}': Ping sent / Pong received / start / stopped; Total Payload sent: {}; Total Payload processed: {}",
+               "ws-conn-07c",
+               "chat",
+               42,
+               41);
+    result.expectTrue(lifecycleRecords.size() == 1 && lifecycleRecords[0].message.find("Ping sent") != std::string::npos &&
+                          lifecycleRecords[0].message.find("Pong received") != std::string::npos &&
+                          lifecycleRecords[0].message.find("Total Payload sent: 42") != std::string::npos &&
+                          lifecycleRecords[0].message.find("Total Payload processed: 41") != std::string::npos,
+                      "representative ping/pong/start/stop/payload-total payload preservation is covered");
+
+    logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+    logger::LogManager::freeze();
+    int hexDumpEvaluations = 0;
+    auto frameLog = web::websocket::semantic::webSocketFrameLog(
+        [&](logger::LogRecord) {
+            ++hexDumpEvaluations;
+        },
+        logger::LogLevel::Error);
+    if (frameLog.enabled(logger::LogLevel::Trace)) {
+        ++hexDumpEvaluations;
+        frameLog.trace("WebSocket receive: Frame data\n{}", "expensive hex dump");
+    }
+    result.expectEqual(0, hexDumpEvaluations, "hex dump guard avoids evaluation when trace is disabled");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation

- Migrate production HTTP client logging in `src/web/http/client` and client-adjacent EventSource URL validation helpers to the semantic `BoundaryLogger` API while preserving existing payloads and identities. 
- Prefer existing semantic owners where available (use `SocketContext::frameworkLog()` for socket-context lifecycle) and provide small file-local semantic helpers where no safe owner exists. 
- Keep logging infrastructure, macro definitions, and other subsystem code unchanged and follow the Migration 7 ownership/severity mapping policy.

### Description

- Added `src/web/http/client/SemanticLog.h` which defines semantic `LogScopeOwner` helpers and sink-taking overloads for `web.http.client`, `web.http.client.upgrade`, and `web.http.client.eventsource`.
- Replaced production `LOG(...)` sites in `src/web/http/client/Request.cpp` with `web::http::client::semantic::httpClientLog()` calls and preserved all request/response/upgrade payload fields and formatting.
- Replaced production `LOG(...)` sites in `src/web/http/client/SocketContext.cpp` with the existing `frameworkLog()` owner (`frameworkLog().debug()/info()/warn()/error()`), preserving connection name, request count, request line, response status/reason, flags, and lifecycle details.
- Migrated the upgrade-selector warning in `src/web/http/client/SocketContextUpgradeFactorySelector.cpp` to `httpClientUpgradeLog()` and EventSource lifecycle/logging in `src/web/http/client/tools/EventSource.h` to `httpClientLog()` traces/debugs.
- Migrated EventSource URL validation `LOG(ERROR)` call sites in the allowed legacy/tls headers (all listed EventSource headers) to `web::http::client::semantic::httpClientEventSourceLog().error()` preserving URL/scheme/sockToken wording.
- Added the required report `docs/logging/semantic-migration-07a-http-client-report.md` documenting inventory, ownership, migrated/ deferred sites, severity mapping, and follow-ups.
- Added `tests/unit/log/HttpClientMigration07aTest.cpp` and registered it in `tests/unit/log/CMakeLists.txt` to cover emitted records, component scope, manager/backend filtering, JSON format, `sysError` errno preservation, sink-taking overloads, suppressed formatting (ExpensiveValue), and representative request/response/upgrade/EventSource payloads.

### Testing

- Built and ran the focused migration test targets: ran `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`, built `HttpClientMigration07aTest` and `http-client`, and executed the focused test set via `ctest` that includes the migration tests listed in the project test selector.
- All focused logging/migration tests passed, and the new `HttpClientMigration07aTest` passed in both normal and ASan-focused builds; the recorded ASan check ran `cmake -S . -B cmake-build-asan -DSNODEC_ENABLE_ASAN=ON`, built the ASan target and `LD_PRELOAD=$ASAN` run of `HttpClientMigration07aTest` passed.
- A broader full build was started and progressed through HTTP client and application targets during validation; the focused migration tests completed successfully in the environment used for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bee1fd038832ca485875b3038ecbe)