### PR TITLE
Reduce disabled semantic logging overhead

### DIFF
--- a/docs/logging/semantic-logging-overhead-repair-report.md
+++ b/docs/logging/semantic-logging-overhead-repair-report.md
@@ -1,0 +1,123 @@
+# Semantic logging runtime-overhead repair
+
+## Problem summary
+
+After the semantic logging migration and root CLI integration, disabled semantic logs could still be too expensive in hot paths. The main risk was that a helper-created `BoundaryLogger` could locally allow `Trace`, format expensive arguments or payload dumps, materialize a record, timestamp it, and only then be rejected by `LogManager`.
+
+## Valgrind observation
+
+The motivating observation was disproportionate overhead while running `httpclient-tls-in` under Valgrind. Valgrind amplifies logging costs, but the underlying issue is real when disabled semantic diagnostics still construct payload dumps or records before policy rejection.
+
+## Disabled-log cost model
+
+A disabled semantic log must be rejected by `BoundaryLogger::enabled(level)` before expensive work. The disabled path must avoid expensive argument formatting, payload dump construction, `LogRecord` materialization, timestamping, and sink calls.
+
+## Convenience helper threshold issue
+
+Root-level no-threshold helpers in `src/SemanticLog.h` previously shared the explicit-threshold overload default of `LogLevel::Trace`. This made production calls such as `snode::semantic::webHttpLog().debug(...)` locally enabled even when the effective semantic policy would reject them later. This PR adds production no-argument and identity-only overloads that construct loggers with `LogScopeOwner(...).logger(Logger::semanticSink())`, which captures `LogManager::effectiveLevel(...)` for the helper scope.
+
+Explicit sink/threshold overloads remain available for tests and custom capture. Those overloads intentionally keep `Trace` as the explicit-test default when a custom sink is supplied, preserving existing migration tests.
+
+## Guarded expensive diagnostics issue
+
+Repeated-helper guards construct and resolve the same logger twice, for example `mqttLog().enabled(...)` followed by `mqttLog().trace() << toHexString(...)`. This PR updates obvious expensive MQTT and HTTP payload diagnostics to bind the logger once before the guard.
+
+## Bind-once rule
+
+Expensive guarded diagnostics should use:
+
+```cpp
+auto log = someSemanticLog();
+if (log.enabled(logger::LogLevel::Trace)) {
+    log.trace() << expensiveThing();
+}
+```
+
+This avoids duplicate helper construction and keeps the expensive expression inside the enabled branch.
+
+## Cached logger rule
+
+Cached `BoundaryLogger` members are allowed only when the scope identity is stable and the logger is constructed after semantic policy initialization. This PR did not add class-member caches because the targeted bind-once fixes were smaller and avoid lifecycle ambiguity.
+
+## Why macros were not added
+
+No macro guard API was added. The logging migration is moving away from macro-based logging, and macros can hide control flow or accidentally evaluate logger expressions more than once.
+
+## Why async logging was not added
+
+Async logging was not added because this PR targets disabled-log overhead. Async sinks can only help accepted-log I/O costs; they do not fix formatting, dump construction, or record materialization before rejection.
+
+## Files inspected
+
+- `src/SemanticLog.h`
+- `src/log/SemanticLogger.h`
+- `src/log/SemanticLogger.cpp`
+- `src/log/LogScopeOwner.h`
+- `src/log/LogScopeOwner.cpp`
+- `src/log/Logger.cpp`
+- `src/iot/mqtt/SemanticLog.h`
+- `src/web/http/client/SemanticLog.h`
+- `src/web/http/server/SemanticLog.h`
+- `src/web/websocket/SemanticLog.h`
+- `src/iot/mqtt/Mqtt.cpp`
+- `src/web/http/client/SocketContext.cpp`
+- `src/web/websocket/Receiver.cpp`
+- `src/web/websocket/Transmitter.cpp`
+- MQTT broker/session files reported by the guard search
+
+## Implementation summary
+
+- Added effective-threshold production overloads for root semantic helpers in `src/SemanticLog.h`.
+- Preserved explicit test/custom capture overloads with explicit sink support.
+- Bound MQTT payload/fixed-header trace diagnostics to a local logger before guarded `toHexString(...)` work.
+- Bound the HTTP client rejected-request dump guard to a local logger before `httputils::toString(...)`.
+- Added `SemanticLoggingOverheadTest` to prove disabled formatting and materialization are avoided and component overrides still enable selected debug logs.
+
+## Tests added/updated
+
+- Added `tests/unit/log/SemanticLoggingOverheadTest.cpp`.
+- Registered `SemanticLoggingOverheadTest` in `tests/unit/log/CMakeLists.txt`.
+
+## Search commands run
+
+Before changes:
+
+```sh
+rg -n "\.enabled\(logger::LogLevel::" src -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "[A-Za-z0-9_:]*Log\(\)\.enabled|semantic::[A-Za-z0-9_:]*Log\(\)\.enabled" src -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "toHexString|httputils::toString|dump\(|Frame data|payload|body|header|certificate|packet|buffer|route" src -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "threshold = logger::LogLevel::Trace|const logger::LogLevel threshold = logger::LogLevel::Trace|LogScopeOwner\(.*\)\.logger\(.*threshold" src -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+After changes:
+
+```sh
+rg -n "[A-Za-z0-9_:]*Log\(\)\.enabled|semantic::[A-Za-z0-9_:]*Log\(\)\.enabled" src -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "SNODEC_.*LOG|LOG_IF|TRACE_IF|DEBUG_IF|IF_ENABLED" src/log src tests docs -g '*.h' -g '*.hpp' -g '*.cpp' -g '*.md'
+rg -n "LogLevel::Trace" src/SemanticLog.h src/iot/mqtt/SemanticLog.h src/web/http src/web/websocket src/log -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "\b(LOG|PLOG|VLOG)\s*\(" src -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+Remaining repeated-helper guard matches are MQTT broker/session `Info`/`Debug` bookkeeping guards, not obvious expensive payload dump construction. They are left unchanged to keep this PR focused.
+
+Remaining `LogLevel::Trace` defaults are explicit sink/test/custom capture overloads, `BoundaryLogger::createForTest`, semantic policy defaults, and intentional trace-level methods/guards. Production no-argument root helpers no longer default to unconditional `Trace`.
+
+The macro search found existing compatibility definitions in `src/log/Logger.h` and non-compiled express compatibility-suite macro uses already documented for the final macro-removal/source-gate work. No new macro guard API was introduced.
+
+## Tests run
+
+```sh
+cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON
+cmake --build cmake-build --parallel 2
+ctest --test-dir cmake-build -R "SemanticLoggingOverheadTest|SemanticCliIntegrationTest|SemanticFilterRound7Test|SemanticEndToEndOutputTest|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test|FinalCleanupMigration09Test|HighFrequencyLoggingSeverityTest|SensitiveLoggingRedactionTest" --output-on-failure
+ctest --test-dir cmake-build --output-on-failure
+```
+
+The full test run passed all 137 registered tests, with environment-dependent integration tests reported as skipped by their own guards.
+
+## Known follow-ups
+
+1. PR G.2 — add instance-scoped semantic `--log-level` to `ConfigInstance`.
+2. Final macro removal/source gate.
+3. Round 10 — book integration.
+4. Optional later async logging backend if accepted-log sink I/O becomes the bottleneck.

--- a/src/SemanticLog.h
+++ b/src/SemanticLog.h
@@ -20,8 +20,16 @@ namespace snode::semantic {
     inline logger::BoundaryLogger scopedLog(const logger::LogOrigin origin,
                                             const logger::LogBoundary boundary,
                                             const std::string& component,
-                                            logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
-                                            const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                            logger::BoundaryLogger::Sink sink,
+                                            logger::BoundaryLogger::Clock clock = {}) {
+        return logger::LogScopeOwner(origin, boundary, component).logger(std::move(sink), std::move(clock));
+    }
+
+    inline logger::BoundaryLogger scopedLog(const logger::LogOrigin origin,
+                                            const logger::LogBoundary boundary,
+                                            const std::string& component,
+                                            logger::BoundaryLogger::Sink sink,
+                                            const logger::LogLevel threshold,
                                             logger::BoundaryLogger::Clock clock = {}) {
         return logger::LogScopeOwner(origin, boundary, component).logger(std::move(sink), threshold, std::move(clock));
     }
@@ -30,43 +38,75 @@ namespace snode::semantic {
                                             const logger::LogBoundary boundary,
                                             const std::string& component,
                                             LogIdentity identity,
-                                            logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
-                                            const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                            logger::BoundaryLogger::Sink sink,
+                                            logger::BoundaryLogger::Clock clock = {}) {
+        return logger::LogScopeOwner(
+                   origin, boundary, component, std::move(identity.instance), identity.role, std::move(identity.connection))
+            .logger(std::move(sink), std::move(clock));
+    }
+
+    inline logger::BoundaryLogger scopedLog(const logger::LogOrigin origin,
+                                            const logger::LogBoundary boundary,
+                                            const std::string& component,
+                                            LogIdentity identity,
+                                            logger::BoundaryLogger::Sink sink,
+                                            const logger::LogLevel threshold,
                                             logger::BoundaryLogger::Clock clock = {}) {
         return logger::LogScopeOwner(
                    origin, boundary, component, std::move(identity.instance), identity.role, std::move(identity.connection))
             .logger(std::move(sink), threshold, std::move(clock));
     }
 
-    inline logger::BoundaryLogger frameworkLog(logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+    inline logger::BoundaryLogger frameworkLog() {
+        return scopedLog(logger::LogOrigin::Framework, logger::LogBoundary::System, "framework", logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger frameworkLog(logger::BoundaryLogger::Sink sink,
                                                const logger::LogLevel threshold = logger::LogLevel::Trace,
                                                logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(
             logger::LogOrigin::Framework, logger::LogBoundary::System, "framework", std::move(sink), threshold, std::move(clock));
     }
 
-    inline logger::BoundaryLogger coreSystemLog(logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+    inline logger::BoundaryLogger coreSystemLog() {
+        return scopedLog(logger::LogOrigin::Framework, logger::LogBoundary::System, "core.system", logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger coreSystemLog(logger::BoundaryLogger::Sink sink,
                                                 const logger::LogLevel threshold = logger::LogLevel::Trace,
                                                 logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(
             logger::LogOrigin::Framework, logger::LogBoundary::System, "core.system", std::move(sink), threshold, std::move(clock));
     }
 
-    inline logger::BoundaryLogger coreSocketLog(logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+    inline logger::BoundaryLogger coreSocketLog() {
+        return scopedLog(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "core.socket", logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger coreSocketLog(logger::BoundaryLogger::Sink sink,
                                                 const logger::LogLevel threshold = logger::LogLevel::Trace,
                                                 logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(
             logger::LogOrigin::Framework, logger::LogBoundary::Connection, "core.socket", std::move(sink), threshold, std::move(clock));
     }
 
-    inline logger::BoundaryLogger netConfigLog(logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+    inline logger::BoundaryLogger netConfigLog() {
+        return scopedLog(logger::LogOrigin::Framework, logger::LogBoundary::Configuration, "net.config", logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger netConfigLog(logger::BoundaryLogger::Sink sink,
                                                const logger::LogLevel threshold = logger::LogLevel::Trace,
                                                logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(
             logger::LogOrigin::Framework, logger::LogBoundary::Configuration, "net.config", std::move(sink), threshold, std::move(clock));
     }
 
-    inline logger::BoundaryLogger tlsConfigLog(logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+    inline logger::BoundaryLogger tlsConfigLog() {
+        return scopedLog(
+            logger::LogOrigin::Framework, logger::LogBoundary::Configuration, "net.config.tls", logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger tlsConfigLog(logger::BoundaryLogger::Sink sink,
                                                const logger::LogLevel threshold = logger::LogLevel::Trace,
                                                logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(logger::LogOrigin::Framework,
@@ -77,36 +117,57 @@ namespace snode::semantic {
                          std::move(clock));
     }
 
-    inline logger::BoundaryLogger mariaDbLog(logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+    inline logger::BoundaryLogger mariaDbLog() {
+        return scopedLog(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "db.mariadb", logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger mariaDbLog(logger::BoundaryLogger::Sink sink,
                                              const logger::LogLevel threshold = logger::LogLevel::Trace,
                                              logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(
             logger::LogOrigin::Framework, logger::LogBoundary::Connection, "db.mariadb", std::move(sink), threshold, std::move(clock));
     }
 
-    inline logger::BoundaryLogger webHttpLog(logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+    inline logger::BoundaryLogger webHttpLog() {
+        return scopedLog(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.http", logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger webHttpLog(logger::BoundaryLogger::Sink sink,
                                              const logger::LogLevel threshold = logger::LogLevel::Trace,
                                              logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(
             logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.http", std::move(sink), threshold, std::move(clock));
     }
 
-    inline logger::BoundaryLogger expressLog(logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+    inline logger::BoundaryLogger expressLog() {
+        return scopedLog(logger::LogOrigin::Framework, logger::LogBoundary::Application, "express", logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger expressLog(logger::BoundaryLogger::Sink sink,
                                              const logger::LogLevel threshold = logger::LogLevel::Trace,
                                              logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(
             logger::LogOrigin::Framework, logger::LogBoundary::Application, "express", std::move(sink), threshold, std::move(clock));
     }
 
-    inline logger::BoundaryLogger appLog(logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+    inline logger::BoundaryLogger appLog() {
+        return scopedLog(logger::LogOrigin::Application, logger::LogBoundary::Application, "app", logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger appLog(logger::BoundaryLogger::Sink sink,
                                          const logger::LogLevel threshold = logger::LogLevel::Trace,
                                          logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(
             logger::LogOrigin::Application, logger::LogBoundary::Application, "app", std::move(sink), threshold, std::move(clock));
     }
 
+    inline logger::BoundaryLogger frameworkLog(LogIdentity identity) {
+        return scopedLog(
+            logger::LogOrigin::Framework, logger::LogBoundary::System, "framework", std::move(identity), logger::Logger::semanticSink());
+    }
+
     inline logger::BoundaryLogger frameworkLog(LogIdentity identity,
-                                               logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                               logger::BoundaryLogger::Sink sink,
                                                const logger::LogLevel threshold = logger::LogLevel::Trace,
                                                logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(logger::LogOrigin::Framework,
@@ -118,8 +179,13 @@ namespace snode::semantic {
                          std::move(clock));
     }
 
+    inline logger::BoundaryLogger coreSystemLog(LogIdentity identity) {
+        return scopedLog(
+            logger::LogOrigin::Framework, logger::LogBoundary::System, "core.system", std::move(identity), logger::Logger::semanticSink());
+    }
+
     inline logger::BoundaryLogger coreSystemLog(LogIdentity identity,
-                                                logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                                logger::BoundaryLogger::Sink sink,
                                                 const logger::LogLevel threshold = logger::LogLevel::Trace,
                                                 logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(logger::LogOrigin::Framework,
@@ -131,8 +197,16 @@ namespace snode::semantic {
                          std::move(clock));
     }
 
+    inline logger::BoundaryLogger coreSocketLog(LogIdentity identity) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Connection,
+                         "core.socket",
+                         std::move(identity),
+                         logger::Logger::semanticSink());
+    }
+
     inline logger::BoundaryLogger coreSocketLog(LogIdentity identity,
-                                                logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                                logger::BoundaryLogger::Sink sink,
                                                 const logger::LogLevel threshold = logger::LogLevel::Trace,
                                                 logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(logger::LogOrigin::Framework,
@@ -144,8 +218,16 @@ namespace snode::semantic {
                          std::move(clock));
     }
 
+    inline logger::BoundaryLogger netConfigLog(LogIdentity identity) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Configuration,
+                         "net.config",
+                         std::move(identity),
+                         logger::Logger::semanticSink());
+    }
+
     inline logger::BoundaryLogger netConfigLog(LogIdentity identity,
-                                               logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                               logger::BoundaryLogger::Sink sink,
                                                const logger::LogLevel threshold = logger::LogLevel::Trace,
                                                logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(logger::LogOrigin::Framework,
@@ -157,8 +239,16 @@ namespace snode::semantic {
                          std::move(clock));
     }
 
+    inline logger::BoundaryLogger tlsConfigLog(LogIdentity identity) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Configuration,
+                         "net.config.tls",
+                         std::move(identity),
+                         logger::Logger::semanticSink());
+    }
+
     inline logger::BoundaryLogger tlsConfigLog(LogIdentity identity,
-                                               logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                               logger::BoundaryLogger::Sink sink,
                                                const logger::LogLevel threshold = logger::LogLevel::Trace,
                                                logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(logger::LogOrigin::Framework,
@@ -170,8 +260,16 @@ namespace snode::semantic {
                          std::move(clock));
     }
 
+    inline logger::BoundaryLogger mariaDbLog(LogIdentity identity) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Connection,
+                         "db.mariadb",
+                         std::move(identity),
+                         logger::Logger::semanticSink());
+    }
+
     inline logger::BoundaryLogger mariaDbLog(LogIdentity identity,
-                                             logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                             logger::BoundaryLogger::Sink sink,
                                              const logger::LogLevel threshold = logger::LogLevel::Trace,
                                              logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(logger::LogOrigin::Framework,
@@ -183,8 +281,13 @@ namespace snode::semantic {
                          std::move(clock));
     }
 
+    inline logger::BoundaryLogger webHttpLog(LogIdentity identity) {
+        return scopedLog(
+            logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.http", std::move(identity), logger::Logger::semanticSink());
+    }
+
     inline logger::BoundaryLogger webHttpLog(LogIdentity identity,
-                                             logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                             logger::BoundaryLogger::Sink sink,
                                              const logger::LogLevel threshold = logger::LogLevel::Trace,
                                              logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(logger::LogOrigin::Framework,
@@ -196,8 +299,13 @@ namespace snode::semantic {
                          std::move(clock));
     }
 
+    inline logger::BoundaryLogger expressLog(LogIdentity identity) {
+        return scopedLog(
+            logger::LogOrigin::Framework, logger::LogBoundary::Application, "express", std::move(identity), logger::Logger::semanticSink());
+    }
+
     inline logger::BoundaryLogger expressLog(LogIdentity identity,
-                                             logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                             logger::BoundaryLogger::Sink sink,
                                              const logger::LogLevel threshold = logger::LogLevel::Trace,
                                              logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(logger::LogOrigin::Framework,
@@ -209,8 +317,13 @@ namespace snode::semantic {
                          std::move(clock));
     }
 
+    inline logger::BoundaryLogger appLog(LogIdentity identity) {
+        return scopedLog(
+            logger::LogOrigin::Application, logger::LogBoundary::Application, "app", std::move(identity), logger::Logger::semanticSink());
+    }
+
     inline logger::BoundaryLogger appLog(LogIdentity identity,
-                                         logger::BoundaryLogger::Sink sink = logger::Logger::semanticSink(),
+                                         logger::BoundaryLogger::Sink sink,
                                          const logger::LogLevel threshold = logger::LogLevel::Trace,
                                          logger::BoundaryLogger::Clock clock = {}) {
         return scopedLog(logger::LogOrigin::Application,

--- a/src/iot/mqtt/Mqtt.cpp
+++ b/src/iot/mqtt/Mqtt.cpp
@@ -211,8 +211,9 @@ namespace iot::mqtt {
     }
 
     void Mqtt::send(const std::vector<char>& data) const {
-        if (iot::mqtt::semantic::mqttLog().enabled(logger::LogLevel::Trace)) {
-            iot::mqtt::semantic::mqttLog().trace() << connectionName << " MQTT: Send data (full message):\n" << toHexString(data);
+        auto log = iot::mqtt::semantic::mqttLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << connectionName << " MQTT: Send data (full message):\n" << toHexString(data);
         }
 
         mqttContext->send(data.data(), data.size());
@@ -224,8 +225,9 @@ namespace iot::mqtt {
         send(iot::mqtt::packets::Publish(packetIdentifier, topic, message, qoS, false, retain));
 
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   Topic: " << topic;
-        if (iot::mqtt::semantic::mqttLog().enabled(logger::LogLevel::Trace)) {
-            iot::mqtt::semantic::mqttLog().trace() << connectionName << " MQTT:   Message:\n" << toHexString(message);
+        auto log = iot::mqtt::semantic::mqttLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << connectionName << " MQTT:   Message:\n" << toHexString(message);
         }
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(qoS);
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: " << packetIdentifier;
@@ -273,8 +275,9 @@ namespace iot::mqtt {
         bool deliver = true;
 
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   Topic: " << publish.getTopic();
-        if (iot::mqtt::semantic::mqttLog().enabled(logger::LogLevel::Trace)) {
-            iot::mqtt::semantic::mqttLog().trace() << connectionName << " MQTT:   Message:\n" << toHexString(publish.getMessage());
+        auto log = iot::mqtt::semantic::mqttLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << connectionName << " MQTT:   Message:\n" << toHexString(publish.getMessage());
         }
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(publish.getQoS());
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: " << publish.getPacketIdentifier();
@@ -412,19 +415,19 @@ namespace iot::mqtt {
     void Mqtt::printVP(const iot::mqtt::ControlPacket& packet) const {
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: " << packet.getName() << " received: " << clientId;
 
-        if (iot::mqtt::semantic::mqttLog().enabled(logger::LogLevel::Trace)) {
+        auto log = iot::mqtt::semantic::mqttLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
             const std::string hexString = toHexString(packet.serializeVP());
             if (!hexString.empty()) {
-                iot::mqtt::semantic::mqttLog().trace() << connectionName << " MQTT: Received data (variable header and payload):\n"
-                                                       << hexString;
+                log.trace() << connectionName << " MQTT: Received data (variable header and payload):\n" << hexString;
             }
         }
     }
 
     void Mqtt::printFixedHeader(const FixedHeader& fixedHeader) const {
-        if (iot::mqtt::semantic::mqttLog().enabled(logger::LogLevel::Trace)) {
-            iot::mqtt::semantic::mqttLog().trace() << connectionName << " MQTT: Received data (fixed header):\n"
-                                                   << toHexString(fixedHeader.serialize());
+        auto log = iot::mqtt::semantic::mqttLog();
+        if (log.enabled(logger::LogLevel::Trace)) {
+            log.trace() << connectionName << " MQTT: Received data (fixed header):\n" << toHexString(fixedHeader.serialize());
         }
 
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: Fixed Header: PacketType: 0x" << std::hex << std::setfill('0')

--- a/src/web/http/client/SocketContext.cpp
+++ b/src/web/http/client/SocketContext.cpp
@@ -135,16 +135,16 @@ namespace web::http::client {
             frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
                                   << ") rejected: " << requestLine;
 
-            if (frameworkLog().enabled(logger::LogLevel::Trace)) {
-                frameworkLog().trace() << httputils::toString(request->method,
-                                                              request->url,
-                                                              "HTTP/" + std::to_string(request->httpMajor) + "." +
-                                                                  std::to_string(request->httpMinor),
-                                                              request->getQueries(),
-                                                              request->getHeaders(),
-                                                              request->getTrailer(),
-                                                              request->getCookies(),
-                                                              {});
+            auto log = frameworkLog();
+            if (log.enabled(logger::LogLevel::Trace)) {
+                log.trace() << httputils::toString(request->method,
+                                                   request->url,
+                                                   "HTTP/" + std::to_string(request->httpMajor) + "." + std::to_string(request->httpMinor),
+                                                   request->getQueries(),
+                                                   request->getHeaders(),
+                                                   request->getTrailer(),
+                                                   request->getCookies(),
+                                                   {});
             }
         }
     }

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -44,6 +44,13 @@ target_include_directories(SemanticOverheadRound9Test PRIVATE ${PROJECT_SOURCE_D
 target_link_libraries(SemanticOverheadRound9Test PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(SemanticOverheadRound9Test PROPERTIES LABELS "unit;log;round9")
 
+
+snodec_add_test(SemanticLoggingOverheadTest SemanticLoggingOverheadTest.cpp)
+target_include_directories(SemanticLoggingOverheadTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(SemanticLoggingOverheadTest PRIVATE cxx_std_20)
+target_link_libraries(SemanticLoggingOverheadTest PRIVATE snodec-test-support snodec::logger)
+set_tests_properties(SemanticLoggingOverheadTest PROPERTIES LABELS "unit;log;overhead")
+
 snodec_add_test(SemanticProductionThresholdRepairTest SemanticProductionThresholdRepairTest.cpp)
 target_include_directories(SemanticProductionThresholdRepairTest PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(SemanticProductionThresholdRepairTest PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)

--- a/tests/unit/log/SemanticLoggingOverheadTest.cpp
+++ b/tests/unit/log/SemanticLoggingOverheadTest.cpp
@@ -1,0 +1,162 @@
+#include "SemanticLog.h"
+#include "iot/mqtt/SemanticLog.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "tests/support/TestResult.h"
+
+#include <chrono>
+#include <ostream>
+#include <string_view>
+
+namespace {
+    struct ExpensiveArgument {
+        int* counter;
+    };
+
+    std::ostream& operator<<(std::ostream& os, const ExpensiveArgument& value) {
+        ++*value.counter;
+        return os << "expensive";
+    }
+
+    logger::LogScope testScope(std::string_view component = "overhead.test") {
+        return {logger::LogOrigin::Framework, logger::LogBoundary::System, component, {}, logger::LogRole::Unknown, {}};
+    }
+
+    std::chrono::system_clock::time_point fixedTimestamp() {
+        return std::chrono::system_clock::time_point{std::chrono::seconds{1783254896}};
+    }
+
+    class SemanticStateGuard {
+    public:
+        SemanticStateGuard() {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+        }
+
+        ~SemanticStateGuard() {
+            logger::Logger::init();
+            logger::LogManager::init();
+        }
+    };
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    {
+        SemanticStateGuard guard;
+        int sinkCalls = 0;
+        auto logger = logger::BoundaryLogger::createForTest(
+            testScope(),
+            [&](logger::LogRecord) {
+                ++sinkCalls;
+            },
+            logger::LogLevel::Info,
+            fixedTimestamp);
+
+        int counter = 0;
+        logger.debug("value={}", ExpensiveArgument{&counter});
+        result.expectEqual(0, counter, "disabled fmt-style semantic debug does not format an expensive argument");
+        result.expectEqual(0, sinkCalls, "disabled fmt-style semantic debug does not materialize a record or call the sink");
+    }
+
+    {
+        SemanticStateGuard guard;
+        int sinkCalls = 0;
+        auto logger = logger::BoundaryLogger::createForTest(
+            testScope(),
+            [&](logger::LogRecord) {
+                ++sinkCalls;
+            },
+            logger::LogLevel::Debug,
+            fixedTimestamp);
+
+        int counter = 0;
+        logger.debug("value={}", ExpensiveArgument{&counter});
+        result.expectEqual(1, counter, "enabled fmt-style semantic debug formats an expensive argument once");
+        result.expectEqual(1, sinkCalls, "enabled fmt-style semantic debug emits one record");
+    }
+
+    {
+        SemanticStateGuard guard;
+        auto logger = logger::BoundaryLogger::createForTest(
+            testScope(),
+            [](logger::LogRecord) {
+            },
+            logger::LogLevel::Info,
+            fixedTimestamp);
+
+        int counter = 0;
+        if (logger.enabled(logger::LogLevel::Debug)) {
+            logger.debug() << ExpensiveArgument{&counter};
+        }
+        result.expectEqual(0, counter, "guarded stream-style expensive diagnostic is not evaluated when disabled");
+    }
+
+    {
+        SemanticStateGuard guard;
+        int sinkCalls = 0;
+        auto logger = logger::BoundaryLogger::createForTest(
+            testScope(),
+            [&](logger::LogRecord) {
+                ++sinkCalls;
+            },
+            logger::LogLevel::Debug,
+            fixedTimestamp);
+
+        int counter = 0;
+        if (logger.enabled(logger::LogLevel::Debug)) {
+            logger.debug() << ExpensiveArgument{&counter};
+        }
+        result.expectEqual(1, counter, "guarded stream-style expensive diagnostic is evaluated once when enabled");
+        result.expectEqual(1, sinkCalls, "enabled guarded stream-style diagnostic emits one record");
+    }
+
+    {
+        SemanticStateGuard guard;
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Info);
+        logger::LogManager::freeze();
+
+        auto log = snode::semantic::webHttpLog();
+        int counter = 0;
+        log.debug("value={}", ExpensiveArgument{&counter});
+        result.expectTrue(!log.enabled(logger::LogLevel::Debug), "no-threshold convenience helper rejects disabled debug locally");
+        result.expectEqual(0, counter, "no-threshold convenience helper does not format disabled debug arguments");
+    }
+
+    {
+        SemanticStateGuard guard;
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Info);
+        logger::LogManager::setComponentLevel("web.http", logger::LogLevel::Debug);
+        logger::LogManager::freeze();
+
+        auto log = snode::semantic::webHttpLog();
+        int counter = 0;
+        log.debug("value={}", ExpensiveArgument{&counter});
+        result.expectTrue(log.enabled(logger::LogLevel::Debug), "component override enables debug for selected component");
+        result.expectEqual(1, counter, "component override allows selected debug logs to format once");
+    }
+
+    {
+        SemanticStateGuard guard;
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Info);
+        logger::LogManager::freeze();
+
+        int sinkCalls = 0;
+        auto log = iot::mqtt::semantic::mqttLog(
+            [&](logger::LogRecord) {
+                ++sinkCalls;
+            },
+            logger::LogLevel::Trace,
+            fixedTimestamp);
+        int counter = 0;
+        log.debug("value={}", ExpensiveArgument{&counter});
+        result.expectTrue(log.enabled(logger::LogLevel::Debug), "explicit test threshold construction remains available");
+        result.expectEqual(1, counter, "explicit test threshold still formats enabled debug once");
+        result.expectEqual(1, sinkCalls, "explicit test threshold still emits to custom capture sink");
+    }
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation

- Reduce runtime overhead caused by disabled semantic logs formatting expensive arguments, constructing payload dumps, materializing LogRecords, timestamping, or invoking sinks before being rejected by the semantic policy.
- Fix convenience helper behavior where production no-threshold helpers could locally default to an overly permissive threshold (commonly `Trace`) and allow expensive work before `LogManager` rejects the record.
- Eliminate obvious repeated-helper guarded patterns that construct/resolve the same helper twice in hot paths.

### Description

- This PR reduces disabled semantic logging overhead by making production no-threshold semantic helpers construct BoundaryLoggers that use the effective semantic threshold for their scope instead of defaulting to an unconditional `Trace` threshold, while preserving explicit sink/threshold overloads for tests and custom capture (key changes in `src/SemanticLog.h`).
- Bind-once fixes added to obvious hot-path diagnostics so guarded expensive work is only evaluated once when enabled, including MQTT payload/fixed-header traces and the HTTP client rejected-request dump (changes in `src/iot/mqtt/Mqtt.cpp` and `src/web/http/client/SocketContext.cpp`).
- Added focused regression tests to assert disabled logs do not format or materialize work and that explicit/test thresholds still work: `tests/unit/log/SemanticLoggingOverheadTest.cpp` and registered it in `tests/unit/log/CMakeLists.txt`.
- Added the required implementation/report document `docs/logging/semantic-logging-overhead-repair-report.md` summarizing the problem, analysis, files inspected, implementation and follow-ups.
- This PR does not add logging macros, does not add async logging, does not change CLI semantics, does not add `ConfigInstance --log-level`, and does not change severity policy or redaction behavior.

Files changed (high level): `src/SemanticLog.h`, `src/iot/mqtt/Mqtt.cpp`, `src/web/http/client/SocketContext.cpp`, `tests/unit/log/SemanticLoggingOverheadTest.cpp`, `tests/unit/log/CMakeLists.txt`, `docs/logging/semantic-logging-overhead-repair-report.md`.

### Testing

- Built with tests and apps: `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build --parallel 2` succeeded.
- Ran focused semantic tests: `ctest --test-dir cmake-build -R "SemanticLoggingOverheadTest|SemanticCliIntegrationTest|SemanticFilterRound7Test|SemanticEndToEndOutputTest|SemanticCompatibilityRound9Test|SemanticOverheadRound9Test|FinalCleanupMigration09Test|HighFrequencyLoggingSeverityTest|SensitiveLoggingRedactionTest" --output-on-failure` and all selected tests passed.
- Ran full test suite with `ctest --test-dir cmake-build --output-on-failure` and the build reported all 137 registered tests passed (some environment-dependent tests were skipped as expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ecc77d8d8832c9f5de949035add8e)