### PR TITLE
Clarify SocketContext detach logging

### DIFF
--- a/docs/logging/socketcontext-detach-logging-report.md
+++ b/docs/logging/socketcontext-detach-logging-report.md
@@ -1,0 +1,118 @@
+# SocketContext Detach Logging Report
+
+## Problem summary
+
+`SocketContext::detach()` served two lifecycle meanings: protocol/context switches where the underlying connection remains open, and final connection cleanup where the connection is closing. Before this change, both cases emitted the same context statistics block. On true close, that block overlapped with the richer `SocketServer` and `SocketClient` disconnect statistics for the same lifecycle event.
+
+## Canonical recipe rule applied
+
+The semantic logging recipe says not to log the same event twice unless the second log adds new information, such as a new decision, consequence, domain interpretation, recovery action, failure boundary, or identity. Adjacent framework layers alone do not justify duplicate close-stat logging.
+
+## Files inspected
+
+- `src/core/socket/stream/SocketConnection.hpp`
+- `src/core/socket/stream/SocketContext.h`
+- `src/core/socket/stream/SocketContext.cpp`
+- `src/core/socket/stream/SocketServer.h`
+- `src/core/socket/stream/SocketClient.h`
+- `tests/unit/log/SocketServerClientMigration03Test.cpp`
+- `tests/unit/log/CoreRuntimeMigration04Test.cpp`
+- `tests/unit/log/CMakeLists.txt`
+- `src/web/http/client/Request.cpp`
+- `src/web/http/server/Response.cpp`
+- `src/web/websocket/SocketContextUpgrade.hpp`
+- `src/web/websocket/SubProtocol.h`
+- `src/web/websocket/SubProtocol.hpp`
+
+## Two detach paths found
+
+### Context-switch path summary
+
+`SocketConnectionT::onReceivedFromPeer(...)` performs a pending `SocketContext` switch when `newSocketContext` is set. The old context is detached, the connection adopts the new context, and the new context is attached. This is a protocol/context switch path, such as an HTTP-to-WebSocket upgrade, and the connection remains open.
+
+### Connection-close path summary
+
+`SocketConnectionT::unobservedEvent()` performs final cleanup when the connection is no longer observed. It detaches the current context, invokes `onDisconnect()`, logs the connection as disconnected, and deletes the connection object. This is the true close path.
+
+## Context-relative counter explanation
+
+`SocketContext::attach()` captures the connection's current queued and processed totals as baselines. `SocketContext::getTotalQueued()` and `SocketContext::getTotalProcessed()` subtract those baselines from the connection totals. Therefore, these values describe the current context tenure, not necessarily the whole connection lifetime.
+
+## Implementation summary
+
+- Added `SocketContext::DetachReason` with `ContextSwitch` and `ConnectionClose` values.
+- Changed `SocketContext::detach()` to accept the explicit detach reason.
+- Marked the pending context switch call as `ContextSwitch`.
+- Marked the final cleanup call as `ConnectionClose`.
+- Kept per-context statistics only in the context-switch branch.
+- Reduced true-close `SocketContext` logging to a detach reason line so `SocketServer` and `SocketClient` remain the close-stat owners.
+
+## Why context-switch stats are preserved
+
+During a context switch, the old context's tenure is ending while the connection remains open. `SocketServer` and `SocketClient` disconnect callbacks do not run at that boundary, so `SocketContext` is the natural owner for context-relative accounting such as context online duration, context queued bytes, and context processed bytes.
+
+## Why true-close SocketContext stats are suppressed/reduced
+
+On final connection close, the `SocketServer` and `SocketClient` disconnect callbacks log the richer connection-lifetime statistics block. Repeating `Online Since`, `Online Duration`, `Total Queued`, `Total Sent`, and `Total Processed` from `SocketContext` at the same close boundary would violate the duplicate-log recipe unless it added distinct close information. The true-close `SocketContext` branch now logs only that the context detached for connection close.
+
+## Why SocketServer/SocketClient remain authoritative for connection-lifetime close stats
+
+`SocketServer.h` and `SocketClient.h` still contain the connection-lifetime close-stat labels: `Online Since`, `Online Duration`, `Total Queued`, `Total Sent`, `Write Delta`, `Total Read`, `Total Processed`, and `Read Delta`. They have access to the connection-lifetime totals and remain the authoritative close-stat logging boundary.
+
+## Mislabeled Total Sent/getTotalQueued note
+
+The old `SocketContext::detach()` log labeled `getTotalQueued()` as `Total Sent`. That label was misleading because queued bytes are not sent bytes. The replacement context-switch diagnostics now label the value as `Context Total Queued`, and true-close `SocketContext` logging no longer emits that statistic.
+
+## Tests added/updated
+
+- Added `tests/unit/log/SocketContextDetachPolicyTest.cpp` to verify the source-level logging policy and ownership boundary.
+- Registered `SocketContextDetachPolicyTest` in `tests/unit/log/CMakeLists.txt`.
+
+## Search commands run
+
+Before changes:
+
+```sh
+rg -n "detach\\(|setSocketContext\\(|SocketContextSwitch|Online Since|Online Duration|Total Sent|Total Processed|Total Queued|Total Read|Write Delta|Read Delta|OnDisconnect|SocketContext: detached" \
+  src/core/socket/stream src/web/http src/web/websocket \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+
+rg -n "SocketContext: detached|Online Duration|Total Sent|Total Processed|getTotalQueued\\(\\)" \
+  tests src \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+After changes:
+
+```sh
+rg -n "detach\\(|setSocketContext\\(|SocketContextSwitch|Online Since|Online Duration|Total Sent|Total Processed|Total Queued|Total Read|Write Delta|Read Delta|OnDisconnect|SocketContext: detached" \
+  src/core/socket/stream src/web/http src/web/websocket \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+
+rg -n "Total Sent:.*getTotalQueued|getTotalQueued\\(\\).*Total Sent" \
+  src/core/socket/stream tests \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+
+rg -n "getPassword\\(|getWillMessage\\(|RefreshToken:|AccessToken:|Invalid access token '|Valid access token '|Password:|WillMessage:|Recieving auth code|Receiving auth code|req\\.query\\(\"code\"\\)|authorization code.*<<" \
+  src \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+
+rg -n "mqttLog\\(\\)\\.info\\(\\)|frameworkLog\\(\\)\\.info\\(\\).*HTTP: Request|frameworkLog\\(\\)\\.info\\(\\).*HTTP: Response|frameworkLog\\(\\)\\.warn\\(\\) << httputils::toString" \
+  src/iot/mqtt src/web/http \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+
+rg -n "\\b(LOG|PLOG|VLOG)\\s*\\(" \
+  src \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+## Tests run
+
+See the PR validation notes for the exact commands run on this branch.
+
+## Known follow-ups
+
+1. PR D — inner epoll robustness and syscall diagnostics.
+2. PR E — broader syscall discipline audit.
+3. Final macro removal/source gate.
+4. Round 10 — book integration.

--- a/src/core/socket/stream/SocketConnection.hpp
+++ b/src/core/socket/stream/SocketConnection.hpp
@@ -319,7 +319,7 @@ namespace core::socket::stream {
             delete newSocketContext;
             newSocketContext = nullptr;
         } else if (newSocketContext != nullptr) { // Perform a pending SocketContextSwitch
-            socketContext->detach();
+            socketContext->detach(SocketContext::DetachReason::ContextSwitch);
 
             socketContext = newSocketContext;
             newSocketContext = nullptr;
@@ -377,7 +377,7 @@ namespace core::socket::stream {
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
     void SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::unobservedEvent() {
         if (socketContext != nullptr) {
-            socketContext->detach();
+            socketContext->detach(SocketContext::DetachReason::ConnectionClose);
         }
 
         onDisconnect();

--- a/src/core/socket/stream/SocketContext.cpp
+++ b/src/core/socket/stream/SocketContext.cpp
@@ -190,14 +190,18 @@ namespace core::socket::stream {
         onConnected();
     }
 
-    void SocketContext::detach() {
+    void SocketContext::detach(DetachReason reason) {
         onDisconnected();
 
-        frameworkLog().debug("SocketContext: detached");
-        frameworkLog().debug("     Online Since: {}", getOnlineSince());
-        frameworkLog().debug("  Online Duration: {}", getOnlineDuration());
-        frameworkLog().debug("       Total Sent: {}", getTotalQueued());
-        frameworkLog().debug("  Total Processed: {}", getTotalProcessed());
+        if (reason == DetachReason::ContextSwitch) {
+            frameworkLog().debug("SocketContext: detached for context switch");
+            frameworkLog().debug("  Context Online Since: {}", getOnlineSince());
+            frameworkLog().debug("  Context Online Duration: {}", getOnlineDuration());
+            frameworkLog().debug("  Context Total Queued: {}", getTotalQueued());
+            frameworkLog().debug("  Context Total Processed: {}", getTotalProcessed());
+        } else {
+            frameworkLog().debug("SocketContext: detached for connection close");
+        }
 
         delete this;
     }

--- a/src/core/socket/stream/SocketContext.h
+++ b/src/core/socket/stream/SocketContext.h
@@ -116,8 +116,10 @@ namespace core::socket::stream {
         virtual void onConnected() = 0;
         virtual void onDisconnected() = 0;
 
+        enum class DetachReason { ContextSwitch, ConnectionClose };
+
         virtual void attach();
-        virtual void detach();
+        virtual void detach(DetachReason reason);
 
         static std::string timePointToString(const std::chrono::time_point<std::chrono::system_clock>& timePoint);
         static std::string

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -119,6 +119,10 @@ target_compile_features(SemanticEndToEndOutputTest PRIVATE cxx_std_20)
 target_link_libraries(SemanticEndToEndOutputTest PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(SemanticEndToEndOutputTest PROPERTIES LABELS "unit;log;e2e")
 
+snodec_add_test(SocketContextDetachPolicyTest SocketContextDetachPolicyTest.cpp)
+target_compile_features(SocketContextDetachPolicyTest PRIVATE cxx_std_20)
+set_tests_properties(SocketContextDetachPolicyTest PROPERTIES LABELS "unit;log;socketcontext")
+
 snodec_add_test(SensitiveLoggingRedactionTest SensitiveLoggingRedactionTest.cpp)
 target_compile_features(SensitiveLoggingRedactionTest PRIVATE cxx_std_20)
 set_tests_properties(SensitiveLoggingRedactionTest PROPERTIES LABELS "unit;log;security")

--- a/tests/unit/log/SocketContextDetachPolicyTest.cpp
+++ b/tests/unit/log/SocketContextDetachPolicyTest.cpp
@@ -1,0 +1,104 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+    std::filesystem::path projectRoot() {
+        if (const char* sourceDir = std::getenv("SNODEC_SOURCE_DIR")) {
+            return sourceDir;
+        }
+
+        std::filesystem::path current = std::filesystem::current_path();
+        while (!current.empty()) {
+            if (std::filesystem::exists(current / "src" / "SemanticLog.h")) {
+                return current;
+            }
+            current = current.parent_path();
+        }
+
+        return std::filesystem::current_path();
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream input(path);
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        return buffer.str();
+    }
+
+    bool contains(std::string_view haystack, std::string_view needle) {
+        return haystack.find(needle) != std::string_view::npos;
+    }
+
+    bool requireContains(std::string_view contents, std::string_view needle, const std::filesystem::path& path) {
+        if (contains(contents, needle)) {
+            return true;
+        }
+
+        std::cerr << "Missing required fragment in " << path << ": " << needle << '\n';
+        return false;
+    }
+
+    bool requireNotContains(std::string_view contents, std::string_view needle, const std::filesystem::path& path) {
+        if (!contains(contents, needle)) {
+            return true;
+        }
+
+        std::cerr << "Forbidden fragment in " << path << ": " << needle << '\n';
+        return false;
+    }
+
+} // namespace
+
+int main() {
+    const std::filesystem::path root = projectRoot();
+    const auto socketConnectionPath = root / "src" / "core" / "socket" / "stream" / "SocketConnection.hpp";
+    const auto socketContextHeaderPath = root / "src" / "core" / "socket" / "stream" / "SocketContext.h";
+    const auto socketContextSourcePath = root / "src" / "core" / "socket" / "stream" / "SocketContext.cpp";
+    const auto socketServerPath = root / "src" / "core" / "socket" / "stream" / "SocketServer.h";
+    const auto socketClientPath = root / "src" / "core" / "socket" / "stream" / "SocketClient.h";
+
+    const std::string socketConnection = readFile(socketConnectionPath);
+    const std::string socketContextHeader = readFile(socketContextHeaderPath);
+    const std::string socketContextSource = readFile(socketContextSourcePath);
+    const std::string socketServer = readFile(socketServerPath);
+    const std::string socketClient = readFile(socketClientPath);
+
+    bool ok = true;
+    ok &= requireContains(socketConnection, "socketContext->detach(SocketContext::DetachReason::ContextSwitch);", socketConnectionPath);
+    ok &= requireContains(socketConnection, "socketContext->detach(SocketContext::DetachReason::ConnectionClose);", socketConnectionPath);
+
+    ok &= requireContains(socketContextHeader, "enum class DetachReason", socketContextHeaderPath);
+    ok &= requireContains(socketContextHeader, "ContextSwitch", socketContextHeaderPath);
+    ok &= requireContains(socketContextHeader, "ConnectionClose", socketContextHeaderPath);
+    ok &= requireContains(socketContextHeader, "detach(DetachReason reason)", socketContextHeaderPath);
+
+    ok &= requireContains(socketContextSource, "if (reason == DetachReason::ContextSwitch)", socketContextSourcePath);
+    ok &= requireContains(socketContextSource, "SocketContext: detached for context switch", socketContextSourcePath);
+    ok &= requireContains(socketContextSource, "Context Online Since", socketContextSourcePath);
+    ok &= requireContains(socketContextSource, "Context Online Duration", socketContextSourcePath);
+    ok &= requireContains(socketContextSource, "Context Total Queued", socketContextSourcePath);
+    ok &= requireContains(socketContextSource, "Context Total Processed", socketContextSourcePath);
+    ok &= requireContains(socketContextSource, "SocketContext: detached for connection close", socketContextSourcePath);
+    ok &= requireNotContains(socketContextSource, "Total Sent: {}", socketContextSourcePath);
+    const std::string misleadingQueuedAsSent = std::string{"Total "} + "Sent: {}\", " + "getTotalQueued()";
+    ok &= requireNotContains(socketContextSource, misleadingQueuedAsSent, socketContextSourcePath);
+
+    for (const auto& pathAndContents :
+         std::vector<std::pair<std::filesystem::path, std::string>>{{socketServerPath, socketServer}, {socketClientPath, socketClient}}) {
+        const auto& path = pathAndContents.first;
+        const auto& contents = pathAndContents.second;
+        for (const std::string_view label :
+             {"Online Duration", "Total Queued", "Total Sent", "Total Read", "Total Processed", "Write Delta", "Read Delta"}) {
+            ok &= requireContains(contents, label, path);
+        }
+    }
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
### Motivation

- Eliminate duplicate connection-close statistics that were emitted both from `SocketContext::detach()` and the `SocketServer`/`SocketClient` disconnect callbacks while preserving per-context diagnostics needed for protocol/context switches (e.g., HTTP→WebSocket upgrades).
- Distinguish the two semantic meanings of `SocketContext::detach()` (context switch vs final connection close) so logging ownership follows the canonical logging recipe and does not repeat the same close event twice.
- Fix a misleading label where `getTotalQueued()` was logged as `Total Sent` and ensure per-context counters remain context-tenure deltas rather than connection-lifetime totals.

### Description

- Introduced `enum class DetachReason { ContextSwitch, ConnectionClose }` inside `SocketContext` and changed the API to `void SocketContext::detach(DetachReason reason)` (file: `src/core/socket/stream/SocketContext.h`).
- Updated call sites to pass the explicit reason: the pending context-switch path now calls `socketContext->detach(SocketContext::DetachReason::ContextSwitch)` and the true-close path calls `socketContext->detach(SocketContext::DetachReason::ConnectionClose)` (file: `src/core/socket/stream/SocketConnection.hpp`).
- Adjusted `SocketContext::detach()` logging so that the `ContextSwitch` branch preserves per-context-tenure diagnostics (`Context Online Since`, `Context Online Duration`, `Context Total Queued`, `Context Total Processed`) while the `ConnectionClose` branch emits only a single detach-for-connection-close line; removed the misleading `Total Sent: {}` label (file: `src/core/socket/stream/SocketContext.cpp`).
- Added source-level regression coverage `tests/unit/log/SocketContextDetachPolicyTest.cpp` and registered it in `tests/unit/log/CMakeLists.txt`, and added `docs/logging/socketcontext-detach-logging-report.md` describing the problem, decision, and follow-ups.
- Preserved all behavioral constraints: socket lifecycle, counters and their calculations, attach/detach ordering and semantics (except for the explicit detach-reason parameter), callback ordering, HTTP/WebSocket/MQTT behavior, PR #168 redaction, PR #169 severity rules, LogManager behavior, and JSON schema.

### Testing

- Ran `clang-format` on touched files and performed repository search checks for the required logging/label patterns; the misleading `Total Sent` / `getTotalQueued()` pattern was removed.
- Configured and built with CMake (`-DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`) and the normal build completed successfully.
- Ran targeted and full unit test suites via `ctest`; focused tests including `SocketContextDetachPolicyTest`, `SocketServerClientMigration03Test`, `CoreRuntimeMigration04Test`, `HighFrequencyLoggingSeverityTest`, `SensitiveLoggingRedactionTest`, `SemanticEndToEndOutputTest`, and `FinalCleanupMigration09Test` passed, and the full `ctest` run completed with all reported tests passing (132 passed, 0 failed; some tests skipped by their own conditions).
- Performed an ASan build and ran the focused ASan tests for `SocketServerClientMigration03Test` and `SocketContextDetachPolicyTest`, and both ASan-targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e49413850832ca0046b5948a84e7f)