### PR TITLE
Redact sensitive logging in MQTT and OAuth2 diagnostics

### DIFF
--- a/docs/logging/sensitive-logging-redaction-report.md
+++ b/docs/logging/sensitive-logging-redaction-report.md
@@ -1,0 +1,102 @@
+# Sensitive logging redaction report
+
+## Problem summary
+
+The logging audit found security-sensitive diagnostics that emitted plaintext MQTT CONNECT credential/payload fields and OAuth2 token values. This report covers the focused PR A remediation for redacting those values without changing authentication, MQTT protocol behavior, OAuth2 response behavior, database schema, JSON schema, LogManager behavior, or legacy macro definitions.
+
+## Files inspected
+
+- `src/iot/mqtt/server/Mqtt.cpp`
+- `src/apps/oauth2/authorization_server/AuthorizationServer.cpp`
+- `src/apps/oauth2/resource_server/ResourceServer.cpp`
+- Broader `src/**/*.h`, `src/**/*.hpp`, and `src/**/*.cpp` matches for password, token, Authorization/Bearer, MQTT Will fields, and related accessor names.
+
+## Findings fixed
+
+1. MQTT CONNECT diagnostics logged plaintext `connect.getPassword()` when the password flag was present.
+2. MQTT CONNECT diagnostics logged plaintext `connect.getWillMessage()` at `info` severity.
+3. MQTT CONNECT diagnostics logged plaintext `connect.getUsername()` at `info` severity.
+4. OAuth2 refresh-token diagnostics logged the plaintext `refresh_token` query value.
+5. OAuth2 resource-server diagnostics logged the plaintext `access_token` query value.
+6. OAuth2 authorization-server validation diagnostics logged plaintext invalid/valid access-token values.
+
+## MQTT redaction changes
+
+- Kept protocol version, connect flags, keep-alive, client id, clean-session, Will QoS, and Will retain diagnostics unchanged where they do not expose secret values.
+- Moved Will topic diagnostics from `info` to `debug` because topic strings can carry deployment/application detail.
+- Replaced plaintext Will message logging with presence and size only.
+- Replaced plaintext username logging with username presence only.
+- Replaced plaintext password logging with password presence only.
+- Left MQTT validation and stored session state unchanged; `willMessage`, `username`, and `password` are still assigned for existing protocol behavior, but their values are not emitted by CONNECT diagnostics.
+
+## OAuth2 redaction changes
+
+- Replaced plaintext refresh-token diagnostics with supplied/length metadata.
+- Replaced plaintext resource-server access-token diagnostics with supplied/length metadata.
+- Replaced authorization-server validation outcome logs with value-free success/failure messages.
+- Left request parsing, SQL lookup strings, response bodies, status codes, and token generation unchanged.
+
+## Search commands run
+
+Before changes:
+
+```sh
+rg -n "password|Password|token|Token|access_token|refresh_token|Authorization|Bearer|WillMessage|WillTopic|getPassword|getUsername|getWillMessage|getWillTopic" \
+  src \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+```sh
+rg -n "(log\(\)|Log\(\)|appLog\(\)|mqtt.*Log\(\)|frameworkLog\(\)|webHttpLog\(\)|expressLog\(\)|debug\(\)|info\(\)|warn\(\)|error\(\)|trace\(\)).*(password|Password|token|Token|access_token|refresh_token|Authorization|Bearer|WillMessage|getPassword|getWillMessage)" \
+  src \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+After changes:
+
+```sh
+rg -n "password|Password|token|Token|access_token|refresh_token|Authorization|Bearer|WillMessage|WillTopic|getPassword|getUsername|getWillMessage|getWillTopic" \
+  src \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+```sh
+rg -n "getPassword\(|getWillMessage\(|RefreshToken:|AccessToken:|Invalid access token '|Valid access token '|Password:|WillMessage:" \
+  src \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+```sh
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" \
+  src \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+## Remaining allowed sensitive-word occurrences
+
+- MQTT accessor declarations/definitions and protocol assignments remain because they are required for protocol state and validation.
+- MQTT redacted diagnostics mention `WillMessage supplied` and `Password supplied` without logging values.
+- OAuth2 SQL/query logic and JSON response keys still use `access_token` and `refresh_token` where required by protocol/API behavior.
+- OAuth2 diagnostics still mention validation outcomes such as `Invalid access token` and `Valid access token` without appending token values.
+- `src/log/Logger.h` still contains legacy `LOG`, `PLOG`, and `VLOG` macro definitions; this PR did not remove macro definitions and did not reintroduce call sites.
+- A separate OAuth2 client-app diagnostic mentions an authorization code/token flow in general terms; it is outside this PR's confirmed password/WillMessage/access-token/refresh-token findings and is left for a broader follow-up audit if needed.
+
+## Tests run
+
+- `git diff --check`
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2`
+- `ctest --test-dir cmake-build -R "SensitiveLoggingRedactionTest|MqttMigration08Test|SemanticEndToEndOutputTest|FinalCleanupMigration09Test" --output-on-failure`
+- `ctest --test-dir cmake-build --output-on-failure`
+- `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`
+- `cmake --build cmake-build-asan --parallel 2 --target MqttMigration08Test SensitiveLoggingRedactionTest`
+- `ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan -R "MqttMigration08Test|SensitiveLoggingRedactionTest" --output-on-failure`
+
+## Known follow-ups
+
+1. PR B — high-frequency severity correction for MQTT packet and HTTP request/response lifecycle logs.
+2. PR C — duplicate connection-close statistics cleanup.
+3. PR D — inner epoll robustness and syscall diagnostics.
+4. PR E — broader syscall discipline audit.
+5. Final macro removal/source gate.
+6. Round 10 — book integration.

--- a/docs/logging/sensitive-logging-redaction-report.md
+++ b/docs/logging/sensitive-logging-redaction-report.md
@@ -9,6 +9,7 @@ The logging audit found security-sensitive diagnostics that emitted plaintext MQ
 - `src/iot/mqtt/server/Mqtt.cpp`
 - `src/apps/oauth2/authorization_server/AuthorizationServer.cpp`
 - `src/apps/oauth2/resource_server/ResourceServer.cpp`
+- `src/apps/oauth2/client_app/ClientApp.cpp`
 - Broader `src/**/*.h`, `src/**/*.hpp`, and `src/**/*.cpp` matches for password, token, Authorization/Bearer, MQTT Will fields, and related accessor names.
 
 ## Findings fixed
@@ -19,6 +20,7 @@ The logging audit found security-sensitive diagnostics that emitted plaintext MQ
 4. OAuth2 refresh-token diagnostics logged the plaintext `refresh_token` query value.
 5. OAuth2 resource-server diagnostics logged the plaintext `access_token` query value.
 6. OAuth2 authorization-server validation diagnostics logged plaintext invalid/valid access-token values.
+7. OAuth2 client-app source hygiene preserved a commented-out example that logged an authorization-code value and a token request URI containing `code=...`.
 
 ## MQTT redaction changes
 
@@ -36,12 +38,16 @@ The logging audit found security-sensitive diagnostics that emitted plaintext MQ
 - Replaced authorization-server validation outcome logs with value-free success/failure messages.
 - Left request parsing, SQL lookup strings, response bodies, status codes, and token generation unchanged.
 
+## OAuth2 authorization-code diagnostics
+
+`src/apps/oauth2/client_app/ClientApp.cpp` did not contain an active runtime authorization-code log, but it did contain a commented-out token-exchange block that appended `req.query("code")` to a token request URI and showed a debug log printing both the authorization-code value and full request URI. The dead commented-out block was removed so the source no longer preserves or suggests logging OAuth2 authorization-code values. The active client-app flow still checks whether a code query parameter was supplied for routing behavior, but it does not log the code value or a token request URI containing `code=...`.
+
 ## Search commands run
 
 Before changes:
 
 ```sh
-rg -n "password|Password|token|Token|access_token|refresh_token|Authorization|Bearer|WillMessage|WillTopic|getPassword|getUsername|getWillMessage|getWillTopic" \
+rg -n "password|Password|token|Token|access_token|refresh_token|authorization_code|auth.?code|Authorization|Bearer|WillMessage|WillTopic|getPassword|getUsername|getWillMessage|getWillTopic|req\.query\(\"code\"\)" \
   src \
   -g '*.h' -g '*.hpp' -g '*.cpp'
 ```
@@ -55,13 +61,13 @@ rg -n "(log\(\)|Log\(\)|appLog\(\)|mqtt.*Log\(\)|frameworkLog\(\)|webHttpLog\(\)
 After changes:
 
 ```sh
-rg -n "password|Password|token|Token|access_token|refresh_token|Authorization|Bearer|WillMessage|WillTopic|getPassword|getUsername|getWillMessage|getWillTopic" \
+rg -n "password|Password|token|Token|access_token|refresh_token|authorization_code|auth.?code|Authorization|Bearer|WillMessage|WillTopic|getPassword|getUsername|getWillMessage|getWillTopic|req\.query\(\"code\"\)" \
   src \
   -g '*.h' -g '*.hpp' -g '*.cpp'
 ```
 
 ```sh
-rg -n "getPassword\(|getWillMessage\(|RefreshToken:|AccessToken:|Invalid access token '|Valid access token '|Password:|WillMessage:" \
+rg -n "getPassword\(|getWillMessage\(|RefreshToken:|AccessToken:|Invalid access token '|Valid access token '|Password:|WillMessage:|Recieving auth code|Receiving auth code|req\.query\(\"code\"\)|authorization code.*<<" \
   src \
   -g '*.h' -g '*.hpp' -g '*.cpp'
 ```
@@ -79,7 +85,7 @@ rg -n "\b(LOG|PLOG|VLOG)\s*\(" \
 - OAuth2 SQL/query logic and JSON response keys still use `access_token` and `refresh_token` where required by protocol/API behavior.
 - OAuth2 diagnostics still mention validation outcomes such as `Invalid access token` and `Valid access token` without appending token values.
 - `src/log/Logger.h` still contains legacy `LOG`, `PLOG`, and `VLOG` macro definitions; this PR did not remove macro definitions and did not reintroduce call sites.
-- A separate OAuth2 client-app diagnostic mentions an authorization code/token flow in general terms; it is outside this PR's confirmed password/WillMessage/access-token/refresh-token findings and is left for a broader follow-up audit if needed.
+- OAuth2 client-app active routing still checks `req->query("code")` for presence, but no active or commented-out diagnostic logs the authorization-code value or a full token request URI containing `code=...`.
 
 ## Tests run
 

--- a/src/apps/oauth2/authorization_server/AuthorizationServer.cpp
+++ b/src/apps/oauth2/authorization_server/AuthorizationServer.cpp
@@ -463,7 +463,8 @@ int main(int argc, char* argv[]) {
         auto queryGrantType = req->query("grant_type");
         snode::semantic::appLog().debug() << "GrandType: " << queryGrantType;
         auto queryRefreshToken = req->query("refresh_token");
-        snode::semantic::appLog().debug() << "RefreshToken: " << queryRefreshToken;
+        snode::semantic::appLog().debug() << "RefreshToken supplied: " << !queryRefreshToken.empty()
+                                          << " (length=" << queryRefreshToken.size() << ")";
         auto queryState = req->query("state");
         snode::semantic::appLog().debug() << "State: " << queryState;
         if (queryGrantType.length() == 0) {
@@ -568,14 +569,14 @@ int main(int argc, char* argv[]) {
                     "' "
                     "and a.uuid = '" +
                     jsonAccessToken + "'",
-                [res, jsonClientId, jsonAccessToken](const MYSQL_ROW row) {
+                [res](const MYSQL_ROW row) {
                     if (row != nullptr) {
                         if (std::stoi(row[0]) == 0) {
                             const nlohmann::json errorJson = {{"error", "Invalid access token"}};
-                            snode::semantic::appLog().debug() << "Sending 401: Invalid access token '" << jsonAccessToken << "'";
+                            snode::semantic::appLog().debug() << "Sending 401: Invalid access token";
                             res->status(401).send(errorJson.dump(4));
                         } else {
-                            snode::semantic::appLog().debug() << "Sending 200: Valid access token '" << jsonAccessToken << "";
+                            snode::semantic::appLog().debug() << "Sending 200: Valid access token";
                             const nlohmann::json successJson = {{"success", "Valid access token"}};
                             res->status(200).send(successJson.dump(4));
                         }

--- a/src/apps/oauth2/client_app/ClientApp.cpp
+++ b/src/apps/oauth2/client_app/ClientApp.cpp
@@ -57,18 +57,6 @@ int main(int argc, char* argv[]) {
                                   snode::semantic::sysError(snode::semantic::appLog(), logger::LogLevel::Error, ret) << req->url;
                               }
                           });
-            /*
-            std::string tokenRequestUri{"http://localhost:8082/oauth2/token"};
-            tokenRequestUri += "?grant_type=authorization_code";
-            tokenRequestUri += "&code=" + req.query("code");
-            if (!req.query("state").empty()) {
-                tokenRequestUri += "&state=" + req.query("state");
-            }
-            tokenRequestUri += "&client_id=911a821a-ea2d-11ec-8e2e-08002771075f";
-            tokenRequestUri += "&redirect_uri=http://localhost:8081/oauth2";
-            snode::semantic::appLog().debug() << "Recieving auth code from auth server: " << req.query("code") << ", requesting token from "
-            << tokenRequestUri; res.redirect(tokenRequestUri);
-            */
         }
     });
 

--- a/src/apps/oauth2/resource_server/ResourceServer.cpp
+++ b/src/apps/oauth2/resource_server/ResourceServer.cpp
@@ -90,7 +90,8 @@ int main(int argc, char* argv[]) {
                 request->url = "/oauth2/token/validate?client_id=" + queryClientId;
                 request->method = "POST";
                 snode::semantic::appLog().debug() << "ClientId: " << queryClientId;
-                snode::semantic::appLog().debug() << "AccessToken: " << queryAccessToken;
+                snode::semantic::appLog().debug()
+                    << "AccessToken supplied: " << !queryAccessToken.empty() << " (length=" << queryAccessToken.size() << ")";
                 const nlohmann::json requestJson = {{"access_token", queryAccessToken}, {"client_id", queryClientId}};
                 const std::string requestJsonString{requestJson.dump(4)};
                 request->send(

--- a/src/iot/mqtt/server/Mqtt.cpp
+++ b/src/iot/mqtt/server/Mqtt.cpp
@@ -232,18 +232,18 @@ namespace iot::mqtt::server {
         iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   CleanSession: " << connect.getCleanSession();
 
         if (connect.getWillFlag()) {
-            iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   WillTopic: " << connect.getWillTopic();
-            iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   WillMessage: " << connect.getWillMessage();
+            iot::mqtt::semantic::mqttServerLog().debug() << connectionName << " MQTT Broker:   WillTopic: " << connect.getWillTopic();
+            iot::mqtt::semantic::mqttServerLog().debug()
+                << connectionName << " MQTT Broker:   WillMessage supplied: " << !connect.getWillMessage().empty()
+                << " (size=" << connect.getWillMessage().size() << ")";
             iot::mqtt::semantic::mqttServerLog().info()
                 << connectionName << " MQTT Broker:   WillQoS: " << static_cast<uint16_t>(connect.getWillQoS());
             iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   WillRetain: " << connect.getWillRetain();
         }
-        if (connect.getUsernameFlag()) {
-            iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   Username: " << connect.getUsername();
-        }
-        if (connect.getPasswordFlag()) {
-            iot::mqtt::semantic::mqttServerLog().info() << connectionName << " MQTT Broker:   Password: " << connect.getPassword();
-        }
+        iot::mqtt::semantic::mqttServerLog().debug()
+            << connectionName << " MQTT Broker:   Username supplied: " << connect.getUsernameFlag();
+        iot::mqtt::semantic::mqttServerLog().debug()
+            << connectionName << " MQTT Broker:   Password supplied: " << connect.getPasswordFlag();
 
         if (connect.getProtocol() != "MQTT") {
             iot::mqtt::semantic::mqttServerLog().error() << connectionName << " MQTT Broker:   Wrong Protocol: " << connect.getProtocol();

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -118,3 +118,7 @@ target_include_directories(SemanticEndToEndOutputTest PRIVATE ${PROJECT_SOURCE_D
 target_compile_features(SemanticEndToEndOutputTest PRIVATE cxx_std_20)
 target_link_libraries(SemanticEndToEndOutputTest PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(SemanticEndToEndOutputTest PROPERTIES LABELS "unit;log;e2e")
+
+snodec_add_test(SensitiveLoggingRedactionTest SensitiveLoggingRedactionTest.cpp)
+target_compile_features(SensitiveLoggingRedactionTest PRIVATE cxx_std_20)
+set_tests_properties(SensitiveLoggingRedactionTest PROPERTIES LABELS "unit;log;security")

--- a/tests/unit/log/SensitiveLoggingRedactionTest.cpp
+++ b/tests/unit/log/SensitiveLoggingRedactionTest.cpp
@@ -44,6 +44,7 @@ int main() {
         root / "src" / "iot" / "mqtt" / "server" / "Mqtt.cpp",
         root / "src" / "apps" / "oauth2" / "authorization_server" / "AuthorizationServer.cpp",
         root / "src" / "apps" / "oauth2" / "resource_server" / "ResourceServer.cpp",
+        root / "src" / "apps" / "oauth2" / "client_app" / "ClientApp.cpp",
     };
     const std::vector<std::string> forbiddenLogFragments = {
         "WillMessage: \" << connect.getWillMessage()",
@@ -53,6 +54,10 @@ int main() {
         "AccessToken: \" <<",
         "Invalid access token '\" <<",
         "Valid access token '\" <<",
+        "Recieving auth code",
+        "Receiving auth code",
+        "req.query(\"code\")",
+        "authorization code value",
     };
 
     bool ok = true;

--- a/tests/unit/log/SensitiveLoggingRedactionTest.cpp
+++ b/tests/unit/log/SensitiveLoggingRedactionTest.cpp
@@ -1,0 +1,75 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+    std::filesystem::path projectRoot() {
+        if (const char* sourceDir = std::getenv("SNODEC_SOURCE_DIR")) {
+            return sourceDir;
+        }
+
+        std::filesystem::path current = std::filesystem::current_path();
+        while (!current.empty()) {
+            if (std::filesystem::exists(current / "src" / "SemanticLog.h")) {
+                return current;
+            }
+            current = current.parent_path();
+        }
+
+        return std::filesystem::current_path();
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream input(path);
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        return buffer.str();
+    }
+
+    bool contains(std::string_view haystack, std::string_view needle) {
+        return haystack.find(needle) != std::string_view::npos;
+    }
+
+} // namespace
+
+int main() {
+    const std::filesystem::path root = projectRoot();
+    const std::vector<std::filesystem::path> sourceFiles = {
+        root / "src" / "iot" / "mqtt" / "server" / "Mqtt.cpp",
+        root / "src" / "apps" / "oauth2" / "authorization_server" / "AuthorizationServer.cpp",
+        root / "src" / "apps" / "oauth2" / "resource_server" / "ResourceServer.cpp",
+    };
+    const std::vector<std::string> forbiddenLogFragments = {
+        "WillMessage: \" << connect.getWillMessage()",
+        "Password: \" << connect.getPassword()",
+        "Username: \" << connect.getUsername()",
+        "RefreshToken: \" <<",
+        "AccessToken: \" <<",
+        "Invalid access token '\" <<",
+        "Valid access token '\" <<",
+    };
+
+    bool ok = true;
+    for (const auto& sourceFile : sourceFiles) {
+        const std::string contents = readFile(sourceFile);
+        if (contents.empty()) {
+            std::cerr << "Unable to read " << sourceFile << '\n';
+            ok = false;
+            continue;
+        }
+        for (const auto& fragment : forbiddenLogFragments) {
+            if (contains(contents, fragment)) {
+                std::cerr << "Forbidden sensitive logging fragment in " << sourceFile << ": " << fragment << '\n';
+                ok = false;
+            }
+        }
+    }
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
### Motivation
- An audit found plaintext MQTT CONNECT credentials/payloads and OAuth2 token values being emitted by diagnostics, so sensitive data (passwords, tokens, WillMessage) must be removed from logs while retaining useful presence/outcome signals.
- The fix must not change authentication, MQTT protocol, OAuth2 responses, database/JSON schema, LogManager behavior, or remove legacy macro definitions.
- The goal is a focused remediation limited to redaction of secrets in diagnostics without a broad severity or behavioral cleanup.

### Description
- `src/iot/mqtt/server/Mqtt.cpp` now avoids printing values for `WillMessage`, `Username`, and `Password`: `WillTopic` was moved to `debug`, `WillMessage` logs only presence and size, and username/password log only presence booleans; protocol/validation/state assignments remain unchanged.
- `src/apps/oauth2/authorization_server/AuthorizationServer.cpp` replaces plaintext `refresh_token` logging with supplied/length metadata and removes access-token values from validation success/failure diagnostics so outcomes are logged without token values.
- `src/apps/oauth2/resource_server/ResourceServer.cpp` replaces plaintext `access_token` logging with supplied/length metadata while preserving forwarded request body and validation behavior.
- Added a source-level regression test `tests/unit/log/SensitiveLoggingRedactionTest.cpp` and registered it in `tests/unit/log/CMakeLists.txt`, and added `docs/logging/sensitive-logging-redaction-report.md` documenting files inspected, changes made, searches run, remaining allowed occurrences, and follow-ups.

### Testing
- Ran focused source searches to confirm forbidden fragments were removed and no token/password/WillMessage values are emitted by CONNECT/OAuth2 diagnostics, which returned only allowed occurrences (accessors, SQL/JSON keys, and redacted presence/length diagnostics).
- Built the project with tests enabled and ran the focused test set including `SensitiveLoggingRedactionTest`, `MqttMigration08Test`, `SemanticEndToEndOutputTest`, and `FinalCleanupMigration09Test`, and all targeted tests passed.
- Ran full `ctest` and an ASan build running `MqttMigration08Test` and `SensitiveLoggingRedactionTest`; both ASan and full test runs passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e2be8c5fc832c8e11613ef5310ec6)