### PR TITLE
Add diagnostics for inner epoll failures

### DIFF
--- a/docs/logging/inner-epoll-diagnostics-report.md
+++ b/docs/logging/inner-epoll-diagnostics-report.md
@@ -1,0 +1,101 @@
+# Inner epoll diagnostics report
+
+## Problem summary
+
+`DescriptorEventPublisher::EPollEvents` owns the inner descriptor-publisher epoll dispatch path and previously consumed several epoll syscall failures without stable diagnostics. The missing checks covered `epoll_create1`, `epoll_ctl` ADD/DEL/MOD, and the non-blocking inner `epoll_wait(..., timeout=0)` drain.
+
+## Outer vs inner epoll distinction
+
+This change targets only the inner `DescriptorEventPublisher::EPollEvents` path. The outer event-loop monitor path still flows through `EventMultiplexer::monitorDescriptors()`, `waitForEvents()`, `TickStatus::TRACE`, and `EventLoop::start()` logging. No outer `EventMultiplexer`/`TickStatus` logic was rewritten.
+
+## Canonical recipe rule applied
+
+The implementation applies the semantic logging recipe at the boundary where each syscall failure is consumed: capture `errno` immediately after the failing syscall and log with `sysError` when the error is relevant.
+
+## Files inspected
+
+- `src/core/multiplexer/epoll/DescriptorEventPublisher.cpp`
+- `src/core/multiplexer/epoll/DescriptorEventPublisher.h`
+- `src/core/multiplexer/epoll/EventMultiplexer.cpp`
+- `src/core/EventMultiplexer.cpp`
+- `src/core/EventLoop.cpp`
+- `src/core/system/epoll.h`
+
+## epfd ownership/reference note
+
+`EPollEvents` keeps the existing caller-owned `int& epfd` model. The constructor still writes the `epoll_create1(EPOLL_CLOEXEC)` result through that reference; this report and implementation do not convert `epfd` into an owned value member.
+
+## interestCount unsigned/underflow note
+
+`interestCount` remains `std::vector<epoll_event>::size_type`, so it is unsigned. The deletion path now decrements it only after a successful DEL or tolerated `EBADF`, and only when it is greater than zero. Real DEL failures log and return without decrementing.
+
+## epoll_create1 handling
+
+The constructor checks the `epoll_create1` result. On failure, it immediately captures `errno`, logs one `sysError` diagnostic, leaves `epfd` invalid, and relies on follow-on invalid-epfd guards to avoid repeated syscall/log noise.
+
+## epoll_ctl ADD handling
+
+ADD success still increments `interestCount` and resizes the event vector as before. `EEXIST` still falls back to MOD. Other ADD failures now capture `errno` immediately and log a concise `sysError` with the fd.
+
+## epoll_ctl DEL handling
+
+DEL success and tolerated `EBADF` still complete cleanup accounting. Other DEL failures now capture `errno` immediately and log a concise `sysError` with the fd. The failure path returns before resizing or decrementing `interestCount`.
+
+## epoll_ctl MOD handling
+
+MOD now checks the return value, captures `errno` immediately on failure, and logs a concise `sysError` with the fd.
+
+## inner epoll_wait handling
+
+The inner non-blocking drain checks `count < 0`. It captures `errno` immediately, ignores `EINTR` at this layer, logs non-`EINTR` failures with `sysError`, and returns before dispatch.
+
+## Invalid epfd / log-storm behavior
+
+The create failure logs once in the constructor. Later ADD/DEL/MOD and drain calls return early when `epfd` is invalid, avoiding repeated invalid-fd syscall failures and per-tick log storms.
+
+## Implementation summary
+
+- Added a local framework/system `core.mux` `epoll` semantic logger helper to `DescriptorEventPublisher.cpp`.
+- Added `epoll_create1` return checking and diagnostics.
+- Added invalid-epfd guards for inner follow-on paths.
+- Added ADD/DEL/MOD failure diagnostics while preserving `EEXIST` and `EBADF` behavior.
+- Added non-`EINTR` inner wait failure diagnostics.
+- Preserved event dispatch ordering, timeout behavior, descriptor ownership, and outer epoll monitor behavior.
+
+## Tests added/updated
+
+- Added `tests/unit/log/InnerEpollDiagnosticsTest.cpp`, a source-level regression test for the inner epoll diagnostics contract.
+- Registered `InnerEpollDiagnosticsTest` in `tests/unit/log/CMakeLists.txt`.
+
+## Search commands run
+
+Before changes:
+
+```sh
+rg -n "epoll_create1|epoll_ctl|epoll_wait|epoll_pwait|TickStatus::TRACE|Core::EventLoop: _tick|sysError|errno" \
+  src/core/multiplexer/epoll src/core/EventMultiplexer.cpp src/core/EventLoop.cpp src/core/system \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "EPOLL_CTL_ADD|EPOLL_CTL_DEL|EPOLL_CTL_MOD|EEXIST|EBADF|EINTR|interestCount|epfd" \
+  src/core/multiplexer/epoll \
+  -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "epfd|interestCount|EPollEvents" \
+  src/core/multiplexer/epoll/DescriptorEventPublisher.cpp \
+  src/core/multiplexer/epoll/DescriptorEventPublisher.h
+```
+
+After changes, the same inner/outer epoll searches plus the required syscall, `interestCount`, sensitive logging, high-frequency logging, detach-policy, and legacy macro searches were run during validation.
+
+## Tests run
+
+- `git diff --check` passed.
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` passed after installing the missing `nlohmann-json3-dev` package required by the existing app configuration.
+- `cmake --build cmake-build --parallel 2` passed.
+- Focused logging/runtime `ctest` passed.
+- Full `ctest --test-dir cmake-build --output-on-failure` passed with the repository's skip-gated component tests reported as skipped.
+- Focused ASan configure/build/ctest passed for `CoreRuntimeMigration04Test` and `InnerEpollDiagnosticsTest`.
+
+## Known follow-ups
+
+1. PR E — broader syscall discipline audit.
+2. Final macro removal/source gate.
+3. Round 10 — book integration.

--- a/src/core/multiplexer/epoll/DescriptorEventPublisher.cpp
+++ b/src/core/multiplexer/epoll/DescriptorEventPublisher.cpp
@@ -45,6 +45,8 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/LogScopeOwner.h"
+#include "log/Logger.h"
 #include "utils/PreserveErrno.h"
 
 #include <cerrno>
@@ -53,51 +55,99 @@
 
 namespace core::multiplexer::epoll {
 
+    namespace {
+        const logger::LogScopeOwner& muxLogScope() {
+            static const logger::LogScopeOwner scope(logger::LogOrigin::Framework, logger::LogBoundary::System, "core.mux", "epoll");
+            return scope;
+        }
+
+        logger::BoundaryLogger muxLog() {
+            return muxLogScope().logger(logger::Logger::semanticSink());
+        }
+    } // namespace
+
     DescriptorEventPublisher::EPollEvents::EPollEvents(int& epfd, uint32_t events)
         : epfd(epfd)
         , events(events) {
         epfd = core::system::epoll_create1(EPOLL_CLOEXEC);
+        if (epfd < 0) {
+            const int errnum = errno;
+            muxLog().sysError(logger::LogLevel::Error, errnum, "core.mux epoll_create1 failed");
+        }
         ePollEvents.resize(1);
     }
 
     void DescriptorEventPublisher::EPollEvents::muxAdd(core::DescriptorEventReceiver* eventReceiver) {
         const utils::PreserveErrno preserveErrno;
 
+        if (epfd < 0) {
+            return;
+        }
+
         epoll_event ePollEvent{};
 
         ePollEvent.data.ptr = eventReceiver;
         ePollEvent.events = events;
 
-        if (core::system::epoll_ctl(epfd, EPOLL_CTL_ADD, eventReceiver->getRegisteredFd(), &ePollEvent) == 0) {
+        const int fd = eventReceiver->getRegisteredFd();
+        if (core::system::epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ePollEvent) == 0) {
             interestCount++;
 
             if (interestCount >= ePollEvents.size()) {
                 ePollEvents.resize(ePollEvents.size() * 2);
             }
-        } else if (errno == EEXIST) {
-            muxMod(eventReceiver->getRegisteredFd(), events, eventReceiver);
+        } else {
+            const int errnum = errno;
+            if (errnum == EEXIST) {
+                muxMod(fd, events, eventReceiver);
+            } else {
+                muxLog().sysError(logger::LogLevel::Error, errnum, "core.mux epoll_ctl ADD failed: fd={}", fd);
+            }
         }
     }
 
     void DescriptorEventPublisher::EPollEvents::muxDel(int fd) {
         const utils::PreserveErrno preserveErrno;
 
-        if (core::system::epoll_ctl(epfd, EPOLL_CTL_DEL, fd, nullptr) == 0 || errno == EBADF) {
-            interestCount--;
+        if (epfd < 0) {
+            return;
+        }
 
-            if (ePollEvents.size() > (interestCount * 2) + 1) {
-                ePollEvents.resize(ePollEvents.size() / 2);
-                ePollEvents.shrink_to_fit();
+        if (core::system::epoll_ctl(epfd, EPOLL_CTL_DEL, fd, nullptr) == 0) {
+            if (interestCount > 0) {
+                interestCount--;
             }
+        } else {
+            const int errnum = errno;
+            if (errnum == EBADF) {
+                if (interestCount > 0) {
+                    interestCount--;
+                }
+            } else {
+                muxLog().sysError(logger::LogLevel::Error, errnum, "core.mux epoll_ctl DEL failed: fd={}", fd);
+                return;
+            }
+        }
+
+        if (ePollEvents.size() > (interestCount * 2) + 1) {
+            ePollEvents.resize(ePollEvents.size() / 2);
+            ePollEvents.shrink_to_fit();
         }
     }
 
     void DescriptorEventPublisher::EPollEvents::muxMod(int fd, uint32_t events, core::DescriptorEventReceiver* eventReceiver) const {
         const utils::PreserveErrno preserveErrno;
 
+        if (epfd < 0) {
+            return;
+        }
+
         epoll_event ePollEvent{events, {eventReceiver}};
 
-        core::system::epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &ePollEvent);
+        if (core::system::epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &ePollEvent) != 0) {
+            const int errnum = errno;
+            muxLog().sysError(logger::LogLevel::Error, errnum, "core.mux epoll_ctl MOD failed: fd={}", fd);
+        }
     }
 
     void DescriptorEventPublisher::EPollEvents::muxOn(core::DescriptorEventReceiver* eventReceiver) {
@@ -143,7 +193,19 @@ namespace core::multiplexer::epoll {
     }
 
     void DescriptorEventPublisher::spanActiveEvents() {
+        if (ePollEvents.getEPFd() < 0) {
+            return;
+        }
+
         const int count = core::system::epoll_wait(ePollEvents.getEPFd(), ePollEvents.getEvents(), ePollEvents.getInterestCount(), 0);
+        if (count < 0) {
+            const int errnum = errno;
+            if (errnum != EINTR) {
+                muxLog().sysError(
+                    logger::LogLevel::Error, errnum, "core.mux epoll_wait failed: interestCount={}", ePollEvents.getInterestCount());
+            }
+            return;
+        }
 
         for (int i = 0; i < count; i++) {
             const epoll_event& ev = ePollEvents.getEvents()[i];

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -130,3 +130,7 @@ set_tests_properties(SensitiveLoggingRedactionTest PROPERTIES LABELS "unit;log;s
 snodec_add_test(HighFrequencyLoggingSeverityTest HighFrequencyLoggingSeverityTest.cpp)
 target_compile_features(HighFrequencyLoggingSeverityTest PRIVATE cxx_std_20)
 set_tests_properties(HighFrequencyLoggingSeverityTest PROPERTIES LABELS "unit;log;severity")
+
+snodec_add_test(InnerEpollDiagnosticsTest InnerEpollDiagnosticsTest.cpp)
+target_compile_features(InnerEpollDiagnosticsTest PRIVATE cxx_std_20)
+set_tests_properties(InnerEpollDiagnosticsTest PROPERTIES LABELS "unit;log;epoll")

--- a/tests/unit/log/InnerEpollDiagnosticsTest.cpp
+++ b/tests/unit/log/InnerEpollDiagnosticsTest.cpp
@@ -1,0 +1,94 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+    std::filesystem::path projectRoot() {
+        if (const char* sourceDir = std::getenv("SNODEC_SOURCE_DIR")) {
+            return sourceDir;
+        }
+
+        std::filesystem::path current = std::filesystem::current_path();
+        while (!current.empty()) {
+            if (std::filesystem::exists(current / "src" / "core" / "multiplexer" / "epoll" / "DescriptorEventPublisher.cpp")) {
+                return current;
+            }
+            current = current.parent_path();
+        }
+
+        return std::filesystem::current_path();
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream input(path);
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        return buffer.str();
+    }
+
+    bool contains(std::string_view haystack, std::string_view needle) {
+        return haystack.find(needle) != std::string_view::npos;
+    }
+
+    bool requireContains(std::string_view source, std::string_view fragment, std::string_view description) {
+        if (contains(source, fragment)) {
+            return true;
+        }
+
+        std::cerr << "Missing inner epoll diagnostic evidence: " << description << "\nExpected fragment: " << fragment << '\n';
+        return false;
+    }
+
+    bool requireAbsent(std::string_view source, std::string_view fragment, std::string_view description) {
+        if (!contains(source, fragment)) {
+            return true;
+        }
+
+        std::cerr << "Forbidden inner epoll diagnostic pattern: " << description << "\nForbidden fragment: " << fragment << '\n';
+        return false;
+    }
+
+} // namespace
+
+int main() {
+    const std::filesystem::path sourcePath = projectRoot() / "src" / "core" / "multiplexer" / "epoll" / "DescriptorEventPublisher.cpp";
+    const std::string source = readFile(sourcePath);
+    if (source.empty()) {
+        std::cerr << "Unable to read " << sourcePath << '\n';
+        return 1;
+    }
+
+    bool ok = true;
+    ok &= requireContains(source, "epfd = core::system::epoll_create1(EPOLL_CLOEXEC);", "inner epoll_create1 call remains local");
+    ok &= requireContains(source, "if (epfd < 0)", "invalid epfd guard after create and before follow-on syscalls");
+    ok &= requireContains(source, "core.mux epoll_create1 failed", "epoll_create1 failure is logged");
+    ok &= requireContains(source, "const int errnum = errno;", "errno is captured immediately for failing syscalls");
+    ok &= requireContains(source, "EPOLL_CTL_ADD", "ADD operation remains explicit");
+    ok &= requireContains(source, "errnum == EEXIST", "EEXIST ADD fallback is preserved");
+    ok &= requireContains(source, "core.mux epoll_ctl ADD failed: fd={}", "ADD failures other than EEXIST are logged");
+    ok &= requireContains(source, "EPOLL_CTL_DEL", "DEL operation remains explicit");
+    ok &= requireContains(source, "errnum == EBADF", "EBADF cleanup tolerance is preserved");
+    ok &= requireContains(source, "core.mux epoll_ctl DEL failed: fd={}", "DEL failures other than EBADF are logged");
+    ok &= requireContains(source, "EPOLL_CTL_MOD", "MOD operation remains explicit");
+    ok &= requireContains(source, "core.mux epoll_ctl MOD failed: fd={}", "MOD failures are logged");
+    ok &= requireContains(source, "const int count = core::system::epoll_wait", "inner non-blocking epoll_wait remains local");
+    ok &= requireContains(source, "if (count < 0)", "epoll_wait failure count is checked");
+    ok &= requireContains(source, "errnum != EINTR", "EINTR wait failures are not escalated as system errors");
+    ok &= requireContains(source, "core.mux epoll_wait failed: interestCount={}", "non-EINTR wait failures are logged");
+    ok &= requireContains(source, ".sysError(logger::LogLevel::Error, errnum", "errno-backed sysError diagnostics are used");
+    ok &= requireContains(source, "if (interestCount > 0)", "unsigned interestCount decrement is guarded");
+
+    ok &= requireAbsent(source,
+                        "core.mux epoll_ctl DEL failed: fd={}\", fd);\n                interestCount--",
+                        "real DEL failure path must not decrement unsigned interestCount");
+    ok &= requireAbsent(source, "--interestCount", "raw pre-decrement can underflow unsigned interestCount");
+    ok &= requireAbsent(source, "interestCount -=", "compound decrement can underflow unsigned interestCount");
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
### Motivation

- Fix a syscall/logging gap in the inner epoll dispatch used by `DescriptorEventPublisher::EPollEvents` so failures are not silently consumed.  The inner path includes `epoll_create1`, `epoll_ctl` (ADD/DEL/MOD) and the non-blocking inner `epoll_wait(..., 0)` drain. 
- Preserve existing architecture and invariants: do not change the outer `EventMultiplexer`/`TickStatus` path, do not change `epfd` ownership (it remains a caller-owned `int&`), do not alter dispatch ordering, or poll/select multiplexers.

### Description

- Added a local semantic logger helper for `core.mux`/`epoll` in `src/core/multiplexer/epoll/DescriptorEventPublisher.cpp` and used `sysError` for errno-backed diagnostics.  
- Check and log `epoll_create1` return value, capture `errno` immediately on failure, and leave `epfd` invalid while adding guards so follow-on calls return early and avoid log storms.  
- Make `epoll_ctl` calls robust: preserve `EEXIST -> MOD` fallback for `ADD`, preserve tolerated `EBADF` behavior for `DEL`, and for all other `ADD`/`DEL`/`MOD` failures capture `errno` and log via `sysError` without decrementing `interestCount` on real DEL failures; guard unsigned `interestCount` decrements so underflow cannot occur.  
- Check inner non-blocking `epoll_wait` result (`count < 0`), capture `errno` immediately, ignore `EINTR` at this layer, and log other errors with `sysError` before returning.  
- Add documentation and source-level regression test artifacts: `docs/logging/inner-epoll-diagnostics-report.md`, `tests/unit/log/InnerEpollDiagnosticsTest.cpp`, and register the test in `tests/unit/log/CMakeLists.txt` (no other files were modified). 

### Testing

- Ran `git diff --check`; no whitespace/format issues were reported.  
- Configured and built with `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build --parallel 2` (missing existing repo dependency `nlohmann-json3-dev` was installed during validation); build succeeded.  
- Ran focused tests via `ctest --test-dir cmake-build -R "InnerEpollDiagnosticsTest|CoreRuntimeMigration04Test|SocketContextDetachPolicyTest|HighFrequencyLoggingSeverityTest|SensitiveLoggingRedactionTest|SemanticEndToEndOutputTest|FinalCleanupMigration09Test" --output-on-failure` and all targeted tests passed.  
- Ran full `ctest --test-dir cmake-build --output-on-failure` and observed all tests pass (skip-gated component tests reported as skipped by the existing test harness).  
- Built ASan variant and ran focused ASan tests for `CoreRuntimeMigration04Test` and `InnerEpollDiagnosticsTest`; both ASan-focused tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e6c2bed1c832c8f051539d6a867f7)