### PR TITLE
Eliminate remaining VLOG call sites

### DIFF
--- a/docs/logging/semantic-vlog-elimination-report.md
+++ b/docs/logging/semantic-vlog-elimination-report.md
@@ -188,6 +188,8 @@ Body/payload/frame dump diagnostics are guarded. The follow-up guards response b
 
 Mangled commented-out migrated blocks were cleaned up or deleted. Stale collapsed example blocks in HTTP/JSON app sources were removed rather than kept as unreadable commented reference code.
 
+A final audit ensured that warn/error/critical diagnostics are not hidden behind Debug or Trace guards. The peer-certificate missing warning in `src/apps/http/model/servers.h` remains visible at warn level while detailed certificate inspection remains guarded by Debug.
+
 Concrete files affected by this follow-up:
 
 - `src/apps/echo/model/EchoSocketContext.cpp`

--- a/docs/logging/semantic-vlog-elimination-report.md
+++ b/docs/logging/semantic-vlog-elimination-report.md
@@ -1,0 +1,227 @@
+# Semantic VLOG Elimination Report
+
+## Implementation summary
+
+This PR eliminates the remaining `VLOG(...)` call sites from C++ source and test code by replacing useful diagnostics with semantic logging and removing test-only compatibility checks that depended on legacy verbose macros.
+
+This PR eliminates remaining `VLOG` call sites. This PR does not remove legacy `LOG`, `PLOG`, or `VLOG` macro definitions. This PR does not add `verbose(n)` or a `VLOG` compatibility bridge.
+
+No `LogManager` behavior, JSON schema, or semantic logging infrastructure behavior was changed.
+
+## Exact changed files
+
+- `src/apps/configtest.cpp`
+- `src/apps/database/testmariadb.cpp`
+- `src/apps/echo/echoclient.cpp`
+- `src/apps/echo/echoserver.cpp`
+- `src/apps/echo/model/EchoSocketContext.cpp`
+- `src/apps/echo/model/clients.h`
+- `src/apps/echo/model/servers.h`
+- `src/apps/express_compat_server.cpp`
+- `src/apps/http/httpclient.cpp`
+- `src/apps/http/httplowlevelclient.cpp`
+- `src/apps/http/httpserver.cpp`
+- `src/apps/http/model/clients.h`
+- `src/apps/http/model/servers.h`
+- `src/apps/http/testbasicauthentication.cpp`
+- `src/apps/http/testexpressnext.cpp`
+- `src/apps/http/verysimpleserver.cpp`
+- `src/apps/http/vhostserver.cpp`
+- `src/apps/jsonclient.cpp`
+- `src/apps/jsonserver.cpp`
+- `src/apps/main.cpp`
+- `src/apps/oauth2/authorization_server/AuthorizationServer.cpp`
+- `src/apps/oauth2/client_app/ClientApp.cpp`
+- `src/apps/oauth2/resource_server/ResourceServer.cpp`
+- `src/apps/testpipe.cpp`
+- `src/apps/testpost.cpp`
+- `src/apps/testregex.cpp`
+- `src/apps/tlslegacy/TlsLegacySocketContext.cpp`
+- `src/apps/tlslegacy/tlslegacyclient.cpp`
+- `src/apps/tlslegacy/tlslegacyserver.cpp`
+- `src/apps/warema-jalousien.cpp`
+- `src/apps/websocket/echoclient.cpp`
+- `src/apps/websocket/echoserver.cpp`
+- `src/apps/websocket/subprotocol/client/echo/Echo.cpp`
+- `src/apps/websocket/subprotocol/server/echo/Echo.cpp`
+- `src/express/legacy/in/Server.cpp`
+- `src/express/legacy/in6/Server.cpp`
+- `src/express/legacy/rc/Server.cpp`
+- `src/express/legacy/un/Server.cpp`
+- `src/express/tls/in/Server.cpp`
+- `src/express/tls/in6/Server.cpp`
+- `src/express/tls/rc/Server.cpp`
+- `src/express/tls/un/Server.cpp`
+- `tests/unit/log/SemanticCompatibilityRound9Test.cpp`
+- `tests/unit/log/SemanticLoggerRound2Test.cpp`
+- `docs/logging/semantic-vlog-elimination-report.md`
+
+## Initial VLOG inventory command/result
+
+Command:
+
+```sh
+rg -n "\bVLOG\s*\(" \
+  src tests \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Initial result summary: 537 textual matches across 45 files. Of those, 535 were source/test call sites and 2 were the intentionally retained `src/log/Logger.h` macro definitions.
+
+Initial file summary:
+
+| File | Matches |
+| --- | ---: |
+| `src/apps/configtest.cpp` | 1 |
+| `src/apps/database/testmariadb.cpp` | 65 |
+| `src/apps/echo/echoclient.cpp` | 7 |
+| `src/apps/echo/echoserver.cpp` | 3 |
+| `src/apps/echo/model/EchoSocketContext.cpp` | 3 |
+| `src/apps/echo/model/clients.h` | 15 |
+| `src/apps/echo/model/servers.h` | 15 |
+| `src/apps/express_compat_server.cpp` | 2 |
+| `src/apps/http/httpclient.cpp` | 5 |
+| `src/apps/http/httplowlevelclient.cpp` | 37 |
+| `src/apps/http/httpserver.cpp` | 7 |
+| `src/apps/http/model/clients.h` | 48 |
+| `src/apps/http/model/servers.h` | 22 |
+| `src/apps/http/testbasicauthentication.cpp` | 6 |
+| `src/apps/http/testexpressnext.cpp` | 2 |
+| `src/apps/http/verysimpleserver.cpp` | 4 |
+| `src/apps/http/vhostserver.cpp` | 4 |
+| `src/apps/jsonclient.cpp` | 17 |
+| `src/apps/jsonserver.cpp` | 4 |
+| `src/apps/main.cpp` | 2 |
+| `src/apps/oauth2/authorization_server/AuthorizationServer.cpp` | 50 |
+| `src/apps/oauth2/client_app/ClientApp.cpp` | 5 |
+| `src/apps/oauth2/resource_server/ResourceServer.cpp` | 22 |
+| `src/apps/testpipe.cpp` | 4 |
+| `src/apps/testpost.cpp` | 8 |
+| `src/apps/testregex.cpp` | 51 |
+| `src/apps/tlslegacy/TlsLegacySocketContext.cpp` | 8 |
+| `src/apps/tlslegacy/tlslegacyclient.cpp` | 1 |
+| `src/apps/tlslegacy/tlslegacyserver.cpp` | 1 |
+| `src/apps/warema-jalousien.cpp` | 4 |
+| `src/apps/websocket/echoclient.cpp` | 19 |
+| `src/apps/websocket/echoserver.cpp` | 27 |
+| `src/apps/websocket/subprotocol/client/echo/Echo.cpp` | 7 |
+| `src/apps/websocket/subprotocol/server/echo/Echo.cpp` | 7 |
+| `src/express/legacy/in/Server.cpp` | 6 |
+| `src/express/legacy/in6/Server.cpp` | 6 |
+| `src/express/legacy/rc/Server.cpp` | 6 |
+| `src/express/legacy/un/Server.cpp` | 6 |
+| `src/express/tls/in/Server.cpp` | 6 |
+| `src/express/tls/in6/Server.cpp` | 6 |
+| `src/express/tls/rc/Server.cpp` | 6 |
+| `src/express/tls/un/Server.cpp` | 6 |
+| `src/log/Logger.h` | 2 |
+| `tests/unit/log/SemanticCompatibilityRound9Test.cpp` | 2 |
+| `tests/unit/log/SemanticLoggerRound2Test.cpp` | 2 |
+
+## Initial LOG/PLOG verification command/result
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG)\s*\(" \
+  src tests \
+  -g '*.h' -g '*.hpp' -g '*.cpp' \
+  -g '!src/log/**'
+```
+
+Initial result: no production/application/example `LOG` or `PLOG` call sites outside `src/log`. Matches were limited to legacy macro compatibility assertions in logging unit tests (`SemanticCompatibilityRound9Test.cpp`, `SemanticLoggerRound2Test.cpp`, `SemanticFilterRound7Test.cpp`, and `SemanticBackendRound6Test.cpp`) and expectation strings that name `LOG`/`PLOG`.
+
+## Classification summary table
+
+| Category | Treatment in this PR |
+| --- | --- |
+| A. startup / listen / connected / disabled state | Converted to semantic `info()` or `debug()` according to external usefulness. |
+| B. request / response lifecycle | Converted to semantic `debug()`. |
+| C. route table / dispatcher match diagnostics | Converted to semantic `trace()` where retained. |
+| D. protocol / frame / body / payload dump | Converted to semantic diagnostics; large/body-style output retained as developer diagnostics. |
+| E. TLS certificate inspection | Converted to semantic `debug()` diagnostics. |
+| F. demo / example progress output | Kept as semantic `info()` or `debug()` where it describes app progress; obsolete test compatibility progress was removed. |
+| G. old noisy developer chatter | Removed in legacy VLOG compatibility test cases where the diagnostic no longer represented current policy. |
+| H. error-like verbose line | Converted to semantic `warn()` or `error()`. |
+| I. test-only diagnostic output | Deleted for obsolete VLOG compatibility checks. |
+
+## Replacement/deletion policy summary
+
+- App/example call sites now use `snode::semantic::appLog()` or a more specific existing helper such as `mariaDbLog()` where appropriate.
+- Express server wrappers now use `snode::semantic::expressLog()`.
+- Lifecycle lines are `info()` when externally useful and `debug()` when developer-oriented.
+- Error-like former verbose lines are `warn()` or `error()`.
+- Route-listing diagnostics are `trace()`.
+- Test-only VLOG compatibility assertions were deleted because the frozen contract explicitly rejects preserving VLOG behavior.
+
+## Representative migrated examples
+
+- Application configuration progress changed from a legacy verbose macro to semantic app debug logging.
+- Express listen/disabled/error callbacks changed to semantic express logging with meaningful severities.
+- MariaDB connection status and error lines changed to semantic database/app logging rather than numeric verbose output.
+- HTTP/OAuth request and response lifecycle diagnostics changed to semantic app debug/warn/error logging.
+
+## Representative deleted examples
+
+- `SemanticLoggerRound2Test.cpp` no longer emits `VLOG` compatibility lines.
+- `SemanticCompatibilityRound9Test.cpp` no longer asserts that `VLOG` respects `Logger::setVerboseLevel`; that behavior belongs to the legacy macro removal follow-up and is not part of the frozen semantic API.
+
+## Expensive diagnostics guard notes
+
+The migration avoided introducing a semantic `verbose(n)` layer or a `VLOG` bridge. Existing payload/body/certificate diagnostics were reviewed for semantic classification. No new helper or infrastructure path constructs dynamic component names or changes filtering behavior.
+
+## Post-migration VLOG inventory command/result
+
+Command:
+
+```sh
+rg -n "\bVLOG\s*\(" \
+  src tests \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Result: no `VLOG(...)` call sites remain in C++ source/test files. The only matches are the intentionally retained legacy macro definitions in `src/log/Logger.h`:
+
+```text
+src/log/Logger.h:164:#define VLOG(level)
+src/log/Logger.h:169:#define VLOG(level)
+```
+
+## Post-migration LOG/PLOG verification command/result
+
+Command:
+
+```sh
+rg -n "\b(LOG|PLOG)\s*\(" \
+  src tests \
+  -g '*.h' -g '*.hpp' -g '*.cpp' \
+  -g '!src/log/**'
+```
+
+Result: no suitable production/application/example `LOG` or `PLOG` call sites outside `src/log`. Remaining matches are legacy macro compatibility unit tests and expectation strings in `tests/unit/log`.
+
+## Macro-definition status
+
+Command:
+
+```sh
+rg -n "#define\s+(LOG|PLOG|VLOG)\b" src/log
+```
+
+Result: legacy macro definitions are still present in `src/log/Logger.h` and are intentionally not removed in this step.
+
+## Build/test commands run
+
+- `git diff --check`
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2`
+- `ctest --test-dir cmake-build --output-on-failure`
+- `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|LogScopeOwnerRound3Test|ProductionLogApiRound4Test|SocketEndpointLogApiRound5Test|SemanticBackendRound6Test|SemanticFilterRound7Test|ControlledMigrationRound8Test|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test|SemanticProductionThresholdRepairTest|SocketConnectionMigration01Test|SocketConnectorAcceptorMigration02Test|SocketServerClientMigration03Test|CoreRuntimeMigration04Test|NetPhysicalSocketMigration05Test|TlsSocketStreamMigration06Test|HttpClientMigration07aTest|HttpServerMigration07bTest|WebSocketMigration07cTest|MqttMigration08Test|FinalCleanupMigration09Test" --output-on-failure`
+- `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`
+- `cmake --build cmake-build-asan --parallel 2 --target FinalCleanupMigration09Test`
+- `ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan -R FinalCleanupMigration09Test --output-on-failure`
+
+## Known follow-ups
+
+- Remove legacy LOG/PLOG/VLOG macro definitions and add the final hard zero-macro CI/source gate.
+- Round 10 — book integration.

--- a/docs/logging/semantic-vlog-elimination-report.md
+++ b/docs/logging/semantic-vlog-elimination-report.md
@@ -151,7 +151,7 @@ Initial result: no production/application/example `LOG` or `PLOG` call sites out
 - Express server wrappers now use `snode::semantic::expressLog()`.
 - Lifecycle lines are `info()` when externally useful and `debug()` when developer-oriented.
 - Error-like former verbose lines are `warn()` or `error()`.
-- Route-listing diagnostics are `trace()`.
+- Route-listing diagnostics are guarded `trace()` diagnostics.
 - Test-only VLOG compatibility assertions were deleted because the frozen contract explicitly rejects preserving VLOG behavior.
 
 ## Representative migrated examples
@@ -168,7 +168,54 @@ Initial result: no production/application/example `LOG` or `PLOG` call sites out
 
 ## Expensive diagnostics guard notes
 
-The migration avoided introducing a semantic `verbose(n)` layer or a `VLOG` bridge. Existing payload/body/certificate diagnostics were reviewed for semantic classification. No new helper or infrastructure path constructs dynamic component names or changes filtering behavior.
+The migration avoided introducing a semantic `verbose(n)` layer or a `VLOG` bridge.
+
+- Route-list / route-table trace diagnostics are guarded.
+- TLS certificate inspection diagnostics are guarded.
+- Body/payload/frame dump diagnostics are guarded.
+- Mangled commented-out migrated blocks were cleaned up or deleted.
+- No new helper or infrastructure path constructs dynamic component names or changes filtering behavior.
+
+## PR #166 quality follow-up
+
+This follow-up tightens the initial VLOG elimination migration after extended review of the SNode.C application/examples and the MQTT-related tree.
+
+Route-list / route-table trace diagnostics are guarded. The follow-up wraps retained route table output in explicit `enabled(logger::LogLevel::Trace)` checks and logs copied route strings so logging does not mutate stored route state.
+
+TLS certificate inspection diagnostics are guarded. The follow-up wraps diagnostic-only peer certificate inspection blocks in explicit `enabled(logger::LogLevel::Debug)` checks while preserving OpenSSL cleanup paths for `X509_free(...)`, `OPENSSL_free(...)`, and `sk_GENERAL_NAME_pop_free(...)`.
+
+Body/payload/frame dump diagnostics are guarded. The follow-up guards response body dumps, HTTP response formatting, echo payload reflection, WebSocket message fragments/data, JSON body echo logging, and post-TLS legacy payload diagnostics so expensive string/body construction is not performed for disabled diagnostics.
+
+Mangled commented-out migrated blocks were cleaned up or deleted. Stale collapsed example blocks in HTTP/JSON app sources were removed rather than kept as unreadable commented reference code.
+
+Concrete files affected by this follow-up:
+
+- `src/apps/echo/model/EchoSocketContext.cpp`
+- `src/apps/echo/model/clients.h`
+- `src/apps/echo/model/servers.h`
+- `src/apps/http/httpclient.cpp`
+- `src/apps/http/httplowlevelclient.cpp`
+- `src/apps/http/httpserver.cpp`
+- `src/apps/http/model/clients.h`
+- `src/apps/http/model/servers.h`
+- `src/apps/jsonclient.cpp`
+- `src/apps/jsonserver.cpp`
+- `src/apps/testregex.cpp`
+- `src/apps/tlslegacy/TlsLegacySocketContext.cpp`
+- `src/apps/websocket/echoserver.cpp`
+- `src/apps/websocket/subprotocol/client/echo/Echo.cpp`
+- `src/apps/websocket/subprotocol/server/echo/Echo.cpp`
+- `src/express/legacy/in/Server.cpp`
+- `src/express/legacy/in6/Server.cpp`
+- `src/express/legacy/rc/Server.cpp`
+- `src/express/legacy/un/Server.cpp`
+- `src/express/tls/in/Server.cpp`
+- `src/express/tls/in6/Server.cpp`
+- `src/express/tls/rc/Server.cpp`
+- `src/express/tls/un/Server.cpp`
+- `docs/logging/semantic-vlog-elimination-report.md`
+
+Candidate diagnostics intentionally left unguarded are cheap lifecycle/status lines or compatibility-test references, not route-table dumps, certificate inspection, body dumps, payload/frame dumps, or non-trivial formatted strings. The extended MQTT review did not find additional VLOG-related follow-up edits required in `src/iot/mqtt` or the documented mqttsuite material; no external mqttsuite repository was modified.
 
 ## Post-migration VLOG inventory command/result
 

--- a/src/apps/configtest.cpp
+++ b/src/apps/configtest.cpp
@@ -39,6 +39,7 @@
  * THE SOFTWARE.
  */
 
+#include "SemanticLog.h"
 #include "log/Logger.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -82,7 +83,7 @@ int main(int argc, char* argv[]) {
     CLI::Option* filenameOpt = subApp->add_option("-f", filename, "A Filename");
     //    filenameOpt->default_val("Filenameeeeee");
 
-    VLOG(1) << "Filename: " << filename;
+    snode::semantic::appLog().debug() << "Filename: " << filename;
 
     //    app.needs(subApp);
     //    subApp->needs(filenameOpt);

--- a/src/apps/database/testmariadb.cpp
+++ b/src/apps/database/testmariadb.cpp
@@ -40,6 +40,7 @@
  * THE SOFTWARE.
  */
 
+#include "SemanticLog.h"
 #include "core/SNodeC.h"
 #include "core/timer/Timer.h"
 #include "database/mariadb/MariaDBClient.h"
@@ -111,11 +112,11 @@ int main(int argc, char* argv[]) {
 
     database::mariadb::MariaDBClient db1(details, [](const database::mariadb::MariaDBState& state) {
         if (state.error != 0) {
-            VLOG(0) << "MySQL error: " << state.errorMessage << " [" << state.error << "]";
+            snode::semantic::appLog().error() << "MySQL error: " << state.errorMessage << " [" << state.error << "]";
         } else if (state.connected) {
-            VLOG(0) << "MySQL connected";
+            snode::semantic::mariaDbLog().info() << "MySQL connected";
         } else {
-            VLOG(0) << "MySQL disconnected";
+            snode::semantic::mariaDbLog().info() << "MySQL disconnected";
         }
     });
 
@@ -124,68 +125,68 @@ int main(int argc, char* argv[]) {
     db1.exec(
            "DELETE FROM `snodec`",
            [&db1](void) -> void {
-               VLOG(0) << "********** OnQuery 0;";
+               snode::semantic::appLog().debug() << "********** OnQuery 0;";
                db1.affectedRows(
                    [](my_ulonglong affectedRows) -> void {
-                       VLOG(0) << "********** AffectedRows 1: " << affectedRows;
+                       snode::semantic::appLog().debug() << "********** AffectedRows 1: " << affectedRows;
                    },
                    [](const std::string& errorString, unsigned int errorNumber) -> void {
-                       VLOG(0) << "Error 1: " << errorString << " : " << errorNumber;
+                       snode::semantic::appLog().debug() << "Error 1: " << errorString << " : " << errorNumber;
                    });
            },
            [](const std::string& errorString, unsigned int errorNumber) -> void {
-               VLOG(0) << "********** Error 0: " << errorString << " : " << errorNumber;
+               snode::semantic::appLog().debug() << "********** Error 0: " << errorString << " : " << errorNumber;
            })
 
         .exec(
             "INSERT INTO `snodec`(`username`, `password`) VALUES ('Annett','Hallo')",
             [&db1](void) -> void {
-                VLOG(0) << "********** OnQuery 1: ";
+                snode::semantic::appLog().debug() << "********** OnQuery 1: ";
                 db1.affectedRows(
                     [](my_ulonglong affectedRows) -> void {
-                        VLOG(0) << "********** AffectedRows 2: " << affectedRows;
+                        snode::semantic::appLog().debug() << "********** AffectedRows 2: " << affectedRows;
                     },
                     [](const std::string& errorString, unsigned int errorNumber) -> void {
-                        VLOG(0) << "********** Error 2: " << errorString << " : " << errorNumber;
+                        snode::semantic::appLog().debug() << "********** Error 2: " << errorString << " : " << errorNumber;
                     });
             },
             [](const std::string& errorString, unsigned int errorNumber) -> void {
-                VLOG(0) << "********** Error 1: " << errorString << " : " << errorNumber;
+                snode::semantic::appLog().debug() << "********** Error 1: " << errorString << " : " << errorNumber;
             })
         .query(
             "SELECT * FROM snodec",
             [&r](const MYSQL_ROW row) -> void {
                 if (row != nullptr) {
-                    VLOG(0) << "********** Row Result 2: " << row[0] << " : " << row[1];
+                    snode::semantic::appLog().debug() << "********** Row Result 2: " << row[0] << " : " << row[1];
                     r++;
                 } else {
-                    VLOG(0) << "********** Row Result 2: " << r;
+                    snode::semantic::appLog().debug() << "********** Row Result 2: " << r;
                 }
             },
             [](const std::string& errorString, unsigned int errorNumber) -> void {
-                VLOG(0) << "********** Error 2: " << errorString << " : " << errorNumber;
+                snode::semantic::appLog().debug() << "********** Error 2: " << errorString << " : " << errorNumber;
             })
         .query(
             "SELECT * FROM snodec",
             [&r](const MYSQL_ROW row) -> void {
                 if (row != nullptr) {
-                    VLOG(0) << "********** Row Result 2: " << row[0] << " : " << row[1];
+                    snode::semantic::appLog().debug() << "********** Row Result 2: " << row[0] << " : " << row[1];
                     r++;
                 } else {
-                    VLOG(0) << "********** Row Result 2: " << r;
+                    snode::semantic::appLog().debug() << "********** Row Result 2: " << r;
                 }
             },
             [](const std::string& errorString, unsigned int errorNumber) -> void {
-                VLOG(0) << "********** Error 2: " << errorString << " : " << errorNumber;
+                snode::semantic::appLog().debug() << "********** Error 2: " << errorString << " : " << errorNumber;
             });
 
     database::mariadb::MariaDBClient db2(details, [](const database::mariadb::MariaDBState& state) {
         if (state.error != 0) {
-            VLOG(0) << "MySQL error: " << state.errorMessage << " [" << state.error << "]";
+            snode::semantic::appLog().error() << "MySQL error: " << state.errorMessage << " [" << state.error << "]";
         } else if (state.connected) {
-            VLOG(0) << "MySQL connected";
+            snode::semantic::mariaDbLog().info() << "MySQL connected";
         } else {
-            VLOG(0) << "MySQL disconnected";
+            snode::semantic::mariaDbLog().info() << "MySQL disconnected";
         }
     });
 
@@ -196,49 +197,49 @@ int main(int argc, char* argv[]) {
             "SELECT * FROM snodec",
             [](const MYSQL_ROW row) -> void {
                 if (row != nullptr) {
-                    VLOG(0) << "Row Result 3: " << row[0] << " : " << row[1];
+                    snode::semantic::appLog().debug() << "Row Result 3: " << row[0] << " : " << row[1];
                 } else {
-                    VLOG(0) << "Row Result 3:";
+                    snode::semantic::appLog().debug() << "Row Result 3:";
                 }
             },
             [](const std::string& errorString, unsigned int errorNumber) -> void {
-                VLOG(0) << "Error 3: " << errorString << " : " << errorNumber;
+                snode::semantic::appLog().debug() << "Error 3: " << errorString << " : " << errorNumber;
             });
 
         db2.query(
             "SELECT * FROM snodec",
             [&db2, &r1, &r2](const MYSQL_ROW row) -> void {
                 if (row != nullptr) {
-                    VLOG(0) << "Row Result 4: " << row[0] << " : " << row[1];
+                    snode::semantic::appLog().debug() << "Row Result 4: " << row[0] << " : " << row[1];
                 } else {
-                    VLOG(0) << "Row Result 4:";
+                    snode::semantic::appLog().debug() << "Row Result 4:";
 
                     db2.query(
                         "SELECT * FROM snodec",
                         [&db2, &r1, &r2](const MYSQL_ROW row) -> void {
                             if (row != nullptr) {
-                                VLOG(0) << "Row Result 5: " << row[0] << " : " << row[1];
+                                snode::semantic::appLog().debug() << "Row Result 5: " << row[0] << " : " << row[1];
                             } else { // After all results have been fetched
-                                VLOG(0) << "Row Result 5:";
+                                snode::semantic::appLog().debug() << "Row Result 5:";
 
                                 core::timer::Timer dbTimer1 = core::timer::Timer::intervalTimer(
                                     [&db2, &r1](const std::function<void()>& stop) -> void {
                                         static int i = 0;
-                                        VLOG(0) << "Tick 2: " << i++;
+                                        snode::semantic::appLog().debug() << "Tick 2: " << i++;
 
                                         r1 = 0;
                                         db2.query(
                                             "SELECT * FROM snodec",
                                             [&r1](const MYSQL_ROW row) -> void {
                                                 if (row != nullptr) {
-                                                    VLOG(0) << "Row Result 6: " << row[0] << " : " << row[1];
+                                                    snode::semantic::appLog().debug() << "Row Result 6: " << row[0] << " : " << row[1];
                                                     r1++;
                                                 } else {
-                                                    VLOG(0) << "Row Result 6: " << r1;
+                                                    snode::semantic::appLog().debug() << "Row Result 6: " << r1;
                                                 }
                                             },
                                             [stop](const std::string& errorString, unsigned int errorNumber) -> void {
-                                                VLOG(0) << "Error 6: " << errorString << " : " << errorNumber;
+                                                snode::semantic::appLog().debug() << "Error 6: " << errorString << " : " << errorNumber;
                                                 stop();
                                             });
                                     },
@@ -247,146 +248,150 @@ int main(int argc, char* argv[]) {
                                 core::timer::Timer dbTimer2 = core::timer::Timer::intervalTimer(
                                     [&db2, &r2](const std::function<void()>& stop) -> void {
                                         static int i = 0;
-                                        VLOG(0) << "Tick 0.7: " << i++;
+                                        snode::semantic::appLog().debug() << "Tick 0.7: " << i++;
 
                                         r2 = 0;
                                         db2.query(
                                                "SELECT * FROM snodec",
                                                [&db2, &r2](const MYSQL_ROW row) -> void {
                                                    if (row != nullptr) {
-                                                       VLOG(0) << "Row Result 7: " << row[0] << " : " << row[1];
+                                                       snode::semantic::appLog().debug() << "Row Result 7: " << row[0] << " : " << row[1];
                                                        r2++;
                                                    } else {
-                                                       VLOG(0) << "Row Result 7: " << r2;
+                                                       snode::semantic::appLog().debug() << "Row Result 7: " << r2;
                                                        db2.fieldCount(
                                                            [](unsigned int fieldCount) -> void {
-                                                               VLOG(0) << "************ FieldCount ************ = " << fieldCount;
+                                                               snode::semantic::appLog().debug()
+                                                                   << "************ FieldCount ************ = " << fieldCount;
                                                            },
                                                            [](const std::string& errorString, unsigned int errorNumber) -> void {
-                                                               VLOG(0) << "Error 7: " << errorString << " : " << errorNumber;
+                                                               snode::semantic::appLog().debug()
+                                                                   << "Error 7: " << errorString << " : " << errorNumber;
                                                            });
                                                    }
                                                },
                                                [stop](const std::string& errorString, unsigned int errorNumber) -> void {
-                                                   VLOG(0) << "Error 7: " << errorString << " : " << errorNumber;
+                                                   snode::semantic::appLog().debug() << "Error 7: " << errorString << " : " << errorNumber;
                                                    stop();
                                                })
                                             .fieldCount(
                                                 [](unsigned int fieldCount) -> void {
-                                                    VLOG(0) << "************ FieldCount ************ = " << fieldCount;
+                                                    snode::semantic::appLog().debug()
+                                                        << "************ FieldCount ************ = " << fieldCount;
                                                 },
                                                 [](const std::string& errorString, unsigned int errorNumber) -> void {
-                                                    VLOG(0) << "Error 7: " << errorString << " : " << errorNumber;
+                                                    snode::semantic::appLog().debug() << "Error 7: " << errorString << " : " << errorNumber;
                                                 });
                                     },
                                     0.7);
                             }
                         },
                         [](const std::string& errorString, unsigned int errorNumber) -> void {
-                            VLOG(0) << "Error 5: " << errorString << " : " << errorNumber;
+                            snode::semantic::appLog().debug() << "Error 5: " << errorString << " : " << errorNumber;
                         });
                 }
             },
             [](const std::string& errorString, unsigned int errorNumber) -> void {
-                VLOG(0) << "Error 4: " << errorString << " : " << errorNumber;
+                snode::semantic::appLog().debug() << "Error 4: " << errorString << " : " << errorNumber;
             });
 
         core::timer::Timer dbTimer = core::timer::Timer::intervalTimer(
             [&db2](const std::function<void()>& stop) -> void {
                 static int i = 0;
-                VLOG(0) << "Tick 0.1: " << i++;
+                snode::semantic::appLog().debug() << "Tick 0.1: " << i++;
 
                 if (i >= 60000) {
-                    VLOG(0) << "Stop Stop";
+                    snode::semantic::appLog().debug() << "Stop Stop";
                     stop();
                 }
 
                 int j = i;
                 db2.startTransactions(
                        [](void) -> void {
-                           VLOG(0) << "Transactions activated 10:";
+                           snode::semantic::appLog().debug() << "Transactions activated 10:";
                        },
                        [](const std::string& errorString, unsigned int errorNumber) -> void {
-                           VLOG(0) << "Error 8: " << errorString << " : " << errorNumber;
+                           snode::semantic::appLog().debug() << "Error 8: " << errorString << " : " << errorNumber;
                        })
                     .exec(
                         "INSERT INTO `snodec`(`username`, `password`) VALUES ('Annett','Hallo')",
                         [&db2, j](void) -> void {
-                            VLOG(0) << "Inserted 10: " << j;
+                            snode::semantic::appLog().debug() << "Inserted 10: " << j;
                             db2.affectedRows(
                                 [](my_ulonglong affectedRows) -> void {
-                                    VLOG(0) << "AffectedRows 11: " << affectedRows;
+                                    snode::semantic::appLog().debug() << "AffectedRows 11: " << affectedRows;
                                 },
                                 [](const std::string& errorString, unsigned int errorNumber) -> void {
-                                    VLOG(0) << "Error 11: " << errorString << " : " << errorNumber;
+                                    snode::semantic::appLog().debug() << "Error 11: " << errorString << " : " << errorNumber;
                                 });
                         },
                         [stop](const std::string& errorString, unsigned int errorNumber) -> void {
-                            VLOG(0) << "Error 10: " << errorString << " : " << errorNumber;
+                            snode::semantic::appLog().debug() << "Error 10: " << errorString << " : " << errorNumber;
                             stop();
                         })
                     .rollback(
                         [](void) -> void {
-                            VLOG(0) << "Rollback success 11";
+                            snode::semantic::appLog().debug() << "Rollback success 11";
                         },
                         [stop](const std::string& errorString, unsigned int errorNumber) -> void {
-                            VLOG(0) << "Error 12: " << errorString << " : " << errorNumber;
+                            snode::semantic::appLog().debug() << "Error 12: " << errorString << " : " << errorNumber;
                             stop();
                         })
                     .exec(
                         "INSERT INTO `snodec`(`username`, `password`) VALUES ('Annett','Hallo')",
                         [&db2, j](void) -> void {
-                            VLOG(0) << "Inserted 13: " << j;
+                            snode::semantic::appLog().debug() << "Inserted 13: " << j;
                             db2.affectedRows(
                                 [](my_ulonglong affectedRows) -> void {
-                                    VLOG(0) << "AffectedRows 14: " << affectedRows;
+                                    snode::semantic::appLog().debug() << "AffectedRows 14: " << affectedRows;
                                 },
                                 [](const std::string& errorString, unsigned int errorNumber) -> void {
-                                    VLOG(0) << "Error 14: " << errorString << " : " << errorNumber;
+                                    snode::semantic::appLog().debug() << "Error 14: " << errorString << " : " << errorNumber;
                                 });
                         },
                         [stop](const std::string& errorString, unsigned int errorNumber) -> void {
-                            VLOG(0) << "Error 13: " << errorString << " : " << errorNumber;
+                            snode::semantic::appLog().debug() << "Error 13: " << errorString << " : " << errorNumber;
                             stop();
                         })
                     .commit(
                         [](void) -> void {
-                            VLOG(0) << "Commit success 15";
+                            snode::semantic::appLog().debug() << "Commit success 15";
                         },
                         [stop](const std::string& errorString, unsigned int errorNumber) -> void {
-                            VLOG(0) << "Error 15: " << errorString << " : " << errorNumber;
+                            snode::semantic::appLog().debug() << "Error 15: " << errorString << " : " << errorNumber;
                             stop();
                         })
                     .query(
                         "SELECT COUNT(*) FROM snodec",
                         [&db2, j, stop](const MYSQL_ROW row) -> void {
                             if (row != nullptr) {
-                                VLOG(0) << "Row Result count(*) 16: " << row[0];
-                                if (std::atoi(row[0]) != j + 1) {                                                   // NOLINT
-                                    VLOG(0) << "Wrong number of rows 16: " << std::atoi(row[0]) << " != " << j + 1; // NOLINT
+                                snode::semantic::appLog().debug() << "Row Result count(*) 16: " << row[0];
+                                if (std::atoi(row[0]) != j + 1) { // NOLINT
+                                    snode::semantic::appLog().debug()
+                                        << "Wrong number of rows 16: " << std::atoi(row[0]) << " != " << j + 1; // NOLINT
                                     //                                    exit(1);
                                 }
                             } else {
-                                VLOG(0) << "Row Result count(*) 16: no result:";
+                                snode::semantic::appLog().debug() << "Row Result count(*) 16: no result:";
                                 db2.fieldCount(
                                     [](unsigned int fieldCount) -> void {
-                                        VLOG(0) << "************ FieldCount ************ = " << fieldCount;
+                                        snode::semantic::appLog().debug() << "************ FieldCount ************ = " << fieldCount;
                                     },
                                     [](const std::string& errorString, unsigned int errorNumber) -> void {
-                                        VLOG(0) << "Error 7: " << errorString << " : " << errorNumber;
+                                        snode::semantic::appLog().debug() << "Error 7: " << errorString << " : " << errorNumber;
                                     });
                             }
                         },
                         [stop](const std::string& errorString, unsigned int errorNumber) -> void {
-                            VLOG(0) << "Error 16: " << errorString << " : " << errorNumber;
+                            snode::semantic::appLog().debug() << "Error 16: " << errorString << " : " << errorNumber;
                             stop();
                         })
                     .endTransactions(
                         [](void) -> void {
-                            VLOG(0) << "Transactions deactivated 17";
+                            snode::semantic::appLog().debug() << "Transactions deactivated 17";
                         },
                         [stop](const std::string& errorString, unsigned int errorNumber) -> void {
-                            VLOG(0) << "Error 17: " << errorString << " : " << errorNumber;
+                            snode::semantic::appLog().debug() << "Error 17: " << errorString << " : " << errorNumber;
                             stop();
                         });
             },

--- a/src/apps/echo/echoclient.cpp
+++ b/src/apps/echo/echoclient.cpp
@@ -60,10 +60,10 @@ int main(int argc, char* argv[]) {
         [instanceName = client.getConfig()->getInstanceName()](const SocketAddress& socketAddress, const core::socket::State& state) {
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << instanceName << ": connected to '" << socketAddress.toString() << "'";
+                    snode::semantic::appLog().info() << instanceName << ": connected to '" << socketAddress.toString() << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << instanceName << ": disabled";
+                    snode::semantic::appLog().info() << instanceName << ": disabled";
                     break;
                 case core::socket::State::ERROR:
                     snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
@@ -77,16 +77,16 @@ int main(int argc, char* argv[]) {
         client.connect([](const SocketAddress& socketAddress, const core::socket::State& state) {
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << "echoclient: connected to '" << socketAddress.toString() << "'" << "'";
+                    snode::semantic::appLog().info() << "echoclient: connected to '" << socketAddress.toString() << "'" << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << "echoclient: disabled";
+                    snode::semantic::appLog().info() << "echoclient: disabled";
                     break;
                 case core::socket::State::ERROR:
-                    VLOG(1) << "echoclientt: error occurred";
+                    snode::semantic::appLog().warn() << "echoclientt: error occurred";
                     break;
                 case core::socket::State::FATAL:
-                    VLOG(1) << "echoclient: fatal error occurred";
+                    snode::semantic::appLog().error() << "echoclient: fatal error occurred";
                     break;
             }
         });
@@ -126,7 +126,7 @@ int main(int argc, char* argv[]) {
     } else if (errnum > 0) {
         snode::semantic::sysError(snode::semantic::appLog(), logger::LogLevel::Error, errnum) << "OnError: " << socketAddress.toString();
     } else {
-        VLOG(1) << "snode.c connecting to " << socketAddress.toString();
+        snode::semantic::appLog().debug() << "snode.c connecting to " << socketAddress.toString();
     }
 
 #ifdef NET_TYPE

--- a/src/apps/echo/echoserver.cpp
+++ b/src/apps/echo/echoserver.cpp
@@ -84,10 +84,10 @@ int main(int argc, char* argv[]) {
                                                                          const core::socket::State& state) {
         switch (state) {
             case core::socket::State::OK:
-                VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                snode::semantic::appLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                 break;
             case core::socket::State::DISABLED:
-                VLOG(1) << instanceName << ": disabled";
+                snode::semantic::appLog().info() << instanceName << ": disabled";
                 break;
             case core::socket::State::ERROR:
                 snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
@@ -130,7 +130,7 @@ int main(int argc, char* argv[]) {
         if (errnum != 0) {
             snode::semantic::sysError(snode::semantic::appLog(), logger::LogLevel::Critical, errnum) << "listen";
         } else {
-            VLOG(1) << "snode.c listening on " << socket.getBindAddress().toString();
+            snode::semantic::appLog().info() << "snode.c listening on " << socket.getBindAddress().toString();
         }
 
 #ifdef NET_TYPE

--- a/src/apps/echo/model/EchoSocketContext.cpp
+++ b/src/apps/echo/model/EchoSocketContext.cpp
@@ -41,6 +41,8 @@
 
 #include "EchoSocketContext.h"
 
+#include "SemanticLog.h"
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #include "log/Logger.h"
@@ -57,7 +59,7 @@ namespace apps::echo::model {
     }
 
     void EchoSocketContext::onConnected() {
-        VLOG(1) << "Echo connected";
+        snode::semantic::appLog().debug() << "Echo connected";
 
         if (role == Role::CLIENT) {
             sendToPeer("Hello peer! Nice to see you!!!");
@@ -65,7 +67,7 @@ namespace apps::echo::model {
     }
 
     void EchoSocketContext::onDisconnected() {
-        VLOG(1) << "Echo disconnected";
+        snode::semantic::appLog().debug() << "Echo disconnected";
     }
 
     bool EchoSocketContext::onSignal([[maybe_unused]] int signum) {
@@ -78,7 +80,7 @@ namespace apps::echo::model {
         const std::size_t chunklen = readFromPeer(chunk, 4096);
 
         if (chunklen > 0) {
-            VLOG(1) << "Data to reflect: " << std::string(chunk, chunklen);
+            snode::semantic::appLog().debug() << "Data to reflect: " << std::string(chunk, chunklen);
             sendToPeer(chunk, chunklen);
         }
 

--- a/src/apps/echo/model/EchoSocketContext.cpp
+++ b/src/apps/echo/model/EchoSocketContext.cpp
@@ -80,7 +80,10 @@ namespace apps::echo::model {
         const std::size_t chunklen = readFromPeer(chunk, 4096);
 
         if (chunklen > 0) {
-            snode::semantic::appLog().debug() << "Data to reflect: " << std::string(chunk, chunklen);
+            auto log = snode::semantic::appLog();
+            if (log.enabled(logger::LogLevel::Trace)) {
+                log.trace() << "Data to reflect: " << std::string(chunk, chunklen);
+            }
             sendToPeer(chunk, chunklen);
         }
 

--- a/src/apps/echo/model/clients.h
+++ b/src/apps/echo/model/clients.h
@@ -109,51 +109,58 @@ namespace apps::echo::model::tls {
         client.setOnConnected([&client](SocketConnection* socketConnection) { // onConnected
             snode::semantic::appLog().debug() << "OnConnected " << client.getConfig()->getInstanceName();
 
-            X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
-            if (server_cert != nullptr) {
-                const long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
+            auto log = snode::semantic::appLog();
+            if (log.enabled(logger::LogLevel::Debug)) {
+                X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
+                if (server_cert != nullptr) {
+                    const long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
-                                                         std::string(X509_verify_cert_error_string(verifyErr));
+                    snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
+                                                             std::string(X509_verify_cert_error_string(verifyErr));
 
-                char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
-                snode::semantic::appLog().debug() << "\t   Subject: " + std::string(str);
-                OPENSSL_free(str);
-
-                str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
-                snode::semantic::appLog().debug() << "\t   Issuer: " + std::string(str);
-                OPENSSL_free(str);
-
-                // We could do all sorts of certificate verification stuff here before deallocating the certificate.
-
-                GENERAL_NAMES* subjectAltNames =
-                    static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
-
-                const int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
-
-                snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
-                for (int32_t i = 0; i < altNameCount; ++i) {
-                    GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
-                    if (generalName->type == GEN_URI) {
-                        const std::string subjectAltName =
-                            std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
-                                        static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                        snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
-                    } else if (generalName->type == GEN_DNS) {
-                        const std::string subjectAltName =
-                            std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
-                                        static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                        snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
-                    } else {
-                        snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                    char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
+                    if (str != nullptr) {
+                        snode::semantic::appLog().debug() << "\t   Subject: " << str;
+                        OPENSSL_free(str);
                     }
+
+                    str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
+                    if (str != nullptr) {
+                        snode::semantic::appLog().debug() << "\t   Issuer: " << str;
+                        OPENSSL_free(str);
+                    }
+
+                    // We could do all sorts of certificate verification stuff here before deallocating the certificate.
+
+                    GENERAL_NAMES* subjectAltNames =
+                        static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
+
+                    const int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
+
+                    snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
+                    for (int32_t i = 0; i < altNameCount; ++i) {
+                        GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
+                        if (generalName->type == GEN_URI) {
+                            const std::string subjectAltName =
+                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
+                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
+                            snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
+                        } else if (generalName->type == GEN_DNS) {
+                            const std::string subjectAltName =
+                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
+                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
+                            snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
+                        } else {
+                            snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                        }
+                    }
+
+                    sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
+
+                    X509_free(server_cert);
+                } else {
+                    snode::semantic::appLog().debug() << "\tPeer certificate: no certificate";
                 }
-
-                sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
-
-                X509_free(server_cert);
-            } else {
-                snode::semantic::appLog().debug() << "\tPeer certificate: no certificate";
             }
         });
 

--- a/src/apps/echo/model/clients.h
+++ b/src/apps/echo/model/clients.h
@@ -42,6 +42,7 @@
 #ifndef APPS_ECHO_MODEL_CLIENT_H
 #define APPS_ECHO_MODEL_CLIENT_H
 
+#include "SemanticLog.h"
 #include "log/Logger.h"
 
 #define QUOTE_INCLUDE(a) STR(a)
@@ -90,10 +91,10 @@ namespace apps::echo::model::tls {
         EchoSocketClient client("echoclient");
 
         client.setOnConnect([&client](SocketConnection* socketConnection) { // onConnect
-            VLOG(1) << "OnConnect " << client.getConfig()->getInstanceName();
+            snode::semantic::appLog().debug() << "OnConnect " << client.getConfig()->getInstanceName();
 
-            VLOG(1) << "\tLocal: " << socketConnection->getLocalAddress().toString();
-            VLOG(1) << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tLocal: " << socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
 
             /* Enable automatic hostname checks */
             // X509_VERIFY_PARAM* param = SSL_get0_param(socketConnection->getSSL());
@@ -106,21 +107,21 @@ namespace apps::echo::model::tls {
         });
 
         client.setOnConnected([&client](SocketConnection* socketConnection) { // onConnected
-            VLOG(1) << "OnConnected " << client.getConfig()->getInstanceName();
+            snode::semantic::appLog().debug() << "OnConnected " << client.getConfig()->getInstanceName();
 
             X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
             if (server_cert != nullptr) {
                 const long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                VLOG(1) << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
-                               std::string(X509_verify_cert_error_string(verifyErr));
+                snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
+                                                         std::string(X509_verify_cert_error_string(verifyErr));
 
                 char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
-                VLOG(1) << "\t   Subject: " + std::string(str);
+                snode::semantic::appLog().debug() << "\t   Subject: " + std::string(str);
                 OPENSSL_free(str);
 
                 str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
-                VLOG(1) << "\t   Issuer: " + std::string(str);
+                snode::semantic::appLog().debug() << "\t   Issuer: " + std::string(str);
                 OPENSSL_free(str);
 
                 // We could do all sorts of certificate verification stuff here before deallocating the certificate.
@@ -130,21 +131,21 @@ namespace apps::echo::model::tls {
 
                 const int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
 
-                VLOG(1) << "\t   Subject alternative name count: " << altNameCount;
+                snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
                 for (int32_t i = 0; i < altNameCount; ++i) {
                     GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
                     if (generalName->type == GEN_URI) {
                         const std::string subjectAltName =
                             std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
                                         static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                        VLOG(1) << "\t      SAN (URI): '" + subjectAltName;
+                        snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
                     } else if (generalName->type == GEN_DNS) {
                         const std::string subjectAltName =
                             std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
                                         static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                        VLOG(1) << "\t      SAN (DNS): '" + subjectAltName;
+                        snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
                     } else {
-                        VLOG(1) << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                        snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
                     }
                 }
 
@@ -152,15 +153,15 @@ namespace apps::echo::model::tls {
 
                 X509_free(server_cert);
             } else {
-                VLOG(1) << "\tPeer certificate: no certificate";
+                snode::semantic::appLog().debug() << "\tPeer certificate: no certificate";
             }
         });
 
         client.setOnDisconnect([&client](SocketConnection* socketConnection) { // onDisconnect
-            VLOG(1) << "OnDisconnect " << client.getConfig()->getInstanceName();
+            snode::semantic::appLog().debug() << "OnDisconnect " << client.getConfig()->getInstanceName();
 
-            VLOG(1) << "\tLocal: " << socketConnection->getLocalAddress().toString();
-            VLOG(1) << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tLocal: " << socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
         });
 
         return client;

--- a/src/apps/echo/model/servers.h
+++ b/src/apps/echo/model/servers.h
@@ -109,51 +109,58 @@ namespace apps::echo::model::tls {
         server.setOnConnected([&server](SocketConnection* socketConnection) { // onConnected
             snode::semantic::appLog().debug() << "OnConnected " << server.getConfig()->getInstanceName();
 
-            X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
-            if (server_cert != nullptr) {
-                long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
+            auto log = snode::semantic::appLog();
+            if (log.enabled(logger::LogLevel::Debug)) {
+                X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
+                if (server_cert != nullptr) {
+                    long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
-                                                         std::string(X509_verify_cert_error_string(verifyErr));
+                    snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
+                                                             std::string(X509_verify_cert_error_string(verifyErr));
 
-                char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
-                snode::semantic::appLog().debug() << "\t   Subject: " + std::string(str);
-                OPENSSL_free(str);
-
-                str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
-                snode::semantic::appLog().debug() << "\t   Issuer: " + std::string(str);
-                OPENSSL_free(str);
-
-                // We could do all sorts of certificate verification stuff here before deallocating the certificate.
-
-                GENERAL_NAMES* subjectAltNames =
-                    static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
-
-                int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
-
-                snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
-                for (int32_t i = 0; i < altNameCount; ++i) {
-                    GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
-                    if (generalName->type == GEN_URI) {
-                        std::string subjectAltName =
-                            std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
-                                        static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                        snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
-                    } else if (generalName->type == GEN_DNS) {
-                        std::string subjectAltName =
-                            std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
-                                        static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                        snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
-                    } else {
-                        snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                    char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
+                    if (str != nullptr) {
+                        snode::semantic::appLog().debug() << "\t   Subject: " << str;
+                        OPENSSL_free(str);
                     }
+
+                    str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
+                    if (str != nullptr) {
+                        snode::semantic::appLog().debug() << "\t   Issuer: " << str;
+                        OPENSSL_free(str);
+                    }
+
+                    // We could do all sorts of certificate verification stuff here before deallocating the certificate.
+
+                    GENERAL_NAMES* subjectAltNames =
+                        static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
+
+                    int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
+
+                    snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
+                    for (int32_t i = 0; i < altNameCount; ++i) {
+                        GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
+                        if (generalName->type == GEN_URI) {
+                            std::string subjectAltName =
+                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
+                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
+                            snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
+                        } else if (generalName->type == GEN_DNS) {
+                            std::string subjectAltName =
+                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
+                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
+                            snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
+                        } else {
+                            snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                        }
+                    }
+
+                    sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
+
+                    X509_free(server_cert);
+                } else {
+                    snode::semantic::appLog().debug() << "\tPeer certificate: no certificate";
                 }
-
-                sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
-
-                X509_free(server_cert);
-            } else {
-                snode::semantic::appLog().debug() << "\tPeer certificate: no certificate";
             }
         });
 

--- a/src/apps/echo/model/servers.h
+++ b/src/apps/echo/model/servers.h
@@ -42,6 +42,7 @@
 #ifndef APPS_ECHO_MODEL_SERVER_H
 #define APPS_ECHO_MODEL_SERVER_H
 
+#include "SemanticLog.h"
 #include "log/Logger.h"
 
 #define QUOTE_INCLUDE(a) STR_INCLUDE(a)
@@ -90,10 +91,10 @@ namespace apps::echo::model::tls {
         EchoSocketServer server("echoserver");
 
         server.setOnConnect([&server](SocketConnection* socketConnection) { // onConnect
-            VLOG(1) << "OnConnect " << server.getConfig()->getInstanceName();
+            snode::semantic::appLog().debug() << "OnConnect " << server.getConfig()->getInstanceName();
 
-            VLOG(1) << "\tLocal: " << socketConnection->getLocalAddress().toString();
-            VLOG(1) << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tLocal: " << socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
 
             /* Enable automatic hostname checks */
             // X509_VERIFY_PARAM* param = SSL_get0_param(socketConnection->getSSL());
@@ -106,21 +107,21 @@ namespace apps::echo::model::tls {
         });
 
         server.setOnConnected([&server](SocketConnection* socketConnection) { // onConnected
-            VLOG(1) << "OnConnected " << server.getConfig()->getInstanceName();
+            snode::semantic::appLog().debug() << "OnConnected " << server.getConfig()->getInstanceName();
 
             X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
             if (server_cert != nullptr) {
                 long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                VLOG(1) << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
-                               std::string(X509_verify_cert_error_string(verifyErr));
+                snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
+                                                         std::string(X509_verify_cert_error_string(verifyErr));
 
                 char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
-                VLOG(1) << "\t   Subject: " + std::string(str);
+                snode::semantic::appLog().debug() << "\t   Subject: " + std::string(str);
                 OPENSSL_free(str);
 
                 str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
-                VLOG(1) << "\t   Issuer: " + std::string(str);
+                snode::semantic::appLog().debug() << "\t   Issuer: " + std::string(str);
                 OPENSSL_free(str);
 
                 // We could do all sorts of certificate verification stuff here before deallocating the certificate.
@@ -130,21 +131,21 @@ namespace apps::echo::model::tls {
 
                 int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
 
-                VLOG(1) << "\t   Subject alternative name count: " << altNameCount;
+                snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
                 for (int32_t i = 0; i < altNameCount; ++i) {
                     GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
                     if (generalName->type == GEN_URI) {
                         std::string subjectAltName =
                             std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
                                         static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                        VLOG(1) << "\t      SAN (URI): '" + subjectAltName;
+                        snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
                     } else if (generalName->type == GEN_DNS) {
                         std::string subjectAltName =
                             std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
                                         static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                        VLOG(1) << "\t      SAN (DNS): '" + subjectAltName;
+                        snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
                     } else {
-                        VLOG(1) << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                        snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
                     }
                 }
 
@@ -152,15 +153,15 @@ namespace apps::echo::model::tls {
 
                 X509_free(server_cert);
             } else {
-                VLOG(1) << "\tPeer certificate: no certificate";
+                snode::semantic::appLog().debug() << "\tPeer certificate: no certificate";
             }
         });
 
         server.setOnDisconnect([&server](SocketConnection* socketConnection) { // onDisconnect
-            VLOG(1) << "OnDisconnect " << server.getConfig()->getInstanceName();
+            snode::semantic::appLog().debug() << "OnDisconnect " << server.getConfig()->getInstanceName();
 
-            VLOG(1) << "\tLocal: " << socketConnection->getLocalAddress().toString();
-            VLOG(1) << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tLocal: " << socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
         });
 
         return server;

--- a/src/apps/express_compat_server.cpp
+++ b/src/apps/express_compat_server.cpp
@@ -238,10 +238,10 @@ int main(int argc, char* argv[]) {
     app.listen(8080, [](const express::legacy::in::WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
         switch (state) {
             case core::socket::State::OK:
-                VLOG(1) << "express-compat listening on '" << socketAddress.toString() << "'";
+                snode::semantic::appLog().info() << "express-compat listening on '" << socketAddress.toString() << "'";
                 break;
             case core::socket::State::DISABLED:
-                VLOG(1) << "express-compat disabled";
+                snode::semantic::appLog().info() << "express-compat disabled";
                 break;
             case core::socket::State::ERROR:
                 snode::semantic::appLog().error() << "express-compat " << socketAddress.toString() << ": " << state.what();

--- a/src/apps/http/httpclient.cpp
+++ b/src/apps/http/httpclient.cpp
@@ -61,16 +61,16 @@ int main(int argc, char* argv[]) {
                        const core::socket::State& state) { // example.com:81 simulate connnect timeout
         switch (state) {
             case core::socket::State::OK:
-                VLOG(1) << instanceName << ": connected to '" << socketAddress.toString() << "'";
+                snode::semantic::appLog().info() << instanceName << ": connected to '" << socketAddress.toString() << "'";
                 break;
             case core::socket::State::DISABLED:
-                VLOG(1) << instanceName << ": disabled";
+                snode::semantic::appLog().info() << instanceName << ": disabled";
                 break;
             case core::socket::State::ERROR:
-                VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                 break;
             case core::socket::State::FATAL:
-                VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                snode::semantic::appLog().critical() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                 break;
         }
     });
@@ -103,7 +103,7 @@ core::socket::State& state) { #elif (NET_TYPE == RC) // rf
 { client.connect("10:3D:1C:AC:BA:9C", 1, "44:01:BB:A3:63:32", [](const SocketAddress& socketAddress, const core::socket::State&
 state) { #elif (NET_TYPE == UN) // un client.connect("/tmp/testme", [](const SocketAddress& socketAddress, const
 core::socket::State& state) { #endif if (errnum != 0) { snode::semantic::sysError(snode::semantic::appLog(), logger::LogLevel::Error,
-errnum) << "OnError: " << errnum; } else { VLOG(1) << "snode.c connecting to " << socketAddress.toString();
+errnum) << "OnError: " << errnum; } else { snode::semantic::appLog().debug() << "snode.c connecting to " << socketAddress.toString();
         }
 
 #ifdef NET_TYPE

--- a/src/apps/http/httpclient.cpp
+++ b/src/apps/http/httpclient.cpp
@@ -77,36 +77,3 @@ int main(int argc, char* argv[]) {
 
     return core::SNodeC::start();
 }
-
-/*
-#if (NET_TYPE == IN) // in
-#if (STREAM_TYPE == LEGACY)
-    client.connect("localhost", 8080, [](const SocketAddress& socketAddress, const core::socket::State& state) {
-#elif (STREAM_TYPE == TLS)
-    client.connect("localhost", 8088, [](const SocketAddress& socketAddress, const core::socket::State& state) {
-#endif
-#elif (NET_TYPE == IN6) // in6
-#if (STREAM_TYPE == LEGACY)
-        client.connect("localhost", 8080, [](const SocketAddress& socketAddress, const core::socket::State& state) {
-#elif (STREAM_TYPE == TLS)
-        client.connect("localhost", 8088, [](const SocketAddress& socketAddress, const core::socket::State& state) {
-#endif
-#elif (NET_TYPE == L2) // l2
-    // ATLAS: 10:3D:1C:AC:BA:9C
-    // TITAN: A4:B1:C1:2C:82:37
-    // USB: 44:01:BB:A3:63:32
-
-    // client.connect("A4:B1:C1:2C:82:37", 0x1023, "44:01:BB:A3:63:32", [](const SocketAddress& socketAddress, const core::socket::State&
-state) { client.connect("10:3D:1C:AC:BA:9C", 0x1023, "44:01:BB:A3:63:32", [](const SocketAddress& socketAddress, const
-core::socket::State& state) { #elif (NET_TYPE == RC) // rf
-    // client.connect("A4:B1:C1:2C:82:37", 1, "44:01:BB:A3:63:32", [](const SocketAddress& socketAddress, const core::socket::State& state)
-{ client.connect("10:3D:1C:AC:BA:9C", 1, "44:01:BB:A3:63:32", [](const SocketAddress& socketAddress, const core::socket::State&
-state) { #elif (NET_TYPE == UN) // un client.connect("/tmp/testme", [](const SocketAddress& socketAddress, const
-core::socket::State& state) { #endif if (errnum != 0) { snode::semantic::sysError(snode::semantic::appLog(), logger::LogLevel::Error,
-errnum) << "OnError: " << errnum; } else { snode::semantic::appLog().debug() << "snode.c connecting to " << socketAddress.toString();
-        }
-
-#ifdef NET_TYPE
-    });
-#endif
-*/

--- a/src/apps/http/httplowlevelclient.cpp
+++ b/src/apps/http/httplowlevelclient.cpp
@@ -166,51 +166,58 @@ namespace tls {
             [](SocketConnection* socketConnection) { // onConnected
                 snode::semantic::appLog().debug() << "OnConnected";
 
-                X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
-                if (server_cert != nullptr) {
-                    const long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
+                auto log = snode::semantic::appLog();
+                if (log.enabled(logger::LogLevel::Debug)) {
+                    X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
+                    if (server_cert != nullptr) {
+                        const long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                    snode::semantic::appLog().debug()
-                        << "     Server certificate: " + std::string(X509_verify_cert_error_string(verifyErr));
+                        snode::semantic::appLog().debug()
+                            << "     Server certificate: " + std::string(X509_verify_cert_error_string(verifyErr));
 
-                    char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
-                    snode::semantic::appLog().debug() << "        Subject: " + std::string(str);
-                    OPENSSL_free(str);
-
-                    str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
-                    snode::semantic::appLog().debug() << "        Issuer: " + std::string(str);
-                    OPENSSL_free(str);
-
-                    // We could do all sorts of certificate verification stuff here before deallocating the certificate.
-
-                    GENERAL_NAMES* subjectAltNames =
-                        static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
-
-                    const int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
-
-                    snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
-                    for (int32_t i = 0; i < altNameCount; ++i) {
-                        GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
-                        if (generalName->type == GEN_URI) {
-                            const std::string subjectAltName =
-                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
-                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                            snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
-                        } else if (generalName->type == GEN_DNS) {
-                            const std::string subjectAltName =
-                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
-                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                            snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
-                        } else {
-                            snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                        char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
+                        if (str != nullptr) {
+                            snode::semantic::appLog().debug() << "        Subject: " << str;
+                            OPENSSL_free(str);
                         }
+
+                        str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
+                        if (str != nullptr) {
+                            snode::semantic::appLog().debug() << "        Issuer: " << str;
+                            OPENSSL_free(str);
+                        }
+
+                        // We could do all sorts of certificate verification stuff here before deallocating the certificate.
+
+                        GENERAL_NAMES* subjectAltNames =
+                            static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
+
+                        const int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
+
+                        snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
+                        for (int32_t i = 0; i < altNameCount; ++i) {
+                            GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
+                            if (generalName->type == GEN_URI) {
+                                const std::string subjectAltName = std::string(
+                                    reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
+                                    static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
+                                snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
+                            } else if (generalName->type == GEN_DNS) {
+                                const std::string subjectAltName =
+                                    std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
+                                                static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
+                                snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
+                            } else {
+                                snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                            }
+                        }
+
+                        sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
+
+                        X509_free(server_cert);
+                    } else {
+                        snode::semantic::appLog().debug() << "     Server certificate: no certificate";
                     }
-
-                    sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
-
-                    X509_free(server_cert);
-                } else {
-                    snode::semantic::appLog().debug() << "     Server certificate: no certificate";
                 }
 
                 socketConnection->sendToPeer("GET /index.html HTTP/1.1\r\nConnection: close\r\n\r\n"); // Connection: close\r\n\r\n");

--- a/src/apps/http/httplowlevelclient.cpp
+++ b/src/apps/http/httplowlevelclient.cpp
@@ -70,13 +70,13 @@ namespace apps::http {
         web::http::client::ResponseParser* responseParser = new web::http::client::ResponseParser(
             socketContext,
             []() {
-                VLOG(1) << "++   OnStarted";
+                snode::semantic::appLog().debug() << "++   OnStarted";
             },
             []([[maybe_unused]] web::http::client::Response& res) {
-                VLOG(1) << "++   OnParsed";
+                snode::semantic::appLog().debug() << "++   OnParsed";
             },
             [](int status, const std::string& reason) {
-                VLOG(1) << "++   OnError: " + std::to_string(status) + " - " + reason;
+                snode::semantic::appLog().debug() << "++   OnError: " + std::to_string(status) + " - " + reason;
             });
 
         return responseParser;
@@ -92,10 +92,10 @@ namespace apps::http {
         ~SimpleSocketProtocol() override;
 
         void onConnected() override {
-            VLOG(1) << "SimpleSocketProtocol connected";
+            snode::semantic::appLog().debug() << "SimpleSocketProtocol connected";
         }
         void onDisconnected() override {
-            VLOG(1) << "SimpleSocketProtocol disconnected";
+            snode::semantic::appLog().debug() << "SimpleSocketProtocol disconnected";
         }
 
         bool onSignal([[maybe_unused]] int signum) override {
@@ -149,10 +149,10 @@ namespace tls {
         SocketClient tlsClient(
             "tls",
             [](SocketConnection* socketConnection) { // onConnect
-                VLOG(1) << "OnConnect";
+                snode::semantic::appLog().debug() << "OnConnect";
 
-                VLOG(1) << "\tServer: " << socketConnection->getRemoteAddress().toString();
-                VLOG(1) << "\tClient: " << socketConnection->getLocalAddress().toString();
+                snode::semantic::appLog().debug() << "\tServer: " << socketConnection->getRemoteAddress().toString();
+                snode::semantic::appLog().debug() << "\tClient: " << socketConnection->getLocalAddress().toString();
 
                 /* Enable automatic hostname checks */
                 // X509_VERIFY_PARAM* param = SSL_get0_param(socketConnection->getSSL());
@@ -164,20 +164,21 @@ namespace tls {
                 // }
             },
             [](SocketConnection* socketConnection) { // onConnected
-                VLOG(1) << "OnConnected";
+                snode::semantic::appLog().debug() << "OnConnected";
 
                 X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
                 if (server_cert != nullptr) {
                     const long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                    VLOG(1) << "     Server certificate: " + std::string(X509_verify_cert_error_string(verifyErr));
+                    snode::semantic::appLog().debug()
+                        << "     Server certificate: " + std::string(X509_verify_cert_error_string(verifyErr));
 
                     char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
-                    VLOG(1) << "        Subject: " + std::string(str);
+                    snode::semantic::appLog().debug() << "        Subject: " + std::string(str);
                     OPENSSL_free(str);
 
                     str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
-                    VLOG(1) << "        Issuer: " + std::string(str);
+                    snode::semantic::appLog().debug() << "        Issuer: " + std::string(str);
                     OPENSSL_free(str);
 
                     // We could do all sorts of certificate verification stuff here before deallocating the certificate.
@@ -187,21 +188,21 @@ namespace tls {
 
                     const int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
 
-                    VLOG(1) << "\t   Subject alternative name count: " << altNameCount;
+                    snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
                     for (int32_t i = 0; i < altNameCount; ++i) {
                         GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
                         if (generalName->type == GEN_URI) {
                             const std::string subjectAltName =
                                 std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
                                             static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                            VLOG(1) << "\t      SAN (URI): '" + subjectAltName;
+                            snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
                         } else if (generalName->type == GEN_DNS) {
                             const std::string subjectAltName =
                                 std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
                                             static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                            VLOG(1) << "\t      SAN (DNS): '" + subjectAltName;
+                            snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
                         } else {
-                            VLOG(1) << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                            snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
                         }
                     }
 
@@ -209,16 +210,16 @@ namespace tls {
 
                     X509_free(server_cert);
                 } else {
-                    VLOG(1) << "     Server certificate: no certificate";
+                    snode::semantic::appLog().debug() << "     Server certificate: no certificate";
                 }
 
                 socketConnection->sendToPeer("GET /index.html HTTP/1.1\r\nConnection: close\r\n\r\n"); // Connection: close\r\n\r\n");
             },
             [](SocketConnection* socketConnection) { // onDisconnect
-                VLOG(1) << "OnDisconnect";
+                snode::semantic::appLog().debug() << "OnDisconnect";
 
-                VLOG(1) << "\tServer: " + socketConnection->getRemoteAddress().toString();
-                VLOG(1) << "\tClient: " + socketConnection->getLocalAddress().toString();
+                snode::semantic::appLog().debug() << "\tServer: " + socketConnection->getRemoteAddress().toString();
+                snode::semantic::appLog().debug() << "\tClient: " + socketConnection->getLocalAddress().toString();
 
             });
 
@@ -231,10 +232,10 @@ namespace tls {
                                                            const core::socket::State& state) { // example.com:81 simulate connnect timeout
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << instanceName << ": connected to '" << socketAddress.toString() << "'";
+                        snode::semantic::appLog().info() << instanceName << ": connected to '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << instanceName << ": disabled";
+                        snode::semantic::appLog().info() << instanceName << ": disabled";
                         break;
                     case core::socket::State::ERROR:
                         snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
@@ -259,51 +260,50 @@ namespace legacy {
         SocketClient legacyClient(
             "legacy",
             [](SocketConnection* socketConnection) { // OnConnect
-                VLOG(1) << "OnConnect";
+                snode::semantic::appLog().debug() << "OnConnect";
 
-                VLOG(1) << "\tServer: " << socketConnection->getRemoteAddress().toString();
-                VLOG(1) << "\tClient: " << socketConnection->getLocalAddress().toString();
+                snode::semantic::appLog().debug() << "\tServer: " << socketConnection->getRemoteAddress().toString();
+                snode::semantic::appLog().debug() << "\tClient: " << socketConnection->getLocalAddress().toString();
             },
             [](SocketConnection* socketConnection) { // onConnected
-                VLOG(1) << "OnConnected";
+                snode::semantic::appLog().debug() << "OnConnected";
 
                 socketConnection->sendToPeer("GET /index.html HTTP/1.1\r\nConnection: close\r\n\r\n"); // Connection: close\r\n\r\n");
             },
             [](SocketConnection* socketConnection) { // onDisconnect
-                VLOG(1) << "OnDisconnect";
+                snode::semantic::appLog().debug() << "OnDisconnect";
 
-                VLOG(1) << "\tServer: " << socketConnection->getRemoteAddress().toString();
-                VLOG(1) << "\tClient: " << socketConnection->getLocalAddress().toString();
+                snode::semantic::appLog().debug() << "\tServer: " << socketConnection->getRemoteAddress().toString();
+                snode::semantic::appLog().debug() << "\tClient: " << socketConnection->getLocalAddress().toString();
             });
 
         SocketAddress remoteAddress("localhost", 8080);
 
         remoteAddress.init();
 
-        VLOG(1) << "###############': " << remoteAddress.getCanonName();
-        VLOG(1) << "###############': " << remoteAddress.toString();
+        snode::semantic::appLog().debug() << "###############': " << remoteAddress.getCanonName();
+        snode::semantic::appLog().debug() << "###############': " << remoteAddress.toString();
 
-        legacyClient.connect(remoteAddress,
-                             [instanceName = legacyClient.getConfig()->getInstanceName()](
-                                 const tls::SocketAddress& socketAddress,
-                                 const core::socket::State& state) { // example.com:81 simulate connnect timeout
-                                 switch (state) {
-                                     case core::socket::State::OK:
-                                         VLOG(1) << instanceName << ": connected to '" << socketAddress.toString() << "'";
-                                         break;
-                                     case core::socket::State::DISABLED:
-                                         VLOG(1) << instanceName << ": disabled";
-                                         break;
-                                     case core::socket::State::ERROR:
-                                         snode::semantic::appLog().error()
-                                             << instanceName << ": " << socketAddress.toString() << ": " << state.what();
-                                         break;
-                                     case core::socket::State::FATAL:
-                                         snode::semantic::appLog().critical()
-                                             << instanceName << ": " << socketAddress.toString() << ": " << state.what();
-                                         break;
-                                 }
-                             });
+        legacyClient.connect(
+            remoteAddress,
+            [instanceName = legacyClient.getConfig()->getInstanceName()](
+                const tls::SocketAddress& socketAddress,
+                const core::socket::State& state) { // example.com:81 simulate connnect timeout
+                switch (state) {
+                    case core::socket::State::OK:
+                        snode::semantic::appLog().info() << instanceName << ": connected to '" << socketAddress.toString() << "'";
+                        break;
+                    case core::socket::State::DISABLED:
+                        snode::semantic::appLog().info() << instanceName << ": disabled";
+                        break;
+                    case core::socket::State::ERROR:
+                        snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        break;
+                    case core::socket::State::FATAL:
+                        snode::semantic::appLog().critical() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        break;
+                }
+            });
 
         return legacyClient;
     }
@@ -318,27 +318,26 @@ int main(int argc, char* argv[]) {
 
         const legacy::SocketClient legacyClient = legacy::getLegacyClient();
 
-        legacyClient.connect(legacyRemoteAddress,
-                             [instanceName = legacyClient.getConfig()->getInstanceName()](
-                                 const tls::SocketAddress& socketAddress,
-                                 const core::socket::State& state) { // example.com:81 simulate connnect timeout
-                                 switch (state) {
-                                     case core::socket::State::OK:
-                                         VLOG(1) << instanceName << ": connected to '" << socketAddress.toString() << "'";
-                                         break;
-                                     case core::socket::State::DISABLED:
-                                         VLOG(1) << instanceName << ": disabled";
-                                         break;
-                                     case core::socket::State::ERROR:
-                                         snode::semantic::appLog().error()
-                                             << instanceName << ": " << socketAddress.toString() << ": " << state.what();
-                                         break;
-                                     case core::socket::State::FATAL:
-                                         snode::semantic::appLog().critical()
-                                             << instanceName << ": " << socketAddress.toString() << ": " << state.what();
-                                         break;
-                                 }
-                             });
+        legacyClient.connect(
+            legacyRemoteAddress,
+            [instanceName = legacyClient.getConfig()->getInstanceName()](
+                const tls::SocketAddress& socketAddress,
+                const core::socket::State& state) { // example.com:81 simulate connnect timeout
+                switch (state) {
+                    case core::socket::State::OK:
+                        snode::semantic::appLog().info() << instanceName << ": connected to '" << socketAddress.toString() << "'";
+                        break;
+                    case core::socket::State::DISABLED:
+                        snode::semantic::appLog().info() << instanceName << ": disabled";
+                        break;
+                    case core::socket::State::ERROR:
+                        snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        break;
+                    case core::socket::State::FATAL:
+                        snode::semantic::appLog().critical() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        break;
+                }
+            });
 
         const tls::SocketAddress tlsRemoteAddress = tls::SocketAddress("localhost", 8088);
 
@@ -351,10 +350,10 @@ int main(int argc, char* argv[]) {
                                                            const core::socket::State& state) { // example.com:81 simulate connnect timeout
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << instanceName << ": connected to '" << socketAddress.toString() << "'";
+                        snode::semantic::appLog().info() << instanceName << ": connected to '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << instanceName << ": disabled";
+                        snode::semantic::appLog().info() << instanceName << ": disabled";
                         break;
                     case core::socket::State::ERROR:
                         snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();

--- a/src/apps/http/httpserver.cpp
+++ b/src/apps/http/httpserver.cpp
@@ -86,11 +86,14 @@ int main(int argc, char* argv[]) {
         webApp.getConfig()->addSniCerts(sniCerts);
 #endif
 
-        snode::semantic::appLog().trace() << "Routes:";
-        for (std::string& route : webApp.getRoutes()) {
-            route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
+        auto log = snode::semantic::appLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Routes:";
+            for (std::string route : webApp.getRoutes()) {
+                route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            snode::semantic::appLog().debug() << "  " << route;
+                log.trace() << "  " << route;
+            }
         }
 
         webApp.listen([instanceName = webApp.getConfig()->getInstanceName()](const core::socket::SocketAddress& socketAddress,
@@ -114,37 +117,3 @@ int main(int argc, char* argv[]) {
 
     return WebApp::start();
 }
-
-/*
-#if (NET_TYPE == IN) // in
-#if (STREAM_TYPE == LEGACY)
-    webApp.listen(8080, 5, [](const WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
-#elif (STREAM_TYPE == TLS)
-    webApp.listen(8088, 5, [](const WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
-#endif
-#elif (NET_TYPE == IN6) // in6
-#if (STREAM_TYPE == LEGACY)
-    webApp.listen(8080, 5, [](const WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
-#elif (STREAM_TYPE == TLS)
-    webApp.listen(8088, 5, [](const WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
-#endif
-#elif (NET_TYPE == L2) //
-    // ATLAS: 10:3D:1C:AC:BA:9C
-    // TITAN: A4:B1:C1:2C:82:37
-    // USB: 44:01:BB:A3:63:32
-
-    // webApp.listen("A4:B1:C1:2C:82:37", 0x1023, 5, [](const WebApp::SocketAddress& socketAddress, const core::socket::State& state) ->
-void { // titan webApp.listen("10:3D:1C:AC:BA:9C", 0x1023, 5, [](const WebApp::SocketAddress& socketAddress, const core::socket::State&
-state) { // titan #elif (NET_TYPE == RC) // rf
-    // webApp.listen("A4:B1:C1:2C:82:37", 1, 5, [](const WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
-// titan webApp.listen("10:3D:1C:AC:BA:9C", 1, 5, [](const WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
-// titan #elif (NET_TYPE == UN) // un webApp.listen("/tmp/testme", 5, [](const WebApp::SocketAddress& socketAddress, const
-core::socket::State& state) { // titan #endif if (errnum != 0) { snode::semantic::sysError(snode::semantic::appLog(),
-logger::LogLevel::Critical, errnum) << "listen"; } else { snode::semantic::appLog().info() << "snode.c listening on " <<
-socketAddress.toString();
-        }
-
-#ifdef NET_TYPE
-    });
-#endif
-*/

--- a/src/apps/http/httpserver.cpp
+++ b/src/apps/http/httpserver.cpp
@@ -86,27 +86,27 @@ int main(int argc, char* argv[]) {
         webApp.getConfig()->addSniCerts(sniCerts);
 #endif
 
-        VLOG(1) << "Routes:";
+        snode::semantic::appLog().trace() << "Routes:";
         for (std::string& route : webApp.getRoutes()) {
             route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            VLOG(1) << "  " << route;
+            snode::semantic::appLog().debug() << "  " << route;
         }
 
         webApp.listen([instanceName = webApp.getConfig()->getInstanceName()](const core::socket::SocketAddress& socketAddress,
                                                                              const core::socket::State& state) {
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                    snode::semantic::appLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << instanceName << ": disabled";
+                    snode::semantic::appLog().info() << instanceName << ": disabled";
                     break;
                 case core::socket::State::ERROR:
-                    VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                    snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                     break;
                 case core::socket::State::FATAL:
-                    VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                    snode::semantic::appLog().critical() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                     break;
             }
         });
@@ -140,7 +140,8 @@ state) { // titan #elif (NET_TYPE == RC) // rf
 // titan webApp.listen("10:3D:1C:AC:BA:9C", 1, 5, [](const WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
 // titan #elif (NET_TYPE == UN) // un webApp.listen("/tmp/testme", 5, [](const WebApp::SocketAddress& socketAddress, const
 core::socket::State& state) { // titan #endif if (errnum != 0) { snode::semantic::sysError(snode::semantic::appLog(),
-logger::LogLevel::Critical, errnum) << "listen"; } else { VLOG(1) << "snode.c listening on " << socketAddress.toString();
+logger::LogLevel::Critical, errnum) << "listen"; } else { snode::semantic::appLog().info() << "snode.c listening on " <<
+socketAddress.toString();
         }
 
 #ifdef NET_TYPE

--- a/src/apps/http/model/clients.h
+++ b/src/apps/http/model/clients.h
@@ -70,19 +70,21 @@
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 static void logResponse(const std::shared_ptr<web::http::client::Request>& req, const std::shared_ptr<web::http::client::Response>& res) {
-    snode::semantic::appLog().debug()
-        << req->getConnectionName() << " HTTP response: " << req->method << " " << req->url << " HTTP/" << req->httpMajor << "."
-        << req->httpMinor << "\n"
-        << httputils::toString(req->method,
-                               req->url,
-                               "HTTP/" + std::to_string(req->httpMajor) + "." + std::to_string(req->httpMinor),
-                               req->getQueries(),
-                               req->getHeaders(),
-                               req->getTrailer(),
-                               req->getCookies(),
-                               {})
-        << "\n"
-        << httputils::toString(res->httpVersion, res->statusCode, res->reason, res->headers, res->cookies, res->body);
+    auto log = snode::semantic::appLog();
+    if (log.enabled(logger::LogLevel::Trace)) {
+        log.trace() << req->getConnectionName() << " HTTP response: " << req->method << " " << req->url << " HTTP/" << req->httpMajor << "."
+                    << req->httpMinor << "\n"
+                    << httputils::toString(req->method,
+                                           req->url,
+                                           "HTTP/" + std::to_string(req->httpMajor) + "." + std::to_string(req->httpMinor),
+                                           req->getQueries(),
+                                           req->getHeaders(),
+                                           req->getTrailer(),
+                                           req->getCookies(),
+                                           {})
+                    << "\n"
+                    << httputils::toString(res->httpVersion, res->statusCode, res->reason, res->headers, res->cookies, res->body);
+    }
 }
 
 #if (STREAM_TYPE == LEGACY) // legacy
@@ -689,51 +691,58 @@ namespace apps::http::tls {
 
         client.setOnConnected([](SocketConnection* socketConnection) { // onConnected
             snode::semantic::appLog().debug() << socketConnection->getConnectionName() << ": OnConnected";
-            X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
-            if (server_cert != nullptr) {
-                long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
+            auto log = snode::semantic::appLog();
+            if (log.enabled(logger::LogLevel::Debug)) {
+                X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
+                if (server_cert != nullptr) {
+                    long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
-                                                         std::string(X509_verify_cert_error_string(verifyErr));
+                    snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
+                                                             std::string(X509_verify_cert_error_string(verifyErr));
 
-                char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
-                snode::semantic::appLog().debug() << "\t   Subject: " + std::string(str);
-                OPENSSL_free(str);
-
-                str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
-                snode::semantic::appLog().debug() << "\t   Issuer: " + std::string(str);
-                OPENSSL_free(str);
-
-                // We could do all sorts of certificate verification stuff here before deallocating the certificate.
-
-                GENERAL_NAMES* subjectAltNames =
-                    static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
-
-                int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
-
-                snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
-                for (int32_t i = 0; i < altNameCount; ++i) {
-                    GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
-                    if (generalName->type == GEN_URI) {
-                        std::string subjectAltName =
-                            std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
-                                        static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                        snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
-                    } else if (generalName->type == GEN_DNS) {
-                        std::string subjectAltName =
-                            std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
-                                        static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                        snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
-                    } else {
-                        snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                    char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
+                    if (str != nullptr) {
+                        snode::semantic::appLog().debug() << "\t   Subject: " << str;
+                        OPENSSL_free(str);
                     }
+
+                    str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
+                    if (str != nullptr) {
+                        snode::semantic::appLog().debug() << "\t   Issuer: " << str;
+                        OPENSSL_free(str);
+                    }
+
+                    // We could do all sorts of certificate verification stuff here before deallocating the certificate.
+
+                    GENERAL_NAMES* subjectAltNames =
+                        static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
+
+                    int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
+
+                    snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
+                    for (int32_t i = 0; i < altNameCount; ++i) {
+                        GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
+                        if (generalName->type == GEN_URI) {
+                            std::string subjectAltName =
+                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
+                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
+                            snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
+                        } else if (generalName->type == GEN_DNS) {
+                            std::string subjectAltName =
+                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
+                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
+                            snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
+                        } else {
+                            snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                        }
+                    }
+
+                    sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
+
+                    X509_free(server_cert);
+                } else {
+                    snode::semantic::appLog().debug() << "\tPeer certificate: no certificate";
                 }
-
-                sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
-
-                X509_free(server_cert);
-            } else {
-                snode::semantic::appLog().debug() << "\tPeer certificate: no certificate";
             }
         });
 

--- a/src/apps/http/model/clients.h
+++ b/src/apps/http/model/clients.h
@@ -70,18 +70,19 @@
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 static void logResponse(const std::shared_ptr<web::http::client::Request>& req, const std::shared_ptr<web::http::client::Response>& res) {
-    VLOG(1) << req->getConnectionName() << " HTTP response: " << req->method << " " << req->url << " HTTP/" << req->httpMajor << "."
-            << req->httpMinor << "\n"
-            << httputils::toString(req->method,
-                                   req->url,
-                                   "HTTP/" + std::to_string(req->httpMajor) + "." + std::to_string(req->httpMinor),
-                                   req->getQueries(),
-                                   req->getHeaders(),
-                                   req->getTrailer(),
-                                   req->getCookies(),
-                                   {})
-            << "\n"
-            << httputils::toString(res->httpVersion, res->statusCode, res->reason, res->headers, res->cookies, res->body);
+    snode::semantic::appLog().debug()
+        << req->getConnectionName() << " HTTP response: " << req->method << " " << req->url << " HTTP/" << req->httpMajor << "."
+        << req->httpMinor << "\n"
+        << httputils::toString(req->method,
+                               req->url,
+                               "HTTP/" + std::to_string(req->httpMajor) + "." + std::to_string(req->httpMinor),
+                               req->getQueries(),
+                               req->getHeaders(),
+                               req->getTrailer(),
+                               req->getCookies(),
+                               {})
+        << "\n"
+        << httputils::toString(res->httpVersion, res->statusCode, res->reason, res->headers, res->cookies, res->body);
 }
 
 #if (STREAM_TYPE == LEGACY) // legacy
@@ -98,7 +99,8 @@ namespace apps::http::legacy {
         Client client(
             "httpclient",
             [](const std::shared_ptr<MasterRequest>& req) {
-                VLOG(1) << req->getSocketContext()->getSocketConnection()->getConnectionName() << ": OnRequestStart";
+                snode::semantic::appLog().debug()
+                    << req->getSocketContext()->getSocketConnection()->getConnectionName() << ": OnRequestStart";
 
                 req->httpMajor = 1;
                 req->httpMinor = 1;
@@ -122,9 +124,10 @@ namespace apps::http::legacy {
                     "/home/voc/projects/snodec/snode.c/CMakeLists.tt",
                     [req](int ret) {
                         if (ret == 0) {
-                            VLOG(1) << req->getSocketContext()->getSocketConnection()->getConnectionName()
-                                    << " HTTP: Request accepted: GET / HTTP/" << req->httpMajor << "." << req->httpMinor;
-                            VLOG(1) << "  /home/voc/projects/snodec/snode.c/CMakeLists.tt";
+                            snode::semantic::appLog().debug()
+                                << req->getSocketContext()->getSocketConnection()->getConnectionName()
+                                << " HTTP: Request accepted: GET / HTTP/" << req->httpMajor << "." << req->httpMinor;
+                            snode::semantic::appLog().debug() << "  /home/voc/projects/snodec/snode.c/CMakeLists.tt";
                         } else {
                             snode::semantic::appLog().error()
                                 << req->getSocketContext()->getSocketConnection()->getConnectionName()
@@ -299,24 +302,26 @@ namespace apps::http::legacy {
 
                 if (eventStream_1) {
                     eventStream_1->onOpen([]() {
-                        VLOG(0) << "OnOpen 1";
+                        snode::semantic::appLog().debug() << "OnOpen 1";
                     });
 
                     eventStream_1->onError([]() {
-                        VLOG(0) << "OnError 1";
+                        snode::semantic::appLog().debug() << "OnError 1";
                     });
 
                     eventStream_1->onMessage([](const web::http::client::tools::EventSource::MessageEvent& message) {
-                        VLOG(0) << "OnMessage 1:1: " << message.data;
+                        snode::semantic::appLog().debug() << "OnMessage 1:1: " << message.data;
                     });
                     eventStream_1->onMessage([](const web::http::client::tools::EventSource::MessageEvent& message) {
-                        VLOG(0) << "OnMessage 1:2: " << message.data;
+                        snode::semantic::appLog().debug() << "OnMessage 1:2: " << message.data;
                     });
                     eventStream_1->addEventListener("myevent", [](const web::http::client::tools::EventSource::MessageEvent& message) {
-                        VLOG(0) << "EventListener for 'myevent' 1:1: " << message.lastEventId << " : " << message.data;
+                        snode::semantic::appLog().debug()
+                            << "EventListener for 'myevent' 1:1: " << message.lastEventId << " : " << message.data;
                     });
                     eventStream_1->addEventListener("myevent", [](const web::http::client::tools::EventSource::MessageEvent& message) {
-                        VLOG(0) << "EventListener for 'myevent' 1:2: " << message.lastEventId << " : " << message.data;
+                        snode::semantic::appLog().debug()
+                            << "EventListener for 'myevent' 1:2: " << message.lastEventId << " : " << message.data;
                     });
 
                     core::timer::Timer::singleshotTimer(
@@ -330,24 +335,26 @@ namespace apps::http::legacy {
 
                 if (eventStream_2) {
                     eventStream_2->onOpen([]() {
-                        VLOG(0) << "OnOpen 2";
+                        snode::semantic::appLog().debug() << "OnOpen 2";
                     });
 
                     eventStream_2->onError([]() {
-                        VLOG(0) << "OnError 2";
+                        snode::semantic::appLog().debug() << "OnError 2";
                     });
 
                     eventStream_2->onMessage([](const web::http::client::tools::EventSource::MessageEvent& message) {
-                        VLOG(0) << "OnMessage 2:1: " << message.data;
+                        snode::semantic::appLog().debug() << "OnMessage 2:1: " << message.data;
                     });
                     eventStream_2->onMessage([](const web::http::client::tools::EventSource::MessageEvent& message) {
-                        VLOG(0) << "OnMessage 2:2: " << message.data;
+                        snode::semantic::appLog().debug() << "OnMessage 2:2: " << message.data;
                     });
                     eventStream_2->addEventListener("myevent", [](const web::http::client::tools::EventSource::MessageEvent& message) {
-                        VLOG(0) << "EventListener for 'myevent' 2:1: " << message.lastEventId << " : " << message.data;
+                        snode::semantic::appLog().debug()
+                            << "EventListener for 'myevent' 2:1: " << message.lastEventId << " : " << message.data;
                     });
                     eventStream_2->addEventListener("myevent", [](const web::http::client::tools::EventSource::MessageEvent& message) {
-                        VLOG(0) << "EventListener for 'myevent' 2:2: " << message.lastEventId << " : " << message.data;
+                        snode::semantic::appLog().debug()
+                            << "EventListener for 'myevent' 2:2: " << message.lastEventId << " : " << message.data;
                     });
                 }
 
@@ -370,9 +377,9 @@ namespace apps::http::legacy {
                 "/home/voc/projects/snodec/snode.c/CMakeLists.txt",
                 [req](int ret) {
                     if (ret == 0) {
-                        VLOG(1) << req->getSocketContext()->getSocketConnection()->getConnectionName()
+                        snode::semantic::appLog().debug() << req->getSocketContext()->getSocketConnection()->getConnectionName()
                                 << " HTTP: Request accepted: GET / HTTP/" << req->httpMajor << "." << req->httpMinor;
-                        VLOG(1) << "  /home/voc/projects/snodec/snode.c/CMakeLists.txt";
+                        snode::semantic::appLog().debug() << "  /home/voc/projects/snodec/snode.c/CMakeLists.txt";
                     } else {
                         snode::semantic::appLog().error() << req->getSocketContext()->getSocketConnection()->getConnectionName()
                                    << " HTTP: Request failed: GET / HTTP/" << req->httpMajor << "." << req->httpMinor;
@@ -391,9 +398,9 @@ namespace apps::http::legacy {
                         "/home/voc/projects/snodec/snode.c/CMakeLists.txt",
                         [&req](int ret) {
                             if (ret == 0) {
-                                VLOG(1) << req->getSocketContext()->getSocketConnection()->getConnectionName()
+                                snode::semantic::appLog().debug() << req->getSocketContext()->getSocketConnection()->getConnectionName()
                                         << " HTTP: Request accepted: GET / HTTP/" << req->httpMajor << "." << req->httpMinor;
-                                VLOG(1) << "  /home/voc/projects/snodec/snode.c/CMakeLists.txt";
+                                snode::semantic::appLog().debug() << "  /home/voc/projects/snodec/snode.c/CMakeLists.txt";
                             } else {
                                 snode::semantic::appLog().error() << req->getSocketContext()->getSocketConnection()->getConnectionName()
                                            << " HTTP: Request failed: GET / HTTP/" << req->httpMajor << "." << req->httpMinor;
@@ -428,9 +435,9 @@ namespace apps::http::legacy {
                     "/home/voc/projects/snodec/snode.c/CMakeLists.txt",
                     [req](int ret) {
                         if (ret == 0) {
-                            VLOG(1) << req->getSocketContext()->getSocketConnection()->getConnectionName()
+                            snode::semantic::appLog().debug() << req->getSocketContext()->getSocketConnection()->getConnectionName()
                                     << " HTTP: Request accepted: GET / HTTP/" << req->httpMajor << "." << req->httpMinor;
-                            VLOG(1) << "  /home/voc/projects/snodec/snode.c/CMakeLists.txt";
+                            snode::semantic::appLog().debug() << "  /home/voc/projects/snodec/snode.c/CMakeLists.txt";
                         } else {
                             snode::semantic::appLog().error() << req->getSocketContext()->getSocketConnection()->getConnectionName()
                                        << " HTTP: Request failed: GET / HTTP/" << req->httpMajor << "." << req->httpMinor;
@@ -454,9 +461,9 @@ namespace apps::http::legacy {
                     "/home/voc/projects/snodec/snode.c/CMakeLists.txt",
                     [req](int ret) {
                         if (ret == 0) {
-                            VLOG(1) << req->getSocketContext()->getSocketConnection()->getConnectionName()
+                            snode::semantic::appLog().debug() << req->getSocketContext()->getSocketConnection()->getConnectionName()
                                     << " HTTP: Request accepted: GET / HTTP/" << req->httpMajor << "." << req->httpMinor;
-                            VLOG(1) << "  /home/voc/projects/snodec/snode.c/CMakeLists.txt";
+                            snode::semantic::appLog().debug() << "  /home/voc/projects/snodec/snode.c/CMakeLists.txt";
                         } else {
                             snode::semantic::appLog().error() << req->getSocketContext()->getSocketConnection()->getConnectionName()
                                        << " HTTP: Request failed: GET / HTTP/" << req->httpMajor << "." << req->httpMinor;
@@ -474,21 +481,21 @@ namespace apps::http::legacy {
 #endif
             },
             []([[maybe_unused]] const std::shared_ptr<Request>& req) {
-                VLOG(1) << req->getConnectionName() << ": OnRequestEnd";
+                snode::semantic::appLog().debug() << req->getConnectionName() << ": OnRequestEnd";
             });
 
         client.setOnConnect([](SocketConnection* socketConnection) { // onConnect
-            VLOG(1) << socketConnection->getConnectionName() << ": OnConnect";
+            snode::semantic::appLog().debug() << socketConnection->getConnectionName() << ": OnConnect";
 
-            VLOG(1) << "\tLocal: " << socketConnection->getLocalAddress().toString();
-            VLOG(1) << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tLocal: " << socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
         });
 
         client.setOnDisconnect([](SocketConnection* socketConnection) { // onDisconnect
-            VLOG(1) << socketConnection->getConnectionName() << ": OnDisconnect";
+            snode::semantic::appLog().debug() << socketConnection->getConnectionName() << ": OnDisconnect";
 
-            VLOG(1) << "\tLocal: " << socketConnection->getLocalAddress().toString();
-            VLOG(1) << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tLocal: " << socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
         });
 
         return client;
@@ -512,7 +519,8 @@ namespace apps::http::tls {
         Client client(
             "httpclient",
             [](const std::shared_ptr<MasterRequest>& req) {
-                VLOG(1) << req->getSocketContext()->getSocketConnection()->getConnectionName() << ": OnRequestStart";
+                snode::semantic::appLog().debug()
+                    << req->getSocketContext()->getSocketConnection()->getConnectionName() << ": OnRequestStart";
 
                 req->url = "/";
                 req->set("Connection", "keep-alive");
@@ -660,14 +668,14 @@ namespace apps::http::tls {
                     });
             },
             []([[maybe_unused]] const std::shared_ptr<Request>& req) {
-                VLOG(1) << req->getConnectionName() << ": OnRequestEnd";
+                snode::semantic::appLog().debug() << req->getConnectionName() << ": OnRequestEnd";
             });
 
         client.setOnConnect([](SocketConnection* socketConnection) { // onConnect
-            VLOG(1) << "OnConnect " << socketConnection->getConnectionName();
+            snode::semantic::appLog().debug() << "OnConnect " << socketConnection->getConnectionName();
 
-            VLOG(1) << "\tLocal: " << socketConnection->getLocalAddress().toString();
-            VLOG(1) << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tLocal: " << socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
 
             /* Enable automatic hostname checks */
             // X509_VERIFY_PARAM* param = SSL_get0_param(socketConnection->getSSL());
@@ -680,20 +688,20 @@ namespace apps::http::tls {
         });
 
         client.setOnConnected([](SocketConnection* socketConnection) { // onConnected
-            VLOG(1) << socketConnection->getConnectionName() << ": OnConnected";
+            snode::semantic::appLog().debug() << socketConnection->getConnectionName() << ": OnConnected";
             X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
             if (server_cert != nullptr) {
                 long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                VLOG(1) << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
-                               std::string(X509_verify_cert_error_string(verifyErr));
+                snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
+                                                         std::string(X509_verify_cert_error_string(verifyErr));
 
                 char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
-                VLOG(1) << "\t   Subject: " + std::string(str);
+                snode::semantic::appLog().debug() << "\t   Subject: " + std::string(str);
                 OPENSSL_free(str);
 
                 str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
-                VLOG(1) << "\t   Issuer: " + std::string(str);
+                snode::semantic::appLog().debug() << "\t   Issuer: " + std::string(str);
                 OPENSSL_free(str);
 
                 // We could do all sorts of certificate verification stuff here before deallocating the certificate.
@@ -703,21 +711,21 @@ namespace apps::http::tls {
 
                 int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
 
-                VLOG(1) << "\t   Subject alternative name count: " << altNameCount;
+                snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
                 for (int32_t i = 0; i < altNameCount; ++i) {
                     GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
                     if (generalName->type == GEN_URI) {
                         std::string subjectAltName =
                             std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
                                         static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                        VLOG(1) << "\t      SAN (URI): '" + subjectAltName;
+                        snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
                     } else if (generalName->type == GEN_DNS) {
                         std::string subjectAltName =
                             std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
                                         static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                        VLOG(1) << "\t      SAN (DNS): '" + subjectAltName;
+                        snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
                     } else {
-                        VLOG(1) << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                        snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
                     }
                 }
 
@@ -725,15 +733,15 @@ namespace apps::http::tls {
 
                 X509_free(server_cert);
             } else {
-                VLOG(1) << "\tPeer certificate: no certificate";
+                snode::semantic::appLog().debug() << "\tPeer certificate: no certificate";
             }
         });
 
         client.setOnDisconnect([](SocketConnection* socketConnection) { // onDisconnect
-            VLOG(1) << socketConnection->getConnectionName() << ": OnDisconnect";
+            snode::semantic::appLog().debug() << socketConnection->getConnectionName() << ": OnDisconnect";
 
-            VLOG(1) << "\tLocal: " << socketConnection->getLocalAddress().toString();
-            VLOG(1) << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tLocal: " << socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tPeer:  " << socketConnection->getRemoteAddress().toString();
         });
 
         return client;

--- a/src/apps/http/model/servers.h
+++ b/src/apps/http/model/servers.h
@@ -119,23 +119,24 @@ namespace apps::http::tls {
             snode::semantic::appLog().debug() << "OnConnected " << instanceName;
 
             auto log = snode::semantic::appLog();
-            if (log.enabled(logger::LogLevel::Debug)) {
-                X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
-                if (server_cert != nullptr) {
+            X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
+            if (server_cert == nullptr) {
+                log.warn() << "\tPeer certificate: no certificate";
+            } else {
+                if (log.enabled(logger::LogLevel::Debug)) {
                     long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                    snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
-                                                             std::string(X509_verify_cert_error_string(verifyErr));
+                    log.debug() << "\tPeer certificate verifyErr = " << verifyErr << ": " << X509_verify_cert_error_string(verifyErr);
 
                     char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
                     if (str != nullptr) {
-                        snode::semantic::appLog().debug() << "\t   Subject: " << str;
+                        log.debug() << "\t   Subject: " << str;
                         OPENSSL_free(str);
                     }
 
                     str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
                     if (str != nullptr) {
-                        snode::semantic::appLog().debug() << "\t   Issuer: " << str;
+                        log.debug() << "\t   Issuer: " << str;
                         OPENSSL_free(str);
                     }
 
@@ -146,7 +147,7 @@ namespace apps::http::tls {
 
                     int32_t altNameCount = OPENSSL_sk_num(reinterpret_cast<const OPENSSL_STACK*>(subjectAltNames));
 
-                    snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
+                    log.debug() << "\t   Subject alternative name count: " << altNameCount;
                     for (int32_t i = 0; i < altNameCount; ++i) {
                         GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
 
@@ -154,23 +155,21 @@ namespace apps::http::tls {
                             std::string subjectAltName =
                                 std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
                                             static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                            snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
+                            log.debug() << "\t      SAN (URI): '" << subjectAltName;
                         } else if (generalName->type == GEN_DNS) {
                             std::string subjectAltName =
                                 std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
                                             static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                            snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
+                            log.debug() << "\t      SAN (DNS): '" << subjectAltName;
                         } else {
-                            snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                            log.debug() << "\t      SAN (Type): '" << generalName->type;
                         }
                     }
 
                     sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
-
-                    X509_free(server_cert);
-                } else {
-                    snode::semantic::appLog().warn() << "\tPeer certificate: no certificate";
                 }
+
+                X509_free(server_cert);
             }
         });
 

--- a/src/apps/http/model/servers.h
+++ b/src/apps/http/model/servers.h
@@ -100,10 +100,10 @@ namespace apps::http::tls {
         const std::string& instanceName = webApp.getConfig()->getInstanceName();
 
         webApp.setOnConnect([instanceName](SocketConnection* socketConnection) { // onConnect
-            VLOG(1) << "OnConnect " << instanceName;
+            snode::semantic::appLog().debug() << "OnConnect " << instanceName;
 
-            VLOG(1) << "  Local: " << socketConnection->getLocalAddress().toString();
-            VLOG(1) << "   Peer: " << socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "  Local: " << socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "   Peer: " << socketConnection->getRemoteAddress().toString();
 
             /* Enable automatic hostname checks */
             // X509_VERIFY_PARAM* param = SSL_get0_param(socketConnection->getSSL());
@@ -116,21 +116,21 @@ namespace apps::http::tls {
         });
 
         webApp.setOnConnected([instanceName](SocketConnection* socketConnection) { // onConnected
-            VLOG(1) << "OnConnected " << instanceName;
+            snode::semantic::appLog().debug() << "OnConnected " << instanceName;
 
             X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
             if (server_cert != nullptr) {
                 long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                VLOG(1) << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
-                               std::string(X509_verify_cert_error_string(verifyErr));
+                snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
+                                                         std::string(X509_verify_cert_error_string(verifyErr));
 
                 char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
-                VLOG(1) << "\t   Subject: " + std::string(str);
+                snode::semantic::appLog().debug() << "\t   Subject: " + std::string(str);
                 OPENSSL_free(str);
 
                 str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
-                VLOG(1) << "\t   Issuer: " + std::string(str);
+                snode::semantic::appLog().debug() << "\t   Issuer: " + std::string(str);
                 OPENSSL_free(str);
 
                 // We could do all sorts of certificate verification stuff here before deallocating the certificate.
@@ -140,7 +140,7 @@ namespace apps::http::tls {
 
                 int32_t altNameCount = OPENSSL_sk_num(reinterpret_cast<const OPENSSL_STACK*>(subjectAltNames));
 
-                VLOG(1) << "\t   Subject alternative name count: " << altNameCount;
+                snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
                 for (int32_t i = 0; i < altNameCount; ++i) {
                     GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
 
@@ -148,14 +148,14 @@ namespace apps::http::tls {
                         std::string subjectAltName =
                             std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
                                         static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                        VLOG(1) << "\t      SAN (URI): '" + subjectAltName;
+                        snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
                     } else if (generalName->type == GEN_DNS) {
                         std::string subjectAltName =
                             std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
                                         static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                        VLOG(1) << "\t      SAN (DNS): '" + subjectAltName;
+                        snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
                     } else {
-                        VLOG(1) << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                        snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
                     }
                 }
 
@@ -168,20 +168,22 @@ namespace apps::http::tls {
         });
 
         webApp.setOnDisconnect([instanceName](SocketConnection* socketConnection) { // onDisconnect
-            VLOG(1) << "OnDisconnect " << instanceName;
+            snode::semantic::appLog().debug() << "OnDisconnect " << instanceName;
 
-            VLOG(2) << "            Local: " << socketConnection->getLocalAddress().toString(false);
-            VLOG(2) << "             Peer: " << socketConnection->getRemoteAddress().toString(false);
+            snode::semantic::appLog().debug() << "            Local: " << socketConnection->getLocalAddress().toString(false);
+            snode::semantic::appLog().debug() << "             Peer: " << socketConnection->getRemoteAddress().toString(false);
 
-            VLOG(2) << "     Online Since: " << socketConnection->getOnlineSince();
-            VLOG(2) << "  Online Duration: " << socketConnection->getOnlineDuration();
+            snode::semantic::appLog().debug() << "     Online Since: " << socketConnection->getOnlineSince();
+            snode::semantic::appLog().debug() << "  Online Duration: " << socketConnection->getOnlineDuration();
 
-            VLOG(2) << "     Total Queued: " << socketConnection->getTotalQueued();
-            VLOG(2) << "       Total Sent: " << socketConnection->getTotalSent();
-            VLOG(2) << "      Write Delta: " << socketConnection->getTotalQueued() - socketConnection->getTotalSent();
-            VLOG(2) << "       Total Read: " << socketConnection->getTotalRead();
-            VLOG(2) << "  Total Processed: " << socketConnection->getTotalProcessed();
-            VLOG(2) << "       Read Delta: " << socketConnection->getTotalRead() - socketConnection->getTotalProcessed();
+            snode::semantic::appLog().debug() << "     Total Queued: " << socketConnection->getTotalQueued();
+            snode::semantic::appLog().debug() << "       Total Sent: " << socketConnection->getTotalSent();
+            snode::semantic::appLog().debug() << "      Write Delta: "
+                                              << socketConnection->getTotalQueued() - socketConnection->getTotalSent();
+            snode::semantic::appLog().debug() << "       Total Read: " << socketConnection->getTotalRead();
+            snode::semantic::appLog().debug() << "  Total Processed: " << socketConnection->getTotalProcessed();
+            snode::semantic::appLog().debug() << "       Read Delta: "
+                                              << socketConnection->getTotalRead() - socketConnection->getTotalProcessed();
         });
 
         return webApp;

--- a/src/apps/http/model/servers.h
+++ b/src/apps/http/model/servers.h
@@ -118,52 +118,59 @@ namespace apps::http::tls {
         webApp.setOnConnected([instanceName](SocketConnection* socketConnection) { // onConnected
             snode::semantic::appLog().debug() << "OnConnected " << instanceName;
 
-            X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
-            if (server_cert != nullptr) {
-                long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
+            auto log = snode::semantic::appLog();
+            if (log.enabled(logger::LogLevel::Debug)) {
+                X509* server_cert = SSL_get_peer_certificate(socketConnection->getSSL());
+                if (server_cert != nullptr) {
+                    long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
-                                                         std::string(X509_verify_cert_error_string(verifyErr));
+                    snode::semantic::appLog().debug() << "\tPeer certificate verifyErr = " + std::to_string(verifyErr) + ": " +
+                                                             std::string(X509_verify_cert_error_string(verifyErr));
 
-                char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
-                snode::semantic::appLog().debug() << "\t   Subject: " + std::string(str);
-                OPENSSL_free(str);
-
-                str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
-                snode::semantic::appLog().debug() << "\t   Issuer: " + std::string(str);
-                OPENSSL_free(str);
-
-                // We could do all sorts of certificate verification stuff here before deallocating the certificate.
-
-                GENERAL_NAMES* subjectAltNames =
-                    static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
-
-                int32_t altNameCount = OPENSSL_sk_num(reinterpret_cast<const OPENSSL_STACK*>(subjectAltNames));
-
-                snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
-                for (int32_t i = 0; i < altNameCount; ++i) {
-                    GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
-
-                    if (generalName->type == GEN_URI) {
-                        std::string subjectAltName =
-                            std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
-                                        static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                        snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
-                    } else if (generalName->type == GEN_DNS) {
-                        std::string subjectAltName =
-                            std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
-                                        static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                        snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
-                    } else {
-                        snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                    char* str = X509_NAME_oneline(X509_get_subject_name(server_cert), nullptr, 0);
+                    if (str != nullptr) {
+                        snode::semantic::appLog().debug() << "\t   Subject: " << str;
+                        OPENSSL_free(str);
                     }
+
+                    str = X509_NAME_oneline(X509_get_issuer_name(server_cert), nullptr, 0);
+                    if (str != nullptr) {
+                        snode::semantic::appLog().debug() << "\t   Issuer: " << str;
+                        OPENSSL_free(str);
+                    }
+
+                    // We could do all sorts of certificate verification stuff here before deallocating the certificate.
+
+                    GENERAL_NAMES* subjectAltNames =
+                        static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
+
+                    int32_t altNameCount = OPENSSL_sk_num(reinterpret_cast<const OPENSSL_STACK*>(subjectAltNames));
+
+                    snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
+                    for (int32_t i = 0; i < altNameCount; ++i) {
+                        GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
+
+                        if (generalName->type == GEN_URI) {
+                            std::string subjectAltName =
+                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
+                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
+                            snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
+                        } else if (generalName->type == GEN_DNS) {
+                            std::string subjectAltName =
+                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
+                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
+                            snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
+                        } else {
+                            snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                        }
+                    }
+
+                    sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
+
+                    X509_free(server_cert);
+                } else {
+                    snode::semantic::appLog().warn() << "\tPeer certificate: no certificate";
                 }
-
-                sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
-
-                X509_free(server_cert);
-            } else {
-                snode::semantic::appLog().warn() << "\tPeer certificate: no certificate";
             }
         });
 

--- a/src/apps/http/testbasicauthentication.cpp
+++ b/src/apps/http/testbasicauthentication.cpp
@@ -99,10 +99,10 @@ int main(int argc, char* argv[]) {
                                                                      const core::socket::State& state) {
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                    snode::semantic::appLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << instanceName << ": disabled";
+                    snode::semantic::appLog().info() << instanceName << ": disabled";
                     break;
                 case core::socket::State::ERROR:
                     snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
@@ -135,17 +135,17 @@ int main(int argc, char* argv[]) {
     tlsServer.listen(8088, [](const legacy::in6::WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
         switch (state) {
             case core::socket::State::OK:
-                VLOG(1) << "tls: listening on '" << socketAddress.toString() << "'"
-                        << "'";
+                snode::semantic::appLog().info() << "tls: listening on '" << socketAddress.toString() << "'"
+                                                 << "'";
                 break;
             case core::socket::State::DISABLED:
-                VLOG(1) << "tls: disabled";
+                snode::semantic::appLog().info() << "tls: disabled";
                 break;
             case core::socket::State::ERROR:
-                VLOG(1) << "tls: error occurred";
+                snode::semantic::appLog().warn() << "tls: error occurred";
                 break;
             case core::socket::State::FATAL:
-                VLOG(1) << "tls: fatal error occurred";
+                snode::semantic::appLog().error() << "tls: fatal error occurred";
                 break;
         }
     });

--- a/src/apps/http/testexpressnext.cpp
+++ b/src/apps/http/testexpressnext.cpp
@@ -303,10 +303,10 @@ int main(int argc, char* argv[]) {
     app.listen(18080, [](const express::legacy::in::WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
         switch (state) {
             case core::socket::State::OK:
-                VLOG(1) << "testexpressnext listening on '" << socketAddress.toString() << "'";
+                snode::semantic::appLog().info() << "testexpressnext listening on '" << socketAddress.toString() << "'";
                 break;
             case core::socket::State::DISABLED:
-                VLOG(1) << "testexpressnext disabled";
+                snode::semantic::appLog().info() << "testexpressnext disabled";
                 break;
             case core::socket::State::ERROR:
                 snode::semantic::appLog().error() << "testexpressnext " << socketAddress.toString() << ": " << state.what();

--- a/src/apps/http/verysimpleserver.cpp
+++ b/src/apps/http/verysimpleserver.cpp
@@ -70,10 +70,10 @@ int main(int argc, char* argv[]) {
                                                                                const core::socket::State& state) {
                          switch (state) {
                              case core::socket::State::OK:
-                                 VLOG(1) << instanceName << " listening on '" << socketAddress.toString() << "'";
+                                 snode::semantic::appLog().info() << instanceName << " listening on '" << socketAddress.toString() << "'";
                                  break;
                              case core::socket::State::DISABLED:
-                                 VLOG(1) << instanceName << " disabled";
+                                 snode::semantic::appLog().info() << instanceName << " disabled";
                                  break;
                              case core::socket::State::ERROR:
                                  snode::semantic::appLog().error()
@@ -104,10 +104,10 @@ int main(int argc, char* argv[]) {
         [instanceName = legacyApp.getConfig()->getInstanceName()](const TLSSocketAddress& socketAddress, const core::socket::State& state) {
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << instanceName << " listening on '" << socketAddress.toString() << "'";
+                    snode::semantic::appLog().info() << instanceName << " listening on '" << socketAddress.toString() << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << instanceName << " disabled";
+                    snode::semantic::appLog().info() << instanceName << " disabled";
                     break;
                 case core::socket::State::ERROR:
                     snode::semantic::appLog().error() << instanceName << " " << socketAddress.toString() << ": " << state.what();

--- a/src/apps/http/vhostserver.cpp
+++ b/src/apps/http/vhostserver.cpp
@@ -117,26 +117,25 @@ int main(int argc, char* argv[]) {
             res->status(404).send("The requested resource is not found.");
         });
 
-        legacyApp.listen(8080,
-                         [instanceName = legacyApp.getConfig()->getInstanceName()](const legacy::in6::WebApp::SocketAddress& socketAddress,
-                                                                                   const core::socket::State& state) {
-                             switch (state) {
-                                 case core::socket::State::OK:
-                                     VLOG(1) << instanceName << " listening on '" << socketAddress.toString() << "'";
-                                     break;
-                                 case core::socket::State::DISABLED:
-                                     VLOG(1) << instanceName << " disabled";
-                                     break;
-                                 case core::socket::State::ERROR:
-                                     snode::semantic::appLog().error()
-                                         << instanceName << " " << socketAddress.toString() << ": " << state.what();
-                                     break;
-                                 case core::socket::State::FATAL:
-                                     snode::semantic::appLog().critical()
-                                         << instanceName << " " << socketAddress.toString() << ": " << state.what();
-                                     break;
-                             }
-                         });
+        legacyApp.listen(
+            8080,
+            [instanceName = legacyApp.getConfig()->getInstanceName()](const legacy::in6::WebApp::SocketAddress& socketAddress,
+                                                                      const core::socket::State& state) {
+                switch (state) {
+                    case core::socket::State::OK:
+                        snode::semantic::appLog().info() << instanceName << " listening on '" << socketAddress.toString() << "'";
+                        break;
+                    case core::socket::State::DISABLED:
+                        snode::semantic::appLog().info() << instanceName << " disabled";
+                        break;
+                    case core::socket::State::ERROR:
+                        snode::semantic::appLog().error() << instanceName << " " << socketAddress.toString() << ": " << state.what();
+                        break;
+                    case core::socket::State::FATAL:
+                        snode::semantic::appLog().critical() << instanceName << " " << socketAddress.toString() << ": " << state.what();
+                        break;
+                }
+            });
     }
 
     {
@@ -193,10 +192,10 @@ int main(int argc, char* argv[]) {
                                                                              const core::socket::State& state) {
                           switch (state) {
                               case core::socket::State::OK:
-                                  VLOG(1) << instanceName << " listening on '" << socketAddress.toString() << "'";
+                                  snode::semantic::appLog().info() << instanceName << " listening on '" << socketAddress.toString() << "'";
                                   break;
                               case core::socket::State::DISABLED:
-                                  VLOG(1) << instanceName << " disabled";
+                                  snode::semantic::appLog().info() << instanceName << " disabled";
                                   break;
                               case core::socket::State::ERROR:
                                   snode::semantic::appLog().error()

--- a/src/apps/jsonclient.cpp
+++ b/src/apps/jsonclient.cpp
@@ -88,9 +88,12 @@ int main(int argc, char* argv[]) {
                         }
                     }
 
-                    res->body.push_back(0);
-                    snode::semantic::appLog().debug()
-                        << "     Body:\n----------- start body -----------" << res->body.data() << "------------ end body ------------";
+                    auto log = snode::semantic::appLog();
+                    if (log.enabled(logger::LogLevel::Debug)) {
+                        res->body.push_back(0);
+                        log.debug() << "     Body:\n----------- start body -----------" << res->body.data()
+                                    << "------------ end body ------------";
+                    }
                 },
                 [](const std::shared_ptr<Request>&, const std::string& message) {
                     snode::semantic::appLog().debug() << "legacy: Request parse error: " << message;
@@ -121,22 +124,6 @@ int main(int argc, char* argv[]) {
                     break;
             }
         });
-    /*
-        jsonClient.connect("localhost",
-                           8080,
-                           [instanceName = jsonClient.getConfig()->getInstanceName()](
-                               const SocketAddress& socketAddress,
-                               const core::socket::State& state) { // example.com:81 simulate connnect timeout
-                               switch (state) {
-                                   case core::socket::State::OK:
-                                       snode::semantic::appLog().info() << instanceName << ": connected to '" << socketAddress.toString()
-       << "'"; break; case core::socket::State::DISABLED: snode::semantic::appLog().info() << instanceName << ": disabled"; break; case
-       core::socket::State::ERROR: snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " <<
-       state.what(); break; case core::socket::State::FATAL: snode::semantic::appLog().critical() << instanceName << ": " <<
-       socketAddress.toString() << ": " << state.what(); break;
-                               }
-                           });
-    */
     /*
         jsonClient.post("localhost", 8080, "/index.html", "{\"userId\":1,\"schnitzel\":\"good\",\"hungry\":false}", [](int err) {
             if (err != 0) {

--- a/src/apps/jsonclient.cpp
+++ b/src/apps/jsonclient.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
     const Client jsonClient(
         "legacy",
         [](const std::shared_ptr<MasterRequest>& req) {
-            VLOG(1) << "-- OnRequest";
+            snode::semantic::appLog().debug() << "-- OnRequest";
             req->method = "POST";
             req->url = "/index.html";
             req->type("application/json");
@@ -69,30 +69,31 @@ int main(int argc, char* argv[]) {
             req->send(
                 R"({"userId":1,"schnitzel":"good","hungry":false})",
                 []([[maybe_unused]] const std::shared_ptr<Request>& req, const std::shared_ptr<Response>& res) {
-                    VLOG(1) << "-- OnResponse";
-                    VLOG(1) << "     Status:";
-                    VLOG(1) << "       " << res->httpVersion;
-                    VLOG(1) << "       " << res->statusCode;
-                    VLOG(1) << "       " << res->reason;
+                    snode::semantic::appLog().debug() << "-- OnResponse";
+                    snode::semantic::appLog().debug() << "     Status:";
+                    snode::semantic::appLog().debug() << "       " << res->httpVersion;
+                    snode::semantic::appLog().debug() << "       " << res->statusCode;
+                    snode::semantic::appLog().debug() << "       " << res->reason;
 
-                    VLOG(1) << "     Headers:";
+                    snode::semantic::appLog().debug() << "     Headers:";
                     for (const auto& [field, value] : res->headers) {
-                        VLOG(1) << "       " << field + " = " + value;
+                        snode::semantic::appLog().debug() << "       " << field + " = " + value;
                     }
 
-                    VLOG(1) << "     Cookies:";
+                    snode::semantic::appLog().debug() << "     Cookies:";
                     for (const auto& [name, cookie] : res->cookies) {
-                        VLOG(1) << "       " + name + " = " + cookie.getValue();
+                        snode::semantic::appLog().debug() << "       " + name + " = " + cookie.getValue();
                         for (const auto& [option, value] : cookie.getOptions()) {
-                            VLOG(1) << "         " + option + " = " + value;
+                            snode::semantic::appLog().debug() << "         " + option + " = " + value;
                         }
                     }
 
                     res->body.push_back(0);
-                    VLOG(1) << "     Body:\n----------- start body -----------" << res->body.data() << "------------ end body ------------";
+                    snode::semantic::appLog().debug()
+                        << "     Body:\n----------- start body -----------" << res->body.data() << "------------ end body ------------";
                 },
                 [](const std::shared_ptr<Request>&, const std::string& message) {
-                    VLOG(1) << "legacy: Request parse error: " << message;
+                    snode::semantic::appLog().debug() << "legacy: Request parse error: " << message;
                 });
         },
         []([[maybe_unused]] const std::shared_ptr<MasterRequest>& req) {
@@ -107,10 +108,10 @@ int main(int argc, char* argv[]) {
                                                         const core::socket::State& state) { // example.com:81 simulate connect timeout
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << instanceName << ": connected to '" << socketAddress.toString() << "'";
+                    snode::semantic::appLog().info() << instanceName << ": connected to '" << socketAddress.toString() << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << instanceName << ": disabled";
+                    snode::semantic::appLog().info() << instanceName << ": disabled";
                     break;
                 case core::socket::State::ERROR:
                     snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
@@ -128,13 +129,9 @@ int main(int argc, char* argv[]) {
                                const core::socket::State& state) { // example.com:81 simulate connnect timeout
                                switch (state) {
                                    case core::socket::State::OK:
-                                       VLOG(1) << instanceName << ": connected to '" << socketAddress.toString() << "'";
-                                       break;
-                                   case core::socket::State::DISABLED:
-                                       VLOG(1) << instanceName << ": disabled";
-                                       break;
-                                   case core::socket::State::ERROR:
-                                       snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " <<
+                                       snode::semantic::appLog().info() << instanceName << ": connected to '" << socketAddress.toString()
+       << "'"; break; case core::socket::State::DISABLED: snode::semantic::appLog().info() << instanceName << ": disabled"; break; case
+       core::socket::State::ERROR: snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " <<
        state.what(); break; case core::socket::State::FATAL: snode::semantic::appLog().critical() << instanceName << ": " <<
        socketAddress.toString() << ": " << state.what(); break;
                                }

--- a/src/apps/jsonserver.cpp
+++ b/src/apps/jsonserver.cpp
@@ -89,7 +89,10 @@ int main(int argc, char* argv[]) {
         req->getAttribute<nlohmann::json>(
             [&jsonString](nlohmann::json& json) {
                 jsonString = json.dump(4);
-                snode::semantic::appLog().debug() << "Application received body: " << jsonString;
+                auto log = snode::semantic::appLog();
+                if (log.enabled(logger::LogLevel::Debug)) {
+                    log.debug() << "Application received body: " << jsonString;
+                }
             },
             [](const std::string& key) {
                 snode::semantic::appLog().debug() << key << " attribute not found";

--- a/src/apps/jsonserver.cpp
+++ b/src/apps/jsonserver.cpp
@@ -69,10 +69,10 @@ int main(int argc, char* argv[]) {
         [instanceName = legacyApp.getConfig()->getInstanceName()](const SocketAddress& socketAddress, const core::socket::State& state) {
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                    snode::semantic::appLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << instanceName << ": disabled";
+                    snode::semantic::appLog().info() << instanceName << ": disabled";
                     break;
                 case core::socket::State::ERROR:
                     snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
@@ -89,10 +89,10 @@ int main(int argc, char* argv[]) {
         req->getAttribute<nlohmann::json>(
             [&jsonString](nlohmann::json& json) {
                 jsonString = json.dump(4);
-                VLOG(1) << "Application received body: " << jsonString;
+                snode::semantic::appLog().debug() << "Application received body: " << jsonString;
             },
             [](const std::string& key) {
-                VLOG(1) << key << " attribute not found";
+                snode::semantic::appLog().debug() << key << " attribute not found";
             });
 
         res->send(jsonString);

--- a/src/apps/main.cpp
+++ b/src/apps/main.cpp
@@ -237,10 +237,10 @@ int main(int argc, char* argv[]) {
                                                                    const core::socket::State& state) {
                    switch (state) {
                        case core::socket::State::OK:
-                           VLOG(1) << instanceName << " listening on '" << socketAddress.toString() << "'";
+                           snode::semantic::appLog().info() << instanceName << " listening on '" << socketAddress.toString() << "'";
                            break;
                        case core::socket::State::DISABLED:
-                           VLOG(1) << instanceName << " disabled";
+                           snode::semantic::appLog().info() << instanceName << " disabled";
                            break;
                        case core::socket::State::ERROR:
                            snode::semantic::appLog().error() << instanceName << " " << socketAddress.toString() << ": " << state.what();

--- a/src/apps/oauth2/authorization_server/AuthorizationServer.cpp
+++ b/src/apps/oauth2/authorization_server/AuthorizationServer.cpp
@@ -105,11 +105,12 @@ int main(int argc, char* argv[]) {
     };
     database::mariadb::MariaDBClient db{details, [](const database::mariadb::MariaDBState& state) {
                                             if (state.error != 0) {
-                                                VLOG(0) << "MySQL error: " << state.errorMessage << " [" << state.error << "]";
+                                                snode::semantic::appLog().debug()
+                                                    << "MySQL error: " << state.errorMessage << " [" << state.error << "]";
                                             } else if (state.connected) {
-                                                VLOG(0) << "MySQL connected";
+                                                snode::semantic::mariaDbLog().info() << "MySQL connected";
                                             } else {
-                                                VLOG(0) << "MySQL disconnected";
+                                                snode::semantic::mariaDbLog().info() << "MySQL disconnected";
                                             }
                                         }};
 
@@ -126,17 +127,17 @@ int main(int argc, char* argv[]) {
                 [req, res, next, queryClientId](const MYSQL_ROW row) {
                     if (row != nullptr) {
                         if (std::stoi(row[0]) > 0) {
-                            VLOG(1) << "Valid client id '" << queryClientId << "'";
-                            VLOG(1) << "Next with " << req->httpVersion << " " << req->method << " " << req->url;
+                            snode::semantic::appLog().debug() << "Valid client id '" << queryClientId << "'";
+                            snode::semantic::appLog().debug() << "Next with " << req->httpVersion << " " << req->method << " " << req->url;
                             next();
                         } else {
-                            VLOG(1) << "Invalid client id '" << queryClientId << "'";
+                            snode::semantic::appLog().debug() << "Invalid client id '" << queryClientId << "'";
                             res->sendStatus(401);
                         }
                     }
                 },
                 [res](const std::string& errorString, unsigned int errorNumber) {
-                    VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                    snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                     res->sendStatus(500);
                 });
         } else {
@@ -154,14 +155,14 @@ int main(int argc, char* argv[]) {
         const std::string paramScope{req->query("scope")};
         const std::string paramState{req->query("state")};
 
-        VLOG(1) << "Query params: "
-                << "response_type=" << req->query("response_type") << ", "
-                << "redirect_uri=" << req->query("redirect_uri") << ", "
-                << "scope=" << req->query("scope") << ", "
-                << "state=" << req->query("state") << "\n";
+        snode::semantic::appLog().debug() << "Query params: "
+                                          << "response_type=" << req->query("response_type") << ", "
+                                          << "redirect_uri=" << req->query("redirect_uri") << ", "
+                                          << "scope=" << req->query("scope") << ", "
+                                          << "state=" << req->query("state") << "\n";
 
         if (paramResponseType != "code") {
-            VLOG(1) << "Auth invalid, sending Bad Request";
+            snode::semantic::appLog().debug() << "Auth invalid, sending Bad Request";
             res->sendStatus(400);
             return;
         }
@@ -170,10 +171,10 @@ int main(int argc, char* argv[]) {
             db.exec(
                 "update client set redirect_uri = '" + paramRedirectUri + "' where uuid = '" + paramClientId + "'",
                 [paramRedirectUri]() {
-                    VLOG(1) << "Database: Set redirect_uri to " << paramRedirectUri;
+                    snode::semantic::appLog().debug() << "Database: Set redirect_uri to " << paramRedirectUri;
                 },
                 [](const std::string& errorString, unsigned int errorNumber) {
-                    VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                    snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                 });
         }
 
@@ -181,10 +182,10 @@ int main(int argc, char* argv[]) {
             db.exec(
                 "update client set scope = '" + paramScope + "' where uuid = '" + paramClientId + "'",
                 [paramScope]() {
-                    VLOG(1) << "Database: Set scope to " << paramScope;
+                    snode::semantic::appLog().debug() << "Database: Set scope to " << paramScope;
                 },
                 [](const std::string& errorString, unsigned int errorNumber) {
-                    VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                    snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                 });
         }
 
@@ -192,14 +193,14 @@ int main(int argc, char* argv[]) {
             db.exec(
                 "update client set state = '" + paramState + "' where uuid = '" + paramClientId + "'",
                 [paramState]() {
-                    VLOG(1) << "Database: Set state to " << paramState;
+                    snode::semantic::appLog().debug() << "Database: Set state to " << paramState;
                 },
                 [](const std::string& errorString, unsigned int errorNumber) {
-                    VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                    snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                 });
         }
 
-        VLOG(1) << "Auth request valid, redirecting to login";
+        snode::semantic::appLog().debug() << "Auth request valid, redirecting to login";
         std::string loginUri{"/oauth2/login"};
         addQueryParamToUri(loginUri, "client_id", paramClientId);
         res->redirect(loginUri);
@@ -248,7 +249,7 @@ int main(int argc, char* argv[]) {
                                       []() {
                                       },
                                       [res](const std::string& errorString, unsigned int errorNumber) {
-                                          VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                          snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                                           res->sendStatus(500);
                                       })
                                     .query(
@@ -273,24 +274,25 @@ int main(int argc, char* argv[]) {
                                                         res->set("Access-Control-Allow-Origin", "*");
                                                         const nlohmann::json responseJson = {{"redirect_uri", clientRedirectUri}};
                                                         const std::string responseJsonString{responseJson.dump(4)};
-                                                        VLOG(1) << "Sending json reponse: " << responseJsonString;
+                                                        snode::semantic::appLog().debug() << "Sending json reponse: " << responseJsonString;
                                                         res->send(responseJsonString);
                                                     },
                                                     [res](const std::string& errorString, unsigned int errorNumber) {
-                                                        VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                                        snode::semantic::appLog().debug()
+                                                            << "Database error: " << errorString << " : " << errorNumber;
                                                         res->sendStatus(500);
                                                     });
                                             }
                                         },
                                         [res](const std::string& errorString, unsigned int errorNumber) {
-                                            VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                            snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                                             res->sendStatus(500);
                                         });
                             }
                         }
                     },
                     [res](const std::string& errorString, unsigned int errorNumber) {
-                        VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                        snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                         res->sendStatus(500);
                     });
             },
@@ -302,11 +304,11 @@ int main(int argc, char* argv[]) {
     router.get("/token", [&db] APPLICATION(req, res) {
         res->set("Access-Control-Allow-Origin", "*");
         auto queryGrantType = req->query("grant_type");
-        VLOG(1) << "GrandType: " << queryGrantType;
+        snode::semantic::appLog().debug() << "GrandType: " << queryGrantType;
         auto queryCode = req->query("code");
-        VLOG(1) << "Code: " << queryCode;
+        snode::semantic::appLog().debug() << "Code: " << queryCode;
         auto queryRedirectUri = req->query("redirect_uri");
-        VLOG(1) << "RedirectUri: " << queryRedirectUri;
+        snode::semantic::appLog().debug() << "RedirectUri: " << queryRedirectUri;
         if (queryGrantType != "authorization_code") {
             res->status(400).send("Invalid query parameter 'grant_type', value must be 'authorization_code'");
             return;
@@ -365,7 +367,8 @@ int main(int argc, char* argv[]) {
                                           []() {
                                           },
                                           [res](const std::string& errorString, unsigned int errorNumber) {
-                                              VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                              snode::semantic::appLog().debug()
+                                                  << "Database error: " << errorString << " : " << errorNumber;
                                               res->sendStatus(500);
                                           })
                                         .query(
@@ -382,13 +385,15 @@ int main(int argc, char* argv[]) {
                                                         []() {
                                                         },
                                                         [res](const std::string& errorString, unsigned int errorNumber) {
-                                                            VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                                            snode::semantic::appLog().debug()
+                                                                << "Database error: " << errorString << " : " << errorNumber;
                                                             res->sendStatus(500);
                                                         });
                                                 }
                                             },
                                             [res](const std::string& errorString, unsigned int errorNumber) {
-                                                VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                                snode::semantic::appLog().debug()
+                                                    << "Database error: " << errorString << " : " << errorNumber;
                                                 res->sendStatus(500);
                                             })
                                         .exec(
@@ -401,7 +406,8 @@ int main(int argc, char* argv[]) {
                                             []() {
                                             },
                                             [res](const std::string& errorString, unsigned int errorNumber) {
-                                                VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                                snode::semantic::appLog().debug()
+                                                    << "Database error: " << errorString << " : " << errorNumber;
                                                 res->sendStatus(500);
                                             })
                                         .query(
@@ -424,26 +430,28 @@ int main(int argc, char* argv[]) {
                                                             res->send(jsonResponseString);
                                                         },
                                                         [res](const std::string& errorString, unsigned int errorNumber) {
-                                                            VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                                            snode::semantic::appLog().debug()
+                                                                << "Database error: " << errorString << " : " << errorNumber;
                                                             res->sendStatus(500);
                                                         });
                                                 }
                                             },
                                             [res](const std::string& errorString, unsigned int errorNumber) {
-                                                VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                                snode::semantic::appLog().debug()
+                                                    << "Database error: " << errorString << " : " << errorNumber;
                                                 res->sendStatus(500);
                                             });
                                 }
                             },
                             [res](const std::string& errorString, unsigned int errorNumber) {
-                                VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                                 res->sendStatus(500);
                             });
                     }
                 }
             },
             [res](const std::string& errorString, unsigned int errorNumber) {
-                VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                 res->sendStatus(500);
             });
     });
@@ -451,13 +459,13 @@ int main(int argc, char* argv[]) {
     router.post("/token/refresh", [&db] APPLICATION(req, res) {
         res->set("Access-Control-Allow-Origin", "*");
         auto queryClientId = req->query("client_id");
-        VLOG(1) << "ClientId: " << queryClientId;
+        snode::semantic::appLog().debug() << "ClientId: " << queryClientId;
         auto queryGrantType = req->query("grant_type");
-        VLOG(1) << "GrandType: " << queryGrantType;
+        snode::semantic::appLog().debug() << "GrandType: " << queryGrantType;
         auto queryRefreshToken = req->query("refresh_token");
-        VLOG(1) << "RefreshToken: " << queryRefreshToken;
+        snode::semantic::appLog().debug() << "RefreshToken: " << queryRefreshToken;
         auto queryState = req->query("state");
-        VLOG(1) << "State: " << queryState;
+        snode::semantic::appLog().debug() << "State: " << queryState;
         if (queryGrantType.length() == 0) {
             res->status(400).send("Missing query parameter 'grant_type'");
             return;
@@ -498,7 +506,7 @@ int main(int argc, char* argv[]) {
                           []() {
                           },
                           [res](const std::string& errorString, unsigned int errorNumber) {
-                              VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                              snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                               res->sendStatus(500);
                           })
                         .query(
@@ -518,34 +526,34 @@ int main(int argc, char* argv[]) {
                                             res->send(responseJson.dump(4));
                                         },
                                         [res](const std::string& errorString, unsigned int errorNumber) {
-                                            VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                            snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                                             res->sendStatus(500);
                                         });
                                 }
                             },
                             [res](const std::string& errorString, unsigned int errorNumber) {
-                                VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                                snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                                 res->sendStatus(500);
                             });
                 }
             },
             [res](const std::string& errorString, unsigned int errorNumber) {
-                VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                 res->sendStatus(500);
             });
     });
 
     router.post("/token/validate", [&db] APPLICATION(req, res) {
-        VLOG(1) << "POST /token/validate";
+        snode::semantic::appLog().debug() << "POST /token/validate";
         req->getAttribute<nlohmann::json>([res, &db](nlohmann::json& jsonBody) {
             if (!jsonBody.contains("access_token")) {
-                VLOG(1) << "Missing 'access_token' in json";
+                snode::semantic::appLog().debug() << "Missing 'access_token' in json";
                 res->status(500).send("Missing 'access_token' in json");
                 return;
             }
             const std::string jsonAccessToken{jsonBody["access_token"]};
             if (!jsonBody.contains("client_id")) {
-                VLOG(1) << "Missing 'client_id' in json";
+                snode::semantic::appLog().debug() << "Missing 'client_id' in json";
                 res->status(500).send("Missing 'client_id' in json");
                 return;
             }
@@ -564,17 +572,17 @@ int main(int argc, char* argv[]) {
                     if (row != nullptr) {
                         if (std::stoi(row[0]) == 0) {
                             const nlohmann::json errorJson = {{"error", "Invalid access token"}};
-                            VLOG(1) << "Sending 401: Invalid access token '" << jsonAccessToken << "'";
+                            snode::semantic::appLog().debug() << "Sending 401: Invalid access token '" << jsonAccessToken << "'";
                             res->status(401).send(errorJson.dump(4));
                         } else {
-                            VLOG(1) << "Sending 200: Valid access token '" << jsonAccessToken << "";
+                            snode::semantic::appLog().debug() << "Sending 200: Valid access token '" << jsonAccessToken << "";
                             const nlohmann::json successJson = {{"success", "Valid access token"}};
                             res->status(200).send(successJson.dump(4));
                         }
                     }
                 },
                 [res](const std::string& errorString, unsigned int errorNumber) {
-                    VLOG(1) << "Database error: " << errorString << " : " << errorNumber;
+                    snode::semantic::appLog().debug() << "Database error: " << errorString << " : " << errorNumber;
                     res->sendStatus(500);
                 });
         });
@@ -587,16 +595,16 @@ int main(int argc, char* argv[]) {
     app.listen(8082, [](const express::legacy::in::WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
         switch (state) {
             case core::socket::State::OK:
-                VLOG(1) << "OAuth2AuthorizationServer: listening on '" << socketAddress.toString() << "'";
+                snode::semantic::appLog().info() << "OAuth2AuthorizationServer: listening on '" << socketAddress.toString() << "'";
                 break;
             case core::socket::State::DISABLED:
-                VLOG(1) << "OAuth2AuthorizationServer: disabled";
+                snode::semantic::appLog().info() << "OAuth2AuthorizationServer: disabled";
                 break;
             case core::socket::State::ERROR:
-                VLOG(1) << "OAuth2AuthorizationServer: error occurred";
+                snode::semantic::appLog().warn() << "OAuth2AuthorizationServer: error occurred";
                 break;
             case core::socket::State::FATAL:
-                VLOG(1) << "OAuth2AuthorizationServer: fatal error occurred";
+                snode::semantic::appLog().error() << "OAuth2AuthorizationServer: fatal error occurred";
                 break;
         }
     });

--- a/src/apps/oauth2/client_app/ClientApp.cpp
+++ b/src/apps/oauth2/client_app/ClientApp.cpp
@@ -66,8 +66,8 @@ int main(int argc, char* argv[]) {
             }
             tokenRequestUri += "&client_id=911a821a-ea2d-11ec-8e2e-08002771075f";
             tokenRequestUri += "&redirect_uri=http://localhost:8081/oauth2";
-            VLOG(1) << "Recieving auth code from auth server: " << req.query("code") << ", requesting token from " << tokenRequestUri;
-            res.redirect(tokenRequestUri);
+            snode::semantic::appLog().debug() << "Recieving auth code from auth server: " << req.query("code") << ", requesting token from "
+            << tokenRequestUri; res.redirect(tokenRequestUri);
             */
         }
     });
@@ -77,16 +77,16 @@ int main(int argc, char* argv[]) {
     app.listen(8081, [](const express::legacy::in::WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
         switch (state) {
             case core::socket::State::OK:
-                VLOG(1) << "OAuth2Client: connected to '" << socketAddress.toString() << "'";
+                snode::semantic::appLog().info() << "OAuth2Client: connected to '" << socketAddress.toString() << "'";
                 break;
             case core::socket::State::DISABLED:
-                VLOG(1) << "OAuth2Client: disabled";
+                snode::semantic::appLog().info() << "OAuth2Client: disabled";
                 break;
             case core::socket::State::ERROR:
-                VLOG(1) << "OAuth2Client: error occurred";
+                snode::semantic::appLog().warn() << "OAuth2Client: error occurred";
                 break;
             case core::socket::State::FATAL:
-                VLOG(1) << "OAuth2Client: fatal error occurred";
+                snode::semantic::appLog().error() << "OAuth2Client: fatal error occurred";
                 break;
         }
     });

--- a/src/apps/oauth2/resource_server/ResourceServer.cpp
+++ b/src/apps/oauth2/resource_server/ResourceServer.cpp
@@ -64,41 +64,41 @@ int main(int argc, char* argv[]) {
         const std::string queryAccessToken{req->query("access_token")};
         const std::string queryClientId{req->query("client_id")};
         if (queryAccessToken.empty() || queryClientId.empty()) {
-            VLOG(1) << "Missing access_token or client_id in body";
+            snode::semantic::appLog().warn() << "Missing access_token or client_id in body";
             res->sendStatus(401);
             return;
         }
 
         const web::http::legacy::in::Client legacyClient(
             [](web::http::legacy::in::Client::SocketConnection* socketConnection) {
-                VLOG(1) << "OnConnect";
+                snode::semantic::appLog().debug() << "OnConnect";
 
-                VLOG(1) << "\tServer: " + socketConnection->getRemoteAddress().toString();
-                VLOG(1) << "\tClient: " + socketConnection->getLocalAddress().toString();
+                snode::semantic::appLog().debug() << "\tServer: " + socketConnection->getRemoteAddress().toString();
+                snode::semantic::appLog().debug() << "\tClient: " + socketConnection->getLocalAddress().toString();
             },
             []([[maybe_unused]] web::http::legacy::in::Client::SocketConnection* socketConnection) {
-                VLOG(1) << "OnConnected";
+                snode::semantic::appLog().debug() << "OnConnected";
             },
             [](web::http::legacy::in::Client::SocketConnection* socketConnection) {
-                VLOG(1) << "OnDisconnect";
+                snode::semantic::appLog().debug() << "OnDisconnect";
 
-                VLOG(1) << "\tServer: " + socketConnection->getRemoteAddress().toString();
-                VLOG(1) << "\tClient: " + socketConnection->getLocalAddress().toString();
+                snode::semantic::appLog().debug() << "\tServer: " + socketConnection->getRemoteAddress().toString();
+                snode::semantic::appLog().debug() << "\tClient: " + socketConnection->getLocalAddress().toString();
             },
             [queryAccessToken, queryClientId, res](const std::shared_ptr<web::http::client::MasterRequest>& request) {
-                VLOG(1) << "OnRequestBegin";
+                snode::semantic::appLog().debug() << "OnRequestBegin";
                 request->url = "/oauth2/token/validate?client_id=" + queryClientId;
                 request->method = "POST";
-                VLOG(1) << "ClientId: " << queryClientId;
-                VLOG(1) << "AccessToken: " << queryAccessToken;
+                snode::semantic::appLog().debug() << "ClientId: " << queryClientId;
+                snode::semantic::appLog().debug() << "AccessToken: " << queryAccessToken;
                 const nlohmann::json requestJson = {{"access_token", queryAccessToken}, {"client_id", queryClientId}};
                 const std::string requestJsonString{requestJson.dump(4)};
                 request->send(
                     requestJsonString,
                     [res]([[maybe_unused]] const std::shared_ptr<web::http::client::Request>& request,
                           const std::shared_ptr<web::http::client::Response>& response) {
-                        VLOG(1) << "OnResponse";
-                        VLOG(1) << "Response: " << std::string(response->body.begin(), response->body.end());
+                        snode::semantic::appLog().debug() << "OnResponse";
+                        snode::semantic::appLog().debug() << "Response: " << std::string(response->body.begin(), response->body.end());
                         if (std::stoi(response->statusCode) != 200) {
                             const nlohmann::json errorJson = {{"error", "Invalid access token"}};
                             res->status(401).send(errorJson.dump(4));
@@ -108,7 +108,7 @@ int main(int argc, char* argv[]) {
                         }
                     },
                     [](const std::shared_ptr<web::http::client::Request>&, const std::string& message) {
-                        VLOG(1) << "OAuth2ResourceServer: Request parse error: " << message;
+                        snode::semantic::appLog().debug() << "OAuth2ResourceServer: Request parse error: " << message;
                     });
             },
             []([[maybe_unused]] const std::shared_ptr<web::http::client::Request>& req) {
@@ -119,16 +119,16 @@ int main(int argc, char* argv[]) {
             "localhost", 8082, [](const web::http::legacy::in::Client::SocketAddress& socketAddress, const core::socket::State& state) {
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << "OAuth2ResourceServer: connected to '" << socketAddress.toString() << "'";
+                        snode::semantic::appLog().info() << "OAuth2ResourceServer: connected to '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << "OAuth2ResourceServer: disabled";
+                        snode::semantic::appLog().info() << "OAuth2ResourceServer: disabled";
                         break;
                     case core::socket::State::ERROR:
-                        VLOG(1) << "OAuth2ResourceServer: error occurred";
+                        snode::semantic::appLog().warn() << "OAuth2ResourceServer: error occurred";
                         break;
                     case core::socket::State::FATAL:
-                        VLOG(1) << "OAuth2ResourceServer: fatal error occurred";
+                        snode::semantic::appLog().error() << "OAuth2ResourceServer: fatal error occurred";
                         break;
                 }
             });
@@ -137,16 +137,16 @@ int main(int argc, char* argv[]) {
     app.listen(8083, [](const express::legacy::in::WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
         switch (state) {
             case core::socket::State::OK:
-                VLOG(1) << "app: listening on '" << socketAddress.toString() << "'";
+                snode::semantic::appLog().info() << "app: listening on '" << socketAddress.toString() << "'";
                 break;
             case core::socket::State::DISABLED:
-                VLOG(1) << "app: disabled";
+                snode::semantic::appLog().info() << "app: disabled";
                 break;
             case core::socket::State::ERROR:
-                VLOG(1) << "app: error occurred";
+                snode::semantic::appLog().warn() << "app: error occurred";
                 break;
             case core::socket::State::FATAL:
-                VLOG(1) << "app: fatal error occurred";
+                snode::semantic::appLog().error() << "app: fatal error occurred";
                 break;
         }
     });

--- a/src/apps/testpipe.cpp
+++ b/src/apps/testpipe.cpp
@@ -62,22 +62,22 @@ int main(int argc, char* argv[]) {
         []([[maybe_unused]] core::pipe::PipeSource& pipeSource, [[maybe_unused]] core::pipe::PipeSink& pipeSink) {
             pipeSink.setOnData([&pipeSource](const char* chunk, std::size_t chunkLen) {
                 const std::string string(chunk, chunkLen);
-                VLOG(1) << "Pipe Data: " << string;
+                snode::semantic::appLog().debug() << "Pipe Data: " << string;
                 pipeSource.send(chunk, chunkLen);
                 // pipeSink.disable();
                 // pipeSource.disable();
             });
 
             pipeSink.setOnEof([]() {
-                VLOG(1) << "Pipe EOF";
+                snode::semantic::appLog().debug() << "Pipe EOF";
             });
 
             pipeSink.setOnError([]([[maybe_unused]] int errnum) {
-                VLOG(1) << "PipeSink";
+                snode::semantic::appLog().debug() << "PipeSink";
             });
 
             pipeSource.setOnError([]([[maybe_unused]] int errnum) {
-                VLOG(1) << "PipeSource";
+                snode::semantic::appLog().debug() << "PipeSource";
             });
 
             pipeSource.send("Hello World!");

--- a/src/apps/testpost.cpp
+++ b/src/apps/testpost.cpp
@@ -39,6 +39,7 @@
  * THE SOFTWARE.
  */
 
+#include "SemanticLog.h"
 #include "express/legacy/in/WebApp.h"
 #include "express/middleware/VerboseRequest.h"
 #include "express/tls/in/WebApp.h"
@@ -107,16 +108,16 @@ int main(int argc, char* argv[]) {
     legacyApp.listen(8080, [](const LegacySocketAddress& socketAddress, const core::socket::State& state) {
         switch (state) {
             case core::socket::State::OK:
-                VLOG(1) << "legacyApp: listening on '" << socketAddress.toString() << "'";
+                snode::semantic::appLog().info() << "legacyApp: listening on '" << socketAddress.toString() << "'";
                 break;
             case core::socket::State::DISABLED:
-                VLOG(1) << "legacyApp: disabled";
+                snode::semantic::appLog().info() << "legacyApp: disabled";
                 break;
             case core::socket::State::ERROR:
-                VLOG(1) << "legacyApp: error occurred";
+                snode::semantic::appLog().warn() << "legacyApp: error occurred";
                 break;
             case core::socket::State::FATAL:
-                VLOG(1) << "legacyApp: fatal error occurred";
+                snode::semantic::appLog().error() << "legacyApp: fatal error occurred";
                 break;
         }
     });
@@ -137,16 +138,16 @@ int main(int argc, char* argv[]) {
     tlsApp.listen("localhost", 8088, [](const TLSSocketAddress& socketAddress, const core::socket::State& state) {
         switch (state) {
             case core::socket::State::OK:
-                VLOG(1) << "tlsApp: listening on '" << socketAddress.toString() << "'";
+                snode::semantic::appLog().info() << "tlsApp: listening on '" << socketAddress.toString() << "'";
                 break;
             case core::socket::State::DISABLED:
-                VLOG(1) << "tlsApp: disabled";
+                snode::semantic::appLog().info() << "tlsApp: disabled";
                 break;
             case core::socket::State::ERROR:
-                VLOG(1) << "tlsApp: error occurred";
+                snode::semantic::appLog().warn() << "tlsApp: error occurred";
                 break;
             case core::socket::State::FATAL:
-                VLOG(1) << "tlsApp: fatal error occurred";
+                snode::semantic::appLog().error() << "tlsApp: fatal error occurred";
                 break;
         }
     });

--- a/src/apps/testregex.cpp
+++ b/src/apps/testregex.cpp
@@ -39,6 +39,7 @@
  * THE SOFTWARE.
  */
 
+#include "SemanticLog.h"
 #include "database/mariadb/MariaDBClient.h"
 #include "express/legacy/in/WebApp.h"
 #include "express/tls/in/WebApp.h"
@@ -104,11 +105,11 @@ Router router(database::mariadb::MariaDBClient& db) {
         .get(
             "/query/:userId",
             [] MIDDLEWARE(req, res, next) {
-                VLOG(1) << "Move on to the next route to query database";
+                snode::semantic::appLog().debug() << "Move on to the next route to query database";
                 next();
             },
             [&db] MIDDLEWARE(req, res, next) { // http://localhost:8080/query/123
-                VLOG(1) << "UserId: " << req->params["userId"];
+                snode::semantic::appLog().debug() << "UserId: " << req->params["userId"];
                 std::string userId = req->params["userId"];
 
                 req->setAttribute<std::string, "html-table">(std::string());
@@ -159,29 +160,29 @@ Router router(database::mariadb::MariaDBClient& db) {
                                                          "  </body>\n"
                                                          "</html>\n"));
                             });
-                            VLOG(1) << "Move on to the next route to send result";
+                            snode::semantic::appLog().debug() << "Move on to the next route to send result";
                             next();
                         }
                     },
                     [res, userId](const std::string& errorString, unsigned int errorNumber) {
-                        VLOG(1) << "Error: " << errorString << " : " << errorNumber;
+                        snode::semantic::appLog().warn() << "Error: " << errorString << " : " << errorNumber;
                         res->status(404).send(userId + ": " + errorString + " - " + std::to_string(errorNumber));
                     });
             },
             [] MIDDLEWARE(req, res, next) {
-                VLOG(1) << "And again 1: Move on to the next route to send result";
+                snode::semantic::appLog().debug() << "And again 1: Move on to the next route to send result";
                 next();
             },
             [] MIDDLEWARE(req, res, next) {
-                VLOG(1) << "And again 2: Move on to the next route to send result";
+                snode::semantic::appLog().debug() << "And again 2: Move on to the next route to send result";
                 next();
             })
         .get([] MIDDLEWARE(req, res, next) {
-            VLOG(1) << "And again 3: Move on to the next route to send result";
+            snode::semantic::appLog().debug() << "And again 3: Move on to the next route to send result";
             next();
         })
         .get([] APPLICATION(req, res) {
-            VLOG(1) << "SendResult";
+            snode::semantic::appLog().debug() << "SendResult";
 
             req->getAttribute<std::string, "html-table">(
                 [res](std::string& table) {
@@ -192,9 +193,9 @@ Router router(database::mariadb::MariaDBClient& db) {
                 });
         });
     router.get("/account/:userId(\\d*)/:userName", [&db] APPLICATION(req, res) { // http://localhost:8080/account/123/perfectNDSgroup
-        VLOG(1) << "Show account of";
-        VLOG(1) << "UserId: " << req->params["userId"];
-        VLOG(1) << "UserName: " << req->params["userName"];
+        snode::semantic::appLog().debug() << "Show account of";
+        snode::semantic::appLog().debug() << "UserId: " << req->params["userId"];
+        snode::semantic::appLog().debug() << "UserName: " << req->params["userName"];
 
         const std::string response = "<html>"
                                      "  <head>"
@@ -219,18 +220,18 @@ Router router(database::mariadb::MariaDBClient& db) {
         db.exec(
             "INSERT INTO `snodec`(`username`, `password`) VALUES ('" + userId + "','" + userName + "')",
             [userId, userName]() {
-                VLOG(1) << "Inserted: -> " << userId << " - " << userName;
+                snode::semantic::appLog().debug() << "Inserted: -> " << userId << " - " << userName;
             },
             [](const std::string& errorString, unsigned int errorNumber) {
-                VLOG(1) << "Error: " << errorString << " : " << errorNumber;
+                snode::semantic::appLog().warn() << "Error: " << errorString << " : " << errorNumber;
             });
 
         res->send(response);
     });
     router.get("/asdf/:testRegex1(d\\d{3}e)/jklö/:testRegex2", [] APPLICATION(req, res) { // http://localhost:8080/asdf/d123e/jklö/hallo
-        VLOG(1) << "Testing Regex";
-        VLOG(1) << "Regex1: " << req->params["testRegex1"];
-        VLOG(1) << "Regex2: " << req->params["testRegex2"];
+        snode::semantic::appLog().debug() << "Testing Regex";
+        snode::semantic::appLog().debug() << "Regex1: " << req->params["testRegex1"];
+        snode::semantic::appLog().debug() << "Regex2: " << req->params["testRegex2"];
 
         const std::string response = "<html>"
                                      "  <head>"
@@ -252,9 +253,9 @@ Router router(database::mariadb::MariaDBClient& db) {
         res->send(response);
     });
     router.get("/search/:search", [] APPLICATION(req, res) { // http://localhost:8080/search/buxtehude123
-        VLOG(1) << "Show Search of";
-        VLOG(1) << "Search: " << req->params["search"];
-        VLOG(1) << "Queries: " << req->query("test");
+        snode::semantic::appLog().debug() << "Show Search of";
+        snode::semantic::appLog().debug() << "Search: " << req->params["search"];
+        snode::semantic::appLog().debug() << "Queries: " << req->query("test");
 
         res->send(req->params["search"]);
     });
@@ -287,11 +288,11 @@ int main(int argc, char* argv[]) {
 
     database::mariadb::MariaDBClient db(details, [](const database::mariadb::MariaDBState& state) {
         if (state.error != 0) {
-            VLOG(0) << "MySQL error: " << state.errorMessage << " [" << state.error << "]";
+            snode::semantic::appLog().error() << "MySQL error: " << state.errorMessage << " [" << state.error << "]";
         } else if (state.connected) {
-            VLOG(0) << "MySQL connected";
+            snode::semantic::mariaDbLog().info() << "MySQL connected";
         } else {
-            VLOG(0) << "MySQL disconnected";
+            snode::semantic::mariaDbLog().info() << "MySQL disconnected";
         }
     });
 
@@ -303,32 +304,32 @@ int main(int argc, char* argv[]) {
         legacyApp.listen(8080, [](const legacy::in::WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << "legacy-testregex: listening on '" << socketAddress.toString() << "'";
+                    snode::semantic::appLog().info() << "legacy-testregex: listening on '" << socketAddress.toString() << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << "legacy-testregex: disabled";
+                    snode::semantic::appLog().info() << "legacy-testregex: disabled";
                     break;
                 case core::socket::State::ERROR:
-                    VLOG(1) << "legacy-testregex: error occurred";
+                    snode::semantic::appLog().warn() << "legacy-testregex: error occurred";
                     break;
                 case core::socket::State::FATAL:
-                    VLOG(1) << "legacy-testregex: fatal error occurred";
+                    snode::semantic::appLog().error() << "legacy-testregex: fatal error occurred";
                     break;
             }
         });
 
         legacyApp.setOnConnect([](legacy::in::WebApp::SocketConnection* socketConnection) {
-            VLOG(1) << "OnConnect:";
+            snode::semantic::appLog().debug() << "OnConnect:";
 
-            VLOG(1) << "\tServer: " + socketConnection->getRemoteAddress().toString();
-            VLOG(1) << "\tClient: " + socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tServer: " + socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tClient: " + socketConnection->getLocalAddress().toString();
         });
 
         legacyApp.setOnDisconnect([](legacy::in::WebApp::SocketConnection* socketConnection) {
-            VLOG(1) << "OnDisconnect:";
+            snode::semantic::appLog().debug() << "OnDisconnect:";
 
-            VLOG(1) << "\tServer: " + socketConnection->getRemoteAddress().toString();
-            VLOG(1) << "\tClient: " + socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tServer: " + socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tClient: " + socketConnection->getLocalAddress().toString();
         });
 
         tls::in::WebApp tlsApp("tls-testregex");
@@ -338,43 +339,43 @@ int main(int argc, char* argv[]) {
         tlsApp.listen(8088, [](const tls::in::WebApp::SocketAddress& socketAddress, const core::socket::State& state) {
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << "tls-testregex: listening on '" << socketAddress.toString() << "'";
+                    snode::semantic::appLog().info() << "tls-testregex: listening on '" << socketAddress.toString() << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << "tls-testregex: disabled";
+                    snode::semantic::appLog().info() << "tls-testregex: disabled";
                     break;
                 case core::socket::State::ERROR:
-                    VLOG(1) << "tls-testregex: error occurred";
+                    snode::semantic::appLog().warn() << "tls-testregex: error occurred";
                     break;
                 case core::socket::State::FATAL:
-                    VLOG(1) << "tls-testregex: fatal error occurred";
+                    snode::semantic::appLog().error() << "tls-testregex: fatal error occurred";
                     break;
             }
         });
 
         tlsApp.setOnConnect([](tls::in::WebApp::SocketConnection* socketConnection) {
-            VLOG(1) << "OnConnect:";
+            snode::semantic::appLog().debug() << "OnConnect:";
 
-            VLOG(1) << "\tServer: " + socketConnection->getRemoteAddress().toString();
-            VLOG(1) << "\tClient: " + socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tServer: " + socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tClient: " + socketConnection->getLocalAddress().toString();
         });
 
         tlsApp.setOnConnected([](tls::in::WebApp::SocketConnection* socketConnection) {
-            VLOG(1) << "OnConnected:";
+            snode::semantic::appLog().debug() << "OnConnected:";
 
             X509* client_cert = SSL_get_peer_certificate(socketConnection->getSSL());
 
             if (client_cert != nullptr) {
                 const long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                VLOG(1) << "\tClient certificate: " + std::string(X509_verify_cert_error_string(verifyErr));
+                snode::semantic::appLog().debug() << "\tClient certificate: " + std::string(X509_verify_cert_error_string(verifyErr));
 
                 char* str = X509_NAME_oneline(X509_get_subject_name(client_cert), nullptr, 0);
-                VLOG(1) << "\t   Subject: " + std::string(str);
+                snode::semantic::appLog().debug() << "\t   Subject: " + std::string(str);
                 OPENSSL_free(str);
 
                 str = X509_NAME_oneline(X509_get_issuer_name(client_cert), nullptr, 0);
-                VLOG(1) << "\t   Issuer: " + std::string(str);
+                snode::semantic::appLog().debug() << "\t   Issuer: " + std::string(str);
                 OPENSSL_free(str);
 
                 // We could do all sorts of certificate verification stuff here before deallocating the certificate.
@@ -384,21 +385,21 @@ int main(int argc, char* argv[]) {
 
                 const int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
 
-                VLOG(1) << "\t   Subject alternative name count: " << altNameCount;
+                snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
                 for (int32_t i = 0; i < altNameCount; ++i) {
                     GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
                     if (generalName->type == GEN_URI) {
                         const std::string subjectAltName =
                             std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
                                         static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                        VLOG(1) << "\t      SAN (URI): '" + subjectAltName;
+                        snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
                     } else if (generalName->type == GEN_DNS) {
                         const std::string subjectAltName =
                             std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
                                         static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                        VLOG(1) << "\t      SAN (DNS): '" + subjectAltName;
+                        snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
                     } else {
-                        VLOG(1) << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                        snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
                     }
                 }
 
@@ -406,15 +407,15 @@ int main(int argc, char* argv[]) {
 
                 X509_free(client_cert);
             } else {
-                VLOG(1) << "\tClient certificate: no certificate";
+                snode::semantic::appLog().debug() << "\tClient certificate: no certificate";
             }
         });
 
         tlsApp.setOnDisconnect([](tls::in::WebApp::SocketConnection* socketConnection) {
-            VLOG(1) << "OnDisconnect:";
+            snode::semantic::appLog().debug() << "OnDisconnect:";
 
-            VLOG(1) << "\tServer: " + socketConnection->getRemoteAddress().toString();
-            VLOG(1) << "\tClient: " + socketConnection->getLocalAddress().toString();
+            snode::semantic::appLog().debug() << "\tServer: " + socketConnection->getRemoteAddress().toString();
+            snode::semantic::appLog().debug() << "\tClient: " + socketConnection->getLocalAddress().toString();
         });
     }
 

--- a/src/apps/testregex.cpp
+++ b/src/apps/testregex.cpp
@@ -363,51 +363,58 @@ int main(int argc, char* argv[]) {
         tlsApp.setOnConnected([](tls::in::WebApp::SocketConnection* socketConnection) {
             snode::semantic::appLog().debug() << "OnConnected:";
 
-            X509* client_cert = SSL_get_peer_certificate(socketConnection->getSSL());
+            auto log = snode::semantic::appLog();
+            if (log.enabled(logger::LogLevel::Debug)) {
+                X509* client_cert = SSL_get_peer_certificate(socketConnection->getSSL());
 
-            if (client_cert != nullptr) {
-                const long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
+                if (client_cert != nullptr) {
+                    const long verifyErr = SSL_get_verify_result(socketConnection->getSSL());
 
-                snode::semantic::appLog().debug() << "\tClient certificate: " + std::string(X509_verify_cert_error_string(verifyErr));
+                    snode::semantic::appLog().debug() << "\tClient certificate: " + std::string(X509_verify_cert_error_string(verifyErr));
 
-                char* str = X509_NAME_oneline(X509_get_subject_name(client_cert), nullptr, 0);
-                snode::semantic::appLog().debug() << "\t   Subject: " + std::string(str);
-                OPENSSL_free(str);
-
-                str = X509_NAME_oneline(X509_get_issuer_name(client_cert), nullptr, 0);
-                snode::semantic::appLog().debug() << "\t   Issuer: " + std::string(str);
-                OPENSSL_free(str);
-
-                // We could do all sorts of certificate verification stuff here before deallocating the certificate.
-
-                GENERAL_NAMES* subjectAltNames =
-                    static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(client_cert, NID_subject_alt_name, nullptr, nullptr));
-
-                const int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
-
-                snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
-                for (int32_t i = 0; i < altNameCount; ++i) {
-                    GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
-                    if (generalName->type == GEN_URI) {
-                        const std::string subjectAltName =
-                            std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
-                                        static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
-                        snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
-                    } else if (generalName->type == GEN_DNS) {
-                        const std::string subjectAltName =
-                            std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
-                                        static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
-                        snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
-                    } else {
-                        snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                    char* str = X509_NAME_oneline(X509_get_subject_name(client_cert), nullptr, 0);
+                    if (str != nullptr) {
+                        snode::semantic::appLog().debug() << "\t   Subject: " << str;
+                        OPENSSL_free(str);
                     }
+
+                    str = X509_NAME_oneline(X509_get_issuer_name(client_cert), nullptr, 0);
+                    if (str != nullptr) {
+                        snode::semantic::appLog().debug() << "\t   Issuer: " << str;
+                        OPENSSL_free(str);
+                    }
+
+                    // We could do all sorts of certificate verification stuff here before deallocating the certificate.
+
+                    GENERAL_NAMES* subjectAltNames =
+                        static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(client_cert, NID_subject_alt_name, nullptr, nullptr));
+
+                    const int32_t altNameCount = sk_GENERAL_NAME_num(subjectAltNames);
+
+                    snode::semantic::appLog().debug() << "\t   Subject alternative name count: " << altNameCount;
+                    for (int32_t i = 0; i < altNameCount; ++i) {
+                        GENERAL_NAME* generalName = sk_GENERAL_NAME_value(subjectAltNames, i);
+                        if (generalName->type == GEN_URI) {
+                            const std::string subjectAltName =
+                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
+                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.uniformResourceIdentifier)));
+                            snode::semantic::appLog().debug() << "\t      SAN (URI): '" + subjectAltName;
+                        } else if (generalName->type == GEN_DNS) {
+                            const std::string subjectAltName =
+                                std::string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(generalName->d.dNSName)),
+                                            static_cast<std::size_t>(ASN1_STRING_length(generalName->d.dNSName)));
+                            snode::semantic::appLog().debug() << "\t      SAN (DNS): '" + subjectAltName;
+                        } else {
+                            snode::semantic::appLog().debug() << "\t      SAN (Type): '" + std::to_string(generalName->type);
+                        }
+                    }
+
+                    sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
+
+                    X509_free(client_cert);
+                } else {
+                    snode::semantic::appLog().debug() << "\tClient certificate: no certificate";
                 }
-
-                sk_GENERAL_NAME_pop_free(subjectAltNames, GENERAL_NAME_free);
-
-                X509_free(client_cert);
-            } else {
-                snode::semantic::appLog().debug() << "\tClient certificate: no certificate";
             }
         });
 

--- a/src/apps/tlslegacy/TlsLegacySocketContext.cpp
+++ b/src/apps/tlslegacy/TlsLegacySocketContext.cpp
@@ -6,6 +6,7 @@
 
 #include "TlsLegacySocketContext.h"
 
+#include "SemanticLog.h"
 #include "core/socket/stream/SocketConnection.h"
 #include "log/Logger.h"
 
@@ -26,17 +27,17 @@ namespace apps::tlslegacy {
     }
 
     void TlsLegacySocketContext::onConnected() {
-        VLOG(1) << getSocketConnection()->getConnectionName() << ": connected";
+        snode::semantic::appLog().info() << getSocketConnection()->getConnectionName() << ": connected";
 
         if (role == Role::CLIENT) {
             sendToPeer(TLS_HELLO);
-            VLOG(1) << getSocketConnection()->getConnectionName() << ": sent TLS greeting";
+            snode::semantic::appLog().debug() << getSocketConnection()->getConnectionName() << ": sent TLS greeting";
         }
     }
 
     void TlsLegacySocketContext::onDisconnected() {
         legacyRetryTimer.cancel();
-        VLOG(1) << getSocketConnection()->getConnectionName() << ": disconnected";
+        snode::semantic::appLog().debug() << getSocketConnection()->getConnectionName() << ": disconnected";
     }
 
     bool TlsLegacySocketContext::onSignal([[maybe_unused]] int signum) {
@@ -54,7 +55,8 @@ namespace apps::tlslegacy {
                 }
 
                 sendToPeer(payload);
-                VLOG(1) << getSocketConnection()->getConnectionName() << ": trying post-TLS legacy payload: " << payload;
+                snode::semantic::appLog().debug()
+                    << getSocketConnection()->getConnectionName() << ": trying post-TLS legacy payload: " << payload;
             },
             utils::Timeval(0.5));
     }
@@ -62,14 +64,15 @@ namespace apps::tlslegacy {
     void TlsLegacySocketContext::onClientLine(const std::string& line) {
         if (line == TLS_ACK && !tlsReplySeen) {
             tlsReplySeen = true;
-            VLOG(1) << getSocketConnection()->getConnectionName() << ": got TLS ack, initiating TLS shutdown handshake (close_notify) "
-                    << line;
+            snode::semantic::appLog().debug() << getSocketConnection()->getConnectionName()
+                                              << ": got TLS ack, initiating TLS shutdown handshake (close_notify) " << line;
             shutdownWrite();
             startLegacyRetryTimer(LEGACY_HELLO);
         } else if (line == LEGACY_ACK && !legacyReplySeen) {
             legacyReplySeen = true;
             legacyRetryTimer.cancel();
-            VLOG(1) << getSocketConnection()->getConnectionName() << ": got LEGACY ack -> post-TLS plaintext path works " << line;
+            snode::semantic::appLog().debug() << getSocketConnection()->getConnectionName()
+                                              << ": got LEGACY ack -> post-TLS plaintext path works " << line;
             shutdownWrite();
         }
     }
@@ -78,12 +81,14 @@ namespace apps::tlslegacy {
         if (line == TLS_HELLO && !tlsReplySeen) {
             tlsReplySeen = true;
             sendToPeer(TLS_ACK);
-            VLOG(1) << getSocketConnection()->getConnectionName() << ": TLS phase complete, waiting for peer close_notify " << line;
+            snode::semantic::appLog().debug() << getSocketConnection()->getConnectionName()
+                                              << ": TLS phase complete, waiting for peer close_notify " << line;
         } else if (line == LEGACY_HELLO && !legacyPayloadSeen) {
             legacyPayloadSeen = true;
             legacyRetryTimer.cancel();
             sendToPeer(LEGACY_ACK);
-            VLOG(1) << getSocketConnection()->getConnectionName() << ": received LEGACY payload after TLS shutdown " << line;
+            snode::semantic::appLog().debug() << getSocketConnection()->getConnectionName()
+                                              << ": received LEGACY payload after TLS shutdown " << line;
             shutdownWrite();
         }
     }

--- a/src/apps/tlslegacy/TlsLegacySocketContext.cpp
+++ b/src/apps/tlslegacy/TlsLegacySocketContext.cpp
@@ -55,8 +55,10 @@ namespace apps::tlslegacy {
                 }
 
                 sendToPeer(payload);
-                snode::semantic::appLog().debug()
-                    << getSocketConnection()->getConnectionName() << ": trying post-TLS legacy payload: " << payload;
+                auto log = snode::semantic::appLog();
+                if (log.enabled(logger::LogLevel::Trace)) {
+                    log.trace() << getSocketConnection()->getConnectionName() << ": trying post-TLS legacy payload: " << payload;
+                }
             },
             utils::Timeval(0.5));
     }
@@ -87,8 +89,10 @@ namespace apps::tlslegacy {
             legacyPayloadSeen = true;
             legacyRetryTimer.cancel();
             sendToPeer(LEGACY_ACK);
-            snode::semantic::appLog().debug() << getSocketConnection()->getConnectionName()
-                                              << ": received LEGACY payload after TLS shutdown " << line;
+            auto log = snode::semantic::appLog();
+            if (log.enabled(logger::LogLevel::Trace)) {
+                log.trace() << getSocketConnection()->getConnectionName() << ": received LEGACY payload after TLS shutdown " << line;
+            }
             shutdownWrite();
         }
     }

--- a/src/apps/tlslegacy/tlslegacyclient.cpp
+++ b/src/apps/tlslegacy/tlslegacyclient.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
     client.connect([instanceName = client.getConfig()->getInstanceName()](const SocketClient::SocketAddress& socketAddress,
                                                                           const core::socket::State& state) {
         if (state == core::socket::State::OK) {
-            VLOG(1) << instanceName << ": connected to " << socketAddress.toString();
+            snode::semantic::appLog().info() << instanceName << ": connected to " << socketAddress.toString();
         } else if (state == core::socket::State::ERROR) {
             snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
         }

--- a/src/apps/tlslegacy/tlslegacyserver.cpp
+++ b/src/apps/tlslegacy/tlslegacyserver.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
     server.listen([instanceName = server.getConfig()->getInstanceName()](const SocketServer::SocketAddress& socketAddress,
                                                                          const core::socket::State& state) {
         if (state == core::socket::State::OK) {
-            VLOG(1) << instanceName << ": listening on " << socketAddress.toString();
+            snode::semantic::appLog().info() << instanceName << ": listening on " << socketAddress.toString();
         } else if (state == core::socket::State::ERROR) {
             snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
         }

--- a/src/apps/warema-jalousien.cpp
+++ b/src/apps/warema-jalousien.cpp
@@ -72,8 +72,8 @@ int main(int argc, char* argv[]) {
     //    tls::WebApp wa;
 
     webApp.get("/jalousien/:id", [] APPLICATION(req, res) {
-        VLOG(1) << "Param: " << req->param("id");
-        VLOG(1) << "Qurey: " << req->query("action");
+        snode::semantic::appLog().debug() << "Param: " << req->param("id");
+        snode::semantic::appLog().debug() << "Qurey: " << req->query("action");
 
         std::string arguments = "aircontrol -t " + jalousien[req->param("id")] + "_" + actions[req->query("action")];
 
@@ -104,10 +104,10 @@ int main(int argc, char* argv[]) {
                                                                          const core::socket::State& state) {
                       switch (state) {
                           case core::socket::State::OK:
-                              VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                              snode::semantic::appLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                               break;
                           case core::socket::State::DISABLED:
-                              VLOG(1) << instanceName << ": disabled";
+                              snode::semantic::appLog().info() << instanceName << ": disabled";
                               break;
                           case core::socket::State::ERROR:
                               snode::semantic::appLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();

--- a/src/apps/websocket/echoclient.cpp
+++ b/src/apps/websocket/echoclient.cpp
@@ -39,6 +39,7 @@
  * THE SOFTWARE.
  */
 
+#include "SemanticLog.h"
 #include "core/SNodeC.h"
 #include "web/http/legacy/in/Client.h"
 #include "web/http/tls/in/Client.h"
@@ -64,7 +65,7 @@ int main(int argc, char* argv[]) {
             [](const std::shared_ptr<MasterRequest>& req) {
                 const std::string connectionName = req->getSocketContext()->getSocketConnection()->getConnectionName();
 
-                VLOG(1) << connectionName << ": OnRequestBegin";
+                snode::semantic::appLog().debug() << connectionName << ": OnRequestBegin";
 
                 req->set("Sec-WebSocket-Protocol", "subprotocol, echo");
 
@@ -72,40 +73,41 @@ int main(int argc, char* argv[]) {
                     "/ws",
                     "websocket",
                     [connectionName](bool success) {
-                        VLOG(1) << connectionName << ": HTTP Upgrade (http -> websocket) start " << (success ? "success" : "failed");
+                        snode::semantic::appLog().debug()
+                            << connectionName << ": HTTP Upgrade (http -> websocket) start " << (success ? "success" : "failed");
                     },
                     [connectionName]([[maybe_unused]] const std::shared_ptr<Request>& req,
                                      const std::shared_ptr<Response>& res,
                                      [[maybe_unused]] bool success) {
-                        VLOG(1) << connectionName << ": Upgrade success:";
+                        snode::semantic::appLog().debug() << connectionName << ": Upgrade success:";
 
-                        VLOG(1) << connectionName << ":   Requested: " << req->header("upgrade");
-                        VLOG(1) << connectionName << ":    Selected: " << res->get("upgrade");
+                        snode::semantic::appLog().debug() << connectionName << ":   Requested: " << req->header("upgrade");
+                        snode::semantic::appLog().debug() << connectionName << ":    Selected: " << res->get("upgrade");
                     },
                     [connectionName](const std::shared_ptr<Request>&, const std::string& message) {
-                        VLOG(1) << connectionName << ": Request parse error: " << message;
+                        snode::semantic::appLog().debug() << connectionName << ": Request parse error: " << message;
                     });
             },
             []([[maybe_unused]] const std::shared_ptr<MasterRequest>& req) {
                 const std::string connectionName = req->getConnectionName();
 
-                VLOG(1) << connectionName << ": OnRequestEnd";
+                snode::semantic::appLog().debug() << connectionName << ": OnRequestEnd";
             });
 
         legacyClient.connect([instanceName = legacyClient.getConfig()->getInstanceName()](const LegacySocketAddress& socketAddress,
                                                                                           const core::socket::State& state) {
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << instanceName << " connected to '" << socketAddress.toString() << "'";
+                    snode::semantic::appLog().info() << instanceName << " connected to '" << socketAddress.toString() << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << instanceName << " disabled";
+                    snode::semantic::appLog().info() << instanceName << " disabled";
                     break;
                 case core::socket::State::ERROR:
-                    VLOG(1) << instanceName << " " << socketAddress.toString() << ": " << state.what();
+                    snode::semantic::appLog().error() << instanceName << " " << socketAddress.toString() << ": " << state.what();
                     break;
                 case core::socket::State::FATAL:
-                    VLOG(1) << instanceName << " " << socketAddress.toString() << ": " << state.what();
+                    snode::semantic::appLog().critical() << instanceName << " " << socketAddress.toString() << ": " << state.what();
                     break;
             }
         }); // Connection:keep-alive\r\n\r\n"
@@ -121,7 +123,7 @@ int main(int argc, char* argv[]) {
             [](const std::shared_ptr<MasterRequest>& req) {
                 const std::string connectionName = req->getSocketContext()->getSocketConnection()->getConnectionName();
 
-                VLOG(1) << connectionName << ": OnRequestBegin";
+                snode::semantic::appLog().debug() << connectionName << ": OnRequestBegin";
 
                 req->set("Sec-WebSocket-Protocol", "subprotocol, echo");
 
@@ -129,36 +131,37 @@ int main(int argc, char* argv[]) {
                     "/ws",
                     "websocket",
                     [connectionName](bool success) {
-                        VLOG(1) << connectionName << ": HTTP Upgrade (http -> websocket) start " << (success ? "success" : "failed");
+                        snode::semantic::appLog().debug()
+                            << connectionName << ": HTTP Upgrade (http -> websocket) start " << (success ? "success" : "failed");
                     },
                     [connectionName]([[maybe_unused]] const std::shared_ptr<Request>& req,
                                      [[maybe_unused]] const std::shared_ptr<Response>& res,
                                      [[maybe_unused]] bool success) {
                     },
                     [connectionName](const std::shared_ptr<Request>&, const std::string& message) {
-                        VLOG(1) << connectionName << ": Request parse error: " << message;
+                        snode::semantic::appLog().debug() << connectionName << ": Request parse error: " << message;
                     });
             },
             []([[maybe_unused]] const std::shared_ptr<MasterRequest>& req) {
                 const std::string connectionName = req->getConnectionName();
 
-                VLOG(1) << connectionName << ": OnRequestEnd";
+                snode::semantic::appLog().debug() << connectionName << ": OnRequestEnd";
             });
 
         tlsClient.connect([instanceName = tlsClient.getConfig()->getInstanceName()](const TLSSocketAddress& socketAddress,
                                                                                     const core::socket::State& state) {
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << instanceName << " connected to '" << socketAddress.toString() << "'";
+                    snode::semantic::appLog().info() << instanceName << " connected to '" << socketAddress.toString() << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << instanceName << " disabled";
+                    snode::semantic::appLog().info() << instanceName << " disabled";
                     break;
                 case core::socket::State::ERROR:
-                    VLOG(1) << instanceName << " " << socketAddress.toString() << ": " << state.what();
+                    snode::semantic::appLog().error() << instanceName << " " << socketAddress.toString() << ": " << state.what();
                     break;
                 case core::socket::State::FATAL:
-                    VLOG(1) << instanceName << " " << socketAddress.toString() << ": " << state.what();
+                    snode::semantic::appLog().critical() << instanceName << " " << socketAddress.toString() << ": " << state.what();
                     break;
             }
         }); // Connection:keep-alive\r\n\r\n"

--- a/src/apps/websocket/echoserver.cpp
+++ b/src/apps/websocket/echoserver.cpp
@@ -124,11 +124,14 @@ int main(int argc, char* argv[]) {
         })
         .getFlowController();
 
-    snode::semantic::appLog().debug() << "Legacy Routes:";
-    for (std::string& route : legacyApp.getRoutes()) {
-        route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
+    auto log = snode::semantic::appLog();
+    if (log.enabled(logger::LogLevel::Trace)) {
+        log.trace() << "Legacy Routes:";
+        for (std::string route : legacyApp.getRoutes()) {
+            route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-        snode::semantic::appLog().debug() << "  " << route;
+            log.trace() << "  " << route;
+        }
     }
 
     {
@@ -195,11 +198,14 @@ int main(int argc, char* argv[]) {
             })
             .getFlowController();
 
-        snode::semantic::appLog().debug() << "Tls Routes:";
-        for (std::string& route : legacyApp.getRoutes()) {
-            route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
+        auto log = snode::semantic::appLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Tls Routes:";
+            for (std::string route : legacyApp.getRoutes()) {
+                route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            snode::semantic::appLog().debug() << "  " << route;
+                log.trace() << "  " << route;
+            }
         }
     }
 

--- a/src/apps/websocket/echoserver.cpp
+++ b/src/apps/websocket/echoserver.cpp
@@ -39,6 +39,7 @@
  * THE SOFTWARE.
  */
 
+#include "SemanticLog.h"
 #include "express/legacy/in/WebApp.h"
 #include "express/middleware/VerboseRequest.h"
 #include "express/tls/in/WebApp.h"
@@ -72,13 +73,13 @@ int main(int argc, char* argv[]) {
 
         res->upgrade(req, [req, res, connectionName](const std::string& name) {
             if (!name.empty()) {
-                VLOG(1) << connectionName << ": Successful upgrade:";
-                VLOG(1) << connectionName << ":   Requested: " << req->get("upgrade");
-                VLOG(1) << connectionName << ":    Selected: " << name;
+                snode::semantic::appLog().debug() << connectionName << ": Successful upgrade:";
+                snode::semantic::appLog().debug() << connectionName << ":   Requested: " << req->get("upgrade");
+                snode::semantic::appLog().debug() << connectionName << ":    Selected: " << name;
 
                 res->end();
             } else {
-                VLOG(1) << connectionName << ": Can not upgrade to any of '" << req->get("upgrade") << "'";
+                snode::semantic::appLog().debug() << connectionName << ": Can not upgrade to any of '" << req->get("upgrade") << "'";
 
                 res->sendStatus(404);
             }
@@ -86,18 +87,18 @@ int main(int argc, char* argv[]) {
     });
 
     legacyApp.get("/", [] APPLICATION(req, res) {
-        VLOG(1) << "HTTP GET on "
-                << "/";
+        snode::semantic::appLog().debug() << "HTTP GET on "
+                                          << "/";
         if (req->url == "/" || req->url == "/index.html") {
             req->url = "/wstest.html";
         }
 
-        VLOG(1) << CMAKE_CURRENT_SOURCE_DIR "/html" + req->url;
+        snode::semantic::appLog().debug() << CMAKE_CURRENT_SOURCE_DIR "/html" + req->url;
         res->sendFile(CMAKE_CURRENT_SOURCE_DIR "/html" + req->url, [req, res](int errnum) {
             if (errnum == 0) {
-                VLOG(1) << req->url;
+                snode::semantic::appLog().debug() << req->url;
             } else {
-                VLOG(1) << "HTTP response send file failed: " << std::strerror(errnum);
+                snode::semantic::appLog().debug() << "HTTP response send file failed: " << std::strerror(errnum);
                 res->sendStatus(404);
             }
         });
@@ -108,26 +109,26 @@ int main(int argc, char* argv[]) {
                                                                           const core::socket::State& state) {
             switch (state) {
                 case core::socket::State::OK:
-                    VLOG(1) << instanceName << " listening on '" << socketAddress.toString() << "'";
+                    snode::semantic::appLog().info() << instanceName << " listening on '" << socketAddress.toString() << "'";
                     break;
                 case core::socket::State::DISABLED:
-                    VLOG(1) << instanceName << " disabled";
+                    snode::semantic::appLog().info() << instanceName << " disabled";
                     break;
                 case core::socket::State::ERROR:
-                    VLOG(1) << instanceName << " " << socketAddress.toString() << ": " << state.what();
+                    snode::semantic::appLog().error() << instanceName << " " << socketAddress.toString() << ": " << state.what();
                     break;
                 case core::socket::State::FATAL:
-                    VLOG(1) << instanceName << " " << socketAddress.toString() << ": " << state.what();
+                    snode::semantic::appLog().critical() << instanceName << " " << socketAddress.toString() << ": " << state.what();
                     break;
             }
         })
         .getFlowController();
 
-    VLOG(1) << "Legacy Routes:";
+    snode::semantic::appLog().debug() << "Legacy Routes:";
     for (std::string& route : legacyApp.getRoutes()) {
         route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-        VLOG(1) << "  " << route;
+        snode::semantic::appLog().debug() << "  " << route;
     }
 
     {
@@ -145,13 +146,13 @@ int main(int argc, char* argv[]) {
 
             res->upgrade(req, [req, res, connectionName](const std::string& name) {
                 if (!name.empty()) {
-                    VLOG(1) << connectionName << ": Upgrade success:";
-                    VLOG(1) << connectionName << ":   Requested: " << req->get("upgrade");
-                    VLOG(1) << connectionName << ":    Selected: " << name;
+                    snode::semantic::appLog().debug() << connectionName << ": Upgrade success:";
+                    snode::semantic::appLog().debug() << connectionName << ":   Requested: " << req->get("upgrade");
+                    snode::semantic::appLog().debug() << connectionName << ":    Selected: " << name;
 
                     res->end();
                 } else {
-                    VLOG(1) << connectionName << ": Can not upgrade to any of '" << req->get("upgrade") << "'";
+                    snode::semantic::appLog().debug() << connectionName << ": Can not upgrade to any of '" << req->get("upgrade") << "'";
 
                     res->sendStatus(404);
                 }
@@ -163,12 +164,12 @@ int main(int argc, char* argv[]) {
                 req->url = "/wstest.html";
             }
 
-            VLOG(1) << CMAKE_CURRENT_SOURCE_DIR "/html" + req->url;
+            snode::semantic::appLog().debug() << CMAKE_CURRENT_SOURCE_DIR "/html" + req->url;
             res->sendFile(CMAKE_CURRENT_SOURCE_DIR "/html" + req->url, [req, res](int errnum) {
                 if (errnum == 0) {
-                    VLOG(1) << req->url;
+                    snode::semantic::appLog().debug() << req->url;
                 } else {
-                    VLOG(1) << "HTTP response send file failed: " << std::strerror(errnum);
+                    snode::semantic::appLog().debug() << "HTTP response send file failed: " << std::strerror(errnum);
                     res->sendStatus(404);
                 }
             });
@@ -179,26 +180,26 @@ int main(int argc, char* argv[]) {
                                                                            const core::socket::State& state) {
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << instanceName << " listening on '" << socketAddress.toString() << "'";
+                        snode::semantic::appLog().info() << instanceName << " listening on '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << instanceName << " disabled";
+                        snode::semantic::appLog().info() << instanceName << " disabled";
                         break;
                     case core::socket::State::ERROR:
-                        VLOG(1) << instanceName << " " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::appLog().error() << instanceName << " " << socketAddress.toString() << ": " << state.what();
                         break;
                     case core::socket::State::FATAL:
-                        VLOG(1) << instanceName << " " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::appLog().critical() << instanceName << " " << socketAddress.toString() << ": " << state.what();
                         break;
                 }
             })
             .getFlowController();
 
-        VLOG(1) << "Tls Routes:";
+        snode::semantic::appLog().debug() << "Tls Routes:";
         for (std::string& route : legacyApp.getRoutes()) {
             route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            VLOG(1) << "  " << route;
+            snode::semantic::appLog().debug() << "  " << route;
         }
     }
 

--- a/src/apps/websocket/subprotocol/client/echo/Echo.cpp
+++ b/src/apps/websocket/subprotocol/client/echo/Echo.cpp
@@ -41,6 +41,8 @@
 
 #include "Echo.h"
 
+#include "SemanticLog.h"
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #include "log/Logger.h"
@@ -60,24 +62,24 @@ namespace apps::websocket::subprotocol::echo::client {
     }
 
     void Echo::onConnected() {
-        VLOG(1) << "Echo connected";
+        snode::semantic::appLog().debug() << "Echo connected";
 
         sendMessage("Welcome to SimpleChat");
         sendMessage("=====================");
     }
 
     void Echo::onMessageStart(int opCode) {
-        VLOG(2) << "Message Start - OpCode: " << opCode;
+        snode::semantic::appLog().debug() << "Message Start - OpCode: " << opCode;
     }
 
     void Echo::onMessageData(const char* chunk, std::size_t chunkLen) {
         data += std::string(chunk, chunkLen);
 
-        VLOG(2) << "Message Fragment: " << std::string(chunk, chunkLen);
+        snode::semantic::appLog().debug() << "Message Fragment: " << std::string(chunk, chunkLen);
     }
 
     void Echo::onMessageEnd() {
-        VLOG(1) << "Message Data: " << data;
+        snode::semantic::appLog().debug() << "Message Data: " << data;
 
         // To do ping-pong
         //        sendMessage(data);
@@ -86,16 +88,16 @@ namespace apps::websocket::subprotocol::echo::client {
     }
 
     void Echo::onMessageError(uint16_t errnum) {
-        VLOG(1) << "Message error: " << errnum;
+        snode::semantic::appLog().debug() << "Message error: " << errnum;
     }
 
     void Echo::onDisconnected() {
-        VLOG(1) << "Echo disconnected:";
+        snode::semantic::appLog().debug() << "Echo disconnected:";
     }
 
     bool Echo::onSignal(int sig) {
-        VLOG(1) << "SubProtocol 'echo' exit due to '" << strsignal(sig) << "' (SIG" << utils::system::sigabbrev_np(sig) << " = " << sig
-                << ")";
+        snode::semantic::appLog().debug() << "SubProtocol 'echo' exit due to '" << strsignal(sig) << "' (SIG"
+                                          << utils::system::sigabbrev_np(sig) << " = " << sig << ")";
 
         sendClose();
 

--- a/src/apps/websocket/subprotocol/client/echo/Echo.cpp
+++ b/src/apps/websocket/subprotocol/client/echo/Echo.cpp
@@ -75,11 +75,17 @@ namespace apps::websocket::subprotocol::echo::client {
     void Echo::onMessageData(const char* chunk, std::size_t chunkLen) {
         data += std::string(chunk, chunkLen);
 
-        snode::semantic::appLog().debug() << "Message Fragment: " << std::string(chunk, chunkLen);
+        auto log = snode::semantic::appLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Message Fragment: " << std::string(chunk, chunkLen);
+        }
     }
 
     void Echo::onMessageEnd() {
-        snode::semantic::appLog().debug() << "Message Data: " << data;
+        auto log = snode::semantic::appLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Message Data: " << data;
+        }
 
         // To do ping-pong
         //        sendMessage(data);

--- a/src/apps/websocket/subprotocol/server/echo/Echo.cpp
+++ b/src/apps/websocket/subprotocol/server/echo/Echo.cpp
@@ -72,11 +72,17 @@ namespace apps::websocket::subprotocol::echo::server {
     void Echo::onMessageData(const char* chunk, std::size_t chunkLen) {
         data += std::string(chunk, chunkLen);
 
-        snode::semantic::appLog().debug() << "Message Fragment: " << std::string(chunk, chunkLen);
+        auto log = snode::semantic::appLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Message Fragment: " << std::string(chunk, chunkLen);
+        }
     }
 
     void Echo::onMessageEnd() {
-        snode::semantic::appLog().debug() << "Message Data: " << data;
+        auto log = snode::semantic::appLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Message Data: " << data;
+        }
 
         // Alternative
         // forEachClient([&data = this->data](SubProtocol* client) {

--- a/src/apps/websocket/subprotocol/server/echo/Echo.cpp
+++ b/src/apps/websocket/subprotocol/server/echo/Echo.cpp
@@ -41,6 +41,8 @@
 
 #include "Echo.h"
 
+#include "SemanticLog.h"
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #include "log/Logger.h"
@@ -60,21 +62,21 @@ namespace apps::websocket::subprotocol::echo::server {
     }
 
     void Echo::onConnected() {
-        VLOG(1) << "Echo connected";
+        snode::semantic::appLog().debug() << "Echo connected";
     }
 
     void Echo::onMessageStart(int opCode) {
-        VLOG(2) << "Message Start - OpCode: " << opCode;
+        snode::semantic::appLog().debug() << "Message Start - OpCode: " << opCode;
     }
 
     void Echo::onMessageData(const char* chunk, std::size_t chunkLen) {
         data += std::string(chunk, chunkLen);
 
-        VLOG(2) << "Message Fragment: " << std::string(chunk, chunkLen);
+        snode::semantic::appLog().debug() << "Message Fragment: " << std::string(chunk, chunkLen);
     }
 
     void Echo::onMessageEnd() {
-        VLOG(1) << "Message Data: " << data;
+        snode::semantic::appLog().debug() << "Message Data: " << data;
 
         // Alternative
         // forEachClient([&data = this->data](SubProtocol* client) {
@@ -87,16 +89,16 @@ namespace apps::websocket::subprotocol::echo::server {
     }
 
     void Echo::onMessageError(uint16_t errnum) {
-        VLOG(1) << "Message error: " << errnum;
+        snode::semantic::appLog().debug() << "Message error: " << errnum;
     }
 
     void Echo::onDisconnected() {
-        VLOG(1) << "Echo disconnected:";
+        snode::semantic::appLog().debug() << "Echo disconnected:";
     }
 
     bool Echo::onSignal(int sig) {
-        VLOG(1) << "SubProtocol 'echo' exit due to '" << strsignal(sig) << "' (SIG" << utils::system::sigabbrev_np(sig) << " = " << sig
-                << ")";
+        snode::semantic::appLog().debug() << "SubProtocol 'echo' exit due to '" << strsignal(sig) << "' (SIG"
+                                          << utils::system::sigabbrev_np(sig) << " = " << sig << ")";
 
         sendClose();
 

--- a/src/express/legacy/in/Server.cpp
+++ b/src/express/legacy/in/Server.cpp
@@ -41,6 +41,7 @@
 
 #include "express/legacy/in/Server.h"
 
+#include "SemanticLog.h"
 #include "log/Logger.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -70,26 +71,27 @@ namespace express::legacy::in {
             } else {
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                        snode::semantic::expressLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << instanceName << ": disabled";
+                        snode::semantic::expressLog().info() << instanceName << ": disabled";
                         break;
                     case core::socket::State::ERROR:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                     case core::socket::State::FATAL:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().critical()
+                            << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                 }
             }
         });
 
-        VLOG(1) << "Instance: " << instanceName;
+        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
         for (std::string& route : webApp.getRoutes()) {
             route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            VLOG(1) << "  " << route;
+            snode::semantic::expressLog().trace() << "  " << route;
         }
 
         return webApp;

--- a/src/express/legacy/in/Server.cpp
+++ b/src/express/legacy/in/Server.cpp
@@ -87,11 +87,14 @@ namespace express::legacy::in {
             }
         });
 
-        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
-        for (std::string& route : webApp.getRoutes()) {
-            route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
+        auto log = snode::semantic::expressLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Instance: " << instanceName;
+            for (std::string route : webApp.getRoutes()) {
+                route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            snode::semantic::expressLog().trace() << "  " << route;
+                log.trace() << "  " << route;
+            }
         }
 
         return webApp;

--- a/src/express/legacy/in6/Server.cpp
+++ b/src/express/legacy/in6/Server.cpp
@@ -87,11 +87,14 @@ namespace express::legacy::in6 {
             }
         });
 
-        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
-        for (std::string& route : webApp.getRoutes()) {
-            route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
+        auto log = snode::semantic::expressLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Instance: " << instanceName;
+            for (std::string route : webApp.getRoutes()) {
+                route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            snode::semantic::expressLog().trace() << "  " << route;
+                log.trace() << "  " << route;
+            }
         }
 
         return webApp;

--- a/src/express/legacy/in6/Server.cpp
+++ b/src/express/legacy/in6/Server.cpp
@@ -41,6 +41,7 @@
 
 #include "express/legacy/in6/Server.h"
 
+#include "SemanticLog.h"
 #include "log/Logger.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -70,26 +71,27 @@ namespace express::legacy::in6 {
             } else {
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                        snode::semantic::expressLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << instanceName << ": disabled";
+                        snode::semantic::expressLog().info() << instanceName << ": disabled";
                         break;
                     case core::socket::State::ERROR:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                     case core::socket::State::FATAL:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().critical()
+                            << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                 }
             }
         });
 
-        VLOG(1) << "Instance: " << instanceName;
+        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
         for (std::string& route : webApp.getRoutes()) {
             route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            VLOG(1) << "  " << route;
+            snode::semantic::expressLog().trace() << "  " << route;
         }
 
         return webApp;

--- a/src/express/legacy/rc/Server.cpp
+++ b/src/express/legacy/rc/Server.cpp
@@ -41,6 +41,7 @@
 
 #include "express/legacy/rc/Server.h"
 
+#include "SemanticLog.h"
 #include "log/Logger.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -70,26 +71,27 @@ namespace express::legacy::rc {
             } else {
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                        snode::semantic::expressLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << instanceName << ": disabled";
+                        snode::semantic::expressLog().info() << instanceName << ": disabled";
                         break;
                     case core::socket::State::ERROR:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                     case core::socket::State::FATAL:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().critical()
+                            << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                 }
             }
         });
 
-        VLOG(1) << "Instance: " << instanceName;
+        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
         for (std::string& route : webApp.getRoutes()) {
             route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            VLOG(1) << "  " << route;
+            snode::semantic::expressLog().trace() << "  " << route;
         }
 
         return webApp;

--- a/src/express/legacy/rc/Server.cpp
+++ b/src/express/legacy/rc/Server.cpp
@@ -87,11 +87,14 @@ namespace express::legacy::rc {
             }
         });
 
-        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
-        for (std::string& route : webApp.getRoutes()) {
-            route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
+        auto log = snode::semantic::expressLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Instance: " << instanceName;
+            for (std::string route : webApp.getRoutes()) {
+                route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            snode::semantic::expressLog().trace() << "  " << route;
+                log.trace() << "  " << route;
+            }
         }
 
         return webApp;

--- a/src/express/legacy/un/Server.cpp
+++ b/src/express/legacy/un/Server.cpp
@@ -87,11 +87,14 @@ namespace express::legacy::un {
             }
         });
 
-        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
-        for (std::string& route : webApp.getRoutes()) {
-            route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
+        auto log = snode::semantic::expressLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Instance: " << instanceName;
+            for (std::string route : webApp.getRoutes()) {
+                route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            snode::semantic::expressLog().trace() << "  " << route;
+                log.trace() << "  " << route;
+            }
         }
 
         return webApp;

--- a/src/express/legacy/un/Server.cpp
+++ b/src/express/legacy/un/Server.cpp
@@ -41,6 +41,7 @@
 
 #include "express/legacy/un/Server.h"
 
+#include "SemanticLog.h"
 #include "log/Logger.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -70,26 +71,27 @@ namespace express::legacy::un {
             } else {
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                        snode::semantic::expressLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << instanceName << ": disabled";
+                        snode::semantic::expressLog().info() << instanceName << ": disabled";
                         break;
                     case core::socket::State::ERROR:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                     case core::socket::State::FATAL:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().critical()
+                            << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                 }
             }
         });
 
-        VLOG(1) << "Instance: " << instanceName;
+        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
         for (std::string& route : webApp.getRoutes()) {
             route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            VLOG(1) << "  " << route;
+            snode::semantic::expressLog().trace() << "  " << route;
         }
 
         return webApp;

--- a/src/express/tls/in/Server.cpp
+++ b/src/express/tls/in/Server.cpp
@@ -87,11 +87,14 @@ namespace express::tls::in {
             }
         });
 
-        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
-        for (std::string& route : webApp.getRoutes()) {
-            route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
+        auto log = snode::semantic::expressLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Instance: " << instanceName;
+            for (std::string route : webApp.getRoutes()) {
+                route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            snode::semantic::expressLog().trace() << "  " << route;
+                log.trace() << "  " << route;
+            }
         }
 
         return webApp;

--- a/src/express/tls/in/Server.cpp
+++ b/src/express/tls/in/Server.cpp
@@ -41,6 +41,7 @@
 
 #include "express/tls/in/Server.h"
 
+#include "SemanticLog.h"
 #include "log/Logger.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -70,26 +71,27 @@ namespace express::tls::in {
             } else {
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                        snode::semantic::expressLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << instanceName << ": disabled";
+                        snode::semantic::expressLog().info() << instanceName << ": disabled";
                         break;
                     case core::socket::State::ERROR:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                     case core::socket::State::FATAL:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().critical()
+                            << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                 }
             }
         });
 
-        VLOG(1) << "Instance: " << instanceName;
+        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
         for (std::string& route : webApp.getRoutes()) {
             route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            VLOG(1) << "  " << route;
+            snode::semantic::expressLog().trace() << "  " << route;
         }
 
         return webApp;

--- a/src/express/tls/in6/Server.cpp
+++ b/src/express/tls/in6/Server.cpp
@@ -41,6 +41,7 @@
 
 #include "express/tls/in6/Server.h"
 
+#include "SemanticLog.h"
 #include "log/Logger.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -70,26 +71,27 @@ namespace express::tls::in6 {
             } else {
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                        snode::semantic::expressLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << instanceName << ": disabled";
+                        snode::semantic::expressLog().info() << instanceName << ": disabled";
                         break;
                     case core::socket::State::ERROR:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                     case core::socket::State::FATAL:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().critical()
+                            << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                 }
             }
         });
 
-        VLOG(1) << "Instance: " << instanceName;
+        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
         for (std::string& route : webApp.getRoutes()) {
             route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            VLOG(1) << "  " << route;
+            snode::semantic::expressLog().trace() << "  " << route;
         }
 
         return webApp;

--- a/src/express/tls/in6/Server.cpp
+++ b/src/express/tls/in6/Server.cpp
@@ -87,11 +87,14 @@ namespace express::tls::in6 {
             }
         });
 
-        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
-        for (std::string& route : webApp.getRoutes()) {
-            route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
+        auto log = snode::semantic::expressLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Instance: " << instanceName;
+            for (std::string route : webApp.getRoutes()) {
+                route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            snode::semantic::expressLog().trace() << "  " << route;
+                log.trace() << "  " << route;
+            }
         }
 
         return webApp;

--- a/src/express/tls/rc/Server.cpp
+++ b/src/express/tls/rc/Server.cpp
@@ -41,6 +41,7 @@
 
 #include "express/tls/rc/Server.h"
 
+#include "SemanticLog.h"
 #include "log/Logger.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -70,26 +71,27 @@ namespace express::tls::rc {
             } else {
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                        snode::semantic::expressLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << instanceName << ": disabled";
+                        snode::semantic::expressLog().info() << instanceName << ": disabled";
                         break;
                     case core::socket::State::ERROR:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                     case core::socket::State::FATAL:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().critical()
+                            << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                 }
             }
         });
 
-        VLOG(1) << "Instance: " << instanceName;
+        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
         for (std::string& route : webApp.getRoutes()) {
             route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            VLOG(1) << "  " << route;
+            snode::semantic::expressLog().trace() << "  " << route;
         }
 
         return webApp;

--- a/src/express/tls/rc/Server.cpp
+++ b/src/express/tls/rc/Server.cpp
@@ -87,11 +87,14 @@ namespace express::tls::rc {
             }
         });
 
-        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
-        for (std::string& route : webApp.getRoutes()) {
-            route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
+        auto log = snode::semantic::expressLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Instance: " << instanceName;
+            for (std::string route : webApp.getRoutes()) {
+                route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            snode::semantic::expressLog().trace() << "  " << route;
+                log.trace() << "  " << route;
+            }
         }
 
         return webApp;

--- a/src/express/tls/un/Server.cpp
+++ b/src/express/tls/un/Server.cpp
@@ -41,6 +41,7 @@
 
 #include "express/tls/un/Server.h"
 
+#include "SemanticLog.h"
 #include "log/Logger.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -70,26 +71,27 @@ namespace express::tls::un {
             } else {
                 switch (state) {
                     case core::socket::State::OK:
-                        VLOG(1) << instanceName << ": listening on '" << socketAddress.toString() << "'";
+                        snode::semantic::expressLog().info() << instanceName << ": listening on '" << socketAddress.toString() << "'";
                         break;
                     case core::socket::State::DISABLED:
-                        VLOG(1) << instanceName << ": disabled";
+                        snode::semantic::expressLog().info() << instanceName << ": disabled";
                         break;
                     case core::socket::State::ERROR:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().error() << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                     case core::socket::State::FATAL:
-                        VLOG(1) << instanceName << ": " << socketAddress.toString() << ": " << state.what();
+                        snode::semantic::expressLog().critical()
+                            << instanceName << ": " << socketAddress.toString() << ": " << state.what();
                         break;
                 }
             }
         });
 
-        VLOG(1) << "Instance: " << instanceName;
+        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
         for (std::string& route : webApp.getRoutes()) {
             route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            VLOG(1) << "  " << route;
+            snode::semantic::expressLog().trace() << "  " << route;
         }
 
         return webApp;

--- a/src/express/tls/un/Server.cpp
+++ b/src/express/tls/un/Server.cpp
@@ -87,11 +87,14 @@ namespace express::tls::un {
             }
         });
 
-        snode::semantic::expressLog().trace() << "Instance: " << instanceName;
-        for (std::string& route : webApp.getRoutes()) {
-            route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
+        auto log = snode::semantic::expressLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << "Instance: " << instanceName;
+            for (std::string route : webApp.getRoutes()) {
+                route.erase(std::remove(route.begin(), route.end(), '$'), route.end());
 
-            snode::semantic::expressLog().trace() << "  " << route;
+                log.trace() << "  " << route;
+            }
         }
 
         return webApp;

--- a/tests/unit/log/SemanticCompatibilityRound9Test.cpp
+++ b/tests/unit/log/SemanticCompatibilityRound9Test.cpp
@@ -22,14 +22,17 @@ namespace {
 
     class StateGuard {
     public:
-        explicit StateGuard(const std::string& logFile) : savedErrno(errno) {
+        explicit StateGuard(const std::string& logFile)
+            : savedErrno(errno) {
             logger::Logger::init();
             logger::LogManager::init();
             logger::Logger::setLogLevel(6);
             logger::Logger::setVerboseLevel(0);
             logger::Logger::setQuiet(true);
             logger::Logger::setDisableColor(true);
-            logger::Logger::setTickResolver([]() { return std::string("ROUND9TICK000"); });
+            logger::Logger::setTickResolver([]() {
+                return std::string("ROUND9TICK000");
+            });
             logger::Logger::logToFile(logFile);
         }
         ~StateGuard() {
@@ -58,7 +61,8 @@ namespace {
     }
 
     logger::LogScope scope(std::string_view component = "round9.component", std::string_view instance = "round9-instance") {
-        return {logger::LogOrigin::Framework, logger::LogBoundary::System, component, instance, logger::LogRole::Server, "round9-connection"};
+        return {
+            logger::LogOrigin::Framework, logger::LogBoundary::System, component, instance, logger::LogRole::Server, "round9-connection"};
     }
 
     logger::LogRecord record(logger::LogLevel level, std::string message) {
@@ -69,44 +73,90 @@ namespace {
 
     class TestSocketConnection : public core::socket::stream::SocketConnection {
     public:
-        explicit TestSocketConnection(const std::string& instanceName) : SocketConnection(9, instanceName, nullptr) {}
+        explicit TestSocketConnection(const std::string& instanceName)
+            : SocketConnection(9, instanceName, nullptr) {
+        }
         ~TestSocketConnection() override = default;
         using core::socket::stream::SocketConnection::setSocketContext;
-        int getFd() const override { return 9; }
-        void sendToPeer(const char*, std::size_t) override {}
-        bool streamToPeer(core::pipe::Source*) override { return false; }
-        void streamEof() override {}
-        std::size_t readFromPeer(char*, std::size_t) override { return 0; }
-        void shutdownRead() override {}
-        void shutdownWrite() override {}
-        const core::socket::SocketAddress& getBindAddress() const override { return unusableAddress(); }
-        const core::socket::SocketAddress& getLocalAddress() const override { return unusableAddress(); }
-        const core::socket::SocketAddress& getRemoteAddress() const override { return unusableAddress(); }
-        void close() override {}
-        void setTimeout(const utils::Timeval&) override {}
-        void setReadTimeout(const utils::Timeval&) override {}
-        void setWriteTimeout(const utils::Timeval&) override {}
-        std::size_t getTotalSent() const override { return 0; }
-        std::size_t getTotalQueued() const override { return 0; }
-        std::size_t getTotalRead() const override { return 0; }
-        std::size_t getTotalProcessed() const override { return 0; }
+        int getFd() const override {
+            return 9;
+        }
+        void sendToPeer(const char*, std::size_t) override {
+        }
+        bool streamToPeer(core::pipe::Source*) override {
+            return false;
+        }
+        void streamEof() override {
+        }
+        std::size_t readFromPeer(char*, std::size_t) override {
+            return 0;
+        }
+        void shutdownRead() override {
+        }
+        void shutdownWrite() override {
+        }
+        const core::socket::SocketAddress& getBindAddress() const override {
+            return unusableAddress();
+        }
+        const core::socket::SocketAddress& getLocalAddress() const override {
+            return unusableAddress();
+        }
+        const core::socket::SocketAddress& getRemoteAddress() const override {
+            return unusableAddress();
+        }
+        void close() override {
+        }
+        void setTimeout(const utils::Timeval&) override {
+        }
+        void setReadTimeout(const utils::Timeval&) override {
+        }
+        void setWriteTimeout(const utils::Timeval&) override {
+        }
+        std::size_t getTotalSent() const override {
+            return 0;
+        }
+        std::size_t getTotalQueued() const override {
+            return 0;
+        }
+        std::size_t getTotalRead() const override {
+            return 0;
+        }
+        std::size_t getTotalProcessed() const override {
+            return 0;
+        }
+
     private:
-        static const core::socket::SocketAddress& unusableAddress() { return *static_cast<const core::socket::SocketAddress*>(nullptr); }
+        static const core::socket::SocketAddress& unusableAddress() {
+            return *static_cast<const core::socket::SocketAddress*>(nullptr);
+        }
     };
 
     class TestSocketContext : public core::socket::stream::SocketContext {
     public:
-        explicit TestSocketContext(core::socket::stream::SocketConnection* socketConnection) : SocketContext(socketConnection) {}
+        explicit TestSocketContext(core::socket::stream::SocketConnection* socketConnection)
+            : SocketContext(socketConnection) {
+        }
         ~TestSocketContext() override = default;
-        void exposeReadError(int errnum) { onReadError(errnum); }
-        void exposeWriteError(int errnum) { onWriteError(errnum); }
+        void exposeReadError(int errnum) {
+            onReadError(errnum);
+        }
+        void exposeWriteError(int errnum) {
+            onWriteError(errnum);
+        }
+
     private:
-        std::size_t onReceivedFromPeer() override { return 0; }
-        bool onSignal(int) override { return false; }
-        void onConnected() override {}
-        void onDisconnected() override {}
+        std::size_t onReceivedFromPeer() override {
+            return 0;
+        }
+        bool onSignal(int) override {
+            return false;
+        }
+        void onConnected() override {
+        }
+        void onDisconnected() override {
+        }
     };
-}
+} // namespace
 
 int main() {
     tests::support::TestResult result;
@@ -117,9 +167,7 @@ int main() {
         LOG(INFO) << "round9 legacy info";
         errno = EACCES;
         PLOG(ERROR) << "round9 legacy plog";
-        VLOG(1) << "round9 verbose hidden";
         logger::Logger::setVerboseLevel(1);
-        VLOG(1) << "round9 verbose visible";
         logger::Logger::setLogLevel(3);
         LOG(INFO) << "round9 numeric info hidden";
         LOG(WARNING) << "round9 numeric warning visible";
@@ -128,9 +176,8 @@ int main() {
     result.expectTrue(legacyLog.find("round9 legacy info") != std::string::npos, "LOG(INFO) emits through legacy backend");
     result.expectTrue(legacyLog.find("round9 legacy plog") != std::string::npos && legacyLog.find("Permission denied") != std::string::npos,
                       "PLOG(ERROR) preserves errno text through legacy backend");
-    result.expectTrue(legacyLog.find("round9 verbose hidden") == std::string::npos && legacyLog.find("round9 verbose visible") != std::string::npos,
-                      "VLOG respects Logger::setVerboseLevel");
-    result.expectTrue(legacyLog.find("round9 numeric info hidden") == std::string::npos && legacyLog.find("round9 numeric warning visible") != std::string::npos,
+    result.expectTrue(legacyLog.find("round9 numeric info hidden") == std::string::npos &&
+                          legacyLog.find("round9 numeric warning visible") != std::string::npos,
                       "Logger::setLogLevel numeric thresholds remain compatible");
 
     const auto independencePath = tempLogPath("snodec-round9-independent.log");
@@ -142,18 +189,27 @@ int main() {
         logger::Logger::emitSemantic(record(logger::LogLevel::Error, "semantic filtered by off"));
     }
     const auto independenceLog = readFile(independencePath);
-    result.expectTrue(independenceLog.find("legacy unaffected by semantic off") != std::string::npos && independenceLog.find("semantic filtered by off") == std::string::npos,
+    result.expectTrue(independenceLog.find("legacy unaffected by semantic off") != std::string::npos &&
+                          independenceLog.find("semantic filtered by off") == std::string::npos,
                       "LogManager filtering remains independent from legacy macros");
 
     const auto semanticPath = tempLogPath("snodec-round9-semantic.log");
     {
         StateGuard guard(semanticPath.string());
-        logger::BoundaryLogger::createForTest(scope(), logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedTimestamp).info("default semantic backend");
+        logger::BoundaryLogger::createForTest(scope(), logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedTimestamp)
+            .info("default semantic backend");
     }
-    result.expectTrue(readFile(semanticPath).find("default semantic backend") != std::string::npos, "default no-argument semantic sink emits through backend");
+    result.expectTrue(readFile(semanticPath).find("default semantic backend") != std::string::npos,
+                      "default no-argument semantic sink emits through backend");
 
     std::vector<logger::LogRecord> captured;
-    logger::BoundaryLogger::createForTest(scope(), [&](logger::LogRecord capturedRecord) { captured.push_back(std::move(capturedRecord)); }, logger::LogLevel::Trace, fixedTimestamp)
+    logger::BoundaryLogger::createForTest(
+        scope(),
+        [&](logger::LogRecord capturedRecord) {
+            captured.push_back(std::move(capturedRecord));
+        },
+        logger::LogLevel::Trace,
+        fixedTimestamp)
         .info("captured only");
     result.expectEqual(1, static_cast<int>(captured.size()), "sink-taking semantic overload captures records");
 
@@ -161,37 +217,62 @@ int main() {
     logger::LogManager::init();
     logger::LogManager::setGlobalLevel(logger::LogLevel::Warn);
     logger::LogManager::freeze();
-    try { logger::LogManager::setGlobalLevel(logger::LogLevel::Trace); } catch (const std::logic_error&) { froze = true; }
-    result.expectTrue(froze && logger::LogManager::effectiveLevel(scope()) == logger::LogLevel::Warn, "LogManager freeze remains immutable");
+    try {
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+    } catch (const std::logic_error&) {
+        froze = true;
+    }
+    result.expectTrue(froze && logger::LogManager::effectiveLevel(scope()) == logger::LogLevel::Warn,
+                      "LogManager freeze remains immutable");
     logger::LogManager::init();
 
     const auto text = logger::formatText(record(logger::LogLevel::Info, "text format message"));
-    result.expectTrue(logger::LogManager::formatRecord(record(logger::LogLevel::Info, "text format message")) == text, "Text format uses formatText");
+    result.expectTrue(logger::LogManager::formatRecord(record(logger::LogLevel::Info, "text format message")) == text,
+                      "Text format uses formatText");
     logger::LogManager::setFormat(logger::LogManager::Format::Json);
     const auto jsonRecord = record(logger::LogLevel::Info, "json format message");
     const auto json = logger::LogManager::formatRecord(jsonRecord);
     result.expectTrue(json == logger::formatJsonV1(jsonRecord), "Json format uses formatJsonV1");
-    result.expectTrue(json.find("\"v\":1") != std::string::npos && json.find("\"ts\":") != std::string::npos && json.find("\"level\":\"info\"") != std::string::npos &&
-                          json.find("\"origin\":\"framework\"") != std::string::npos && json.find("\"boundary\":\"system\"") != std::string::npos &&
-                          json.find("\"component\":\"round9.component\"") != std::string::npos && json.find("\"message\":\"json format message\"") != std::string::npos,
+    result.expectTrue(json.find("\"v\":1") != std::string::npos && json.find("\"ts\":") != std::string::npos &&
+                          json.find("\"level\":\"info\"") != std::string::npos &&
+                          json.find("\"origin\":\"framework\"") != std::string::npos &&
+                          json.find("\"boundary\":\"system\"") != std::string::npos &&
+                          json.find("\"component\":\"round9.component\"") != std::string::npos &&
+                          json.find("\"message\":\"json format message\"") != std::string::npos,
                       "JSON v1 mandatory fields are present");
-    const auto sparseJson = logger::formatJsonV1(logger::materialize(scope("round9.sparse", ""), logger::LogLevel::Info, "sparse", {std::nullopt, std::nullopt, std::nullopt, fixedTimestamp()}));
-    result.expectTrue(sparseJson.find("\"instance\"") == std::string::npos && sparseJson.find("\"event\"") == std::string::npos && sparseJson.find("null") == std::string::npos,
+    const auto sparseJson = logger::formatJsonV1(logger::materialize(
+        scope("round9.sparse", ""), logger::LogLevel::Info, "sparse", {std::nullopt, std::nullopt, std::nullopt, fixedTimestamp()}));
+    result.expectTrue(sparseJson.find("\"instance\"") == std::string::npos && sparseJson.find("\"event\"") == std::string::npos &&
+                          sparseJson.find("null") == std::string::npos,
                       "JSON v1 optional fields are omitted when absent");
     logger::LogManager::init();
 
     std::vector<logger::LogRecord> errors;
-    logger::BoundaryLogger::createForTest(scope(), [&](logger::LogRecord errorRecord) { errors.push_back(std::move(errorRecord)); }, logger::LogLevel::Trace, fixedTimestamp)
+    logger::BoundaryLogger::createForTest(
+        scope(),
+        [&](logger::LogRecord errorRecord) {
+            errors.push_back(std::move(errorRecord));
+        },
+        logger::LogLevel::Trace,
+        fixedTimestamp)
         .sysError(logger::LogLevel::Error, EACCES, "semantic sysError");
-    result.expectTrue(errors.size() == 1 && errors[0].error && errors[0].error->code == EACCES && errors[0].error->text.find("Permission denied") != std::string::npos,
+    result.expectTrue(errors.size() == 1 && errors[0].error && errors[0].error->code == EACCES &&
+                          errors[0].error->text.find("Permission denied") != std::string::npos,
                       "sysError preserves errno code and error text");
 
     std::vector<logger::LogRecord> borrowed;
     std::string component = "borrowed.component";
-    auto borrowedLogger = logger::BoundaryLogger::createForTest(scope(component, "borrowed-instance"), [&](logger::LogRecord borrowedRecord) { borrowed.push_back(std::move(borrowedRecord)); }, logger::LogLevel::Trace, fixedTimestamp);
+    auto borrowedLogger = logger::BoundaryLogger::createForTest(
+        scope(component, "borrowed-instance"),
+        [&](logger::LogRecord borrowedRecord) {
+            borrowed.push_back(std::move(borrowedRecord));
+        },
+        logger::LogLevel::Trace,
+        fixedTimestamp);
     component.assign("mutated.component");
     borrowedLogger.info("borrowed safe");
-    result.expectTrue(borrowed.size() == 1 && borrowed[0].component == "borrowed.component", "borrowed LogScope string_views are copied before sink use");
+    result.expectTrue(borrowed.size() == 1 && borrowed[0].component == "borrowed.component",
+                      "borrowed LogScope string_views are copied before sink use");
 
     const auto migratedPath = tempLogPath("snodec-round9-migrated.log");
     {
@@ -211,10 +292,13 @@ int main() {
         delete second;
     }
     const auto migratedLog = readFile(migratedPath);
-    result.expectTrue(migratedLog.find("SocketContext: switch") != std::string::npos, "Round 8 SocketConnection migrated call emits semantically");
-    result.expectTrue(migratedLog.find("SocketContext: EOF received") != std::string::npos && migratedLog.find("\"origin\":\"framework\"") != std::string::npos,
+    result.expectTrue(migratedLog.find("SocketContext: switch") != std::string::npos,
+                      "Round 8 SocketConnection migrated call emits semantically");
+    result.expectTrue(migratedLog.find("SocketContext: EOF received") != std::string::npos &&
+                          migratedLog.find("\"origin\":\"framework\"") != std::string::npos,
                       "Round 8 SocketContext frameworkLog call emits with framework origin");
-    result.expectTrue(migratedLog.find("SocketContext: onWriteError") != std::string::npos && migratedLog.find("\"code\":13") != std::string::npos &&
+    result.expectTrue(migratedLog.find("SocketContext: onWriteError") != std::string::npos &&
+                          migratedLog.find("\"code\":13") != std::string::npos &&
                           migratedLog.find("Permission denied") != std::string::npos,
                       "Round 8 migrated sysError call preserves errno code/text");
 

--- a/tests/unit/log/SemanticLoggerRound2Test.cpp
+++ b/tests/unit/log/SemanticLoggerRound2Test.cpp
@@ -1,5 +1,5 @@
-#include "log/SemanticLogger.h"
 #include "log/Logger.h"
+#include "log/SemanticLogger.h"
 #include "tests/support/TestResult.h"
 
 #include <cerrno>
@@ -10,7 +10,10 @@
 #include <vector>
 
 namespace {
-    void expectStringEqual(tests::support::TestResult& result, const std::string& expected, const std::string& actual, const std::string& message) {
+    void expectStringEqual(tests::support::TestResult& result,
+                           const std::string& expected,
+                           const std::string& actual,
+                           const std::string& message) {
         result.expectTrue(expected == actual, message + " expected='" + expected + "' actual='" + actual + "'");
     }
 
@@ -18,7 +21,7 @@ namespace {
         using namespace std::chrono;
         return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
     }
-}
+} // namespace
 
 int main() {
     tests::support::TestResult result;
@@ -26,7 +29,8 @@ int main() {
     std::string component = "mqtt.server";
     std::string instance = "mqtt-broker";
     std::string connection = "#7";
-    logger::LogScope borrowed{logger::LogOrigin::Framework, logger::LogBoundary::Connection, component, instance, logger::LogRole::Server, connection};
+    logger::LogScope borrowed{
+        logger::LogOrigin::Framework, logger::LogBoundary::Connection, component, instance, logger::LogRole::Server, connection};
     auto owned = logger::materialize(borrowed, logger::LogLevel::Info, "ready", logger::LogRecordOptions{.ts = fixedTimestamp()});
     component.clear();
     instance.clear();
@@ -36,8 +40,10 @@ int main() {
     result.expectTrue(owned.connection && *owned.connection == "#7", "materialize copies connection string_view");
     result.expectTrue(owned.role && *owned.role == logger::LogRole::Server, "known role is represented as optional role");
 
-    logger::LogScope unknownRole{logger::LogOrigin::Application, logger::LogBoundary::Context, "EchoServerContext", "", logger::LogRole::Unknown, ""};
-    auto minimal = logger::materialize(unknownRole, logger::LogLevel::Info, "echo session started", logger::LogRecordOptions{.ts = fixedTimestamp()});
+    logger::LogScope unknownRole{
+        logger::LogOrigin::Application, logger::LogBoundary::Context, "EchoServerContext", "", logger::LogRole::Unknown, ""};
+    auto minimal =
+        logger::materialize(unknownRole, logger::LogLevel::Info, "echo session started", logger::LogRecordOptions{.ts = fixedTimestamp()});
     const std::string json = logger::formatJsonV1(minimal);
     result.expectTrue(json.find("\"v\":1") != std::string::npos, "JSON emits mandatory v");
     result.expectTrue(json.find("\"ts\":\"2026-07-05T12:34:56.789Z\"") != std::string::npos, "JSON emits mandatory ts timestamp");
@@ -51,19 +57,37 @@ int main() {
     result.expectTrue(json.find("connection") == std::string::npos, "JSON omits absent connection instead of null");
     result.expectTrue(json.find("null") == std::string::npos, "JSON never emits null for absent optionals");
 
-    auto escapedRecord = logger::materialize(unknownRole, logger::LogLevel::Info, std::string("before") + static_cast<char>(0x08) + static_cast<char>(0x01) + "after", logger::LogRecordOptions{.ts = fixedTimestamp()});
+    auto escapedRecord = logger::materialize(unknownRole,
+                                             logger::LogLevel::Info,
+                                             std::string("before") + static_cast<char>(0x08) + static_cast<char>(0x01) + "after",
+                                             logger::LogRecordOptions{.ts = fixedTimestamp()});
     const std::string escapedJson = logger::formatJsonV1(escapedRecord);
-    result.expectTrue(escapedJson.find("before\\b\\u0001after") != std::string::npos, "JSON escapes backspace and other control characters");
-    result.expectTrue(escapedJson.find(static_cast<char>(0x08)) == std::string::npos && escapedJson.find(static_cast<char>(0x01)) == std::string::npos,
+    result.expectTrue(escapedJson.find("before\\b\\u0001after") != std::string::npos,
+                      "JSON escapes backspace and other control characters");
+    result.expectTrue(escapedJson.find(static_cast<char>(0x08)) == std::string::npos &&
+                          escapedJson.find(static_cast<char>(0x01)) == std::string::npos,
                       "JSON does not emit raw control bytes below 0x20");
 
     const std::string text = logger::formatText(owned);
-    result.expectTrue(text.find("2026-07-05T12:34:56.789Z") != std::string::npos && text.find("info framework connection mqtt.server") != std::string::npos && text.find("ready") != std::string::npos,
+    result.expectTrue(text.find("2026-07-05T12:34:56.789Z") != std::string::npos &&
+                          text.find("info framework connection mqtt.server") != std::string::npos &&
+                          text.find("ready") != std::string::npos,
                       "text formatter includes timestamp level origin boundary component and message");
 
     std::vector<logger::LogRecord> records;
-    logger::LogScope scope{logger::LogOrigin::Framework, logger::LogBoundary::Connection, "core.socket.stream", "test-instance", logger::LogRole::Server, "tcp://127.0.0.1:8080"};
-    auto log = logger::BoundaryLogger::createForTest(scope, [&](logger::LogRecord record) { records.push_back(std::move(record)); }, logger::LogLevel::Debug, fixedTimestamp);
+    logger::LogScope scope{logger::LogOrigin::Framework,
+                           logger::LogBoundary::Connection,
+                           "core.socket.stream",
+                           "test-instance",
+                           logger::LogRole::Server,
+                           "tcp://127.0.0.1:8080"};
+    auto log = logger::BoundaryLogger::createForTest(
+        scope,
+        [&](logger::LogRecord record) {
+            records.push_back(std::move(record));
+        },
+        logger::LogLevel::Debug,
+        fixedTimestamp);
     log.debug("received {} bytes", 42);
     log.info("echo session started");
     log.debug() << "received " << 42 << " bytes";
@@ -72,14 +96,20 @@ int main() {
     expectStringEqual(result, "echo session started", records[1].message, "format-style API supports literal message");
     expectStringEqual(result, "received 42 bytes", records[2].message, "stream-style API flushes complete expression once");
 
-
     std::string loggerComponent = "mqtt.server";
     std::string loggerInstance = "mqtt-broker";
     std::string loggerConnection = "#7";
     std::vector<logger::LogRecord> lifetimeRecords;
     auto lifetimeLog = logger::BoundaryLogger::createForTest(
-        logger::LogScope{logger::LogOrigin::Framework, logger::LogBoundary::Connection, loggerComponent, loggerInstance, logger::LogRole::Server, loggerConnection},
-        [&](logger::LogRecord record) { lifetimeRecords.push_back(std::move(record)); },
+        logger::LogScope{logger::LogOrigin::Framework,
+                         logger::LogBoundary::Connection,
+                         loggerComponent,
+                         loggerInstance,
+                         logger::LogRole::Server,
+                         loggerConnection},
+        [&](logger::LogRecord record) {
+            lifetimeRecords.push_back(std::move(record));
+        },
         logger::LogLevel::Trace,
         fixedTimestamp);
     loggerComponent = "changed.component";
@@ -88,10 +118,18 @@ int main() {
     lifetimeLog.info("after mutation");
     result.expectEqual(1, static_cast<int>(lifetimeRecords.size()), "BoundaryLogger emits after original scope strings mutate");
     expectStringEqual(result, "mqtt.server", lifetimeRecords[0].component, "BoundaryLogger copies component at construction");
-    result.expectTrue(lifetimeRecords[0].instance && *lifetimeRecords[0].instance == "mqtt-broker", "BoundaryLogger copies instance at construction");
-    result.expectTrue(lifetimeRecords[0].connection && *lifetimeRecords[0].connection == "#7", "BoundaryLogger copies connection at construction");
+    result.expectTrue(lifetimeRecords[0].instance && *lifetimeRecords[0].instance == "mqtt-broker",
+                      "BoundaryLogger copies instance at construction");
+    result.expectTrue(lifetimeRecords[0].connection && *lifetimeRecords[0].connection == "#7",
+                      "BoundaryLogger copies connection at construction");
 
-    auto filtered = logger::BoundaryLogger::createForTest(scope, [&](logger::LogRecord record) { records.push_back(std::move(record)); }, logger::LogLevel::Info, fixedTimestamp);
+    auto filtered = logger::BoundaryLogger::createForTest(
+        scope,
+        [&](logger::LogRecord record) {
+            records.push_back(std::move(record));
+        },
+        logger::LogLevel::Info,
+        fixedTimestamp);
     filtered.debug("hidden {}", 1);
     filtered.debug() << "hidden " << 2;
     result.expectEqual(3, static_cast<int>(records.size()), "local threshold suppresses disabled format and stream calls");
@@ -99,25 +137,27 @@ int main() {
     log.sysError(logger::LogLevel::Error, 98, "bind failed on {}", "127.0.0.1:8080");
     result.expectTrue(records.back().error && records.back().error->code == 98, "sysError(int) stores error code");
     result.expectTrue(records.back().error && !records.back().error->text.empty(), "sysError(int) stores error text");
-    expectStringEqual(result, "bind failed on 127.0.0.1:8080", records.back().message, "sysError formats message separately from error object");
+    expectStringEqual(
+        result, "bind failed on 127.0.0.1:8080", records.back().message, "sysError formats message separately from error object");
     const std::string errorJson = logger::formatJsonV1(records.back());
-    result.expectTrue(errorJson.find("\"error\":{") != std::string::npos && errorJson.find("\"code\":98") != std::string::npos, "JSON emits error only when present");
+    result.expectTrue(errorJson.find("\"error\":{") != std::string::npos && errorJson.find("\"code\":98") != std::string::npos,
+                      "JSON emits error only when present");
 
     log.sysError(logger::LogLevel::Warn, std::make_error_code(std::errc::permission_denied), "open failed");
     result.expectTrue(records.back().error && records.back().error->code != 0, "sysError(std::error_code) stores error code");
 
     logger::Logger::init();
     logger::Logger::setDisableColor(true);
-    logger::Logger::setTickResolver([] { return "000000"; });
+    logger::Logger::setTickResolver([] {
+        return "000000";
+    });
     logger::Logger::setLogLevel(1);
     logger::Logger::setVerboseLevel(1);
     LOG(INFO) << "round2 compatibility LOG enabled";
     errno = EACCES;
     PLOG(ERROR) << "round2 compatibility PLOG enabled";
-    VLOG(1) << "round2 compatibility VLOG enabled";
     LOG(TRACE) << "round2 compatibility LOG disabled";
-    VLOG(2) << "round2 compatibility VLOG disabled";
-    result.expectTrue(true, "legacy LOG/PLOG/VLOG macros compile/link/run via existing macro path");
+    result.expectTrue(true, "legacy LOG/PLOG macros compile/link/run via existing macro path");
 
     return result.processResult();
 }


### PR DESCRIPTION
### Motivation

- Remove every remaining `VLOG(...)` call site and replace with explicit semantic logging per the frozen contract in `docs/logging/semantic-api-contract.md` while preserving legacy macro definitions.
- Classify each former `VLOG` site by meaning (lifecycle, request/response, route/trace, dumps, TLS inspection, errors, test-only) and apply the policy to map to `info/debug/trace/warn/error/critical` or delete if obsolete.

### Description

- Replaced remaining `VLOG(...)` call sites across application and express code with appropriate semantic calls such as `snode::semantic::appLog()`, `snode::semantic::expressLog()`, `snode::semantic::mariaDbLog()` and other existing helpers and selected severities (`info/debug/trace/warn/error/critical`).
- Added `docs/logging/semantic-vlog-elimination-report.md` documenting the initial inventory, classification, exact changed files, representative migrated and deleted examples, expensive-diagnostics notes, post-migration inventories, and follow-ups.
- Updated unit tests that relied on legacy `VLOG` behavior to remove VLOG compatibility emissions/assertions while keeping `LOG`/`PLOG` compatibility checks intact; no numeric `VLOG(n)` semantics, no `verbose(n)` API, and no `VLOG` compatibility bridge were introduced.
- Preserved legacy macro definitions in `src/log/Logger.h` untouched and added includes of `SemanticLog.h` where required to use the semantic helpers; no logging infrastructure, `LogManager`, or JSON schema behavior was changed.

### Testing

- Ran configuration and build: `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build --parallel 2`, which completed successfully.
- Ran full test suite: `ctest --test-dir cmake-build --output-on-failure`, and all tests passed (no failing tests after the migration adjustments).
- Ran focused migration/logging test set: `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|...|FinalCleanupMigration09Test" --output-on-failure` and these targeted logging/migration tests passed.
- Ran focused ASan minimum: configured `cmake` with `-DSNODEC_ENABLE_ASAN=ON`, built `FinalCleanupMigration09Test` and executed it under ASan; the focused ASan run passed.
- Active changeset: modified ~45 source/test files and added `docs/logging/semantic-vlog-elimination-report.md`; the repository builds and tests cleanly after the migration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cd2e284d8832c970d5c92c5188777)