### PR TITLE
Semantic logging migration 08 — MQTT

### DIFF
--- a/docs/logging/semantic-migration-08-mqtt-report.md
+++ b/docs/logging/semantic-migration-08-mqtt-report.md
@@ -137,7 +137,7 @@ The WebSocket subprotocol call sites inside `src/iot/mqtt/SubProtocol.hpp` were 
 
 ## Expensive payload / dump guard notes
 
-Hex-dump and serialized-packet payloads that call `toHexString(...)` or `serializeVP()` are guarded with `enabled(...)` checks before constructing expensive strings. Retained-message and subscription-message dumps are guarded at the corresponding info/debug levels. `MqttMigration08Test` includes an explicit disabled expensive-dump guard assertion.
+Hex-dump and serialized-packet payloads that call `toHexString(...)` or `serializeVP()` are guarded with `enabled(...)` checks before constructing expensive strings. Retained-message and subscription-message dumps are guarded at the corresponding info/debug levels. The MQTT-over-WebSocket `WsMqtt: Frame Data` dump in `src/iot/mqtt/SubProtocol.hpp` is guarded at `Debug` before constructing `std::vector<char>`, calling `utils::hexDump(...)`, or building the padded string. `MqttMigration08Test` includes explicit disabled expensive-dump guard assertions, including a WebSocket frame-dump guard simulation.
 
 ## Post-migration inventory command/result
 

--- a/docs/logging/semantic-migration-08-mqtt-report.md
+++ b/docs/logging/semantic-migration-08-mqtt-report.md
@@ -1,0 +1,216 @@
+# Semantic logging migration 08 — MQTT
+
+## Implementation summary
+
+This is the complete Migration 8 in one PR. It is a production migration, not inventory-only, and it modifies production MQTT logging under `src/iot/mqtt`. The branch was prepared from the current repository tip that contains merge commit `9b052c8` for PR #161, so Migration 7a HTTP client, Migration 7b HTTP server/upgrade, and Migration 7c WebSocket are already merged. This PR does not duplicate previous migrations and does not split Migration 8.
+
+## Exact changed files
+
+- `docs/logging/semantic-migration-08-mqtt-report.md`
+- `src/iot/mqtt/SemanticLog.h`
+- `src/iot/mqtt/Mqtt.cpp`
+- `src/iot/mqtt/SubProtocol.hpp`
+- `src/iot/mqtt/client/Mqtt.cpp`
+- `src/iot/mqtt/server/Mqtt.cpp`
+- `src/iot/mqtt/server/broker/Broker.cpp`
+- `src/iot/mqtt/server/broker/RetainTree.cpp`
+- `src/iot/mqtt/server/broker/Session.cpp`
+- `src/iot/mqtt/server/broker/SubscriptionTree.cpp`
+- `tests/unit/log/CMakeLists.txt`
+- `tests/unit/log/MqttMigration08Test.cpp`
+
+## Focused MQTT inventory command/result
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" src/iot/mqtt -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Focused inventory result before migration: 181 call sites.
+
+Complete focused inventory by file:
+
+| File | Count |
+| --- | ---: |
+| `src/iot/mqtt/Mqtt.cpp` | 46 |
+| `src/iot/mqtt/client/Mqtt.cpp` | 19 |
+| `src/iot/mqtt/server/Mqtt.cpp` | 35 |
+| `src/iot/mqtt/server/broker/Broker.cpp` | 11 |
+| `src/iot/mqtt/server/broker/RetainTree.cpp` | 23 |
+| `src/iot/mqtt/server/broker/Session.cpp` | 9 |
+| `src/iot/mqtt/server/broker/SubscriptionTree.cpp` | 30 |
+| `src/iot/mqtt/SubProtocol.hpp` | 8 |
+
+## Focused inventory classification table
+
+| Class | Scope | Files / representative payloads | Count |
+| --- | --- | --- | ---: |
+| A | MQTT core / MqttContext / SocketContext lifecycle | `Mqtt.cpp`: connected, disconnected, keep-alive, packet availability and parse errors | 12 |
+| B | MQTT client lifecycle and control-packet flow | `client/Mqtt.cpp`: session store, CONNACK, SUBACK/UNSUBACK, CONNECT/SUBSCRIBE/UNSUBSCRIBE | 19 |
+| C | MQTT server lifecycle and control-packet flow | `server/Mqtt.cpp`: session selection, CONNECT protocol fields, SUBSCRIBE/UNSUBSCRIBE packet ids/topics | 35 |
+| D | MQTT broker/session/subscription/retained-message flow | `server/broker/*.cpp`: session store, retained releases, subscriptions, publish distribution | 73 |
+| E | MQTT packet parsing/serialization/fixed-header diagnostics | `Mqtt.cpp`: send/receive packet names, fixed header, variable header/payload dumps | 19 |
+| F | MQTT topic/filter/matching diagnostics | `SubscriptionTree.cpp`, `RetainTree.cpp`: topic filters, wildcard placement, matches | 15 |
+| G | MQTT-over-WebSocket subprotocol logging inside `src/iot/mqtt` | `SubProtocol.hpp`: connect, opcode, frame data, message end/error, signal exit | 8 |
+| H | PLOG / errno-sensitive call sites | `client/Mqtt.cpp`, `server/broker/Broker.cpp` session-store read/write failures | 4 |
+| I | VLOG / verbose diagnostics | None found in focused inventory | 0 |
+| J | Deferred/unclear call sites | None | 0 |
+
+## Ownership discovery summary
+
+Command:
+
+```sh
+rg -n "\blog\(\)|logger::|BoundaryLogger|LogScopeOwner|semantic|scope|getInstanceName|getConnectionName|Mqtt|MQTT|Session|SocketContext|SubProtocol|Broker|Topic|ControlPacket|FixedHeader" src/iot/mqtt -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+The MQTT classes carry useful payload identity such as `connectionName`, `clientId`, session identifiers, packet identifiers, topics, filters, packet types, and WebSocket subprotocol names, but they did not expose existing semantic owners. To avoid broad constructor/API churn, Migration 8 adds a single MQTT-local helper header, `src/iot/mqtt/SemanticLog.h`, with framework/connection scoped helpers for `iot.mqtt`, `iot.mqtt.client`, `iot.mqtt.server`, `iot.mqtt.broker`, `iot.mqtt.session`, `iot.mqtt.packet`, `iot.mqtt.topic`, and `iot.mqtt.websocket`.
+
+The user-requested extended general review covered SNode.C migration boundaries and mqttsuite references: no external mqttsuite repository is present in this checkout, and no external mqttsuite files were changed.
+
+## Migrated call-site table
+
+| Area | Files | Migrated call sites | Semantic helper |
+| --- | --- | ---: | --- |
+| MQTT core/packet flow | `src/iot/mqtt/Mqtt.cpp` | 46 | `mqttLog()` |
+| MQTT client | `src/iot/mqtt/client/Mqtt.cpp` | 19 | `mqttClientLog()` |
+| MQTT server | `src/iot/mqtt/server/Mqtt.cpp` | 35 | `mqttServerLog()` |
+| Broker persistence and publish | `src/iot/mqtt/server/broker/Broker.cpp` | 11 | `mqttBrokerLog()` |
+| Retained messages | `src/iot/mqtt/server/broker/RetainTree.cpp` | 23 | `mqttBrokerLog()` |
+| Broker session delivery | `src/iot/mqtt/server/broker/Session.cpp` | 9 | `mqttSessionLog()` |
+| Subscription tree | `src/iot/mqtt/server/broker/SubscriptionTree.cpp` | 30 | `mqttBrokerLog()` |
+| MQTT-over-WebSocket | `src/iot/mqtt/SubProtocol.hpp` | 8 | `mqttWebSocketLog()` |
+| Total |  | 181 |  |
+
+## Deferred call-site table
+
+No focused MQTT call sites were deferred. No VLOG call sites were present.
+
+## Semantic owner/helper used
+
+`src/iot/mqtt/SemanticLog.h` is the single MQTT-local semantic helper. It uses `logger::LogOrigin::Framework` and `logger::LogBoundary::Connection` with component names:
+
+- `iot.mqtt`
+- `iot.mqtt.client`
+- `iot.mqtt.server`
+- `iot.mqtt.broker`
+- `iot.mqtt.session`
+- `iot.mqtt.packet`
+- `iot.mqtt.topic`
+- `iot.mqtt.websocket`
+
+Each helper has a production sink overload and a sink-taking overload for tests and compatibility.
+
+## Severity mapping
+
+- `LOG(TRACE)` -> `trace()`
+- `LOG(DEBUG)` -> `debug()`
+- `LOG(INFO)` -> `info()`
+- `LOG(WARNING)` -> `warn()`
+- `LOG(ERROR)` -> `error()`
+- `LOG(FATAL)` -> `critical()`; no focused MQTT `LOG(FATAL)` call sites were present.
+- `PLOG(WARNING)` and `PLOG(ERROR)`/`PLOG(DEBUG)` -> `sysError(logger::LogLevel::Warn/Error/Debug, errnum, ...)`.
+
+## PLOG/sysError errno handling
+
+Four errno-sensitive `PLOG` call sites were migrated:
+
+- MQTT client session-store read failure: captures `errno` immediately and emits `sysError(Warn, errnum, ...)`.
+- MQTT client session-store write failure: captures `errno` immediately and emits `sysError(Debug, errnum, ...)`.
+- MQTT broker session-store read failure: captures `errno` immediately and emits `sysError(Warn, errnum, ...)`.
+- MQTT broker session-store write failure: captures `errno` immediately and emits `sysError(Error, errnum, ...)`.
+
+`MqttMigration08Test` verifies errno code/text preservation through the MQTT broker helper.
+
+## VLOG result
+
+No `VLOG` call sites were found in the focused MQTT inventory. No verbose logging semantics were changed.
+
+## MQTT payload preservation notes
+
+Migration 8 preserves the existing MQTT technical diagnostics: connection name, client id, session state, protocol name/version, connect flags, keep-alive, will fields, username/password where already logged, packet identifiers, packet types, fixed-header flags and remaining length, topic names/filters, QoS, DUP, RETAIN, retained-message state, broker/session identity, publish/subscribe/unsubscribe/ack flow, ping lifecycle, disconnect lifecycle, and parse/deserialization failure reasons. Manual `MQTT`, `MQTT Client`, and `MQTT Broker` prefixes remain where they carry protocol readability beyond the semantic component.
+
+## MQTT-over-WebSocket notes
+
+The WebSocket subprotocol call sites inside `src/iot/mqtt/SubProtocol.hpp` were migrated to `iot.mqtt.websocket`. This PR did not modify `src/web/http` or `src/web/websocket` framework files.
+
+## Expensive payload / dump guard notes
+
+Hex-dump and serialized-packet payloads that call `toHexString(...)` or `serializeVP()` are guarded with `enabled(...)` checks before constructing expensive strings. Retained-message and subscription-message dumps are guarded at the corresponding info/debug levels. `MqttMigration08Test` includes an explicit disabled expensive-dump guard assertion.
+
+## Post-migration inventory command/result
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" src/iot/mqtt -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Post-migration result: no remaining `LOG`, `PLOG`, or `VLOG` call sites in `src/iot/mqtt`. All suitable focused MQTT call sites are migrated.
+
+## Filter/backend/format compatibility
+
+`MqttMigration08Test` covers:
+
+- MQTT semantic logger emission when enabled.
+- Framework/connection component scope for `iot.mqtt` and narrower helpers.
+- `LogManager` filtering suppression.
+- `Logger::setLogLevel` backend filtering suppression.
+- JSON v1 format selection.
+- `sysError` errno code/text preservation.
+- Sink-taking helper overload compatibility.
+- Suppressed production formatting not evaluating `ExpensiveValue`.
+- Representative client/server/broker/session/packet/topic/WebSocket payload preservation.
+- Expensive payload/dump guard behavior.
+
+## Production-scope confirmations
+
+- This PR changes only allowed Migration 8 files.
+- This PR is not inventory-only.
+- This PR modifies production MQTT logging.
+- This PR does not split Migration 8.
+- This PR does not modify `SemanticLogger.*`.
+- This PR does not modify `LogScopeOwner.*`.
+- This PR does not modify `Logger.*`.
+- This PR does not modify `ConfigInstance.cpp`.
+- This PR does not modify `src/net/config/stream/tls`.
+- This PR does not modify `src/web/http`.
+- This PR does not modify `src/web/websocket`.
+- This PR does not modify DB/apps/examples.
+- This PR does not modify external mqttsuite repository.
+- This PR does not modify previous migration tests except `tests/unit/log/CMakeLists.txt` registration.
+- This PR does not change `LOG`/`PLOG`/`VLOG` macro definitions.
+- This PR does not change `LogManager` precedence.
+- This PR does not change `LogManager` freeze behavior.
+- This PR does not change JSON v1 schema.
+- This PR does not start Round 10.
+
+## Build commands run
+
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2 --target MqttMigration08Test`
+- `cmake --build cmake-build --parallel 2`
+
+The first configure attempt failed because `nlohmann-json3-dev` was missing; it was installed with `apt-get update && apt-get install -y nlohmann-json3-dev`, after which configure and build completed.
+
+## Test commands run
+
+- `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test|SemanticProductionThresholdRepairTest|SocketConnectionMigration01Test|SocketConnectorAcceptorMigration02Test|SocketServerClientMigration03Test|CoreRuntimeMigration04Test|NetPhysicalSocketMigration05Test|TlsSocketStreamMigration06Test|HttpClientMigration07aTest|HttpServerMigration07bTest|WebSocketMigration07cTest|MqttMigration08Test" --output-on-failure`
+- `ctest --test-dir cmake-build --output-on-failure`
+
+## ASan result
+
+ASan commands were run for the focused MQTT migration test:
+
+- `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`
+- `cmake --build cmake-build-asan --parallel 2 --target MqttMigration08Test`
+- `ASAN=$(gcc -print-file-name=libasan.so); LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan -R MqttMigration08Test --output-on-failure`
+
+Full ASan was not run because the non-ASan full suite is already large in this environment; the required focused ASan test passed.
+
+## Known follow-ups
+
+- Migration 9 — DB / apps / examples / remaining cleanup.
+- Round 10 — book integration.
+- TLS configuration/SNI policy logs under `src/net/config/stream/tls` remain deferred outside Migration 8.

--- a/src/iot/mqtt/Mqtt.cpp
+++ b/src/iot/mqtt/Mqtt.cpp
@@ -44,6 +44,7 @@
 #include "MqttContext.h"
 #include "core/socket/stream/SocketConnection.h"
 #include "iot/mqtt/ControlPacketDeserializer.h"
+#include "iot/mqtt/SemanticLog.h"
 #include "iot/mqtt/Session.h"
 #include "iot/mqtt/packets/Puback.h"
 #include "iot/mqtt/packets/Pubcomp.h"
@@ -92,7 +93,7 @@ namespace iot::mqtt {
     }
 
     void Mqtt::onConnected() {
-        LOG(INFO) << "MQTT: Connected";
+        iot::mqtt::semantic::mqttLog().info() << "MQTT: Connected";
     }
 
     std::size_t Mqtt::onReceivedFromPeer() {
@@ -116,13 +117,14 @@ namespace iot::mqtt {
                 fixedHeader.reset();
 
                 if (controlPacketDeserializer == nullptr) {
-                    LOG(DEBUG) << connectionName << " MQTT: Received packet-type is unavailable ... closing connection";
+                    iot::mqtt::semantic::mqttLog().debug()
+                        << connectionName << " MQTT: Received packet-type is unavailable ... closing connection";
 
                     mqttContext->close();
                     break;
                 }
                 if (controlPacketDeserializer->isError()) {
-                    LOG(DEBUG) << connectionName << " MQTT: Fixed header has error ... closing connection";
+                    iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: Fixed header has error ... closing connection";
 
                     delete controlPacketDeserializer;
                     controlPacketDeserializer = nullptr;
@@ -138,7 +140,7 @@ namespace iot::mqtt {
                 consumed += controlPacketDeserializer->deserialize(mqttContext);
 
                 if (controlPacketDeserializer->isError()) {
-                    LOG(DEBUG) << connectionName << " MQTT: Control packet has error ... closing connection";
+                    iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: Control packet has error ... closing connection";
                     mqttContext->close();
 
                     delete controlPacketDeserializer;
@@ -163,7 +165,7 @@ namespace iot::mqtt {
     }
 
     void Mqtt::onDisconnected() {
-        LOG(INFO) << connectionName << " MQTT: Disconnected";
+        iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT: Disconnected";
     }
 
     const std::string& Mqtt::getConnectionName() const {
@@ -174,13 +176,13 @@ namespace iot::mqtt {
         this->session = session;
 
         for (const auto& [packetIdentifier, publish] : session->outgoingPublishMap) {
-            LOG(INFO) << connectionName << " MQTT: PUBLISH Resend";
+            iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT: PUBLISH Resend";
 
             send(publish);
         }
 
         for (const uint16_t packetIdentifier : session->pubrelPacketIdentifierSet) {
-            LOG(INFO) << connectionName << " MQTT: PUBREL Resend";
+            iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT: PUBREL Resend";
 
             sendPubrel(packetIdentifier);
         }
@@ -188,11 +190,12 @@ namespace iot::mqtt {
         if (keepAlive > 0) {
             keepAlive *= 1.5;
 
-            LOG(INFO) << connectionName << " MQTT: Keep alive initialized with: " << keepAlive;
+            iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT: Keep alive initialized with: " << keepAlive;
 
             keepAliveTimer = core::timer::Timer::singleshotTimer(
                 [this, keepAlive]() {
-                    LOG(ERROR) << connectionName << " MQTT: Keep-alive timer expired. Interval was: " << keepAlive;
+                    iot::mqtt::semantic::mqttLog().error()
+                        << connectionName << " MQTT: Keep-alive timer expired. Interval was: " << keepAlive;
                     mqttContext->close();
                 },
                 keepAlive);
@@ -202,13 +205,15 @@ namespace iot::mqtt {
     }
 
     void Mqtt::send(const ControlPacket& controlPacket) const {
-        LOG(INFO) << connectionName << " MQTT: " << controlPacket.getName() << " send: " << clientId;
+        iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT: " << controlPacket.getName() << " send: " << clientId;
 
         send(controlPacket.serialize());
     }
 
     void Mqtt::send(const std::vector<char>& data) const {
-        LOG(TRACE) << connectionName << " MQTT: Send data (full message):\n" << toHexString(data);
+        if (iot::mqtt::semantic::mqttLog().enabled(logger::LogLevel::Trace)) {
+            iot::mqtt::semantic::mqttLog().trace() << connectionName << " MQTT: Send data (full message):\n" << toHexString(data);
+        }
 
         mqttContext->send(data.data(), data.size());
     }
@@ -218,12 +223,14 @@ namespace iot::mqtt {
 
         send(iot::mqtt::packets::Publish(packetIdentifier, topic, message, qoS, false, retain));
 
-        LOG(INFO) << connectionName << " MQTT:   Topic: " << topic;
-        LOG(INFO) << connectionName << " MQTT:   Message:\n" << toHexString(message);
-        LOG(DEBUG) << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(qoS);
-        LOG(DEBUG) << connectionName << " MQTT:   PacketIdentifier: " << packetIdentifier;
-        LOG(DEBUG) << connectionName << " MQTT:   DUP: " << false;
-        LOG(DEBUG) << connectionName << " MQTT:   Retain: " << retain;
+        iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT:   Topic: " << topic;
+        if (iot::mqtt::semantic::mqttLog().enabled(logger::LogLevel::Info)) {
+            iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT:   Message:\n" << toHexString(message);
+        }
+        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(qoS);
+        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: " << packetIdentifier;
+        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   DUP: " << false;
+        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   Retain: " << retain;
 
         if (qoS >= 1) {
             session->outgoingPublishMap.insert_or_assign(packetIdentifier,
@@ -265,23 +272,25 @@ namespace iot::mqtt {
     bool Mqtt::_onPublish(const iot::mqtt::packets::Publish& publish) {
         bool deliver = true;
 
-        LOG(INFO) << connectionName << " MQTT:   Topic: " << publish.getTopic();
-        LOG(INFO) << connectionName << " MQTT:   Message:\n" << toHexString(publish.getMessage());
-        LOG(DEBUG) << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(publish.getQoS());
-        LOG(DEBUG) << connectionName << " MQTT:   PacketIdentifier: " << publish.getPacketIdentifier();
-        LOG(DEBUG) << connectionName << " MQTT:   DUP: " << publish.getDup();
-        LOG(DEBUG) << connectionName << " MQTT:   Retain: " << publish.getRetain();
+        iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT:   Topic: " << publish.getTopic();
+        if (iot::mqtt::semantic::mqttLog().enabled(logger::LogLevel::Info)) {
+            iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT:   Message:\n" << toHexString(publish.getMessage());
+        }
+        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(publish.getQoS());
+        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: " << publish.getPacketIdentifier();
+        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   DUP: " << publish.getDup();
+        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   Retain: " << publish.getRetain();
 
         if (publish.getQoS() > 2) {
-            LOG(ERROR) << connectionName << " MQTT:   Received invalid QoS: " << publish.getQoS();
+            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   Received invalid QoS: " << publish.getQoS();
             mqttContext->close();
             deliver = false;
         } else if (publish.getPacketIdentifier() == 0 && publish.getQoS() > 0) {
-            LOG(ERROR) << connectionName << " MQTT:   Received QoS > 0 but no PackageIdentifier present";
+            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   Received QoS > 0 but no PackageIdentifier present";
             mqttContext->close();
             deliver = false;
         } else if (publish.getQoS() == 0 && publish.getDup()) {
-            LOG(ERROR) << connectionName << " MQTT:   Received QoS == 0 but dup is set";
+            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   Received QoS == 0 but dup is set";
             mqttContext->close();
             deliver = false;
         } else {
@@ -301,13 +310,15 @@ namespace iot::mqtt {
                         if (!publish.getDup()) {
                             session->pubcompPacketIdentifierSet.erase(pid);
                         } else {
-                            LOG(WARNING) << connectionName << " MQTT:   Duplicate QoS2 PUBLISH after PUBCOMP for PacketIdentifier: " << pid;
+                            iot::mqtt::semantic::mqttLog().warn()
+                                << connectionName << " MQTT:   Duplicate QoS2 PUBLISH after PUBCOMP for PacketIdentifier: " << pid;
                             break;
                         }
                     }
 
                     if (session->incomingPublishMap.contains(pid)) {
-                        LOG(INFO) << connectionName << " MQTT:   Duplicate QoS2 PUBLISH suppressed for PacketIdentifier: " << pid;
+                        iot::mqtt::semantic::mqttLog().info()
+                            << connectionName << " MQTT:   Duplicate QoS2 PUBLISH suppressed for PacketIdentifier: " << pid;
                     } else {
                         session->incomingPublishMap.emplace(pid, publish);
                     }
@@ -321,11 +332,11 @@ namespace iot::mqtt {
 
     void Mqtt::_onPuback(const iot::mqtt::packets::Puback& puback) {
         if (puback.getPacketIdentifier() == 0) {
-            LOG(ERROR) << connectionName << " MQTT:   PackageIdentifier missing";
+            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            LOG(DEBUG) << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                       << puback.getPacketIdentifier() << std::dec;
+            iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0')
+                                                   << std::setw(4) << puback.getPacketIdentifier() << std::dec;
 
             session->outgoingPublishMap.erase(puback.getPacketIdentifier());
         }
@@ -335,11 +346,11 @@ namespace iot::mqtt {
 
     void Mqtt::_onPubrec(const iot::mqtt::packets::Pubrec& pubrec) {
         if (pubrec.getPacketIdentifier() == 0) {
-            LOG(ERROR) << connectionName << " MQTT:   PackageIdentifier missing";
+            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            LOG(DEBUG) << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                       << pubrec.getPacketIdentifier() << std::dec;
+            iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0')
+                                                   << std::setw(4) << pubrec.getPacketIdentifier() << std::dec;
 
             session->outgoingPublishMap.erase(pubrec.getPacketIdentifier());
             session->pubrelPacketIdentifierSet.insert(pubrec.getPacketIdentifier());
@@ -352,25 +363,27 @@ namespace iot::mqtt {
 
     void Mqtt::_onPubrel(const iot::mqtt::packets::Pubrel& pubrel) {
         if (pubrel.getPacketIdentifier() == 0) {
-            LOG(ERROR) << connectionName << " MQTT:   PackageIdentifier missing";
+            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            LOG(DEBUG) << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                       << pubrel.getPacketIdentifier() << std::dec;
+            iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0')
+                                                   << std::setw(4) << pubrel.getPacketIdentifier() << std::dec;
 
             const uint16_t pid = pubrel.getPacketIdentifier();
 
             if (session->incomingPublishMap.contains(pid)) {
-                LOG(INFO) << connectionName << " MQTT:   QoS2 PUBREL received. Deliver publish: " << pid;
+                iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT:   QoS2 PUBREL received. Deliver publish: " << pid;
 
                 distributePublish(session->incomingPublishMap[pid]);
 
                 session->incomingPublishMap.erase(pid);
                 session->pubcompPacketIdentifierSet.insert(pid);
             } else if (session->pubcompPacketIdentifierSet.contains(pid)) {
-                LOG(INFO) << connectionName << " MQTT:   Duplicate QoS2 PUBREL for completed PacketIdentifier: " << pid;
+                iot::mqtt::semantic::mqttLog().info()
+                    << connectionName << " MQTT:   Duplicate QoS2 PUBREL for completed PacketIdentifier: " << pid;
             } else {
-                LOG(WARNING) << connectionName << " MQTT:   QoS2 PUBREL received for unknown PacketIdentifier: " << pid;
+                iot::mqtt::semantic::mqttLog().warn()
+                    << connectionName << " MQTT:   QoS2 PUBREL received for unknown PacketIdentifier: " << pid;
 
                 session->pubcompPacketIdentifierSet.insert(pid);
             }
@@ -383,11 +396,11 @@ namespace iot::mqtt {
 
     void Mqtt::_onPubcomp(const iot::mqtt::packets::Pubcomp& pubcomp) {
         if (pubcomp.getPacketIdentifier() == 0) {
-            LOG(ERROR) << connectionName << " MQTT:   PackageIdentifier missing";
+            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            LOG(DEBUG) << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                       << pubcomp.getPacketIdentifier() << std::dec;
+            iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0')
+                                                   << std::setw(4) << pubcomp.getPacketIdentifier() << std::dec;
 
             session->outgoingPublishMap.erase(pubcomp.getPacketIdentifier());
             session->pubrelPacketIdentifierSet.erase(pubcomp.getPacketIdentifier());
@@ -397,25 +410,31 @@ namespace iot::mqtt {
     }
 
     void Mqtt::printVP(const iot::mqtt::ControlPacket& packet) const {
-        LOG(INFO) << connectionName << " MQTT: " << packet.getName() << " received: " << clientId;
+        iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT: " << packet.getName() << " received: " << clientId;
 
-        const std::string hexString = toHexString(packet.serializeVP());
-        if (!hexString.empty()) {
-            LOG(TRACE) << connectionName << " MQTT: Received data (variable header and payload):\n" << hexString;
+        if (iot::mqtt::semantic::mqttLog().enabled(logger::LogLevel::Trace)) {
+            const std::string hexString = toHexString(packet.serializeVP());
+            if (!hexString.empty()) {
+                iot::mqtt::semantic::mqttLog().trace() << connectionName << " MQTT: Received data (variable header and payload):\n"
+                                                       << hexString;
+            }
         }
     }
 
     void Mqtt::printFixedHeader(const FixedHeader& fixedHeader) const {
-        LOG(INFO) << connectionName << " MQTT: ====================================";
+        iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT: ====================================";
 
-        LOG(TRACE) << connectionName << " MQTT: Received data (fixed header):\n" << toHexString(fixedHeader.serialize());
+        if (iot::mqtt::semantic::mqttLog().enabled(logger::LogLevel::Trace)) {
+            iot::mqtt::semantic::mqttLog().trace() << connectionName << " MQTT: Received data (fixed header):\n"
+                                                   << toHexString(fixedHeader.serialize());
+        }
 
-        LOG(DEBUG) << connectionName << " MQTT: Fixed Header: PacketType: 0x" << std::hex << std::setfill('0') << std::setw(2)
-                   << static_cast<uint16_t>(fixedHeader.getType()) << " (" << iot::mqtt::mqttPackageName[fixedHeader.getType()] << ")"
-                   << std::dec;
-        LOG(DEBUG) << connectionName << " MQTT:   PacketFlags: 0x" << std::hex << std::setfill('0') << std::setw(2)
-                   << static_cast<uint16_t>(fixedHeader.getFlags()) << std::dec;
-        LOG(DEBUG) << connectionName << " MQTT:   RemainingLength: " << fixedHeader.getRemainingLength();
+        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: Fixed Header: PacketType: 0x" << std::hex << std::setfill('0')
+                                               << std::setw(2) << static_cast<uint16_t>(fixedHeader.getType()) << " ("
+                                               << iot::mqtt::mqttPackageName[fixedHeader.getType()] << ")" << std::dec;
+        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketFlags: 0x" << std::hex << std::setfill('0')
+                                               << std::setw(2) << static_cast<uint16_t>(fixedHeader.getFlags()) << std::dec;
+        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   RemainingLength: " << fixedHeader.getRemainingLength();
     }
 
     std::string Mqtt::toHexString(const std::vector<char>& data) {

--- a/src/iot/mqtt/SemanticLog.h
+++ b/src/iot/mqtt/SemanticLog.h
@@ -1,0 +1,74 @@
+#ifndef IOT_MQTT_SEMANTICLOG_H
+#define IOT_MQTT_SEMANTICLOG_H
+
+#include "log/LogScopeOwner.h"
+#include "log/Logger.h"
+
+#include <utility>
+
+namespace iot::mqtt::semantic {
+
+    inline const logger::LogScopeOwner& mqttLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "iot.mqtt");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& mqttClientLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "iot.mqtt.client");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& mqttServerLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "iot.mqtt.server");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& mqttBrokerLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "iot.mqtt.broker");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& mqttSessionLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "iot.mqtt.session");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& mqttPacketLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "iot.mqtt.packet");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& mqttTopicLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "iot.mqtt.topic");
+        return scope;
+    }
+
+    inline const logger::LogScopeOwner& mqttWebSocketLogScope() {
+        static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "iot.mqtt.websocket");
+        return scope;
+    }
+
+#define IOT_MQTT_SEMANTIC_HELPER(name)                                                                                                     \
+    inline logger::BoundaryLogger name() {                                                                                                 \
+        return name##Scope().logger(logger::Logger::semanticSink());                                                                       \
+    }                                                                                                                                      \
+    inline logger::BoundaryLogger name(logger::BoundaryLogger::Sink sink,                                                                  \
+                                       logger::LogLevel threshold = logger::LogLevel::Trace,                                               \
+                                       logger::BoundaryLogger::Clock clock = {}) {                                                         \
+        return name##Scope().logger(std::move(sink), threshold, std::move(clock));                                                         \
+    }
+
+    IOT_MQTT_SEMANTIC_HELPER(mqttLog)
+    IOT_MQTT_SEMANTIC_HELPER(mqttClientLog)
+    IOT_MQTT_SEMANTIC_HELPER(mqttServerLog)
+    IOT_MQTT_SEMANTIC_HELPER(mqttBrokerLog)
+    IOT_MQTT_SEMANTIC_HELPER(mqttSessionLog)
+    IOT_MQTT_SEMANTIC_HELPER(mqttPacketLog)
+    IOT_MQTT_SEMANTIC_HELPER(mqttTopicLog)
+    IOT_MQTT_SEMANTIC_HELPER(mqttWebSocketLog)
+
+#undef IOT_MQTT_SEMANTIC_HELPER
+
+} // namespace iot::mqtt::semantic
+
+#endif // IOT_MQTT_SEMANTICLOG_H

--- a/src/iot/mqtt/SubProtocol.hpp
+++ b/src/iot/mqtt/SubProtocol.hpp
@@ -125,9 +125,11 @@ namespace iot::mqtt {
     void SubProtocol<WSSubProtocolRole>::onMessageData(const char* chunk, std::size_t chunkLen) {
         data.append(std::string(chunk, chunkLen));
 
-        iot::mqtt::semantic::mqttWebSocketLog().debug()
-            << getSocketConnection()->getConnectionName() << " WsMqtt: Frame Data:\n"
-            << std::string(32, ' ').append(utils::hexDump(std::vector<char>(chunk, chunk + chunkLen), 32));
+        auto log = iot::mqtt::semantic::mqttWebSocketLog();
+        if (log.enabled(logger::LogLevel::Debug)) {
+            log.debug() << getSocketConnection()->getConnectionName() << " WsMqtt: Frame Data:\n"
+                        << std::string(32, ' ').append(utils::hexDump(std::vector<char>(chunk, chunk + chunkLen), 32));
+        }
     }
 
     template <typename WSSubProtocolRole>

--- a/src/iot/mqtt/SubProtocol.hpp
+++ b/src/iot/mqtt/SubProtocol.hpp
@@ -40,6 +40,7 @@
  */
 
 #include "core/socket/stream/SocketConnection.h"
+#include "iot/mqtt/SemanticLog.h"
 #include "iot/mqtt/SubProtocol.h"
 #include "log/Logger.h"
 #include "utils/system/signal.h"
@@ -104,17 +105,19 @@ namespace iot::mqtt {
 
     template <typename WSSubProtocolRole>
     void SubProtocol<WSSubProtocolRole>::onConnected() {
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " WsMqtt: connected:";
+        iot::mqtt::semantic::mqttWebSocketLog().info() << getSocketConnection()->getConnectionName() << " WsMqtt: connected:";
         iot::mqtt::MqttContext::onConnected();
     }
 
     template <typename WSSubProtocolRole>
     void SubProtocol<WSSubProtocolRole>::onMessageStart(int opCode) {
         if (opCode == web::websocket::SubProtocolContext::OpCode::TEXT) {
-            LOG(ERROR) << getSocketConnection()->getConnectionName() << " WsMqtt: Wrong Opcode: " << opCode << " (TEXT)";
+            iot::mqtt::semantic::mqttWebSocketLog().error()
+                << getSocketConnection()->getConnectionName() << " WsMqtt: Wrong Opcode: " << opCode << " (TEXT)";
             this->close();
         } else {
-            LOG(DEBUG) << getSocketConnection()->getConnectionName() << " WsMqtt: Message START: " << opCode << " (BIN)";
+            iot::mqtt::semantic::mqttWebSocketLog().debug()
+                << getSocketConnection()->getConnectionName() << " WsMqtt: Message START: " << opCode << " (BIN)";
         }
     }
 
@@ -122,13 +125,14 @@ namespace iot::mqtt {
     void SubProtocol<WSSubProtocolRole>::onMessageData(const char* chunk, std::size_t chunkLen) {
         data.append(std::string(chunk, chunkLen));
 
-        LOG(DEBUG) << getSocketConnection()->getConnectionName() << " WsMqtt: Frame Data:\n"
-                   << std::string(32, ' ').append(utils::hexDump(std::vector<char>(chunk, chunk + chunkLen), 32));
+        iot::mqtt::semantic::mqttWebSocketLog().debug()
+            << getSocketConnection()->getConnectionName() << " WsMqtt: Frame Data:\n"
+            << std::string(32, ' ').append(utils::hexDump(std::vector<char>(chunk, chunk + chunkLen), 32));
     }
 
     template <typename WSSubProtocolRole>
     void SubProtocol<WSSubProtocolRole>::onMessageEnd() {
-        LOG(DEBUG) << getSocketConnection()->getConnectionName() << " WsMqtt: Message END";
+        iot::mqtt::semantic::mqttWebSocketLog().debug() << getSocketConnection()->getConnectionName() << " WsMqtt: Message END";
 
         buffer.insert(buffer.end(), data.begin(), data.end());
         size += data.size();
@@ -144,20 +148,21 @@ namespace iot::mqtt {
 
     template <typename WSSubProtocolRole>
     void SubProtocol<WSSubProtocolRole>::onMessageError(uint16_t errnum) {
-        LOG(ERROR) << getSocketConnection()->getConnectionName() << " WsMqtt: Message error: " << errnum;
+        iot::mqtt::semantic::mqttWebSocketLog().error()
+            << getSocketConnection()->getConnectionName() << " WsMqtt: Message error: " << errnum;
     }
 
     template <typename WSSubProtocolRole>
     void SubProtocol<WSSubProtocolRole>::onDisconnected() {
         iot::mqtt::MqttContext::onDisconnected();
-        LOG(DEBUG) << getSocketConnection()->getConnectionName() << " WsMqtt: disconnected";
+        iot::mqtt::semantic::mqttWebSocketLog().debug() << getSocketConnection()->getConnectionName() << " WsMqtt: disconnected";
     }
 
     template <typename WSSubProtocolRole>
     bool SubProtocol<WSSubProtocolRole>::onSignal(int sig) {
         bool ret = iot::mqtt::MqttContext::onSignal(sig);
-        LOG(INFO) << getSocketConnection()->getConnectionName() << " WsMqtt: exit due to signal SIG" << utils::system::sigabbrev_np(sig)
-                  << " (" << sig << ")";
+        iot::mqtt::semantic::mqttWebSocketLog().info() << getSocketConnection()->getConnectionName() << " WsMqtt: exit due to signal SIG"
+                                                       << utils::system::sigabbrev_np(sig) << " (" << sig << ")";
 
         this->sendClose();
 

--- a/src/iot/mqtt/client/Mqtt.cpp
+++ b/src/iot/mqtt/client/Mqtt.cpp
@@ -42,6 +42,7 @@
 #include "iot/mqtt/client/Mqtt.h"
 
 #include "iot/mqtt/MqttContext.h"
+#include "iot/mqtt/SemanticLog.h"
 #include "iot/mqtt/client/packets/Connack.h"
 #include "iot/mqtt/client/packets/Pingresp.h"
 #include "iot/mqtt/client/packets/Puback.h"
@@ -61,6 +62,7 @@
 
 #include "log/Logger.h"
 
+#include <cerrno>
 #include <cstdio>
 #include <fstream>
 #include <functional>
@@ -90,10 +92,12 @@ namespace iot::mqtt::client {
 
                     session.fromJson(sessionStoreJson);
 
-                    LOG(DEBUG) << connectionName << " MQTT Client:   ... Persistent session data loaded successful";
+                    iot::mqtt::semantic::mqttClientLog().debug()
+                        << connectionName << " MQTT Client:   ... Persistent session data loaded successful";
                 } catch (const nlohmann::json::exception&) {
-                    LOG(DEBUG) << connectionName << " MQTT Client:   ... Starting with empty session: Session store '"
-                               << sessionStoreFileName << "' empty or corrupted";
+                    iot::mqtt::semantic::mqttClientLog().debug()
+                        << connectionName << " MQTT Client:   ... Starting with empty session: Session store '" << sessionStoreFileName
+                        << "' empty or corrupted";
 
                     session.clear();
                 }
@@ -101,12 +105,18 @@ namespace iot::mqtt::client {
                 sessionStoreFile.close();
                 std::remove(sessionStoreFileName.data()); // NOLINT
 
-                LOG(INFO) << connectionName << " MQTT Client: Restoring saved session done";
+                iot::mqtt::semantic::mqttClientLog().info() << connectionName << " MQTT Client: Restoring saved session done";
             } else {
-                PLOG(WARNING) << connectionName << " MQTT Client:   ... Could not read session store '" << sessionStoreFileName << "'";
+                const int errnum = errno;
+                iot::mqtt::semantic::mqttClientLog().sysError(logger::LogLevel::Warn,
+                                                              errnum,
+                                                              "{} MQTT Client:   ... Could not read session store '{}'",
+                                                              connectionName,
+                                                              sessionStoreFileName);
             }
         } else {
-            LOG(INFO) << connectionName << " MQTT Client: Session not reloaded: Session store filename empty";
+            iot::mqtt::semantic::mqttClientLog().info()
+                << connectionName << " MQTT Client: Session not reloaded: Session store filename empty";
         }
     }
 
@@ -123,10 +133,16 @@ namespace iot::mqtt::client {
 
                 sessionStoreFile.close();
             } else {
-                PLOG(DEBUG) << connectionName << " MQTT Client: Could not write session store '" << sessionStoreFileName << "'";
+                const int errnum = errno;
+                iot::mqtt::semantic::mqttClientLog().sysError(logger::LogLevel::Debug,
+                                                              errnum,
+                                                              "{} MQTT Client: Could not write session store '{}'",
+                                                              connectionName,
+                                                              sessionStoreFileName);
             }
         } else {
-            LOG(INFO) << connectionName << " MQTT Client: Session not saved: Session store filename empty";
+            iot::mqtt::semantic::mqttClientLog().info()
+                << connectionName << " MQTT Client: Session not saved: Session store filename empty";
         }
 
         pingTimer.cancel();
@@ -192,12 +208,14 @@ namespace iot::mqtt::client {
     }
 
     void Mqtt::_onConnack(const iot::mqtt::client::packets::Connack& connack) {
-        LOG(INFO) << connectionName << " MQTT Client:   Acknowledge Flag: " << static_cast<int>(connack.getAcknowledgeFlags());
-        LOG(INFO) << connectionName << " MQTT Client:   Return code: " << static_cast<int>(connack.getReturnCode());
-        LOG(INFO) << connectionName << " MQTT Client:   Session present: " << connack.getSessionPresent();
+        iot::mqtt::semantic::mqttClientLog().info()
+            << connectionName << " MQTT Client:   Acknowledge Flag: " << static_cast<int>(connack.getAcknowledgeFlags());
+        iot::mqtt::semantic::mqttClientLog().info()
+            << connectionName << " MQTT Client:   Return code: " << static_cast<int>(connack.getReturnCode());
+        iot::mqtt::semantic::mqttClientLog().info() << connectionName << " MQTT Client:   Session present: " << connack.getSessionPresent();
 
         if (connack.getReturnCode() != MQTT_CONNACK_ACCEPT) {
-            LOG(ERROR) << connectionName << " MQTT Client:   Negative ack received";
+            iot::mqtt::semantic::mqttClientLog().error() << connectionName << " MQTT Client:   Negative ack received";
         } else {
             initSession(&session, keepAlive);
 
@@ -219,11 +237,11 @@ namespace iot::mqtt::client {
 
     void Mqtt::_onSuback(const iot::mqtt::client::packets::Suback& suback) {
         if (suback.getPacketIdentifier() == 0) {
-            LOG(ERROR) << connectionName << " MQTT Client:   PackageIdentifier missing";
+            iot::mqtt::semantic::mqttClientLog().error() << connectionName << " MQTT Client:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            LOG(DEBUG) << connectionName << " MQTT Client:  PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                       << suback.getPacketIdentifier() << std::dec;
+            iot::mqtt::semantic::mqttClientLog().debug() << connectionName << " MQTT Client:  PacketIdentifier: 0x" << std::hex
+                                                         << std::setfill('0') << std::setw(4) << suback.getPacketIdentifier() << std::dec;
 
             std::stringstream ss;
             std::list<uint8_t>::size_type i = 0;
@@ -237,7 +255,7 @@ namespace iot::mqtt::client {
                 ss << "0x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<uint16_t>(returnCode) << " "; // << " | ";
             }
 
-            LOG(DEBUG) << connectionName << " MQTT Client:  Return codes: " << ss.str();
+            iot::mqtt::semantic::mqttClientLog().debug() << connectionName << " MQTT Client:  Return codes: " << ss.str();
 
             onSuback(suback);
         }
@@ -245,11 +263,11 @@ namespace iot::mqtt::client {
 
     void Mqtt::_onUnsuback(const iot::mqtt::client::packets::Unsuback& unsuback) {
         if (unsuback.getPacketIdentifier() == 0) {
-            LOG(ERROR) << connectionName << " MQTT Client:  PacketIdentifier missing";
+            iot::mqtt::semantic::mqttClientLog().error() << connectionName << " MQTT Client:  PacketIdentifier missing";
             mqttContext->close();
         } else {
-            LOG(DEBUG) << connectionName << " MQTT Client:  PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                       << unsuback.getPacketIdentifier() << std::dec;
+            iot::mqtt::semantic::mqttClientLog().debug() << connectionName << " MQTT Client:  PacketIdentifier: 0x" << std::hex
+                                                         << std::setfill('0') << std::setw(4) << unsuback.getPacketIdentifier() << std::dec;
 
             onUnsuback(unsuback);
         }
@@ -271,7 +289,7 @@ namespace iot::mqtt::client {
                            const std::string& username,
                            const std::string& password,
                            bool loopPrevention) const { // Client
-        LOG(INFO) << connectionName << " MQTT Client: CONNECT send: " << clientId;
+        iot::mqtt::semantic::mqttClientLog().info() << connectionName << " MQTT Client: CONNECT send: " << clientId;
 
         send(iot::mqtt::packets::Connect(
             clientId, keepAlive, cleanSession, willTopic, willMessage, willQoS, willRetain, username, password, loopPrevention));
@@ -279,8 +297,9 @@ namespace iot::mqtt::client {
 
     void Mqtt::sendSubscribe(const std::list<iot::mqtt::Topic>& topics) const { // Client
         for (const iot::mqtt::Topic& topic : topics) {
-            LOG(INFO) << connectionName << " MQTT Client: SUBSCRIBE with qos=" << static_cast<uint16_t>(topic.getQoS()) << " for "
-                      << topic.getName();
+            iot::mqtt::semantic::mqttClientLog().info()
+                << connectionName << " MQTT Client: SUBSCRIBE with qos=" << static_cast<uint16_t>(topic.getQoS()) << " for "
+                << topic.getName();
         }
 
         if (!topics.empty()) {
@@ -290,7 +309,7 @@ namespace iot::mqtt::client {
 
     void Mqtt::sendUnsubscribe(const std::list<std::string>& topics) const { // Client
         for (const std::string& topic : topics) {
-            LOG(INFO) << connectionName << " MQTT Client: UNSUBSCRIBE from " << topic;
+            iot::mqtt::semantic::mqttClientLog().info() << connectionName << " MQTT Client: UNSUBSCRIBE from " << topic;
         }
 
         if (!topics.empty()) {

--- a/src/iot/mqtt/server/Mqtt.cpp
+++ b/src/iot/mqtt/server/Mqtt.cpp
@@ -42,6 +42,7 @@
 #include "iot/mqtt/server/Mqtt.h"
 
 #include "iot/mqtt/MqttContext.h"
+#include "iot/mqtt/SemanticLog.h"
 #include "iot/mqtt/packets/Connack.h"
 #include "iot/mqtt/packets/Pingresp.h"
 #include "iot/mqtt/packets/Suback.h"
@@ -147,30 +148,32 @@ namespace iot::mqtt::server {
         bool success = true;
 
         if (broker->hasActiveSession(clientId)) {
-            LOG(ERROR) << connectionName << " MQTT Broker: Existing session found for ClientId = " << clientId;
-            LOG(ERROR) << connectionName << " MQTT Broker:   closing";
+            iot::mqtt::semantic::mqttServerLog().error()
+                << connectionName << " MQTT Broker: Existing session found for ClientId = " << clientId;
+            iot::mqtt::semantic::mqttServerLog().error() << connectionName << " MQTT Broker:   closing";
             sendConnack(MQTT_CONNACK_IDENTIFIERREJECTED, 0);
 
             willFlag = false;
             success = false;
         } else if (broker->hasRetainedSession(clientId)) {
-            LOG(INFO) << connectionName << " MQTT Broker: Retained session found for ClientId = " << clientId;
+            iot::mqtt::semantic::mqttServerLog().info()
+                << connectionName << " MQTT Broker: Retained session found for ClientId = " << clientId;
             if (cleanSession) {
-                LOG(DEBUG) << connectionName << "   New SessionId = " << this;
+                iot::mqtt::semantic::mqttServerLog().debug() << connectionName << "   New SessionId = " << this;
                 sendConnack(MQTT_CONNACK_ACCEPT, MQTT_SESSION_NEW);
 
                 broker->unsubscribe(clientId);
                 initSession(broker->newSession(clientId, this), keepAlive);
             } else {
-                LOG(DEBUG) << connectionName << "   Renew SessionId = " << this;
+                iot::mqtt::semantic::mqttServerLog().debug() << connectionName << "   Renew SessionId = " << this;
                 sendConnack(MQTT_CONNACK_ACCEPT, MQTT_SESSION_PRESENT);
 
                 initSession(broker->renewSession(clientId, this), keepAlive);
                 broker->restartSession(clientId);
             }
         } else {
-            LOG(INFO) << connectionName << " MQTT Broker: No session found for ClientId = " << clientId;
-            LOG(INFO) << connectionName << " MQTT Broker:   new SessionId = " << this;
+            iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker: No session found for ClientId = " << clientId;
+            iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   new SessionId = " << this;
 
             sendConnack(MQTT_CONNACK_ACCEPT, MQTT_SESSION_NEW);
 
@@ -183,12 +186,14 @@ namespace iot::mqtt::server {
     void Mqtt::releaseSession() {
         if (broker->isActiveSession(clientId, this)) {
             if (cleanSession) {
-                LOG(DEBUG) << connectionName << " MQTT Broker: Delete session for ClientId = " << clientId;
-                LOG(DEBUG) << connectionName << " MQTT Broker:   SessionId = " << this;
+                iot::mqtt::semantic::mqttServerLog().debug()
+                    << connectionName << " MQTT Broker: Delete session for ClientId = " << clientId;
+                iot::mqtt::semantic::mqttServerLog().debug() << connectionName << " MQTT Broker:   SessionId = " << this;
                 broker->deleteSession(clientId);
             } else {
-                LOG(DEBUG) << connectionName << " MQTT Broker: Retain session for ClientId = " << clientId;
-                LOG(DEBUG) << connectionName << " MQTT Broker:   SessionId = " << this;
+                iot::mqtt::semantic::mqttServerLog().debug()
+                    << connectionName << " MQTT Broker: Retain session for ClientId = " << clientId;
+                iot::mqtt::semantic::mqttServerLog().debug() << connectionName << " MQTT Broker:   SessionId = " << this;
                 broker->retainSession(clientId);
             }
         }
@@ -216,50 +221,55 @@ namespace iot::mqtt::server {
     }
 
     void Mqtt::_onConnect(const iot::mqtt::server::packets::Connect& connect) {
-        LOG(INFO) << connectionName << " MQTT Broker:   Protocol: " << connect.getProtocol();
-        LOG(INFO) << connectionName << " MQTT Broker:   Version: " << static_cast<uint16_t>(connect.getLevel());
-        LOG(INFO) << connectionName << " MQTT Broker:   ConnectFlags: 0x" << std::hex << std::setfill('0') << std::setw(2)
-                  << static_cast<uint16_t>(connect.getConnectFlags()) << std::dec << std::setw(0);
-        LOG(INFO) << connectionName << " MQTT Broker:   KeepAlive: " << connect.getKeepAlive();
-        LOG(INFO) << connectionName << " MQTT Broker:   ClientID: " << connect.getClientId();
-        LOG(INFO) << connectionName << " MQTT Broker:   CleanSession: " << connect.getCleanSession();
+        iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   Protocol: " << connect.getProtocol();
+        iot::mqtt::semantic::mqttServerLog().info()
+            << connectionName << " MQTT Broker:   Version: " << static_cast<uint16_t>(connect.getLevel());
+        iot::mqtt::semantic::mqttServerLog().info()
+            << connectionName << " MQTT Broker:   ConnectFlags: 0x" << std::hex << std::setfill('0') << std::setw(2)
+            << static_cast<uint16_t>(connect.getConnectFlags()) << std::dec << std::setw(0);
+        iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   KeepAlive: " << connect.getKeepAlive();
+        iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   ClientID: " << connect.getClientId();
+        iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   CleanSession: " << connect.getCleanSession();
 
         if (connect.getWillFlag()) {
-            LOG(INFO) << connectionName << " MQTT Broker:   WillTopic: " << connect.getWillTopic();
-            LOG(INFO) << connectionName << " MQTT Broker:   WillMessage: " << connect.getWillMessage();
-            LOG(INFO) << connectionName << " MQTT Broker:   WillQoS: " << static_cast<uint16_t>(connect.getWillQoS());
-            LOG(INFO) << connectionName << " MQTT Broker:   WillRetain: " << connect.getWillRetain();
+            iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   WillTopic: " << connect.getWillTopic();
+            iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   WillMessage: " << connect.getWillMessage();
+            iot::mqtt::semantic::mqttServerLog().info()
+                << connectionName << " MQTT Broker:   WillQoS: " << static_cast<uint16_t>(connect.getWillQoS());
+            iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   WillRetain: " << connect.getWillRetain();
         }
         if (connect.getUsernameFlag()) {
-            LOG(INFO) << connectionName << " MQTT Broker:   Username: " << connect.getUsername();
+            iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   Username: " << connect.getUsername();
         }
         if (connect.getPasswordFlag()) {
-            LOG(INFO) << connectionName << " MQTT Broker:   Password: " << connect.getPassword();
+            iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   Password: " << connect.getPassword();
         }
 
         if (connect.getProtocol() != "MQTT") {
-            LOG(ERROR) << connectionName << " MQTT Broker:   Wrong Protocol: " << connect.getProtocol();
+            iot::mqtt::semantic::mqttServerLog().error() << connectionName << " MQTT Broker:   Wrong Protocol: " << connect.getProtocol();
             mqttContext->close();
         } else if ((connect.getLevel()) != MQTT_VERSION_3_1_1) {
-            LOG(ERROR) << connectionName << " MQTT Broker:   Wrong Protocol Level: " << MQTT_VERSION_3_1_1 << " != " << connect.getLevel();
+            iot::mqtt::semantic::mqttServerLog().error()
+                << connectionName << " MQTT Broker:   Wrong Protocol Level: " << MQTT_VERSION_3_1_1 << " != " << connect.getLevel();
             sendConnack(MQTT_CONNACK_UNACEPTABLEVERSION, MQTT_SESSION_NEW);
 
             mqttContext->close();
         } else if (connect.isFakedClientId() && !connect.getCleanSession()) {
-            LOG(ERROR) << connectionName << " MQTT Broker:   Resume session but no ClientId present";
+            iot::mqtt::semantic::mqttServerLog().error() << connectionName << " MQTT Broker:   Resume session but no ClientId present";
             sendConnack(MQTT_CONNACK_IDENTIFIERREJECTED, MQTT_SESSION_NEW);
 
             mqttContext->close();
         } else if (!connect.getWillFlag() && (connect.getWillQoS() != 0 || connect.getWillRetain())) {
-            LOG(ERROR) << connectionName << " MQTT Broker:   WillFlag not set but WillQoS or WillRetain set";
+            iot::mqtt::semantic::mqttServerLog().error()
+                << connectionName << " MQTT Broker:   WillFlag not set but WillQoS or WillRetain set";
 
             mqttContext->close();
         } else if (connect.getWillQoS() > 2) {
-            LOG(ERROR) << connectionName << " MQTT Broker:   WillQoS larger than 2";
+            iot::mqtt::semantic::mqttServerLog().error() << connectionName << " MQTT Broker:   WillQoS larger than 2";
 
             mqttContext->close();
         } else if (connect.getPasswordFlag() && !connect.getUsernameFlag()) {
-            LOG(ERROR) << connectionName << " MQTT Broker:   Password flag set but username flag not";
+            iot::mqtt::semantic::mqttServerLog().error() << connectionName << " MQTT Broker:   Password flag set but username flag not";
 
             mqttContext->close();
         } else {
@@ -301,15 +311,16 @@ namespace iot::mqtt::server {
 
     void Mqtt::_onSubscribe(const iot::mqtt::server::packets::Subscribe& subscribe) {
         if (subscribe.getPacketIdentifier() == 0) {
-            LOG(ERROR) << connectionName << " MQTT Broker:   PackageIdentifier missing";
+            iot::mqtt::semantic::mqttServerLog().error() << connectionName << " MQTT Broker:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            LOG(DEBUG) << connectionName << " MQTT Broker:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                       << subscribe.getPacketIdentifier() << std::dec;
+            iot::mqtt::semantic::mqttServerLog().debug()
+                << connectionName << " MQTT Broker:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
+                << subscribe.getPacketIdentifier() << std::dec;
 
             for (const iot::mqtt::Topic& topic : subscribe.getTopics()) {
-                LOG(INFO) << connectionName << " MQTT Broker:   Topic filter: '" << topic.getName()
-                          << "', QoS: " << static_cast<uint16_t>(topic.getQoS());
+                iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   Topic filter: '" << topic.getName()
+                                                            << "', QoS: " << static_cast<uint16_t>(topic.getQoS());
             }
 
             std::list<uint8_t> returnCodes;
@@ -326,14 +337,15 @@ namespace iot::mqtt::server {
 
     void Mqtt::_onUnsubscribe(const iot::mqtt::server::packets::Unsubscribe& unsubscribe) {
         if (unsubscribe.getPacketIdentifier() == 0) {
-            LOG(ERROR) << connectionName << " MQTT Broker:   PackageIdentifier missing";
+            iot::mqtt::semantic::mqttServerLog().error() << connectionName << " MQTT Broker:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            LOG(DEBUG) << connectionName << " MQTT Broker:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                       << unsubscribe.getPacketIdentifier() << std::dec;
+            iot::mqtt::semantic::mqttServerLog().debug()
+                << connectionName << " MQTT Broker:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
+                << unsubscribe.getPacketIdentifier() << std::dec;
 
             for (const std::string& topic : unsubscribe.getTopics()) {
-                LOG(INFO) << connectionName << " MQTT Broker:   Topic: " << topic;
+                iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   Topic: " << topic;
             }
 
             for (const std::string& topic : unsubscribe.getTopics()) {

--- a/src/iot/mqtt/server/broker/Broker.cpp
+++ b/src/iot/mqtt/server/broker/Broker.cpp
@@ -41,11 +41,14 @@
 
 #include "iot/mqtt/server/broker/Broker.h"
 
+#include "iot/mqtt/SemanticLog.h"
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #include "log/Logger.h"
 
 #include <algorithm>
+#include <cerrno>
 #include <cstdio>
 #include <fstream>
 #include <nlohmann/json.hpp>
@@ -77,10 +80,10 @@ namespace iot::mqtt::server::broker {
                     retainTree.fromJson(sessionStoreJson["retain_tree"]);
                     subscriptionTree.fromJson(sessionStoreJson["subscription_tree"]);
 
-                    LOG(INFO) << "MQTT Broker: Persistent session data loaded successful";
+                    iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Persistent session data loaded successful";
                 } catch (const nlohmann::json::exception&) {
-                    LOG(INFO) << "MQTT Broker: Starting with empty session: Session store '" << sessionStoreFileName
-                              << "' empty or corrupted";
+                    iot::mqtt::semantic::mqttBrokerLog().info()
+                        << "MQTT Broker: Starting with empty session: Session store '" << sessionStoreFileName << "' empty or corrupted";
 
                     sessionStore.clear();
                     retainTree.clear();
@@ -90,12 +93,14 @@ namespace iot::mqtt::server::broker {
                 sessionStoreFile.close();
                 std::remove(sessionStoreFileName.data()); // NOLINT
 
-                LOG(INFO) << "MQTT Broker: Restoring saved session done";
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Restoring saved session done";
             } else {
-                PLOG(WARNING) << "MQTT Broker: Could not read session store '" << sessionStoreFileName << "'";
+                const int errnum = errno;
+                iot::mqtt::semantic::mqttBrokerLog().sysError(
+                    logger::LogLevel::Warn, errnum, "MQTT Broker: Could not read session store '{}'", sessionStoreFileName);
             }
         } else {
-            LOG(INFO) << "MQTT Broker: Session not reloaded: Session store filename empty";
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Session not reloaded: Session store filename empty";
         }
     }
 
@@ -128,12 +133,14 @@ namespace iot::mqtt::server::broker {
 
                 sessionStoreFile.close();
 
-                LOG(INFO) << "MQTT Broker: Session store written '" << sessionStoreFileName << "'";
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Session store written '" << sessionStoreFileName << "'";
             } else {
-                PLOG(ERROR) << "MQTT Broker: Could not write session store '" << sessionStoreFileName << "'";
+                const int errnum = errno;
+                iot::mqtt::semantic::mqttBrokerLog().sysError(
+                    logger::LogLevel::Error, errnum, "MQTT Broker: Could not write session store '{}'", sessionStoreFileName);
             }
         } else {
-            LOG(INFO) << "MQTT Broker: Session not saved: Session store filename empty";
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Session not saved: Session store filename empty";
         }
     }
 
@@ -163,10 +170,10 @@ namespace iot::mqtt::server::broker {
     }
 
     void Broker::restartSession(const std::string& clientId) {
-        LOG(INFO) << "MQTT Broker:   Retained: Send PUBLISH: " << clientId;
+        iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Retained: Send PUBLISH: " << clientId;
         subscriptionTree.appear(clientId);
 
-        LOG(INFO) << "MQTT Broker:   Queued: Send PUBLISH: " << clientId;
+        iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Queued: Send PUBLISH: " << clientId;
         sessionStore[clientId].publishQueued();
     }
 
@@ -235,7 +242,7 @@ namespace iot::mqtt::server::broker {
     }
 
     void Broker::sendPublish(const std::string& clientId, Message& message, uint8_t qoS, bool retain) {
-        LOG(INFO) << "MQTT Broker: Send PUBLISH: " << clientId;
+        iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Send PUBLISH: " << clientId;
 
         sessionStore[clientId].sendPublish(message, qoS, retain);
     }

--- a/src/iot/mqtt/server/broker/RetainTree.cpp
+++ b/src/iot/mqtt/server/broker/RetainTree.cpp
@@ -42,6 +42,7 @@
 #include "iot/mqtt/server/broker/RetainTree.h"
 
 #include "iot/mqtt/Mqtt.h"
+#include "iot/mqtt/SemanticLog.h"
 #include "iot/mqtt/server/broker/Broker.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -117,10 +118,13 @@ namespace iot::mqtt::server::broker {
     }
     void RetainTree::TopicLevel::retain(const Message& message, std::string topic) {
         if (topic.empty()) {
-            LOG(DEBUG) << "MQTT Broker: Retain:";
-            LOG(DEBUG) << "MQTT Broker:   Topic: " << message.getTopic();
-            LOG(DEBUG) << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
-            LOG(DEBUG) << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
+            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker: Retain:";
+            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Topic: " << message.getTopic();
+            if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Debug)) {
+                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Message:\n"
+                                                             << iot::mqtt::Mqtt::toHexString(message.getMessage());
+            }
+            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
 
             this->message = message;
         } else {
@@ -134,8 +138,8 @@ namespace iot::mqtt::server::broker {
 
     bool RetainTree::TopicLevel::release(std::string topic) {
         if (topic.empty()) {
-            LOG(DEBUG) << "MQTT Broker: Release retained:";
-            LOG(DEBUG) << "MQTT Broker:   Topic: " << message.getTopic();
+            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker: Release retained:";
+            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Topic: " << message.getTopic();
 
             message = Message();
         } else {
@@ -146,7 +150,7 @@ namespace iot::mqtt::server::broker {
                 topic.erase(0, topicLevel.size() + 1);
 
                 if (it->second.release(topic)) {
-                    LOG(DEBUG) << "               Erase: " << topicLevel;
+                    iot::mqtt::semantic::mqttBrokerLog().debug() << "               Erase: " << topicLevel;
 
                     subTopicLevels.erase(it);
                 }
@@ -159,16 +163,19 @@ namespace iot::mqtt::server::broker {
     void RetainTree::TopicLevel::appear(const std::string& clientId, std::string topic, uint8_t qoS) {
         if (topic.empty()) {
             if (!message.getTopic().empty()) {
-                LOG(INFO) << "MQTT Broker: Retained Topic found:";
-                LOG(INFO) << "MQTT Broker:   Topic: " << message.getTopic();
-                LOG(INFO) << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
-                LOG(DEBUG) << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
-                LOG(DEBUG) << "MQTT Broker:   Client:";
-                LOG(DEBUG) << "MQTT Broker:     QoS: " << static_cast<uint16_t>(qoS);
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Retained Topic found:";
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << message.getTopic();
+                if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Info)) {
+                    iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Message:\n"
+                                                                << iot::mqtt::Mqtt::toHexString(message.getMessage());
+                }
+                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
+                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Client:";
+                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(qoS);
 
-                LOG(INFO) << "MQTT Broker: Distributing message ...";
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Distributing message ...";
                 broker->sendPublish(clientId, message, std::min(message.getQoS(), qoS), true);
-                LOG(INFO) << "MQTT Broker: ... distributing message completed";
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: ... distributing message completed";
             }
         } else {
             const std::string topicLevel = topic.substr(0, topic.find('/'));
@@ -194,16 +201,19 @@ namespace iot::mqtt::server::broker {
 
     void RetainTree::TopicLevel::appear(const std::string& clientId, uint8_t clientQoS) {
         if (!message.getTopic().empty()) {
-            LOG(INFO) << "MQTT Broker: Retained Topic found:";
-            LOG(INFO) << "MQTT Broker:   Topic: " << message.getTopic();
-            LOG(INFO) << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
-            LOG(DEBUG) << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
-            LOG(DEBUG) << "MQTT Broker:   Client:";
-            LOG(DEBUG) << "MQTT Broker:     QoS: " << static_cast<uint16_t>(clientQoS);
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Retained Topic found:";
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << message.getTopic();
+            if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Info)) {
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Message:\n"
+                                                            << iot::mqtt::Mqtt::toHexString(message.getMessage());
+            }
+            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
+            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Client:";
+            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(clientQoS);
 
-            LOG(INFO) << "MQTT Broker: Distributing message ...";
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Distributing message ...";
             broker->sendPublish(clientId, message, std::min(message.getQoS(), clientQoS), true);
-            LOG(INFO) << "MQTT Broker: ... distributing message completed";
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: ... distributing message completed";
         }
 
         for (auto& [topicLevel, subTopicLevel] : subTopicLevels) {

--- a/src/iot/mqtt/server/broker/Session.cpp
+++ b/src/iot/mqtt/server/broker/Session.cpp
@@ -41,6 +41,7 @@
 
 #include "iot/mqtt/server/broker/Session.h"
 
+#include "iot/mqtt/SemanticLog.h"
 #include "iot/mqtt/server/Mqtt.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -64,13 +65,16 @@ namespace iot::mqtt::server::broker {
     }
 
     void Session::sendPublish(Message& message, uint8_t qoS, bool retain) {
-        LOG(INFO) << "MQTT Broker:   TopicName: " << message.getTopic();
-        LOG(INFO) << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
-        LOG(DEBUG) << "MQTT Broker:   QoS: " << static_cast<uint16_t>(std::min(qoS, message.getQoS()));
+        iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:   TopicName: " << message.getTopic();
+        if (iot::mqtt::semantic::mqttSessionLog().enabled(logger::LogLevel::Info)) {
+            iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:   Message:\n"
+                                                         << iot::mqtt::Mqtt::toHexString(message.getMessage());
+        }
+        iot::mqtt::semantic::mqttSessionLog().debug() << "MQTT Broker:   QoS: " << static_cast<uint16_t>(std::min(qoS, message.getQoS()));
 
         if (isActive()) {
-            LOG(DEBUG) << "MQTT Broker:   ClientId: " << mqtt->getClientId();
-            LOG(DEBUG) << "MQTT Broker:   OriginClientId: " << message.getOriginClientId();
+            iot::mqtt::semantic::mqttSessionLog().debug() << "MQTT Broker:   ClientId: " << mqtt->getClientId();
+            iot::mqtt::semantic::mqttSessionLog().debug() << "MQTT Broker:   OriginClientId: " << message.getOriginClientId();
 
             if ((mqtt->getReflect() || mqtt->getClientId() != message.getOriginClientId())) {
                 mqtt->sendPublish(message.getTopic(),
@@ -78,7 +82,7 @@ namespace iot::mqtt::server::broker {
                                   std::min(message.getQoS(), qoS),
                                   !mqtt->getReflect() ? message.getOriginRetain() || retain : retain);
             } else {
-                LOG(INFO) << "MQTT Broker:     Suppress reflection to origin to avoid message looping";
+                iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:     Suppress reflection to origin to avoid message looping";
             }
         } else {
             // Offline session behavior:
@@ -89,17 +93,17 @@ namespace iot::mqtt::server::broker {
                 message.setQoS(effectiveQoS);
                 messageQueue.emplace_back(message);
             } else {
-                LOG(INFO) << "MQTT Broker:     Drop QoS0 message for inactive session";
+                iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:     Drop QoS0 message for inactive session";
             }
         }
     }
 
     void Session::publishQueued() {
-        LOG(INFO) << "MQTT Broker:     send queued messages ...";
+        iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:     send queued messages ...";
         for (iot::mqtt::server::broker::Message& message : messageQueue) {
             sendPublish(message, message.getQoS(), false);
         }
-        LOG(INFO) << "MQTT Broker:     ... done";
+        iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:     ... done";
 
         messageQueue.clear();
     }

--- a/src/iot/mqtt/server/broker/SubscriptionTree.cpp
+++ b/src/iot/mqtt/server/broker/SubscriptionTree.cpp
@@ -42,6 +42,7 @@
 #include "iot/mqtt/server/broker/SubscriptionTree.h"
 
 #include "iot/mqtt/Mqtt.h"
+#include "iot/mqtt/SemanticLog.h"
 #include "iot/mqtt/server/broker/Broker.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -75,7 +76,7 @@ namespace iot::mqtt::server::broker {
 
             success = true;
         } else {
-            LOG(ERROR) << "MQTT Broker: Subscribe: Wrong '#' placement: " << topic;
+            iot::mqtt::semantic::mqttBrokerLog().error() << "MQTT Broker: Subscribe: Wrong '#' placement: " << topic;
         }
 
         return success;
@@ -86,7 +87,7 @@ namespace iot::mqtt::server::broker {
         if (!message.getTopic().empty() && (hashCount == 0 || (hashCount == 1 && message.getTopic().ends_with('#')))) {
             head.publish(message, message.getTopic());
         } else {
-            LOG(ERROR) << "MQTT Broker: Publish: Wrong '#' placement: " << message.getTopic();
+            iot::mqtt::semantic::mqttBrokerLog().error() << "MQTT Broker: Publish: Wrong '#' placement: " << message.getTopic();
         }
     }
 
@@ -95,7 +96,7 @@ namespace iot::mqtt::server::broker {
         if (!topic.empty() && (hashCount == 0 || (hashCount == 1 && topic.ends_with('#')))) {
             head.unsubscribe(clientId, topic);
         } else {
-            LOG(ERROR) << "MQTT Broker: Unsubscribe: Wrong '#' placement: " << topic;
+            iot::mqtt::semantic::mqttBrokerLog().error() << "MQTT Broker: Unsubscribe: Wrong '#' placement: " << topic;
         }
     }
 
@@ -142,8 +143,8 @@ namespace iot::mqtt::server::broker {
 
     bool SubscriptionTree::TopicLevel::subscribe(const std::string& clientId, uint8_t qoS, std::string topic) {
         if (topic.empty()) {
-            LOG(INFO) << "MQTT Broker: Subscribe";
-            LOG(INFO) << "MQTT Broker:   ClientId: " << clientId;
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Subscribe";
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   ClientId: " << clientId;
 
             clientIds[clientId] = qoS;
         } else {
@@ -154,11 +155,11 @@ namespace iot::mqtt::server::broker {
             const auto& [it, inserted] = topicLevels.insert({topicLevel, SubscriptionTree::TopicLevel(broker, topicLevel)});
 
             if (!it->second.subscribe(clientId, qoS, topic)) {
-                LOG(DEBUG) << "MQTT Broker:   Erase topic: " << topicLevel << " /" << topic;
+                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Erase topic: " << topicLevel << " /" << topic;
 
                 topicLevels.erase(it);
             } else {
-                LOG(INFO) << "MQTT Broker:   Topic: " << topicLevel << " /" << topic;
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << topicLevel << " /" << topic;
             }
         }
 
@@ -167,27 +168,33 @@ namespace iot::mqtt::server::broker {
 
     void SubscriptionTree::TopicLevel::publish(Message& message, std::string topic) {
         if (topic.empty()) {
-            LOG(INFO) << "MQTT Broker: Found match:";
-            LOG(INFO) << "MQTT Broker:   Topic: '" << message.getTopic() << "';";
-            LOG(INFO) << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Found match:";
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: '" << message.getTopic() << "';";
+            if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Info)) {
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Message:\n"
+                                                            << iot::mqtt::Mqtt::toHexString(message.getMessage());
+            }
 
-            LOG(INFO) << "MQTT Broker: Distribute PUBLISH for match ...";
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Distribute PUBLISH for match ...";
             for (auto& [clientId, clientQoS] : clientIds) {
                 broker->sendPublish(clientId, message, clientQoS, false);
             }
-            LOG(INFO) << "MQTT Broker: ... distributing PUBLISH for match completed";
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: ... distributing PUBLISH for match completed";
 
             const auto nextHashLevel = topicLevels.find("#");
             if (nextHashLevel != topicLevels.end()) {
-                LOG(INFO) << "MQTT Broker: Found parent match:";
-                LOG(INFO) << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
-                LOG(INFO) << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Found parent match:";
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
+                if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Info)) {
+                    iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Message:\n"
+                                                                << iot::mqtt::Mqtt::toHexString(message.getMessage());
+                }
 
-                LOG(INFO) << "MQTT Broker: Distribute PUBLISH for match ...";
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Distribute PUBLISH for match ...";
                 for (auto& [clientId, clientQoS] : nextHashLevel->second.clientIds) {
                     broker->sendPublish(clientId, message, clientQoS, false);
                 }
-                LOG(INFO) << "MQTT Broker: ... distributing PUBLISH for match completed";
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: ... distributing PUBLISH for match completed";
             }
         } else {
             const std::string topicLevel = topic.substr(0, topic.find('/'));
@@ -206,15 +213,19 @@ namespace iot::mqtt::server::broker {
 
             foundNode = topicLevels.find("#");
             if (foundNode != topicLevels.end()) {
-                LOG(INFO) << "MQTT Broker: Found match:";
-                LOG(INFO) << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
-                LOG(INFO) << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Found match:";
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
+                if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Info)) {
+                    iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Message:\n"
+                                                                << iot::mqtt::Mqtt::toHexString(message.getMessage());
+                }
 
-                LOG(INFO) << "MQTT Broker: Distribute PUBLISH for match '" << message.getTopic() << "' ...";
+                iot::mqtt::semantic::mqttBrokerLog().info()
+                    << "MQTT Broker: Distribute PUBLISH for match '" << message.getTopic() << "' ...";
                 for (auto& [clientId, clientQoS] : foundNode->second.clientIds) {
                     broker->sendPublish(clientId, message, clientQoS, false);
                 }
-                LOG(INFO) << "MQTT Broker: ... distributing PUBLISH for match completed";
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: ... distributing PUBLISH for match completed";
             }
         }
     }
@@ -222,9 +233,9 @@ namespace iot::mqtt::server::broker {
     bool SubscriptionTree::TopicLevel::unsubscribe(const std::string& clientId, std::string topic) {
         if (topic.empty()) {
             if (clientIds.erase(clientId) != 0) {
-                LOG(INFO) << "MQTT Broker: Unsubscribe";
-                LOG(INFO) << "MQTT Broker:   ClientId: " << clientId;
-                LOG(INFO) << "MQTT Broker:   Topic: " << topicLevel;
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Unsubscribe";
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   ClientId: " << clientId;
+                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << topicLevel;
             }
         } else {
             const std::string topicLevel = topic.substr(0, topic.find('/'));
@@ -234,7 +245,7 @@ namespace iot::mqtt::server::broker {
                 topic.erase(0, topicLevel.size() + 1);
 
                 if (it->second.unsubscribe(clientId, topic)) {
-                    LOG(DEBUG) << "MQTT Broker:   Erase Topic: " << it->first;
+                    iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Erase Topic: " << it->first;
 
                     topicLevels.erase(it);
                 }
@@ -246,14 +257,14 @@ namespace iot::mqtt::server::broker {
 
     bool SubscriptionTree::TopicLevel::unsubscribe(const std::string& clientId) {
         if (clientIds.erase(clientId) != 0) {
-            LOG(INFO) << "MQTT Broker: Unsubscribe";
-            LOG(INFO) << "MQTT Broker:   ClientId: " << clientId;
-            LOG(INFO) << "MQTT Broker:   Topic: " << topicLevel;
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Unsubscribe";
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   ClientId: " << clientId;
+            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << topicLevel;
         }
 
         for (auto it = topicLevels.begin(); it != topicLevels.end();) {
             if (it->second.unsubscribe(clientId)) {
-                LOG(DEBUG) << "MQTT Broker:   Erase Topic: " << it->first;
+                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Erase Topic: " << it->first;
 
                 it = topicLevels.erase(it);
             } else {

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -100,3 +100,9 @@ target_include_directories(WebSocketMigration07cTest PRIVATE ${PROJECT_SOURCE_DI
 target_compile_features(WebSocketMigration07cTest PRIVATE cxx_std_20)
 target_link_libraries(WebSocketMigration07cTest PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(WebSocketMigration07cTest PROPERTIES LABELS "unit;log;migration07c")
+
+snodec_add_test(MqttMigration08Test MqttMigration08Test.cpp)
+target_include_directories(MqttMigration08Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(MqttMigration08Test PRIVATE cxx_std_20)
+target_link_libraries(MqttMigration08Test PRIVATE snodec-test-support snodec::logger)
+set_tests_properties(MqttMigration08Test PROPERTIES LABELS "unit;log;migration08")

--- a/tests/unit/log/MqttMigration08Test.cpp
+++ b/tests/unit/log/MqttMigration08Test.cpp
@@ -171,5 +171,16 @@ int main() {
     }
     result.expectTrue(!expensiveDumpBuilt, "expensive payload/dump guard suppresses construction when disabled");
 
+    bool webSocketDumpBuilt = false;
+    const auto webSocketLog = iot::mqtt::semantic::mqttWebSocketLog(
+        [](logger::LogRecord) {
+        },
+        logger::LogLevel::Error);
+    if (webSocketLog.enabled(logger::LogLevel::Debug)) {
+        webSocketDumpBuilt = true;
+        webSocketLog.debug("WsMqtt: Frame Data:\n{}", "expensive hex dump");
+    }
+    result.expectTrue(!webSocketDumpBuilt, "WsMqtt frame dump guard suppresses construction when debug is disabled");
+
     return result.processResult();
 }

--- a/tests/unit/log/MqttMigration08Test.cpp
+++ b/tests/unit/log/MqttMigration08Test.cpp
@@ -1,0 +1,175 @@
+#include "iot/mqtt/SemanticLog.h"
+#include "log/Logger.h"
+#include "tests/support/TestResult.h"
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+    struct ExpensiveValue {
+        int* evaluations;
+    };
+
+    std::ostream& operator<<(std::ostream& out, const ExpensiveValue& value) {
+        ++*value.evaluations;
+        return out << "expensive";
+    }
+
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() {
+                return std::string("MIGRATION08TICK");
+            });
+            logger::Logger::logToFile(logFile);
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto enabledPath = tempLogPath("snodec-migration08-enabled.log");
+    {
+        LoggerStateGuard guard(enabledPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        iot::mqtt::semantic::mqttLog().debug("mqtt semantic logger emitted");
+    }
+    const auto enabledLog = readFile(enabledPath);
+    result.expectTrue(enabledLog.find("mqtt semantic logger emitted") != std::string::npos, "MQTT semantic logger emits when enabled");
+    result.expectTrue(enabledLog.find(" framework connection iot.mqtt ") != std::string::npos,
+                      "records carry framework iot.mqtt component scope");
+
+    const auto managerFilterPath = tempLogPath("snodec-migration08-manager-filter.log");
+    {
+        LoggerStateGuard guard(managerFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        iot::mqtt::semantic::mqttClientLog().debug("mqtt client suppressed by manager");
+    }
+    result.expectTrue(readFile(managerFilterPath).find("suppressed by manager") == std::string::npos,
+                      "LogManager filtering suppresses migrated MQTT semantic calls");
+
+    const auto backendFilterPath = tempLogPath("snodec-migration08-backend-filter.log");
+    {
+        LoggerStateGuard guard(backendFilterPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+        logger::Logger::setLogLevel(3);
+        iot::mqtt::semantic::mqttServerLog().debug("mqtt server suppressed by backend");
+    }
+    result.expectTrue(readFile(backendFilterPath).find("suppressed by backend") == std::string::npos,
+                      "Logger::setLogLevel backend filtering suppresses output");
+
+    const auto jsonPath = tempLogPath("snodec-migration08-json.log");
+    {
+        LoggerStateGuard guard(jsonPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+        iot::mqtt::semantic::mqttPacketLog().debug("mqtt packet json format respected");
+    }
+    const auto jsonLog = readFile(jsonPath);
+    result.expectTrue(jsonLog.find("{\"v\":1") != std::string::npos &&
+                          jsonLog.find("\"message\":\"mqtt packet json format respected\"") != std::string::npos &&
+                          jsonLog.find("\"origin\":\"framework\"") != std::string::npos &&
+                          jsonLog.find("\"component\":\"iot.mqtt.packet\"") != std::string::npos,
+                      "JSON format selection is respected");
+
+    std::vector<logger::LogRecord> sysErrorRecords;
+    iot::mqtt::semantic::mqttBrokerLog([&](logger::LogRecord record) {
+        sysErrorRecords.push_back(std::move(record));
+    }).sysError(logger::LogLevel::Error, ENOENT, "MQTT Broker: Could not read session store '{}'", "missing-session.json");
+    result.expectTrue(sysErrorRecords.size() == 1 && sysErrorRecords[0].error && sysErrorRecords[0].error->code == ENOENT &&
+                          sysErrorRecords[0].error->text.find("No such file") != std::string::npos,
+                      "sysError errno code/text is preserved by MQTT helper");
+
+    std::vector<logger::LogRecord> sinkRecords;
+    iot::mqtt::semantic::mqttTopicLog([&](logger::LogRecord record) {
+        sinkRecords.push_back(std::move(record));
+    }).info("MQTT Broker:   Topic filter: '{}' QoS={} ", "sensors/+/temp", 1);
+    result.expectTrue(sinkRecords.size() == 1 && sinkRecords[0].component == "iot.mqtt.topic" &&
+                          sinkRecords[0].message.find("sensors/+/temp") != std::string::npos,
+                      "sink-taking overload remains compatible and topic/filter payload is preserved");
+
+    const auto suppressedPath = tempLogPath("snodec-migration08-suppressed.log");
+    {
+        LoggerStateGuard guard(suppressedPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Error);
+        logger::LogManager::freeze();
+        int evaluations = 0;
+        iot::mqtt::semantic::mqttLog().debug("{}", ExpensiveValue{&evaluations});
+        result.expectEqual(0, evaluations, "suppressed production formatting does not evaluate ExpensiveValue after PR #151");
+    }
+
+    std::vector<logger::LogRecord> records;
+    const auto collect = [&](logger::LogRecord record) {
+        records.push_back(std::move(record));
+    };
+    iot::mqtt::semantic::mqttClientLog(collect).info("{} MQTT Client: CONNECT send: {}", "conn08", "client08");
+    iot::mqtt::semantic::mqttServerLog(collect).info("{} MQTT Broker:   Protocol: {}", "conn08", "MQTT");
+    iot::mqtt::semantic::mqttBrokerLog(collect).info("MQTT Broker: Send PUBLISH: {}", "client08");
+    iot::mqtt::semantic::mqttSessionLog(collect).debug("MQTT Broker:   OriginClientId: {}", "origin08");
+    iot::mqtt::semantic::mqttPacketLog(collect).debug("{} MQTT: Fixed Header: PacketType: 0x{} ({})", "conn08", "03", "PUBLISH");
+    iot::mqtt::semantic::mqttWebSocketLog(collect).info("{} WsMqtt: connected:", "conn08");
+
+    result.expectTrue(records.size() == 6, "representative MQTT client/server/broker/session/packet/WebSocket payloads emitted");
+    result.expectTrue(records[0].message.find("CONNECT send: client08") != std::string::npos,
+                      "representative MQTT client lifecycle payload preservation is covered");
+    result.expectTrue(records[1].message.find("Protocol: MQTT") != std::string::npos,
+                      "representative MQTT server lifecycle payload preservation is covered");
+    result.expectTrue(records[2].message.find("Send PUBLISH: client08") != std::string::npos,
+                      "representative MQTT broker payload preservation is covered");
+    result.expectTrue(records[3].message.find("OriginClientId: origin08") != std::string::npos,
+                      "representative MQTT session payload preservation is covered");
+    result.expectTrue(records[4].message.find("Fixed Header: PacketType: 0x03 (PUBLISH)") != std::string::npos,
+                      "representative MQTT packet/control-packet payload preservation is covered");
+    result.expectTrue(records[5].message.find("WsMqtt: connected") != std::string::npos,
+                      "representative MQTT-over-WebSocket payload preservation is covered");
+
+    bool expensiveDumpBuilt = false;
+    const auto packetLog = iot::mqtt::semantic::mqttPacketLog(
+        [](logger::LogRecord) {
+        },
+        logger::LogLevel::Error);
+    if (packetLog.enabled(logger::LogLevel::Trace)) {
+        expensiveDumpBuilt = true;
+        packetLog.trace("expensive dump {}", "payload");
+    }
+    result.expectTrue(!expensiveDumpBuilt, "expensive payload/dump guard suppresses construction when disabled");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation
- Replace ad-hoc `LOG`/`PLOG` MQTT framework traces with the new semantic logging API to provide consistent framework/component scope and backend/filter compatibility for MQTT telemetry.
- Provide safe ownership and minimal API churn by adding a small MQTT-local semantic helper rather than broad constructor changes.
- Preserve all protocol detail and errno semantics while preventing expensive payload serialization when logs are disabled.

### Description
- Added `src/iot/mqtt/SemanticLog.h` with `iot::mqtt` scoped `LogScopeOwner` helpers and sink-taking overloads (`mqttLog`, `mqttClientLog`, `mqttServerLog`, `mqttBrokerLog`, `mqttSessionLog`, `mqttPacketLog`, `mqttTopicLog`, `mqttWebSocketLog`).
- Replaced `LOG(...)` / `PLOG(...)` sites inside `src/iot/mqtt` (core, client, server, broker, session, retain/subscription trees, WebSocket subprotocol) with the corresponding semantic calls and mapped severities (`trace/debug/info/warn/error/critical`).
- Converted errno-sensitive `PLOG` usages to `sysError(...)` with immediate `errno` capture to preserve code/text; guarded expensive dumps/hex serializations with `enabled(...)` checks to avoid constructing expensive strings when not enabled.
- Added the migration report `docs/logging/semantic-migration-08-mqtt-report.md`, the unit test `tests/unit/log/MqttMigration08Test.cpp`, and registered it in `tests/unit/log/CMakeLists.txt` to cover scope/format/filtering/sysError/expensive-dump guards and representative MQTT payloads.

### Testing
- Built and ran unit tests: configured with `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`, built, and ran `ctest` for the logging/migration suite including `MqttMigration08Test`; all selected tests passed.
- Ran focused ASan build and test for the migration test: configured `cmake -S . -B cmake-build-asan -DSNODEC_ENABLE_ASAN=ON`, built `MqttMigration08Test`, and ran it under ASan; the focused ASan test passed.
- Post-migration inventory shows no remaining `LOG`/`PLOG`/`VLOG` call sites in `src/iot/mqtt` (all suitable call sites migrated); a short-form report file documents inventory, ownership, migrated/ deferred sites, and follow-ups.
- Notes: initial configure required installing `nlohmann-json3-dev` in the environment; full ASan for the entire test-suite was not run due to resource/time constraints, while the required focused ASan `MqttMigration08Test` was executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c064fdb6c832cb178dd47daddeee6)