### PR TITLE
Fix source-policy test root discovery

### DIFF
--- a/docs/logging/source-policy-test-root-discovery-report.md
+++ b/docs/logging/source-policy-test-root-discovery-report.md
@@ -1,0 +1,72 @@
+# Source-policy test root discovery report
+
+## Problem summary
+
+Several source-level logging and syscall policy tests locate the repository root before scanning production source files. Their previous fallback discovery logic depended on walking parent directories from the current working directory when `SNODEC_SOURCE_DIR` was not provided.
+
+## Local failure summary
+
+The affected local CTest failures were timeouts in source-scanning tests rather than runtime networking failures:
+
+- `SocketContextDetachPolicyTest`
+- `SensitiveLoggingRedactionTest`
+- `HighFrequencyLoggingSeverityTest`
+- `InnerEpollDiagnosticsTest`
+- `BroaderSyscallDisciplineTest`
+
+## Root cause
+
+The fallback root discovery loop used `std::filesystem::parent_path()` until the current path became empty. For an absolute filesystem root such as `/`, `parent_path()` can return the same path again. If the marker file was not found from the CTest working directory, the loop could stay at the filesystem root forever.
+
+## Files inspected
+
+- `tests/unit/log/CMakeLists.txt`
+- `tests/unit/log/SensitiveLoggingRedactionTest.cpp`
+- `tests/unit/log/HighFrequencyLoggingSeverityTest.cpp`
+- `tests/unit/log/SocketContextDetachPolicyTest.cpp`
+- `tests/unit/log/InnerEpollDiagnosticsTest.cpp`
+- `tests/unit/log/BroaderSyscallDisciplineTest.cpp`
+
+## Tests fixed
+
+- `SensitiveLoggingRedactionTest`
+- `HighFrequencyLoggingSeverityTest`
+- `SocketContextDetachPolicyTest`
+- `InnerEpollDiagnosticsTest`
+- `BroaderSyscallDisciplineTest`
+
+## CMake environment fix
+
+`tests/unit/log/CMakeLists.txt` now assigns `SNODEC_SOURCE_DIR=${CMAKE_SOURCE_DIR}` through CTest for each source-policy test while preserving its existing labels. This gives the tests a deterministic source root during normal CTest execution.
+
+## Fallback loop fix
+
+The duplicated root discovery logic was replaced by a small header-only helper in `tests/unit/log/SourcePolicyTestRoot.h`. The fallback walk now compares each path with its parent and breaks when `parent == current`, so it cannot loop forever at the filesystem root.
+
+## Common root marker decision
+
+All affected tests now use the same stable project-root marker, `src/SemanticLog.h`. This marker is used only to locate the repository root; each policy test still reads and validates its own target files after the root is found.
+
+## Fail-fast behavior
+
+If `SNODEC_SOURCE_DIR` is set but does not point at the project root, the helper prints a clear diagnostic and returns an empty path. If the fallback walk cannot locate the marker, the helper prints the starting directory and returns an empty path. Each fixed test exits with status 1 when the root is unavailable.
+
+## Validation run
+
+Validation performed for this PR:
+
+- Required pre-change root-discovery searches.
+- Required post-change root-discovery searches.
+- Timeout/skip/disable guard search.
+- Legacy macro call-site regression search.
+- `clang-format` on the touched C++ tests and shared helper.
+- `git diff --check`.
+- CMake configure and build with tests and apps enabled.
+- Focused CTest run for the five affected source-policy tests.
+- Focused CTest run from `/tmp` using the build directory.
+- Full CTest run.
+
+## Known follow-ups
+
+1. Final macro removal/source gate.
+2. Round 10 — book integration.

--- a/tests/unit/log/BroaderSyscallDisciplineTest.cpp
+++ b/tests/unit/log/BroaderSyscallDisciplineTest.cpp
@@ -1,39 +1,12 @@
-#include <cstdlib>
+#include "SourcePolicyTestRoot.h"
+
 #include <filesystem>
-#include <fstream>
+#include <initializer_list>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <string_view>
 
 namespace {
-
-    std::filesystem::path projectRoot() {
-        if (const char* sourceDir = std::getenv("SNODEC_SOURCE_DIR")) {
-            return sourceDir;
-        }
-
-        std::filesystem::path current = std::filesystem::current_path();
-        while (!current.empty()) {
-            if (std::filesystem::exists(current / "src" / "core" / "EventLoop.cpp")) {
-                return current;
-            }
-            current = current.parent_path();
-        }
-
-        return std::filesystem::current_path();
-    }
-
-    std::string readFile(const std::filesystem::path& path) {
-        std::ifstream input(path);
-        std::ostringstream buffer;
-        buffer << input.rdbuf();
-        return buffer.str();
-    }
-
-    bool contains(std::string_view haystack, std::string_view needle) {
-        return haystack.find(needle) != std::string_view::npos;
-    }
 
     bool ordered(std::string_view source, std::initializer_list<std::string_view> fragments) {
         std::size_t pos = 0;
@@ -48,7 +21,7 @@ namespace {
     }
 
     bool requireContains(std::string_view source, std::string_view fragment, std::string_view description) {
-        if (contains(source, fragment)) {
+        if (source_policy::contains(source, fragment)) {
             return true;
         }
 
@@ -68,16 +41,23 @@ namespace {
 } // namespace
 
 int main() {
-    const std::filesystem::path root = projectRoot();
-    const std::string epollMux = readFile(root / "src" / "core" / "multiplexer" / "epoll" / "EventMultiplexer.cpp");
-    const std::string eventLoop = readFile(root / "src" / "core" / "EventLoop.cpp");
-    const std::string innerEpoll = readFile(root / "src" / "core" / "multiplexer" / "epoll" / "DescriptorEventPublisher.cpp");
-    const std::string pollMux = readFile(root / "src" / "core" / "multiplexer" / "poll" / "EventMultiplexer.cpp");
-    const std::string selectMux = readFile(root / "src" / "core" / "multiplexer" / "select" / "EventMultiplexer.cpp");
-    const std::string epollWrapper = readFile(root / "src" / "core" / "system" / "epoll.cpp");
-    const std::string pollWrapper = readFile(root / "src" / "core" / "system" / "poll.cpp");
-    const std::string selectWrapper = readFile(root / "src" / "core" / "system" / "select.cpp");
-    const std::string coreMux = readFile(root / "src" / "core" / "EventMultiplexer.cpp");
+    const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
+    if (root.empty()) {
+        return 1;
+    }
+    const std::string epollMux =
+        source_policy::readSourcePolicyFile(root / "src" / "core" / "multiplexer" / "epoll" / "EventMultiplexer.cpp");
+    const std::string eventLoop = source_policy::readSourcePolicyFile(root / "src" / "core" / "EventLoop.cpp");
+    const std::string innerEpoll =
+        source_policy::readSourcePolicyFile(root / "src" / "core" / "multiplexer" / "epoll" / "DescriptorEventPublisher.cpp");
+    const std::string pollMux =
+        source_policy::readSourcePolicyFile(root / "src" / "core" / "multiplexer" / "poll" / "EventMultiplexer.cpp");
+    const std::string selectMux =
+        source_policy::readSourcePolicyFile(root / "src" / "core" / "multiplexer" / "select" / "EventMultiplexer.cpp");
+    const std::string epollWrapper = source_policy::readSourcePolicyFile(root / "src" / "core" / "system" / "epoll.cpp");
+    const std::string pollWrapper = source_policy::readSourcePolicyFile(root / "src" / "core" / "system" / "poll.cpp");
+    const std::string selectWrapper = source_policy::readSourcePolicyFile(root / "src" / "core" / "system" / "select.cpp");
+    const std::string coreMux = source_policy::readSourcePolicyFile(root / "src" / "core" / "EventMultiplexer.cpp");
 
     bool ok = true;
     ok &= requireContains(epollMux, ", epfd(core::system::epoll_create1(EPOLL_CLOEXEC))", "outer epoll_create1 remains in the initializer");

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -119,22 +119,28 @@ target_compile_features(SemanticEndToEndOutputTest PRIVATE cxx_std_20)
 target_link_libraries(SemanticEndToEndOutputTest PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(SemanticEndToEndOutputTest PROPERTIES LABELS "unit;log;e2e")
 
+function(snodec_set_source_policy_test_properties test_name labels)
+    set_tests_properties(${test_name} PROPERTIES
+        LABELS "${labels}"
+        ENVIRONMENT "SNODEC_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
+endfunction()
+
 snodec_add_test(SocketContextDetachPolicyTest SocketContextDetachPolicyTest.cpp)
 target_compile_features(SocketContextDetachPolicyTest PRIVATE cxx_std_20)
-set_tests_properties(SocketContextDetachPolicyTest PROPERTIES LABELS "unit;log;socketcontext")
+snodec_set_source_policy_test_properties(SocketContextDetachPolicyTest "unit;log;socketcontext")
 
 snodec_add_test(SensitiveLoggingRedactionTest SensitiveLoggingRedactionTest.cpp)
 target_compile_features(SensitiveLoggingRedactionTest PRIVATE cxx_std_20)
-set_tests_properties(SensitiveLoggingRedactionTest PROPERTIES LABELS "unit;log;security")
+snodec_set_source_policy_test_properties(SensitiveLoggingRedactionTest "unit;log;security")
 
 snodec_add_test(HighFrequencyLoggingSeverityTest HighFrequencyLoggingSeverityTest.cpp)
 target_compile_features(HighFrequencyLoggingSeverityTest PRIVATE cxx_std_20)
-set_tests_properties(HighFrequencyLoggingSeverityTest PROPERTIES LABELS "unit;log;severity")
+snodec_set_source_policy_test_properties(HighFrequencyLoggingSeverityTest "unit;log;severity")
 
 snodec_add_test(InnerEpollDiagnosticsTest InnerEpollDiagnosticsTest.cpp)
 target_compile_features(InnerEpollDiagnosticsTest PRIVATE cxx_std_20)
-set_tests_properties(InnerEpollDiagnosticsTest PROPERTIES LABELS "unit;log;epoll")
+snodec_set_source_policy_test_properties(InnerEpollDiagnosticsTest "unit;log;epoll")
 
 snodec_add_test(BroaderSyscallDisciplineTest BroaderSyscallDisciplineTest.cpp)
 target_compile_features(BroaderSyscallDisciplineTest PRIVATE cxx_std_20)
-set_tests_properties(BroaderSyscallDisciplineTest PROPERTIES LABELS "unit;log;syscall")
+snodec_set_source_policy_test_properties(BroaderSyscallDisciplineTest "unit;log;syscall")

--- a/tests/unit/log/HighFrequencyLoggingSeverityTest.cpp
+++ b/tests/unit/log/HighFrequencyLoggingSeverityTest.cpp
@@ -1,40 +1,12 @@
-#include <cstdlib>
+#include "SourcePolicyTestRoot.h"
+
 #include <filesystem>
-#include <fstream>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace {
-
-    std::filesystem::path projectRoot() {
-        if (const char* sourceDir = std::getenv("SNODEC_SOURCE_DIR")) {
-            return sourceDir;
-        }
-
-        std::filesystem::path current = std::filesystem::current_path();
-        while (!current.empty()) {
-            if (std::filesystem::exists(current / "src" / "SemanticLog.h")) {
-                return current;
-            }
-            current = current.parent_path();
-        }
-
-        return std::filesystem::current_path();
-    }
-
-    std::string readFile(const std::filesystem::path& path) {
-        std::ifstream input(path);
-        std::ostringstream buffer;
-        buffer << input.rdbuf();
-        return buffer.str();
-    }
-
-    bool contains(std::string_view haystack, std::string_view needle) {
-        return haystack.find(needle) != std::string_view::npos;
-    }
 
     struct ForbiddenFragment {
         std::filesystem::path sourceFile;
@@ -44,7 +16,10 @@ namespace {
 } // namespace
 
 int main() {
-    const std::filesystem::path root = projectRoot();
+    const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
+    if (root.empty()) {
+        return 1;
+    }
     const std::vector<ForbiddenFragment> forbiddenFragments = {
         {root / "src" / "iot" / "mqtt" / "Mqtt.cpp", "mqttLog().info() << connectionName << \" MQTT: \" << packet.getName()"},
         {root / "src" / "iot" / "mqtt" / "Mqtt.cpp",
@@ -85,13 +60,13 @@ int main() {
 
     bool ok = true;
     for (const auto& forbiddenFragment : forbiddenFragments) {
-        const std::string contents = readFile(forbiddenFragment.sourceFile);
+        const std::string contents = source_policy::readSourcePolicyFile(forbiddenFragment.sourceFile);
         if (contents.empty()) {
             std::cerr << "Unable to read " << forbiddenFragment.sourceFile << '\n';
             ok = false;
             continue;
         }
-        if (contains(contents, forbiddenFragment.fragment)) {
+        if (source_policy::contains(contents, forbiddenFragment.fragment)) {
             std::cerr << "Forbidden high-frequency info logging fragment in " << forbiddenFragment.sourceFile << ": "
                       << forbiddenFragment.fragment << '\n';
             ok = false;

--- a/tests/unit/log/InnerEpollDiagnosticsTest.cpp
+++ b/tests/unit/log/InnerEpollDiagnosticsTest.cpp
@@ -1,43 +1,15 @@
-#include <cstdlib>
+#include "SourcePolicyTestRoot.h"
+
 #include <filesystem>
-#include <fstream>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace {
 
-    std::filesystem::path projectRoot() {
-        if (const char* sourceDir = std::getenv("SNODEC_SOURCE_DIR")) {
-            return sourceDir;
-        }
-
-        std::filesystem::path current = std::filesystem::current_path();
-        while (!current.empty()) {
-            if (std::filesystem::exists(current / "src" / "core" / "multiplexer" / "epoll" / "DescriptorEventPublisher.cpp")) {
-                return current;
-            }
-            current = current.parent_path();
-        }
-
-        return std::filesystem::current_path();
-    }
-
-    std::string readFile(const std::filesystem::path& path) {
-        std::ifstream input(path);
-        std::ostringstream buffer;
-        buffer << input.rdbuf();
-        return buffer.str();
-    }
-
-    bool contains(std::string_view haystack, std::string_view needle) {
-        return haystack.find(needle) != std::string_view::npos;
-    }
-
     bool requireContains(std::string_view source, std::string_view fragment, std::string_view description) {
-        if (contains(source, fragment)) {
+        if (source_policy::contains(source, fragment)) {
             return true;
         }
 
@@ -46,7 +18,7 @@ namespace {
     }
 
     bool requireAbsent(std::string_view source, std::string_view fragment, std::string_view description) {
-        if (!contains(source, fragment)) {
+        if (!source_policy::contains(source, fragment)) {
             return true;
         }
 
@@ -57,8 +29,12 @@ namespace {
 } // namespace
 
 int main() {
-    const std::filesystem::path sourcePath = projectRoot() / "src" / "core" / "multiplexer" / "epoll" / "DescriptorEventPublisher.cpp";
-    const std::string source = readFile(sourcePath);
+    const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
+    if (root.empty()) {
+        return 1;
+    }
+    const std::filesystem::path sourcePath = root / "src" / "core" / "multiplexer" / "epoll" / "DescriptorEventPublisher.cpp";
+    const std::string source = source_policy::readSourcePolicyFile(sourcePath);
     if (source.empty()) {
         std::cerr << "Unable to read " << sourcePath << '\n';
         return 1;

--- a/tests/unit/log/SensitiveLoggingRedactionTest.cpp
+++ b/tests/unit/log/SensitiveLoggingRedactionTest.cpp
@@ -1,45 +1,16 @@
-#include <cstdlib>
+#include "SourcePolicyTestRoot.h"
+
 #include <filesystem>
-#include <fstream>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 
-namespace {
-
-    std::filesystem::path projectRoot() {
-        if (const char* sourceDir = std::getenv("SNODEC_SOURCE_DIR")) {
-            return sourceDir;
-        }
-
-        std::filesystem::path current = std::filesystem::current_path();
-        while (!current.empty()) {
-            if (std::filesystem::exists(current / "src" / "SemanticLog.h")) {
-                return current;
-            }
-            current = current.parent_path();
-        }
-
-        return std::filesystem::current_path();
-    }
-
-    std::string readFile(const std::filesystem::path& path) {
-        std::ifstream input(path);
-        std::ostringstream buffer;
-        buffer << input.rdbuf();
-        return buffer.str();
-    }
-
-    bool contains(std::string_view haystack, std::string_view needle) {
-        return haystack.find(needle) != std::string_view::npos;
-    }
-
-} // namespace
-
 int main() {
-    const std::filesystem::path root = projectRoot();
+    const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
+    if (root.empty()) {
+        return 1;
+    }
     const std::vector<std::filesystem::path> sourceFiles = {
         root / "src" / "iot" / "mqtt" / "server" / "Mqtt.cpp",
         root / "src" / "apps" / "oauth2" / "authorization_server" / "AuthorizationServer.cpp",
@@ -62,14 +33,14 @@ int main() {
 
     bool ok = true;
     for (const auto& sourceFile : sourceFiles) {
-        const std::string contents = readFile(sourceFile);
+        const std::string contents = source_policy::readSourcePolicyFile(sourceFile);
         if (contents.empty()) {
             std::cerr << "Unable to read " << sourceFile << '\n';
             ok = false;
             continue;
         }
         for (const auto& fragment : forbiddenLogFragments) {
-            if (contains(contents, fragment)) {
+            if (source_policy::contains(contents, fragment)) {
                 std::cerr << "Forbidden sensitive logging fragment in " << sourceFile << ": " << fragment << '\n';
                 ok = false;
             }

--- a/tests/unit/log/SocketContextDetachPolicyTest.cpp
+++ b/tests/unit/log/SocketContextDetachPolicyTest.cpp
@@ -1,43 +1,15 @@
-#include <cstdlib>
+#include "SourcePolicyTestRoot.h"
+
 #include <filesystem>
-#include <fstream>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace {
 
-    std::filesystem::path projectRoot() {
-        if (const char* sourceDir = std::getenv("SNODEC_SOURCE_DIR")) {
-            return sourceDir;
-        }
-
-        std::filesystem::path current = std::filesystem::current_path();
-        while (!current.empty()) {
-            if (std::filesystem::exists(current / "src" / "SemanticLog.h")) {
-                return current;
-            }
-            current = current.parent_path();
-        }
-
-        return std::filesystem::current_path();
-    }
-
-    std::string readFile(const std::filesystem::path& path) {
-        std::ifstream input(path);
-        std::ostringstream buffer;
-        buffer << input.rdbuf();
-        return buffer.str();
-    }
-
-    bool contains(std::string_view haystack, std::string_view needle) {
-        return haystack.find(needle) != std::string_view::npos;
-    }
-
     bool requireContains(std::string_view contents, std::string_view needle, const std::filesystem::path& path) {
-        if (contains(contents, needle)) {
+        if (source_policy::contains(contents, needle)) {
             return true;
         }
 
@@ -46,7 +18,7 @@ namespace {
     }
 
     bool requireNotContains(std::string_view contents, std::string_view needle, const std::filesystem::path& path) {
-        if (!contains(contents, needle)) {
+        if (!source_policy::contains(contents, needle)) {
             return true;
         }
 
@@ -57,18 +29,21 @@ namespace {
 } // namespace
 
 int main() {
-    const std::filesystem::path root = projectRoot();
+    const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
+    if (root.empty()) {
+        return 1;
+    }
     const auto socketConnectionPath = root / "src" / "core" / "socket" / "stream" / "SocketConnection.hpp";
     const auto socketContextHeaderPath = root / "src" / "core" / "socket" / "stream" / "SocketContext.h";
     const auto socketContextSourcePath = root / "src" / "core" / "socket" / "stream" / "SocketContext.cpp";
     const auto socketServerPath = root / "src" / "core" / "socket" / "stream" / "SocketServer.h";
     const auto socketClientPath = root / "src" / "core" / "socket" / "stream" / "SocketClient.h";
 
-    const std::string socketConnection = readFile(socketConnectionPath);
-    const std::string socketContextHeader = readFile(socketContextHeaderPath);
-    const std::string socketContextSource = readFile(socketContextSourcePath);
-    const std::string socketServer = readFile(socketServerPath);
-    const std::string socketClient = readFile(socketClientPath);
+    const std::string socketConnection = source_policy::readSourcePolicyFile(socketConnectionPath);
+    const std::string socketContextHeader = source_policy::readSourcePolicyFile(socketContextHeaderPath);
+    const std::string socketContextSource = source_policy::readSourcePolicyFile(socketContextSourcePath);
+    const std::string socketServer = source_policy::readSourcePolicyFile(socketServerPath);
+    const std::string socketClient = source_policy::readSourcePolicyFile(socketClientPath);
 
     bool ok = true;
     ok &= requireContains(socketConnection, "socketContext->detach(SocketContext::DetachReason::ContextSwitch);", socketConnectionPath);

--- a/tests/unit/log/SourcePolicyTestRoot.h
+++ b/tests/unit/log/SourcePolicyTestRoot.h
@@ -1,0 +1,57 @@
+#ifndef TESTS_UNIT_LOG_SOURCEPOLICYTESTROOT_H
+#define TESTS_UNIT_LOG_SOURCEPOLICYTESTROOT_H
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+namespace source_policy {
+
+    inline constexpr auto kProjectRootMarker = "src/SemanticLog.h";
+
+    inline std::filesystem::path sourcePolicyProjectRoot() {
+        if (const char* sourceDir = std::getenv("SNODEC_SOURCE_DIR")) {
+            const std::filesystem::path root = sourceDir;
+            if (std::filesystem::exists(root / kProjectRootMarker)) {
+                return root;
+            }
+
+            std::cerr << "SNODEC_SOURCE_DIR does not look like the project root: " << root << '\n';
+            return {};
+        }
+
+        std::filesystem::path current = std::filesystem::current_path();
+        while (!current.empty()) {
+            if (std::filesystem::exists(current / kProjectRootMarker)) {
+                return current;
+            }
+
+            const std::filesystem::path parent = current.parent_path();
+            if (parent == current) {
+                break;
+            }
+            current = parent;
+        }
+
+        std::cerr << "Unable to locate SNode.C project root from " << std::filesystem::current_path() << '\n';
+        return {};
+    }
+
+    inline std::string readSourcePolicyFile(const std::filesystem::path& path) {
+        std::ifstream input(path);
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        return buffer.str();
+    }
+
+    inline bool contains(std::string_view haystack, std::string_view needle) {
+        return haystack.find(needle) != std::string_view::npos;
+    }
+
+} // namespace source_policy
+
+#endif // TESTS_UNIT_LOG_SOURCEPOLICYTESTROOT_H


### PR DESCRIPTION
### Motivation

- Source-scanning policy tests could hang locally because their fallback `projectRoot()` walked parents indefinitely when the source marker was not found, causing CTest timeouts for several tests. 
- The change must make root discovery deterministic, bounded, and fail-fast without touching production code or weakening tests.

### Description

- Add a tiny header-only helper `tests/unit/log/SourcePolicyTestRoot.h` that first validates `SNODEC_SOURCE_DIR`, uses the common marker `src/SemanticLog.h`, bounds the fallback parent walk with `parent == current`, prints clear diagnostics, and returns an empty `path` on failure.
- Configure CTest to provide `SNODEC_SOURCE_DIR=${CMAKE_SOURCE_DIR}` for all five source-policy tests via a helper function `snodec_set_source_policy_test_properties` in `tests/unit/log/CMakeLists.txt`, preserving existing labels.
- Update the five tests (`SensitiveLoggingRedactionTest.cpp`, `HighFrequencyLoggingSeverityTest.cpp`, `SocketContextDetachPolicyTest.cpp`, `InnerEpollDiagnosticsTest.cpp`, `BroaderSyscallDisciplineTest.cpp`) to use the shared helper, read files via the helper, and `return 1` immediately if the root cannot be located.
- Add the required report `docs/logging/source-policy-test-root-discovery-report.md` documenting the problem, root cause, files inspected, tests fixed, CMake environment fix, fallback loop fix, marker choice, fail-fast behavior, validation, and known follow-ups.

### Testing

- Ran the required repository searches and static checks including `rg` for `projectRoot(`, `SNODEC_SOURCE_DIR`, `current_path(`, `parent_path(` and for timeout/skip/disable markers, all passing as expected.
- Formatted changed files with `clang-format` and ran `git diff --check` with no issues.
- Configured and built with CMake (`-DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`) and the build completed successfully.
- Ran focused CTest for the five affected tests and a full `ctest` run; all focused tests passed quickly and the full test suite completed with no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e8a28c274832ca1d6236937ba83fd)