### PR TITLE
Tighten remaining syscall diagnostics

### DIFF
--- a/docs/logging/broader-syscall-discipline-report.md
+++ b/docs/logging/broader-syscall-discipline-report.md
@@ -1,0 +1,101 @@
+# Broader syscall discipline report
+
+## Problem summary
+
+PR E audits the remaining concrete syscall diagnostics outside the PR #171 inner `DescriptorEventPublisher::EPollEvents` path. The main gaps were unchecked outer epoll setup syscalls and unchecked EventLoop signal syscalls. Poll/select outer wait behavior was inspected and documented rather than rewritten.
+
+## Canonical recipe rule applied
+
+System call failures must be logged at the boundary where they are consumed, `errno` must be captured immediately after the failing syscall, errno-bearing failures use `sysError`, duplicate/follow-on setup noise is avoided, and success-looking lifecycle diagnostics must not be emitted after setup failure.
+
+## Files inspected
+
+- `src/core/multiplexer/epoll/EventMultiplexer.cpp`
+- `src/core/multiplexer/epoll/DescriptorEventPublisher.cpp`
+- `src/core/multiplexer/epoll/DescriptorEventPublisher.h`
+- `src/core/multiplexer/poll/EventMultiplexer.cpp`
+- `src/core/multiplexer/poll/DescriptorEventPublisher.cpp`
+- `src/core/multiplexer/poll/EventMultiplexer.h`
+- `src/core/multiplexer/select/EventMultiplexer.cpp`
+- `src/core/multiplexer/select/DescriptorEventPublisher.cpp`
+- `src/core/multiplexer/select/EventMultiplexer.h`
+- `src/core/EventMultiplexer.cpp`
+- `src/core/EventLoop.cpp`
+- `src/core/system/epoll.h` and `src/core/system/epoll.cpp`
+- `src/core/system/poll.h` and `src/core/system/poll.cpp`
+- `src/core/system/select.h` and `src/core/system/select.cpp`
+- `utils/system/signal.h` as the available signal helper header; no `src/core/system/signal.h` exists in this tree.
+
+## Outer epoll setup findings
+
+The outer epoll multiplexer created its top-level epoll descriptor in the constructor initializer list and then unconditionally issued three `EPOLL_CTL_ADD` registrations. The `epoll_create1` result and the three `epoll_ctl` results were previously ignored, and the final `Core::multiplexer: epoll` debug line was emitted even if setup failed.
+
+## Outer epoll implementation summary
+
+The constructor now checks `epfd` as the first constructor-body action. If creation failed, it captures `errno` immediately, logs a critical `sysError` for `Core::multiplexer epoll_create1 failed`, leaves the invalid descriptor in place, and returns without issuing follow-on `epoll_ctl` calls.
+
+Each outer publisher registration now goes through a small local helper that checks `core::system::epoll_ctl(epfd, EPOLL_CTL_ADD, ...)`, captures `errno` immediately on failure, and logs `Core::multiplexer epoll_ctl ADD failed: fd=... publisher=...` with `sysError`.
+
+## Outer epoll success-log gating note
+
+The success-looking `Core::multiplexer: epoll` debug line is emitted only when all three outer setup registrations succeed. It is not emitted after failed `epoll_create1` and is not emitted after a failed outer `EPOLL_CTL_ADD` registration.
+
+## Signal syscall findings
+
+`EventLoop::init()`, `EventLoop::_tick()`, `EventLoop::tick()`, and `EventLoop::start()` contained multiple unchecked `sigemptyset`, `sigaddset`, `sigaction`, and `sigprocmask` calls. These calls are bounded setup/restore or tick-boundary operations where failure matters for diagnostics.
+
+## Signal syscall implementation summary
+
+Small local helpers now check signal syscall return values, capture `errno` immediately on failure, and log EventLoop `sysError` diagnostics including the syscall, signal where applicable, and phase. The implementation intentionally continues after logging, matching the prior best-effort behavior while adding diagnostics.
+
+## Signal ordering preservation note
+
+Signal install and restore call order was preserved. In particular, the `start()` restore path still restores `SIGPIPE`, `SIGTERM`, `SIGALRM`, and `SIGHUP`, then calls `free()`, then restores `SIGINT` last.
+
+## Poll/select outer wait assessment
+
+Poll and select multiplexers were inspected and left unchanged. Poll still uses `core::system::ppoll(...)` directly in `poll::EventMultiplexer::monitorDescriptors()`. Select still uses `core::system::pselect(...)` directly in `select::EventMultiplexer::monitorDescriptors()`. Epoll still uses `core::system::epoll_pwait(...)` directly in `epoll::EventMultiplexer::monitorDescriptors()`.
+
+## Poll/select errno preservation verification
+
+The backend `monitorDescriptors()` implementations return the syscall result directly. The `core::system` wrappers set `errno = 0` and directly return the libc call. The generic `EventMultiplexer::waitForEvents()` assigns `activeDescriptorCount = monitorDescriptors(...)` and immediately checks `activeDescriptorCount < 0`; no intervening code runs between the syscall return and the `errno` classification. `EINTR` maps to `TickStatus::INTERRUPTED`; other negative results map to `TickStatus::TRACE`, which `EventLoop::start()` logs with `sysError`. No poll/select errno-preservation gap was found.
+
+## Inner epoll PR #171 verification
+
+The inner epoll path still checks/logs inner `epoll_create1`, `EPOLL_CTL_ADD`, `EPOLL_CTL_DEL`, `EPOLL_CTL_MOD`, and non-`EINTR` `epoll_wait` failures. The `EEXIST` and `EBADF` behavior remains present, invalid-epfd guards remain present, and `interestCount` decrement remains guarded.
+
+## Descriptor-precondition notes for poll/select
+
+`select::FdSet::set()`, `clr()`, and `isSet()` call `FD_SET`, `FD_CLR`, and `FD_ISSET` without local fd-range guards. `poll::PollFdsManager::muxDel()`, `muxOn()`, and `muxOff()` assume a descriptor exists in `pollFdIndices` before dereferencing lookup results. These are descriptor-container/precondition hardening concerns rather than errno-bearing syscall diagnostics, so they were left for a later focused PR.
+
+## Invalid setup / log-storm behavior
+
+If outer `epoll_create1` fails, PR E logs exactly that setup failure and skips the three outer `EPOLL_CTL_ADD` calls, avoiding three predictable follow-on `EBADF` logs. If an outer `EPOLL_CTL_ADD` fails after a valid outer epoll descriptor is created, only that concrete registration failure is logged, and the success-looking debug line is withheld.
+
+## Tests added/updated
+
+- Added `tests/unit/log/BroaderSyscallDisciplineTest.cpp` as a source-level regression test for outer epoll setup diagnostics, EventLoop signal syscall diagnostics, poll/select direct monitor paths, direct core system wrappers, and inner epoll PR #171 diagnostic evidence.
+- Registered `BroaderSyscallDisciplineTest` in `tests/unit/log/CMakeLists.txt`.
+
+## Search commands run
+
+- `rg -n "epoll_create1|epoll_ctl|epoll_wait|epoll_pwait|ppoll|pselect|select\\(|poll\\(|sigaction|sigprocmask|sigemptyset|sigaddset|sysError|errno" src/core -g '*.h' -g '*.hpp' -g '*.cpp'`
+- `rg -n "FD_SET|FD_CLR|FD_ISSET|FD_ZERO|pollFdIndices\\.find|pollFdIndices\\[|interestCount|epfd|TickStatus::TRACE" src/core/multiplexer src/core/EventMultiplexer.cpp src/core/EventLoop.cpp -g '*.h' -g '*.hpp' -g '*.cpp'`
+- `rg -n "sigaction\\(|sigprocmask\\(|sigemptyset\\(|sigaddset\\(" src/core -g '*.h' -g '*.hpp' -g '*.cpp'`
+- Post-change syscall, signal, sensitive logging, high-frequency logging, SocketContext detach, inner epoll, and legacy macro regression searches requested for PR E.
+
+## Tests run
+
+- `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`
+- `cmake --build cmake-build --parallel 2`
+- `ctest --test-dir cmake-build -R "BroaderSyscallDisciplineTest|InnerEpollDiagnosticsTest|CoreRuntimeMigration04Test|SocketContextDetachPolicyTest|HighFrequencyLoggingSeverityTest|SensitiveLoggingRedactionTest|SemanticEndToEndOutputTest|FinalCleanupMigration09Test" --output-on-failure`
+- `ctest --test-dir cmake-build --output-on-failure`
+- `cmake -S . -B cmake-build-asan -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON -DSNODEC_ENABLE_ASAN=ON`
+- `cmake --build cmake-build-asan --parallel 2 --target CoreRuntimeMigration04Test BroaderSyscallDisciplineTest InnerEpollDiagnosticsTest`
+- `ASAN=$(gcc -print-file-name=libasan.so) LD_PRELOAD=$ASAN ctest --test-dir cmake-build-asan -R "CoreRuntimeMigration04Test|BroaderSyscallDisciplineTest|InnerEpollDiagnosticsTest" --output-on-failure`
+
+## Known follow-ups
+
+1. Final macro removal/source gate.
+2. Round 10 — book integration.
+3. Optional: descriptor-container/precondition hardening for poll/select.

--- a/src/core/EventLoop.cpp
+++ b/src/core/EventLoop.cpp
@@ -62,6 +62,48 @@ namespace core {
     unsigned long EventLoop::tickCounter = 0;
     core::State EventLoop::eventLoopState = State::LOADED;
 
+    namespace {
+        std::string signalName(int signum) {
+            std::string signal = "SIG" + utils::system::sigabbrev_np(signum);
+            if (signal == "SIGUNKNOWN") {
+                signal += "(" + std::to_string(signum) + ")";
+            }
+            return signal;
+        }
+
+        bool logSignalFailure(int result, const char* syscall, const char* phase) {
+            if (result == 0) {
+                return true;
+            }
+
+            const int errnum = errno;
+            EventLoop::instance().log().sysError(logger::LogLevel::Error, errnum, "Core::EventLoop {} failed: phase={}", syscall, phase);
+            return false;
+        }
+
+        bool logSigactionFailure(int result, int signum, const char* phase) {
+            if (result == 0) {
+                return true;
+            }
+
+            const int errnum = errno;
+            EventLoop::instance().log().sysError(
+                logger::LogLevel::Error, errnum, "Core::EventLoop sigaction failed: signal={} phase={}", signalName(signum), phase);
+            return false;
+        }
+
+        bool logSigaddsetFailure(int result, int signum, const char* phase) {
+            if (result == 0) {
+                return true;
+            }
+
+            const int errnum = errno;
+            EventLoop::instance().log().sysError(
+                logger::LogLevel::Error, errnum, "Core::EventLoop sigaddset failed: signal={} phase={}", signalName(signum), phase);
+            return false;
+        }
+    } // namespace
+
     static std::string getTickCounterAsString() {
         std::string tick = std::to_string(EventLoop::getTickCounter());
 
@@ -107,24 +149,24 @@ namespace core {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, hicpp-avoid-c-arrays, modernize-avoid-c-arrays)
     bool EventLoop::init(int argc, char* argv[]) {
         struct sigaction sact{};
-        sigemptyset(&sact.sa_mask);
+        logSignalFailure(sigemptyset(&sact.sa_mask), "sigemptyset", "init-install-mask");
         sact.sa_flags = 0;
         sact.sa_handler = SIG_IGN;
 
         struct sigaction oldPipeAct{};
-        sigaction(SIGPIPE, &sact, &oldPipeAct);
+        logSigactionFailure(sigaction(SIGPIPE, &sact, &oldPipeAct), SIGPIPE, "init-install-ignore");
 
         struct sigaction oldIntAct{};
-        sigaction(SIGINT, &sact, &oldIntAct);
+        logSigactionFailure(sigaction(SIGINT, &sact, &oldIntAct), SIGINT, "init-install-ignore");
 
         struct sigaction oldTermAct{};
-        sigaction(SIGTERM, &sact, &oldTermAct);
+        logSigactionFailure(sigaction(SIGTERM, &sact, &oldTermAct), SIGTERM, "init-install-ignore");
 
         struct sigaction oldAlarmAct{};
-        sigaction(SIGALRM, &sact, &oldAlarmAct);
+        logSigactionFailure(sigaction(SIGALRM, &sact, &oldAlarmAct), SIGALRM, "init-install-ignore");
 
         struct sigaction oldHupAct{};
-        sigaction(SIGHUP, &sact, &oldHupAct);
+        logSigactionFailure(sigaction(SIGHUP, &sact, &oldHupAct), SIGHUP, "init-install-ignore");
 
         logger::Logger::setTickResolver(core::getTickCounterAsString);
 
@@ -134,11 +176,11 @@ namespace core {
             EventLoop::instance().log().trace("SNode.C: Starting ... HELLO");
         }
 
-        sigaction(SIGPIPE, &oldPipeAct, nullptr);
-        sigaction(SIGINT, &oldIntAct, nullptr);
-        sigaction(SIGTERM, &oldTermAct, nullptr);
-        sigaction(SIGALRM, &oldAlarmAct, nullptr);
-        sigaction(SIGHUP, &oldHupAct, nullptr);
+        logSigactionFailure(sigaction(SIGPIPE, &oldPipeAct, nullptr), SIGPIPE, "init-restore");
+        logSigactionFailure(sigaction(SIGINT, &oldIntAct, nullptr), SIGINT, "init-restore");
+        logSigactionFailure(sigaction(SIGTERM, &oldTermAct, nullptr), SIGTERM, "init-restore");
+        logSigactionFailure(sigaction(SIGALRM, &oldAlarmAct, nullptr), SIGALRM, "init-restore");
+        logSigactionFailure(sigaction(SIGHUP, &oldHupAct, nullptr), SIGHUP, "init-restore");
 
         return eventLoopState == State::INITIALIZED;
     }
@@ -149,19 +191,20 @@ namespace core {
         tickCounter++;
 
         sigset_t newSet{};
-        sigaddset(&newSet, SIGINT);
-        sigaddset(&newSet, SIGTERM);
-        sigaddset(&newSet, SIGALRM);
-        sigaddset(&newSet, SIGHUP);
+        logSignalFailure(sigemptyset(&newSet), "sigemptyset", "tick-block-mask");
+        logSigaddsetFailure(sigaddset(&newSet, SIGINT), SIGINT, "tick-block-mask");
+        logSigaddsetFailure(sigaddset(&newSet, SIGTERM), SIGTERM, "tick-block-mask");
+        logSigaddsetFailure(sigaddset(&newSet, SIGALRM), SIGALRM, "tick-block-mask");
+        logSigaddsetFailure(sigaddset(&newSet, SIGHUP), SIGHUP, "tick-block-mask");
 
         sigset_t oldSet{};
-        sigprocmask(SIG_BLOCK, &newSet, &oldSet);
+        logSignalFailure(sigprocmask(SIG_BLOCK, &newSet, &oldSet), "sigprocmask", "tick-block");
 
         if (eventLoopState == State::RUNNING || eventLoopState == State::STOPPING) {
             tickStatus = eventMultiplexer.tick(timeOut, oldSet);
         }
 
-        sigprocmask(SIG_SETMASK, &oldSet, nullptr);
+        logSignalFailure(sigprocmask(SIG_SETMASK, &oldSet, nullptr), "sigprocmask", "tick-restore");
 
         return tickStatus;
     }
@@ -171,16 +214,16 @@ namespace core {
 
         if (eventLoopState == State::INITIALIZED) {
             struct sigaction sact{};
-            sigemptyset(&sact.sa_mask);
+            logSignalFailure(sigemptyset(&sact.sa_mask), "sigemptyset", "tick-install-mask");
             sact.sa_flags = 0;
             sact.sa_handler = SIG_IGN;
 
             struct sigaction oldPipeAct{};
-            sigaction(SIGPIPE, &sact, &oldPipeAct);
+            logSigactionFailure(sigaction(SIGPIPE, &sact, &oldPipeAct), SIGPIPE, "tick-install-ignore");
 
             tickStatus = EventLoop::instance()._tick(timeOut);
 
-            sigaction(SIGPIPE, &oldPipeAct, nullptr);
+            logSigactionFailure(sigaction(SIGPIPE, &oldPipeAct, nullptr), SIGPIPE, "tick-restore");
         } else {
             EventLoop::instance().eventMultiplexer.clearEventQueue();
             free();
@@ -197,26 +240,26 @@ namespace core {
 
     int EventLoop::start(const utils::Timeval& timeOut) {
         struct sigaction sact{};
-        sigemptyset(&sact.sa_mask);
+        logSignalFailure(sigemptyset(&sact.sa_mask), "sigemptyset", "start-install-mask");
         sact.sa_flags = 0;
         sact.sa_handler = SIG_IGN;
 
         struct sigaction oldPipeAct{};
-        sigaction(SIGPIPE, &sact, &oldPipeAct);
+        logSigactionFailure(sigaction(SIGPIPE, &sact, &oldPipeAct), SIGPIPE, "start-install-ignore");
 
         sact.sa_handler = EventLoop::stoponsig;
 
         struct sigaction oldIntAct{};
-        sigaction(SIGINT, &sact, &oldIntAct);
+        logSigactionFailure(sigaction(SIGINT, &sact, &oldIntAct), SIGINT, "start-install-handler");
 
         struct sigaction oldTermAct{};
-        sigaction(SIGTERM, &sact, &oldTermAct);
+        logSigactionFailure(sigaction(SIGTERM, &sact, &oldTermAct), SIGTERM, "start-install-handler");
 
         struct sigaction oldAlarmAct{};
-        sigaction(SIGALRM, &sact, &oldAlarmAct);
+        logSigactionFailure(sigaction(SIGALRM, &sact, &oldAlarmAct), SIGALRM, "start-install-handler");
 
         struct sigaction oldHupAct{};
-        sigaction(SIGHUP, &sact, &oldHupAct);
+        logSigactionFailure(sigaction(SIGHUP, &sact, &oldHupAct), SIGHUP, "start-install-handler");
 
         if (eventLoopState == State::INITIALIZED) {
             if (utils::Config::bootstrap()) {
@@ -251,14 +294,14 @@ namespace core {
             stopsig = -1;
         }
 
-        sigaction(SIGPIPE, &oldPipeAct, nullptr);
-        sigaction(SIGTERM, &oldTermAct, nullptr);
-        sigaction(SIGALRM, &oldAlarmAct, nullptr);
-        sigaction(SIGHUP, &oldHupAct, nullptr);
+        logSigactionFailure(sigaction(SIGPIPE, &oldPipeAct, nullptr), SIGPIPE, "start-restore");
+        logSigactionFailure(sigaction(SIGTERM, &oldTermAct, nullptr), SIGTERM, "start-restore");
+        logSigactionFailure(sigaction(SIGALRM, &oldAlarmAct, nullptr), SIGALRM, "start-restore");
+        logSigactionFailure(sigaction(SIGHUP, &oldHupAct, nullptr), SIGHUP, "start-restore");
 
         free();
 
-        sigaction(SIGINT, &oldIntAct, nullptr);
+        logSigactionFailure(sigaction(SIGINT, &oldIntAct, nullptr), SIGINT, "start-restore");
 
         return -stopsig;
     }

--- a/src/core/multiplexer/epoll/EventMultiplexer.cpp
+++ b/src/core/multiplexer/epoll/EventMultiplexer.cpp
@@ -50,6 +50,7 @@
 #include "utils/Timeval.h"
 
 #include <array>
+#include <cerrno>
 #include <string>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -71,6 +72,21 @@ namespace core::multiplexer::epoll {
         logger::BoundaryLogger muxLog() {
             return muxLogScope().logger(logger::Logger::semanticSink());
         }
+
+        bool addPublisherToOuterEpoll(int epfd, int publisherFd, core::DescriptorEventPublisher* publisher, const char* publisherName) {
+            epoll_event event{};
+            event.events = EPOLLIN;
+            event.data.ptr = publisher;
+
+            if (core::system::epoll_ctl(epfd, EPOLL_CTL_ADD, publisherFd, &event) == 0) {
+                return true;
+            }
+
+            const int errnum = errno;
+            muxLog().sysError(
+                logger::LogLevel::Error, errnum, "Core::multiplexer epoll_ctl ADD failed: fd={} publisher={}", publisherFd, publisherName);
+            return false;
+        }
     } // namespace
 
     EventMultiplexer::EventMultiplexer()
@@ -87,19 +103,23 @@ namespace core::multiplexer::epoll {
                                                                                         EPOLLPRI,
                                                                                         EPOLLPRI))
         , epfd(core::system::epoll_create1(EPOLL_CLOEXEC)) {
-        epoll_event event{};
-        event.events = EPOLLIN;
+        if (epfd < 0) {
+            const int errnum = errno;
+            muxLog().sysError(logger::LogLevel::Critical, errnum, "Core::multiplexer epoll_create1 failed");
+            return;
+        }
 
-        event.data.ptr = descriptorEventPublishers[core::EventMultiplexer::DISP_TYPE::RD];
-        core::system::epoll_ctl(epfd, EPOLL_CTL_ADD, epfds[core::EventMultiplexer::DISP_TYPE::RD], &event);
+        bool setupSucceeded = true;
+        setupSucceeded &= addPublisherToOuterEpoll(
+            epfd, epfds[core::EventMultiplexer::DISP_TYPE::RD], descriptorEventPublishers[core::EventMultiplexer::DISP_TYPE::RD], "READ");
+        setupSucceeded &= addPublisherToOuterEpoll(
+            epfd, epfds[core::EventMultiplexer::DISP_TYPE::WR], descriptorEventPublishers[core::EventMultiplexer::DISP_TYPE::WR], "WRITE");
+        setupSucceeded &= addPublisherToOuterEpoll(
+            epfd, epfds[core::EventMultiplexer::DISP_TYPE::EX], descriptorEventPublishers[core::EventMultiplexer::DISP_TYPE::EX], "EXCEPT");
 
-        event.data.ptr = descriptorEventPublishers[core::EventMultiplexer::DISP_TYPE::WR];
-        core::system::epoll_ctl(epfd, EPOLL_CTL_ADD, epfds[core::EventMultiplexer::DISP_TYPE::WR], &event);
-
-        event.data.ptr = descriptorEventPublishers[core::EventMultiplexer::DISP_TYPE::EX];
-        core::system::epoll_ctl(epfd, EPOLL_CTL_ADD, epfds[core::EventMultiplexer::DISP_TYPE::EX], &event);
-
-        muxLog().debug("Core::multiplexer: epoll");
+        if (setupSucceeded) {
+            muxLog().debug("Core::multiplexer: epoll");
+        }
     }
 
     int EventMultiplexer::monitorDescriptors(utils::Timeval& tickTimeout, const sigset_t& sigMask) {

--- a/tests/unit/log/BroaderSyscallDisciplineTest.cpp
+++ b/tests/unit/log/BroaderSyscallDisciplineTest.cpp
@@ -1,0 +1,130 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+namespace {
+
+    std::filesystem::path projectRoot() {
+        if (const char* sourceDir = std::getenv("SNODEC_SOURCE_DIR")) {
+            return sourceDir;
+        }
+
+        std::filesystem::path current = std::filesystem::current_path();
+        while (!current.empty()) {
+            if (std::filesystem::exists(current / "src" / "core" / "EventLoop.cpp")) {
+                return current;
+            }
+            current = current.parent_path();
+        }
+
+        return std::filesystem::current_path();
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream input(path);
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        return buffer.str();
+    }
+
+    bool contains(std::string_view haystack, std::string_view needle) {
+        return haystack.find(needle) != std::string_view::npos;
+    }
+
+    bool ordered(std::string_view source, std::initializer_list<std::string_view> fragments) {
+        std::size_t pos = 0;
+        for (const std::string_view fragment : fragments) {
+            pos = source.find(fragment, pos);
+            if (pos == std::string_view::npos) {
+                return false;
+            }
+            pos += fragment.size();
+        }
+        return true;
+    }
+
+    bool requireContains(std::string_view source, std::string_view fragment, std::string_view description) {
+        if (contains(source, fragment)) {
+            return true;
+        }
+
+        std::cerr << "Missing broader syscall discipline evidence: " << description << "\nExpected fragment: " << fragment << '\n';
+        return false;
+    }
+
+    bool requireOrdered(std::string_view source, std::initializer_list<std::string_view> fragments, std::string_view description) {
+        if (ordered(source, fragments)) {
+            return true;
+        }
+
+        std::cerr << "Missing broader syscall discipline ordering evidence: " << description << '\n';
+        return false;
+    }
+
+} // namespace
+
+int main() {
+    const std::filesystem::path root = projectRoot();
+    const std::string epollMux = readFile(root / "src" / "core" / "multiplexer" / "epoll" / "EventMultiplexer.cpp");
+    const std::string eventLoop = readFile(root / "src" / "core" / "EventLoop.cpp");
+    const std::string innerEpoll = readFile(root / "src" / "core" / "multiplexer" / "epoll" / "DescriptorEventPublisher.cpp");
+    const std::string pollMux = readFile(root / "src" / "core" / "multiplexer" / "poll" / "EventMultiplexer.cpp");
+    const std::string selectMux = readFile(root / "src" / "core" / "multiplexer" / "select" / "EventMultiplexer.cpp");
+    const std::string epollWrapper = readFile(root / "src" / "core" / "system" / "epoll.cpp");
+    const std::string pollWrapper = readFile(root / "src" / "core" / "system" / "poll.cpp");
+    const std::string selectWrapper = readFile(root / "src" / "core" / "system" / "select.cpp");
+    const std::string coreMux = readFile(root / "src" / "core" / "EventMultiplexer.cpp");
+
+    bool ok = true;
+    ok &= requireContains(epollMux, ", epfd(core::system::epoll_create1(EPOLL_CLOEXEC))", "outer epoll_create1 remains in the initializer");
+    ok &= requireOrdered(epollMux,
+                         {"epfd(core::system::epoll_create1(EPOLL_CLOEXEC)) {",
+                          "if (epfd < 0)",
+                          "const int errnum = errno;",
+                          "Core::multiplexer epoll_create1 failed",
+                          "return;"},
+                         "outer epoll_create1 is checked first and skips follow-on ctl calls");
+    ok &= requireContains(epollMux, "core::system::epoll_ctl(epfd, EPOLL_CTL_ADD", "outer epoll_ctl ADD calls remain explicit");
+    ok &= requireContains(epollMux,
+                          "Core::multiplexer epoll_ctl ADD failed: fd={} publisher={}",
+                          "outer epoll_ctl ADD failures are logged with fd and publisher");
+    ok &= requireOrdered(
+        epollMux,
+        {"bool setupSucceeded = true;", "setupSucceeded &= addPublisherToOuterEpoll", "if (setupSucceeded)", "Core::multiplexer: epoll"},
+        "outer epoll success-looking debug line is gated on setup success");
+
+    ok &= requireContains(eventLoop, "logSignalFailure(sigemptyset", "sigemptyset return values are checked");
+    ok &= requireContains(eventLoop, "logSigaddsetFailure(sigaddset", "sigaddset return values are checked");
+    ok &= requireContains(eventLoop, "logSigactionFailure(sigaction", "sigaction return values are checked");
+    ok &= requireContains(eventLoop, "logSignalFailure(sigprocmask", "sigprocmask return values are checked");
+    ok &= requireContains(eventLoop, "Core::EventLoop sigaction failed", "sigaction failures use EventLoop sysError diagnostics");
+    ok &= requireContains(eventLoop, "logSignalFailure(sigprocmask", "sigprocmask failures use checked EventLoop diagnostics");
+    ok &= requireContains(
+        eventLoop, "Core::EventLoop {} failed: phase={}", "generic signal syscall failures use EventLoop sysError diagnostics");
+    ok &= requireOrdered(
+        eventLoop,
+        {"SIGPIPE, &oldPipeAct", "SIGTERM, &oldTermAct", "SIGALRM, &oldAlarmAct", "SIGHUP, &oldHupAct", "free();", "SIGINT, &oldIntAct"},
+        "start restore ordering, including SIGINT restore-last behavior, is preserved");
+
+    ok &= requireContains(innerEpoll, "core.mux epoll_create1 failed", "inner epoll PR #171 create diagnostics remain present");
+    ok &= requireContains(innerEpoll, "core.mux epoll_ctl ADD failed: fd={}", "inner epoll ADD diagnostics remain present");
+    ok &= requireContains(innerEpoll, "core.mux epoll_wait failed: interestCount={}", "inner epoll wait diagnostics remain present");
+    ok &= requireContains(innerEpoll, "errnum == EEXIST", "inner epoll EEXIST behavior remains present");
+    ok &= requireContains(innerEpoll, "errnum == EBADF", "inner epoll EBADF behavior remains present");
+    ok &= requireContains(innerEpoll, "if (interestCount > 0)", "inner epoll interestCount underflow guard remains present");
+
+    ok &= requireContains(pollMux, "return core::system::ppoll", "poll outer monitor path directly returns ppoll");
+    ok &= requireContains(selectMux, "return core::system::pselect", "select outer monitor path directly returns pselect");
+    ok &= requireContains(epollMux, "return core::system::epoll_pwait", "epoll outer monitor path directly returns epoll_pwait");
+    ok &= requireContains(coreMux, "activeDescriptorCount = monitorDescriptors", "generic wait path consumes monitorDescriptors directly");
+    ok &= requireContains(coreMux, "if (activeDescriptorCount < 0)", "generic wait path checks negative syscall result immediately");
+    ok &= requireContains(epollWrapper, "return ::epoll_pwait", "epoll_pwait wrapper remains direct pass-through");
+    ok &= requireContains(pollWrapper, "return ::ppoll", "ppoll wrapper remains direct pass-through");
+    ok &= requireContains(selectWrapper, "return ::pselect", "pselect wrapper remains direct pass-through");
+
+    return ok ? 0 : 1;
+}

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -134,3 +134,7 @@ set_tests_properties(HighFrequencyLoggingSeverityTest PROPERTIES LABELS "unit;lo
 snodec_add_test(InnerEpollDiagnosticsTest InnerEpollDiagnosticsTest.cpp)
 target_compile_features(InnerEpollDiagnosticsTest PRIVATE cxx_std_20)
 set_tests_properties(InnerEpollDiagnosticsTest PROPERTIES LABELS "unit;log;epoll")
+
+snodec_add_test(BroaderSyscallDisciplineTest BroaderSyscallDisciplineTest.cpp)
+target_compile_features(BroaderSyscallDisciplineTest PRIVATE cxx_std_20)
+set_tests_properties(BroaderSyscallDisciplineTest PROPERTIES LABELS "unit;log;syscall")


### PR DESCRIPTION
### Motivation

- Close remaining syscall-diagnostic gaps outside the inner-epoll path by applying the canonical logging recipe for errno-backed failures. 
- Primary targets were the outer epoll setup in the epoll multiplexer and signal-related syscalls in `EventLoop` while preserving existing event-loop architecture and ordering. 
- Avoid follow-on log storms and remove unconditional success-looking setup diagnostics that could be emitted after setup failure.

### Description

- `src/core/multiplexer/epoll/EventMultiplexer.cpp`: check `epfd` immediately after `epoll_create1`, capture `errno` on failure and `sysError`-log it, skip follow-on `EPOLL_CTL_ADD` calls when create failed, add `addPublisherToOuterEpoll(...)` helper to check each `epoll_ctl` and log `sysError` with fd/publisher, and emit the `Core::multiplexer: epoll` debug line only when outer setup fully succeeds. 
- `src/core/EventLoop.cpp`: add small local helpers (`logSignalFailure`, `logSigactionFailure`, `logSigaddsetFailure`, `signalName`) and wrap `sigemptyset`, `sigaddset`, `sigaction`, and `sigprocmask` call sites to capture `errno` immediately and emit `EventLoop` `sysError` diagnostics without changing signal ordering or semantics. 
- Tests and docs: add `docs/logging/broader-syscall-discipline-report.md` documenting findings and decisions, and add `tests/unit/log/BroaderSyscallDisciplineTest.cpp` plus CMake registration to assert presence/order of the new checks and to verify PR #171 inner-epoll diagnostics remain intact. 
- Left poll/select outer wait paths and core `ppoll`/`pselect`/`epoll_pwait` wrappers unchanged after verification that errno preservation is already safe, and intentionally avoided descriptor-container hardening here.

### Testing

- Project configured and built successfully with `cmake` and `cmake --build`, and formatting applied to touched C++ files with `clang-format`.
- Unit test `BroaderSyscallDisciplineTest` was added and passed in the test runs, and the focused test set including `InnerEpollDiagnosticsTest`, `CoreRuntimeMigration04Test`, `SocketContextDetachPolicyTest`, `HighFrequencyLoggingSeverityTest`, `SensitiveLoggingRedactionTest`, `SemanticEndToEndOutputTest`, and `FinalCleanupMigration09Test` passed. 
- Full test-suite run (`ctest`) completed successfully in the environment (all unit/component tests that ran passed). 
- ASan build (`cmake -DSNODEC_ENABLE_ASAN=ON`) and focused ASan test invocation for `CoreRuntimeMigration04Test`, `BroaderSyscallDisciplineTest`, and `InnerEpollDiagnosticsTest` completed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e7a0de67c832cbe4ca685be664702)