### PR TITLE
Fix semantic logger end-to-end output path

### DIFF
--- a/docs/logging/semantic-output-double-wrapping-report.md
+++ b/docs/logging/semantic-output-double-wrapping-report.md
@@ -1,0 +1,121 @@
+# Semantic output double-wrapping report
+
+## Problem summary
+
+Semantic records emitted through `logger::Logger::semanticSink()` were formatted by `logger::LogManager::formatRecord(record)` and then passed through the legacy `emitLine(...)` path. That caused semantic output to receive legacy severity labeling and logger framing after it had already been formatted as semantic text or JSON.
+
+## Root cause
+
+`Logger::emitSemantic(...)` correctly applied semantic filtering and the legacy numeric threshold mapping, but then called `emitLine(*mappedLevel, LogManager::formatRecord(record), false, 0)`. `emitLine(...)` is the legacy LOG/PLOG/VLOG backend; it adds errno text for PLOG and prepends the legacy severity label before writing through the configured loggers. JSON records therefore could be prefixed before the `{`, and text records could be wrapped in a second legacy format.
+
+## Implementation summary
+
+- Kept `emitLine(...)` as the legacy-only backend for `LOG`, `PLOG`, and `VLOG`.
+- Added an internal `emitFormattedLine(...)` semantic backend that writes an already formatted semantic line without adding legacy severity, color, or errno decoration.
+- Added semantic stdout/file logger instances using a `%v` pattern so semantic records are written exactly as selected by `LogManager::formatRecord(record)`.
+- Preserved `LogManager::shouldEmit(record)` and the existing mapped legacy numeric threshold check in `Logger::emitSemantic(...)`.
+- Added backward-compatible identity-capable helper overloads in `src/SemanticLog.h`.
+
+## Changed files
+
+- `src/log/Logger.cpp`
+- `src/SemanticLog.h`
+- `tests/unit/log/CMakeLists.txt`
+- `tests/unit/log/SemanticEndToEndOutputTest.cpp`
+- `docs/logging/semantic-output-double-wrapping-report.md`
+
+## End-to-end test coverage
+
+`SemanticEndToEndOutputTest` exercises the production semantic output path:
+
+1. `snode::semantic::*Log(...)` helper creates a `BoundaryLogger`.
+2. The helper uses `logger::Logger::semanticSink()`.
+3. The sink calls `Logger::emitSemantic(...)`.
+4. The semantic backend writes to the configured file logger.
+5. The test reads the emitted file line back and checks the real output.
+
+The identity helper assertion intentionally uses a capture sink because it validates helper materialization, not the production output path.
+
+## Proof that semantic text output is not legacy-wrapped
+
+The text-output test configures semantic text format, emits one `core.socket` info record through `Logger::semanticSink()`, reads the file, and asserts:
+
+- exactly one non-empty line was emitted;
+- the line contains the formatter-selected semantic fields and message;
+- the line does not start with a legacy severity label;
+- the line does not contain the legacy logger tick wrapper.
+
+## Proof that semantic JSON output is one clean JSON object per line
+
+The JSON-output test configures semantic JSON format, emits multiple records through `Logger::semanticSink()`, reads every non-empty line, and asserts:
+
+- each line starts with `{`;
+- no line starts with legacy severity text;
+- no line contains the legacy logger tick wrapper;
+- each line contains `"v":1`, the expected component, a message field, and an expected level;
+- each line ends with `}`.
+
+This catches the previous broken case where JSON was prefixed by legacy text before the JSON object.
+
+## Proof that legacy LOG/PLOG behavior remains unchanged
+
+The legacy regression section emits:
+
+- `LOG(INFO) << "legacy info still works";`
+- `PLOG(ERROR) << "legacy plog still works";` with `errno = EACCES`.
+
+It verifies that the configured file output still contains the legacy severity labels, the legacy messages, and the PLOG errno text (`Permission denied`). Legacy output is intentionally not asserted to be semantic JSON.
+
+## Identity helper overload summary
+
+`src/SemanticLog.h` now exposes `snode::semantic::LogIdentity` with optional `instance`, `role`, and `connection` fields. A new `scopedLog(...)` overload forwards those values into `logger::LogScopeOwner`, and identity-capable overloads were added for the public helper layer:
+
+- `frameworkLog(LogIdentity, ...)`
+- `coreSystemLog(LogIdentity, ...)`
+- `coreSocketLog(LogIdentity, ...)`
+- `netConfigLog(LogIdentity, ...)`
+- `tlsConfigLog(LogIdentity, ...)`
+- `mariaDbLog(LogIdentity, ...)`
+- `webHttpLog(LogIdentity, ...)`
+- `expressLog(LogIdentity, ...)`
+- `appLog(LogIdentity, ...)`
+
+Existing overloads remain intact, so current call sites stay source-compatible.
+
+## Logger caching style note
+
+When multiple semantic lines are emitted in one local scope, prefer `auto log = ...;` and reuse it. Existing app/example call sites may be polished later; this is not a correctness blocker.
+
+## SNODEC_VLOG compat-suite note
+
+Non-compiled compat-suite artifact still contains `SNODEC_VLOG`. It is outside the built app target and will be handled or explicitly excluded in the final macro-removal/source-gate PR.
+
+## Commands run
+
+- `git fetch origin` (failed: repository has no `origin` remote in this workspace)
+- `git checkout master` / `git pull --ff-only origin master` were not possible because this workspace has no `master` branch or `origin` remote; the starting `work` branch was already at merge commit `4eef54d` for PR #166.
+- `git status --short`
+- `git log --oneline -n 30`
+- `test -f docs/logging/semantic-api-contract.md`
+- `test -f docs/logging/semantic-vlog-elimination-report.md`
+- `test -f src/SemanticLog.h`
+- `git checkout -b codex/fix-semantic-output-double-wrapping`
+- `rg -n "emitSemantic|formatRecord\(|emitLine\(" src/log -g '*.cpp' -g '*.h' -g '*.hpp'`
+- `rg -n "SNODEC_VLOG|\bVLOG\s*\(" src tests -g '*.h' -g '*.hpp' -g '*.cpp'`
+- `clang-format -i src/log/Logger.cpp src/log/Logger.h src/SemanticLog.h tests/unit/log/SemanticEndToEndOutputTest.cpp`
+- `git diff --check`
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2`
+- `ctest --test-dir cmake-build -R SemanticEndToEndOutputTest --output-on-failure`
+- `ctest --test-dir cmake-build -R "SemanticLoggerRound2Test|SemanticCompatibilityRound9Test|SemanticProductionThresholdRepairTest|FinalCleanupMigration09Test|SemanticEndToEndOutputTest" --output-on-failure`
+- `ctest --test-dir cmake-build --output-on-failure`
+- `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`
+- `cmake --build cmake-build-asan --parallel 2 --target SemanticEndToEndOutputTest`
+- `ASAN=$(gcc -print-file-name=libasan.so); LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan -R SemanticEndToEndOutputTest --output-on-failure`
+
+## Known follow-ups
+
+1. Remove legacy LOG/PLOG/VLOG macro definitions and add the final hard source gate.
+2. Decide whether the non-compiled compat-suite SNODEC_VLOG artifact is removed, rewritten, or explicitly excluded by the final gate.
+3. Optional polish: use identity-capable helpers in selected app/framework call sites where instance/connection identity matters.
+4. Round 10 — book integration.

--- a/src/SemanticLog.h
+++ b/src/SemanticLog.h
@@ -11,6 +11,12 @@
 
 namespace snode::semantic {
 
+    struct LogIdentity {
+        std::optional<std::string> instance;
+        std::optional<logger::LogRole> role;
+        std::optional<std::string> connection;
+    };
+
     inline logger::BoundaryLogger scopedLog(const logger::LogOrigin origin,
                                             const logger::LogBoundary boundary,
                                             const std::string& component,
@@ -18,6 +24,18 @@ namespace snode::semantic {
                                             const logger::LogLevel threshold = logger::LogLevel::Trace,
                                             logger::BoundaryLogger::Clock clock = {}) {
         return logger::LogScopeOwner(origin, boundary, component).logger(std::move(sink), threshold, std::move(clock));
+    }
+
+    inline logger::BoundaryLogger scopedLog(const logger::LogOrigin origin,
+                                            const logger::LogBoundary boundary,
+                                            const std::string& component,
+                                            LogIdentity identity,
+                                            logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                            const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                            logger::BoundaryLogger::Clock clock = {}) {
+        return logger::LogScopeOwner(
+                   origin, boundary, component, std::move(identity.instance), identity.role, std::move(identity.connection))
+            .logger(std::move(sink), threshold, std::move(clock));
     }
 
     inline logger::BoundaryLogger frameworkLog(logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
@@ -85,6 +103,123 @@ namespace snode::semantic {
                                          logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(
             logger::LogOrigin::Application, logger::LogBoundary::Application, "app", std::move(sink), threshold, std::move(clock));
+    }
+
+    inline logger::BoundaryLogger frameworkLog(LogIdentity identity,
+                                               logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                               const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                               logger::BoundaryLogger::Clock clock = {}) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::System,
+                         "framework",
+                         std::move(identity),
+                         std::move(sink),
+                         threshold,
+                         std::move(clock));
+    }
+
+    inline logger::BoundaryLogger coreSystemLog(LogIdentity identity,
+                                                logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                                const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                logger::BoundaryLogger::Clock clock = {}) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::System,
+                         "core.system",
+                         std::move(identity),
+                         std::move(sink),
+                         threshold,
+                         std::move(clock));
+    }
+
+    inline logger::BoundaryLogger coreSocketLog(LogIdentity identity,
+                                                logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                                const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                logger::BoundaryLogger::Clock clock = {}) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Connection,
+                         "core.socket",
+                         std::move(identity),
+                         std::move(sink),
+                         threshold,
+                         std::move(clock));
+    }
+
+    inline logger::BoundaryLogger netConfigLog(LogIdentity identity,
+                                               logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                               const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                               logger::BoundaryLogger::Clock clock = {}) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Configuration,
+                         "net.config",
+                         std::move(identity),
+                         std::move(sink),
+                         threshold,
+                         std::move(clock));
+    }
+
+    inline logger::BoundaryLogger tlsConfigLog(LogIdentity identity,
+                                               logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                               const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                               logger::BoundaryLogger::Clock clock = {}) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Configuration,
+                         "net.config.tls",
+                         std::move(identity),
+                         std::move(sink),
+                         threshold,
+                         std::move(clock));
+    }
+
+    inline logger::BoundaryLogger mariaDbLog(LogIdentity identity,
+                                             logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                             const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                             logger::BoundaryLogger::Clock clock = {}) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Connection,
+                         "db.mariadb",
+                         std::move(identity),
+                         std::move(sink),
+                         threshold,
+                         std::move(clock));
+    }
+
+    inline logger::BoundaryLogger webHttpLog(LogIdentity identity,
+                                             logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                             const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                             logger::BoundaryLogger::Clock clock = {}) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Connection,
+                         "web.http",
+                         std::move(identity),
+                         std::move(sink),
+                         threshold,
+                         std::move(clock));
+    }
+
+    inline logger::BoundaryLogger expressLog(LogIdentity identity,
+                                             logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                             const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                             logger::BoundaryLogger::Clock clock = {}) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Application,
+                         "express",
+                         std::move(identity),
+                         std::move(sink),
+                         threshold,
+                         std::move(clock));
+    }
+
+    inline logger::BoundaryLogger appLog(LogIdentity identity,
+                                         logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                         const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                         logger::BoundaryLogger::Clock clock = {}) {
+        return scopedLog(logger::LogOrigin::Application,
+                         logger::LogBoundary::Application,
+                         "app",
+                         std::move(identity),
+                         std::move(sink),
+                         threshold,
+                         std::move(clock));
     }
 
     class SysErrorStream {

--- a/src/log/Logger.cpp
+++ b/src/log/Logger.cpp
@@ -49,6 +49,7 @@
 #include <cerrno>
 #include <chrono>
 #include <cstring>
+#include <optional>
 #include <spdlog/logger.h>
 #include <spdlog/pattern_formatter.h>
 #include <spdlog/sinks/basic_file_sink.h>
@@ -56,15 +57,17 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <unistd.h>
 
-#include <optional>
-
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace {
     std::shared_ptr<spdlog::sinks::stdout_color_sink_st> stdoutSink;
+    std::shared_ptr<spdlog::sinks::stdout_color_sink_st> semanticStdoutSink;
     std::shared_ptr<spdlog::sinks::rotating_file_sink_st> fileSink;
+    std::shared_ptr<spdlog::sinks::rotating_file_sink_st> semanticFileSink;
     std::shared_ptr<spdlog::logger> stdoutLogger;
     std::shared_ptr<spdlog::logger> fileLogger;
+    std::shared_ptr<spdlog::logger> semanticStdoutLogger;
+    std::shared_ptr<spdlog::logger> semanticFileLogger;
 
     int configuredLogLevel = 0;
     int configuredVerboseLevel = 0;
@@ -221,9 +224,14 @@ namespace logger {
         auto stdoutPattern = std::make_unique<spdlog::pattern_formatter>();
         stdoutPattern->add_flag<TickFlagFormatter>('*').set_pattern("%Y-%m-%d %H:%M:%S %* %v");
         stdoutLogger->set_formatter(std::move(stdoutPattern));
+        semanticStdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
+        semanticStdoutLogger = std::make_shared<spdlog::logger>("snodec-semantic-stdout", semanticStdoutSink);
+        semanticStdoutLogger->set_pattern("%v");
 
         fileSink.reset();
+        semanticFileSink.reset();
         fileLogger.reset();
+        semanticFileLogger.reset();
         quietMode = false;
         disableColorLog = ::isatty(::fileno(stdout)) == 0;
         configuredVerboseLevel = 0;
@@ -250,9 +258,14 @@ namespace logger {
         auto filePattern = std::make_unique<spdlog::pattern_formatter>();
         filePattern->add_flag<TickFlagFormatter>('*').set_pattern("%Y-%m-%d %H:%M:%S %* %v");
         fileLogger->set_formatter(std::move(filePattern));
+        semanticFileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
+        semanticFileLogger = std::make_shared<spdlog::logger>("snodec-semantic-file", semanticFileSink);
+        semanticFileLogger->set_pattern("%v");
     }
 
     void Logger::disableLogToFile() {
+        semanticFileLogger.reset();
+        semanticFileSink.reset();
         fileLogger.reset();
         fileSink.reset();
     }
@@ -275,6 +288,15 @@ namespace logger {
 
     bool Logger::shouldVerbose(int verboseLevel) {
         return verboseLevel >= 0 && verboseLevel <= configuredVerboseLevel;
+    }
+
+    static void emitFormattedLine(const std::string& line) {
+        if (!quietMode && semanticStdoutLogger) {
+            semanticStdoutLogger->log(spdlog::level::info, line);
+        }
+        if (semanticFileLogger) {
+            semanticFileLogger->log(spdlog::level::info, line);
+        }
     }
 
     static void emitLine(Level level, std::string message, const bool withErrno, const int errnoValue) {
@@ -309,7 +331,7 @@ namespace logger {
             return;
         }
 
-        emitLine(*mappedLevel, LogManager::formatRecord(record), false, 0);
+        emitFormattedLine(LogManager::formatRecord(record));
     }
 
     BoundaryLogger::Sink Logger::semanticSink() {

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -112,3 +112,9 @@ target_include_directories(FinalCleanupMigration09Test PRIVATE ${PROJECT_SOURCE_
 target_compile_features(FinalCleanupMigration09Test PRIVATE cxx_std_20)
 target_link_libraries(FinalCleanupMigration09Test PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(FinalCleanupMigration09Test PROPERTIES LABELS "unit;log;migration09")
+
+snodec_add_test(SemanticEndToEndOutputTest SemanticEndToEndOutputTest.cpp)
+target_include_directories(SemanticEndToEndOutputTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(SemanticEndToEndOutputTest PRIVATE cxx_std_20)
+target_link_libraries(SemanticEndToEndOutputTest PRIVATE snodec-test-support snodec::logger)
+set_tests_properties(SemanticEndToEndOutputTest PROPERTIES LABELS "unit;log;e2e")

--- a/tests/unit/log/SemanticEndToEndOutputTest.cpp
+++ b/tests/unit/log/SemanticEndToEndOutputTest.cpp
@@ -1,0 +1,179 @@
+#include "SemanticLog.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "tests/support/TestResult.h"
+
+#include <cerrno>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace {
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::filesystem::path& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(1);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() {
+                return std::string("E2ETICK");
+            });
+            logger::Logger::logToFile(logFile.string());
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        std::filesystem::remove(path.string() + ".2", error);
+        std::filesystem::remove(path.string() + ".3", error);
+        return path;
+    }
+
+    std::vector<std::string> readLines(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        std::vector<std::string> lines;
+        std::string line;
+        while (std::getline(in, line)) {
+            if (!line.empty()) {
+                lines.push_back(line);
+            }
+        }
+        return lines;
+    }
+
+    bool startsWith(const std::string& value, const std::string& prefix) {
+        return value.rfind(prefix, 0) == 0;
+    }
+
+    bool contains(const std::string& value, const std::string& needle) {
+        return value.find(needle) != std::string::npos;
+    }
+
+    std::chrono::system_clock::time_point fixedTimestamp() {
+        using namespace std::chrono;
+        return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
+    }
+
+    logger::BoundaryLogger::Clock fixedClock() {
+        return []() {
+            return fixedTimestamp();
+        };
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    const auto textPath = tempLogPath("snodec-semantic-e2e-text.log");
+    {
+        LoggerStateGuard guard(textPath);
+        logger::LogManager::setFormat(logger::LogManager::Format::Text);
+        auto log = snode::semantic::coreSocketLog(logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedClock());
+        log.info("semantic text output");
+    }
+    const auto textLines = readLines(textPath);
+    result.expectEqual(1, static_cast<int>(textLines.size()), "semantic text emits one logical output line");
+    if (!textLines.empty()) {
+        const auto& line = textLines.front();
+        result.expectTrue(contains(line, "2026-07-05T12:34:56.789Z info framework connection core.socket - semantic text output"),
+                          "semantic text contains the formatter-selected text fields");
+        result.expectTrue(!startsWith(line, "INFO") && !startsWith(line, "DEBUG") && !startsWith(line, "TRACE") &&
+                              !startsWith(line, "WARNING") && !startsWith(line, "ERROR") && !startsWith(line, "FATAL"),
+                          "semantic text is not wrapped with a legacy severity prefix");
+        result.expectTrue(!contains(line, " INFO   ") && !contains(line, " E2ETICK "),
+                          "semantic text is not wrapped with legacy logger date/tick output");
+    }
+
+    const auto jsonPath = tempLogPath("snodec-semantic-e2e-json.log");
+    {
+        LoggerStateGuard guard(jsonPath);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        auto log = snode::semantic::webHttpLog(logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedClock());
+        log.info("semantic json output");
+        log.warn("semantic json warning");
+    }
+    const auto jsonLines = readLines(jsonPath);
+    result.expectEqual(2, static_cast<int>(jsonLines.size()), "semantic JSON emits one object per record line");
+    for (const auto& line : jsonLines) {
+        result.expectTrue(startsWith(line, "{"), "semantic JSON line starts with a JSON object");
+        result.expectTrue(!startsWith(line, "INFO ") && !startsWith(line, "WARNING") && !startsWith(line, "ERROR") &&
+                              !contains(line, " E2ETICK "),
+                          "semantic JSON line is not legacy-prefixed");
+        result.expectTrue(contains(line, "\"v\":1"), "semantic JSON line contains schema version");
+        result.expectTrue(contains(line, "\"component\":\"web.http\""), "semantic JSON line contains component");
+        result.expectTrue(contains(line, "\"message\":"), "semantic JSON line contains message");
+        result.expectTrue(line.back() == '}', "semantic JSON line ends as one object");
+    }
+    result.expectTrue(contains(jsonLines.empty() ? std::string() : jsonLines.front(), "\"level\":\"info\""),
+                      "semantic JSON info record contains expected level");
+
+    const auto legacyPath = tempLogPath("snodec-semantic-e2e-legacy.log");
+    {
+        LoggerStateGuard guard(legacyPath);
+        LOG(INFO) << "legacy info still works";
+        errno = EACCES;
+        PLOG(ERROR) << "legacy plog still works";
+    }
+    const auto legacyLines = readLines(legacyPath);
+    std::ostringstream legacyLog;
+    for (const auto& line : legacyLines) {
+        legacyLog << line << '\n';
+    }
+    result.expectTrue(contains(legacyLog.str(), "INFO") && contains(legacyLog.str(), "legacy info still works"),
+                      "legacy LOG still emits through the legacy path");
+    result.expectTrue(contains(legacyLog.str(), "ERROR") && contains(legacyLog.str(), "legacy plog still works") &&
+                          contains(legacyLog.str(), "Permission denied"),
+                      "legacy PLOG still appends errno text through the legacy path");
+
+    std::vector<logger::LogRecord> identityRecords;
+    auto identityLog = snode::semantic::coreSocketLog(
+        snode::semantic::LogIdentity{"socket-instance", logger::LogRole::Server, "tcp://127.0.0.1:8080"},
+        [&](logger::LogRecord record) {
+            identityRecords.push_back(std::move(record));
+        },
+        logger::LogLevel::Trace,
+        fixedClock());
+    identityLog.info("identity helper output");
+    result.expectEqual(1, static_cast<int>(identityRecords.size()), "identity-capable helper emits one captured record");
+    if (!identityRecords.empty()) {
+        result.expectTrue(identityRecords.front().component == "core.socket", "identity helper preserves component");
+        result.expectTrue(identityRecords.front().instance && *identityRecords.front().instance == "socket-instance",
+                          "identity helper preserves instance");
+        result.expectTrue(identityRecords.front().role && *identityRecords.front().role == logger::LogRole::Server,
+                          "identity helper preserves role");
+        result.expectTrue(identityRecords.front().connection && *identityRecords.front().connection == "tcp://127.0.0.1:8080",
+                          "identity helper preserves connection");
+    }
+
+    const auto quietFilePath = tempLogPath("snodec-semantic-e2e-quiet-file.log");
+    {
+        LoggerStateGuard guard(quietFilePath);
+        logger::Logger::setQuiet(true);
+        auto log = snode::semantic::appLog(logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedClock());
+        log.info("quiet still writes file");
+    }
+    const auto quietFileLines = readLines(quietFilePath);
+    result.expectEqual(1, static_cast<int>(quietFileLines.size()), "quiet mode does not suppress configured semantic file logging");
+    result.expectTrue(!quietFileLines.empty() && contains(quietFileLines.front(), "quiet still writes file"),
+                      "semanticSink still writes to file logger when quiet mode is enabled");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation

- Fix the semantic-to-legacy double-wrapping bug where semantic records formatted via `LogManager::formatRecord(...)` were sent through the legacy `emitLine(...)` path and received legacy severity/tick/errno decoration. 
- Ensure semantic output emitted through `logger::Logger::semanticSink()` is exactly the formatted semantic text/JSON with no additional legacy wrapping while preserving legacy `LOG`/`PLOG`/`VLOG` behavior. 
- Provide an end-to-end regression that exercises the real production sink and proves both text and JSON semantic outputs are emitted correctly. 
- Add minimal, backward-compatible identity support to the semantic helper layer so helpers can carry `instance`, `role`, and `connection` when needed.

### Description

- Added an internal semantic-only output path: `emitFormattedLine(const std::string&)` and separate semantic stdout/file loggers that use a raw `%v` pattern so formatted semantic lines are written verbatim; `Logger::emitSemantic(...)` now calls this helper instead of `emitLine(...)` (file: `src/log/Logger.cpp`).
- Kept the legacy `emitLine(...)` path intact and used exclusively by legacy macros so `LOG`, `PLOG`, and `VLOG` continue to behave unchanged and still perform prefixing, color, and errno handling (file: `src/log/Logger.cpp`).
- Added a small identity type `snode::semantic::LogIdentity` and a backward-compatible `scopedLog(...)` overload plus identity-capable overloads for the public helpers such as `coreSocketLog`, `frameworkLog`, `appLog`, etc., preserving existing overloads for source compatibility (file: `src/SemanticLog.h`).
- Introduced `tests/unit/log/SemanticEndToEndOutputTest.cpp` and registered it in `tests/unit/log/CMakeLists.txt`; the test exercises the full production path (`BoundaryLogger` -> `Logger::semanticSink()` -> `Logger::emitSemantic()` -> stdout/file sinks) and also verifies legacy `LOG`/`PLOG` behavior, identity helper propagation, and quiet/file semantics. A short report documenting root cause, implementation, changed files and follow-ups was added at `docs/logging/semantic-output-double-wrapping-report.md`.

### Testing

- Built the project and ran focused tests; `ctest -R SemanticEndToEndOutputTest` passed (the new end-to-end test passed). 
- Ran the focused logging test suite `ctest -R "SemanticLoggerRound2Test|SemanticCompatibilityRound9Test|SemanticProductionThresholdRepairTest|FinalCleanupMigration09Test|SemanticEndToEndOutputTest"` and all selected tests passed. 
- Ran the full `ctest` against the build and the test run completed with all tests passing in this environment. 
- Built and ran the focused ASan build for `SemanticEndToEndOutputTest` and the ASan-run test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e1122a4d8832c9dd02f0dfe06e51f)