### PR TITLE
Cache resolved semantic loggers in hot paths

### DIFF
--- a/docs/logging/semantic-logger-cache-report.md
+++ b/docs/logging/semantic-logger-cache-report.md
@@ -1,0 +1,133 @@
+# Semantic logger cache report
+
+## Problem summary
+
+PR G.1b targets the remaining disabled semantic logging overhead in hot stable paths. PR #175 made guarded diagnostics bind helpers once locally, but a single helper call such as `iot::mqtt::semantic::mqttLog()` still resolved `LogManager::effectiveLevel(scope)` on each function invocation before checking `enabled(level)`.
+
+## What PR #175 fixed
+
+- No-threshold production semantic helpers now use effective startup thresholds.
+- Disabled fmt-style semantic logs avoid formatting expensive arguments.
+- Selected repeated-helper guarded diagnostics in MQTT and HTTP client code were changed to local bind-once form.
+
+## What PR #175 did not fix
+
+PR #175 intentionally did not store resolved `BoundaryLogger` values on hot objects. Therefore hot accessors/helpers could still allocate/copy scope lookup data and call `LogManager::effectiveLevel(...)` for disabled logs.
+
+## LogScopeOwner vs BoundaryLogger caching distinction
+
+`LogScopeOwner` caches stable semantic identity: origin, boundary, component, instance, role, and connection. It does not cache the resolved effective threshold. `BoundaryLogger` owns a copied `OwnedLogScope`, sink, threshold, and clock, so caching a `BoundaryLogger` also caches the resolved threshold selected when the logger is constructed.
+
+## BoundaryLogger value/copy safety verification
+
+- `BoundaryLogger::createForTest()` and `LogScopeOwner::logger(...)` construct a `BoundaryLogger` from `copyLogScope(...)` or from a `LogScopeOwner`'s owned scope.
+- `OwnedLogScope` stores strings and optionals rather than borrowing temporary `std::string_view` data.
+- `BoundaryLogger` has value members only (`OwnedLogScope`, `std::function` sink, threshold, and clock) and uses compiler-generated copy/move operations safely for the cached-by-value pattern.
+- This PR does not return references to temporary `BoundaryLogger` objects. The MQTT cache is a class member and guarded calls use it directly.
+- Returning/copying an already constructed `BoundaryLogger` does not call `LogManager::effectiveLevel(...)`; that call occurs in `LogScopeOwner::logger(sink, clock)` before the `BoundaryLogger` is constructed.
+
+## Freeze safety rule
+
+Caching a resolved logger is allowed only when semantic identity is stable, construction is post CLI/config policy application, the log policy is frozen or demonstrably in runtime post-freeze code, and no later policy update is expected.
+
+## Construction-order verification per inspected target
+
+### MQTT core (`iot::mqtt::Mqtt`)
+
+Caching was added only to the core MQTT object. MQTT server contexts are created by MQTT `SocketContextFactory::create(...)` and shared factory `create(...)`, which allocate contexts during accepted connection handling. HTTP/WebSocket/MQTT factories are runtime socket-context factories, not configuration objects. Root configuration applies semantic policy and calls `logger::LogManager::freeze()` in `ConfigRoot::bootstrap(...)` before normal runtime starts. The cached MQTT logger has framework/connection component identity `iot.mqtt`, which is stable for the object lifetime.
+
+### MQTT broker/session construction
+
+Broker tree/session code was not converted to member cached loggers in this PR. These classes can be tied to broker/session-store lifecycle and offline session state; the PR only performs mechanical local bind-once cleanup for the remaining guarded expensive diagnostics.
+
+### Core `SocketContext`
+
+`SocketContext` has stable `applicationLogScope` and `frameworkLogScope` members that include instance and connection identity. However it is a base class for many protocol/application contexts. Because caching there would affect every subclass, this PR leaves it unchanged unless each subclass path is verified and measured in a future rollout.
+
+### HTTP client `SocketContext`
+
+HTTP client contexts are created by `web::http::client::SocketContextFactory::create(...)` during connection establishment. This appears runtime/post-freeze in normal application flow, but because the base `SocketContext` cache would be inherited broadly and because direct HTTP-client-only caching would require API churn around `frameworkLog()`, no caching was added in this PR.
+
+### HTTP server `SocketContext`
+
+HTTP server contexts are created by `web::http::server::SocketContextFactory::create(...)` for accepted connections. This appears runtime/post-freeze in normal application flow, but no caching was added for the same conditional/base-class reasons as HTTP client.
+
+### WebSocket context
+
+WebSocket send/receive frame logging uses semantic helper functions in frame transmitter/receiver code rather than the core `SocketContext` accessors. WebSocket upgrade/context creation spans HTTP upgrade factories; this PR inspected those paths but did not add caching because the requested safe, minimal proof point is MQTT core.
+
+## Classes/files inspected
+
+- `src/log/SemanticLogger.h`
+- `src/log/SemanticLogger.cpp`
+- `src/log/LogScopeOwner.cpp`
+- `src/iot/mqtt/Mqtt.h`
+- `src/iot/mqtt/Mqtt.cpp`
+- `src/iot/mqtt/SemanticLog.h`
+- `src/iot/mqtt/server/SocketContextFactory.cpp`
+- `src/iot/mqtt/server/SharedSocketContextFactory.cpp`
+- `src/iot/mqtt/server/broker/RetainTree.cpp`
+- `src/iot/mqtt/server/broker/SubscriptionTree.cpp`
+- `src/iot/mqtt/server/broker/Session.cpp`
+- `src/core/socket/stream/SocketContext.h`
+- `src/core/socket/stream/SocketContext.cpp`
+- `src/web/http/client/SocketContext.cpp`
+- `src/web/http/client/SocketContextFactory.cpp`
+- `src/web/http/server/SocketContext.cpp`
+- `src/web/http/server/SocketContextFactory.cpp`
+- `src/web/websocket`
+- `src/utils/Config.cpp`
+
+## Where caching was added
+
+- `iot::mqtt::Mqtt` now stores a resolved `logger::BoundaryLogger log_` member initialized from `iot::mqtt::semantic::mqttLog()` in both constructors.
+- MQTT trace guards in send/publish/receive dump paths use `log_.enabled(...)` and `log_.trace()` instead of reconstructing the helper/accessor logger on every call.
+
+## Where caching was deliberately not added and why
+
+- Core `SocketContext` was not cached because it is a broad base class with many subclasses; this PR treats SocketContext caching as conditional on per-subclass verification and future measurement.
+- HTTP client/server contexts were not cached directly because doing so without base-class changes would create broader API churn than this focused PR needs.
+- WebSocket frame helpers were not cached because their transmitter/receiver construction and upgrade paths need a separate minimal design if measurements identify them as the next bottleneck.
+- MQTT broker trees/sessions were not cached as members because the remaining issue there was the repeated-helper guard pattern, fixed locally without changing object layout.
+
+## Remaining MQTT broker bind-once cleanup
+
+The remaining repeated-helper guarded diagnostics in `RetainTree.cpp`, `SubscriptionTree.cpp`, and `Session.cpp` now bind the semantic logger once to a local `auto log` before `enabled(...)` and the expensive `Mqtt::toHexString(...)` formatting path.
+
+## Tests added/updated
+
+- Added `tests/unit/log/SemanticCachedLoggerOverheadTest.cpp`.
+- Registered `SemanticCachedLoggerOverheadTest` in `tests/unit/log/CMakeLists.txt`.
+- The test checks global threshold rejection, component override acceptance, disabled expensive-argument suppression, enabled expensive-argument formatting exactly once, cached logger copy/value threshold behavior, and the source-policy absence of repeated MQTT broker helper guards.
+
+## Search commands run
+
+Before changes:
+
+```sh
+rg -n "\.enabled\(logger::LogLevel::" src -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "[A-Za-z0-9_:]*Log\(\)\.enabled|semantic::[A-Za-z0-9_:]*Log\(\)\.enabled" src -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "auto log = .*Log\(\)|auto log = .*frameworkLog\(\)|auto log = .*\.log\(\)" src -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "LogScopeOwner|BoundaryLogger" src/iot/mqtt src/core/socket/stream src/web/http src/web/websocket -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "toHexString|httputils::toString|dump\(|payload|body|header|packet|buffer|retain|subscription" src/iot/mqtt src/web/http src/web/websocket src/core/socket/stream -g '*.h' -g '*.hpp' -g '*.cpp'
+```
+
+After changes:
+
+```sh
+rg -n "[A-Za-z0-9_:]*Log\(\)\.enabled|semantic::[A-Za-z0-9_:]*Log\(\)\.enabled" src -g '*.h' -g '*.hpp' -g '*.cpp'
+rg -n "cached|BoundaryLogger.*log_|logger::BoundaryLogger" src/iot/mqtt src/core/socket/stream src/web/http src/web/websocket docs/logging tests/unit/log -g '*.h' -g '*.hpp' -g '*.cpp' -g '*.md'
+rg -n "SNODEC_.*LOG|LOG_IF|TRACE_IF|DEBUG_IF|IF_ENABLED" src/log src tests docs -g '*.h' -g '*.hpp' -g '*.cpp' -g '*.md'
+```
+
+## Tests run
+
+The validation commands and results are recorded in the PR body/final summary for this change.
+
+## Known follow-ups
+
+1. PR G.2 — ConfigInstance instance-scoped `--log-level`.
+2. Optional broader cache rollout if measurements show remaining overhead.
+3. Optional async logging backend only if accepted-log sink I/O becomes the bottleneck.
+4. Final macro removal/source gate.
+5. Round 10 book integration.

--- a/docs/logging/semantic-logger-cache-report.md
+++ b/docs/logging/semantic-logger-cache-report.md
@@ -81,7 +81,8 @@ WebSocket send/receive frame logging uses semantic helper functions in frame tra
 ## Where caching was added
 
 - `iot::mqtt::Mqtt` now stores a resolved `logger::BoundaryLogger log_` member initialized from `iot::mqtt::semantic::mqttLog()` in both constructors.
-- MQTT trace guards in send/publish/receive dump paths use `log_.enabled(...)` and `log_.trace()` instead of reconstructing the helper/accessor logger on every call.
+- `Mqtt.cpp` now uses cached `log_` for all same-scope `trace`/`debug`/`info`/`warn`/`error`/`critical` logs instead of reconstructing `iot::mqtt::semantic::mqttLog()` on each call.
+- No same-scope `mqttLog().trace/debug/info/warn/error/critical` calls remain in `Mqtt.cpp`; any future reintroduction is covered by the source-policy test.
 
 ## Where caching was deliberately not added and why
 
@@ -97,8 +98,10 @@ The remaining repeated-helper guarded diagnostics in `RetainTree.cpp`, `Subscrip
 ## Tests added/updated
 
 - Added `tests/unit/log/SemanticCachedLoggerOverheadTest.cpp`.
+- The cached logger member and constructor initialization are structurally verified by `SemanticCachedLoggerOverheadTest`, which also fails if a direct same-scope `iot::mqtt::semantic::mqttLog().trace/debug/info/warn/error/critical` call returns to `Mqtt.cpp`.
+- The test uses `tests/unit/log/SourcePolicyTestRoot.h` for source-root discovery and source file reading.
 - Registered `SemanticCachedLoggerOverheadTest` in `tests/unit/log/CMakeLists.txt`.
-- The test checks global threshold rejection, component override acceptance, disabled expensive-argument suppression, enabled expensive-argument formatting exactly once, cached logger copy/value threshold behavior, and the source-policy absence of repeated MQTT broker helper guards.
+- The test checks global threshold rejection, component override acceptance, disabled expensive-argument suppression, enabled expensive-argument formatting exactly once, cached logger copy/value threshold behavior, structural cached MQTT member usage, absence of direct same-scope MQTT helper severity calls in `Mqtt.cpp`, and the source-policy absence of repeated MQTT broker helper guards.
 
 ## Search commands run
 

--- a/src/iot/mqtt/Mqtt.cpp
+++ b/src/iot/mqtt/Mqtt.cpp
@@ -95,7 +95,7 @@ namespace iot::mqtt {
     }
 
     void Mqtt::onConnected() {
-        iot::mqtt::semantic::mqttLog().info() << "MQTT: Connected";
+        log_.info() << "MQTT: Connected";
     }
 
     std::size_t Mqtt::onReceivedFromPeer() {
@@ -119,14 +119,13 @@ namespace iot::mqtt {
                 fixedHeader.reset();
 
                 if (controlPacketDeserializer == nullptr) {
-                    iot::mqtt::semantic::mqttLog().debug()
-                        << connectionName << " MQTT: Received packet-type is unavailable ... closing connection";
+                    log_.debug() << connectionName << " MQTT: Received packet-type is unavailable ... closing connection";
 
                     mqttContext->close();
                     break;
                 }
                 if (controlPacketDeserializer->isError()) {
-                    iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: Fixed header has error ... closing connection";
+                    log_.debug() << connectionName << " MQTT: Fixed header has error ... closing connection";
 
                     delete controlPacketDeserializer;
                     controlPacketDeserializer = nullptr;
@@ -142,7 +141,7 @@ namespace iot::mqtt {
                 consumed += controlPacketDeserializer->deserialize(mqttContext);
 
                 if (controlPacketDeserializer->isError()) {
-                    iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: Control packet has error ... closing connection";
+                    log_.debug() << connectionName << " MQTT: Control packet has error ... closing connection";
                     mqttContext->close();
 
                     delete controlPacketDeserializer;
@@ -167,7 +166,7 @@ namespace iot::mqtt {
     }
 
     void Mqtt::onDisconnected() {
-        iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT: Disconnected";
+        log_.info() << connectionName << " MQTT: Disconnected";
     }
 
     const std::string& Mqtt::getConnectionName() const {
@@ -178,13 +177,13 @@ namespace iot::mqtt {
         this->session = session;
 
         for (const auto& [packetIdentifier, publish] : session->outgoingPublishMap) {
-            iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: PUBLISH Resend";
+            log_.debug() << connectionName << " MQTT: PUBLISH Resend";
 
             send(publish);
         }
 
         for (const uint16_t packetIdentifier : session->pubrelPacketIdentifierSet) {
-            iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: PUBREL Resend";
+            log_.debug() << connectionName << " MQTT: PUBREL Resend";
 
             sendPubrel(packetIdentifier);
         }
@@ -192,12 +191,11 @@ namespace iot::mqtt {
         if (keepAlive > 0) {
             keepAlive *= 1.5;
 
-            iot::mqtt::semantic::mqttLog().info() << connectionName << " MQTT: Keep alive initialized with: " << keepAlive;
+            log_.info() << connectionName << " MQTT: Keep alive initialized with: " << keepAlive;
 
             keepAliveTimer = core::timer::Timer::singleshotTimer(
                 [this, keepAlive]() {
-                    iot::mqtt::semantic::mqttLog().error()
-                        << connectionName << " MQTT: Keep-alive timer expired. Interval was: " << keepAlive;
+                    log_.error() << connectionName << " MQTT: Keep-alive timer expired. Interval was: " << keepAlive;
                     mqttContext->close();
                 },
                 keepAlive);
@@ -207,7 +205,7 @@ namespace iot::mqtt {
     }
 
     void Mqtt::send(const ControlPacket& controlPacket) const {
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: " << controlPacket.getName() << " send: " << clientId;
+        log_.debug() << connectionName << " MQTT: " << controlPacket.getName() << " send: " << clientId;
 
         send(controlPacket.serialize());
     }
@@ -225,14 +223,14 @@ namespace iot::mqtt {
 
         send(iot::mqtt::packets::Publish(packetIdentifier, topic, message, qoS, false, retain));
 
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   Topic: " << topic;
+        log_.debug() << connectionName << " MQTT:   Topic: " << topic;
         if (log_.enabled(logger::LogLevel::Trace)) {
             log_.trace() << connectionName << " MQTT:   Message:\n" << toHexString(message);
         }
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(qoS);
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: " << packetIdentifier;
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   DUP: " << false;
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   Retain: " << retain;
+        log_.debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(qoS);
+        log_.debug() << connectionName << " MQTT:   PacketIdentifier: " << packetIdentifier;
+        log_.debug() << connectionName << " MQTT:   DUP: " << false;
+        log_.debug() << connectionName << " MQTT:   Retain: " << retain;
 
         if (qoS >= 1) {
             session->outgoingPublishMap.insert_or_assign(packetIdentifier,
@@ -274,25 +272,25 @@ namespace iot::mqtt {
     bool Mqtt::_onPublish(const iot::mqtt::packets::Publish& publish) {
         bool deliver = true;
 
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   Topic: " << publish.getTopic();
+        log_.debug() << connectionName << " MQTT:   Topic: " << publish.getTopic();
         if (log_.enabled(logger::LogLevel::Trace)) {
             log_.trace() << connectionName << " MQTT:   Message:\n" << toHexString(publish.getMessage());
         }
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(publish.getQoS());
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: " << publish.getPacketIdentifier();
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   DUP: " << publish.getDup();
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   Retain: " << publish.getRetain();
+        log_.debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(publish.getQoS());
+        log_.debug() << connectionName << " MQTT:   PacketIdentifier: " << publish.getPacketIdentifier();
+        log_.debug() << connectionName << " MQTT:   DUP: " << publish.getDup();
+        log_.debug() << connectionName << " MQTT:   Retain: " << publish.getRetain();
 
         if (publish.getQoS() > 2) {
-            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   Received invalid QoS: " << publish.getQoS();
+            log_.error() << connectionName << " MQTT:   Received invalid QoS: " << publish.getQoS();
             mqttContext->close();
             deliver = false;
         } else if (publish.getPacketIdentifier() == 0 && publish.getQoS() > 0) {
-            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   Received QoS > 0 but no PackageIdentifier present";
+            log_.error() << connectionName << " MQTT:   Received QoS > 0 but no PackageIdentifier present";
             mqttContext->close();
             deliver = false;
         } else if (publish.getQoS() == 0 && publish.getDup()) {
-            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   Received QoS == 0 but dup is set";
+            log_.error() << connectionName << " MQTT:   Received QoS == 0 but dup is set";
             mqttContext->close();
             deliver = false;
         } else {
@@ -312,15 +310,13 @@ namespace iot::mqtt {
                         if (!publish.getDup()) {
                             session->pubcompPacketIdentifierSet.erase(pid);
                         } else {
-                            iot::mqtt::semantic::mqttLog().warn()
-                                << connectionName << " MQTT:   Duplicate QoS2 PUBLISH after PUBCOMP for PacketIdentifier: " << pid;
+                            log_.warn() << connectionName << " MQTT:   Duplicate QoS2 PUBLISH after PUBCOMP for PacketIdentifier: " << pid;
                             break;
                         }
                     }
 
                     if (session->incomingPublishMap.contains(pid)) {
-                        iot::mqtt::semantic::mqttLog().debug()
-                            << connectionName << " MQTT:   Duplicate QoS2 PUBLISH suppressed for PacketIdentifier: " << pid;
+                        log_.debug() << connectionName << " MQTT:   Duplicate QoS2 PUBLISH suppressed for PacketIdentifier: " << pid;
                     } else {
                         session->incomingPublishMap.emplace(pid, publish);
                     }
@@ -334,11 +330,11 @@ namespace iot::mqtt {
 
     void Mqtt::_onPuback(const iot::mqtt::packets::Puback& puback) {
         if (puback.getPacketIdentifier() == 0) {
-            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   PackageIdentifier missing";
+            log_.error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0')
-                                                   << std::setw(4) << puback.getPacketIdentifier() << std::dec;
+            log_.debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
+                         << puback.getPacketIdentifier() << std::dec;
 
             session->outgoingPublishMap.erase(puback.getPacketIdentifier());
         }
@@ -348,11 +344,11 @@ namespace iot::mqtt {
 
     void Mqtt::_onPubrec(const iot::mqtt::packets::Pubrec& pubrec) {
         if (pubrec.getPacketIdentifier() == 0) {
-            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   PackageIdentifier missing";
+            log_.error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0')
-                                                   << std::setw(4) << pubrec.getPacketIdentifier() << std::dec;
+            log_.debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
+                         << pubrec.getPacketIdentifier() << std::dec;
 
             session->outgoingPublishMap.erase(pubrec.getPacketIdentifier());
             session->pubrelPacketIdentifierSet.insert(pubrec.getPacketIdentifier());
@@ -365,27 +361,25 @@ namespace iot::mqtt {
 
     void Mqtt::_onPubrel(const iot::mqtt::packets::Pubrel& pubrel) {
         if (pubrel.getPacketIdentifier() == 0) {
-            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   PackageIdentifier missing";
+            log_.error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0')
-                                                   << std::setw(4) << pubrel.getPacketIdentifier() << std::dec;
+            log_.debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
+                         << pubrel.getPacketIdentifier() << std::dec;
 
             const uint16_t pid = pubrel.getPacketIdentifier();
 
             if (session->incomingPublishMap.contains(pid)) {
-                iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   QoS2 PUBREL received. Deliver publish: " << pid;
+                log_.debug() << connectionName << " MQTT:   QoS2 PUBREL received. Deliver publish: " << pid;
 
                 distributePublish(session->incomingPublishMap[pid]);
 
                 session->incomingPublishMap.erase(pid);
                 session->pubcompPacketIdentifierSet.insert(pid);
             } else if (session->pubcompPacketIdentifierSet.contains(pid)) {
-                iot::mqtt::semantic::mqttLog().debug()
-                    << connectionName << " MQTT:   Duplicate QoS2 PUBREL for completed PacketIdentifier: " << pid;
+                log_.debug() << connectionName << " MQTT:   Duplicate QoS2 PUBREL for completed PacketIdentifier: " << pid;
             } else {
-                iot::mqtt::semantic::mqttLog().warn()
-                    << connectionName << " MQTT:   QoS2 PUBREL received for unknown PacketIdentifier: " << pid;
+                log_.warn() << connectionName << " MQTT:   QoS2 PUBREL received for unknown PacketIdentifier: " << pid;
 
                 session->pubcompPacketIdentifierSet.insert(pid);
             }
@@ -398,11 +392,11 @@ namespace iot::mqtt {
 
     void Mqtt::_onPubcomp(const iot::mqtt::packets::Pubcomp& pubcomp) {
         if (pubcomp.getPacketIdentifier() == 0) {
-            iot::mqtt::semantic::mqttLog().error() << connectionName << " MQTT:   PackageIdentifier missing";
+            log_.error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0')
-                                                   << std::setw(4) << pubcomp.getPacketIdentifier() << std::dec;
+            log_.debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
+                         << pubcomp.getPacketIdentifier() << std::dec;
 
             session->outgoingPublishMap.erase(pubcomp.getPacketIdentifier());
             session->pubrelPacketIdentifierSet.erase(pubcomp.getPacketIdentifier());
@@ -412,7 +406,7 @@ namespace iot::mqtt {
     }
 
     void Mqtt::printVP(const iot::mqtt::ControlPacket& packet) const {
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: " << packet.getName() << " received: " << clientId;
+        log_.debug() << connectionName << " MQTT: " << packet.getName() << " received: " << clientId;
 
         if (log_.enabled(logger::LogLevel::Trace)) {
             const std::string hexString = toHexString(packet.serializeVP());
@@ -427,12 +421,12 @@ namespace iot::mqtt {
             log_.trace() << connectionName << " MQTT: Received data (fixed header):\n" << toHexString(fixedHeader.serialize());
         }
 
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: Fixed Header: PacketType: 0x" << std::hex << std::setfill('0')
-                                               << std::setw(2) << static_cast<uint16_t>(fixedHeader.getType()) << " ("
-                                               << iot::mqtt::mqttPackageName[fixedHeader.getType()] << ")" << std::dec;
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketFlags: 0x" << std::hex << std::setfill('0')
-                                               << std::setw(2) << static_cast<uint16_t>(fixedHeader.getFlags()) << std::dec;
-        iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   RemainingLength: " << fixedHeader.getRemainingLength();
+        log_.debug() << connectionName << " MQTT: Fixed Header: PacketType: 0x" << std::hex << std::setfill('0') << std::setw(2)
+                     << static_cast<uint16_t>(fixedHeader.getType()) << " (" << iot::mqtt::mqttPackageName[fixedHeader.getType()] << ")"
+                     << std::dec;
+        log_.debug() << connectionName << " MQTT:   PacketFlags: 0x" << std::hex << std::setfill('0') << std::setw(2)
+                     << static_cast<uint16_t>(fixedHeader.getFlags()) << std::dec;
+        log_.debug() << connectionName << " MQTT:   RemainingLength: " << fixedHeader.getRemainingLength();
     }
 
     std::string Mqtt::toHexString(const std::vector<char>& data) {

--- a/src/iot/mqtt/Mqtt.cpp
+++ b/src/iot/mqtt/Mqtt.cpp
@@ -67,12 +67,14 @@
 namespace iot::mqtt {
 
     Mqtt::Mqtt(const std::string& connectionName)
-        : connectionName(connectionName) {
+        : connectionName(connectionName)
+        , log_(iot::mqtt::semantic::mqttLog()) {
     }
 
     Mqtt::Mqtt(const std::string& connectionName, const std::string& clientId)
         : connectionName(connectionName)
-        , clientId(clientId) {
+        , clientId(clientId)
+        , log_(iot::mqtt::semantic::mqttLog()) {
     }
 
     Mqtt::~Mqtt() {
@@ -211,9 +213,8 @@ namespace iot::mqtt {
     }
 
     void Mqtt::send(const std::vector<char>& data) const {
-        auto log = iot::mqtt::semantic::mqttLog();
-        if (log.enabled(logger::LogLevel::Trace)) {
-            log.trace() << connectionName << " MQTT: Send data (full message):\n" << toHexString(data);
+        if (log_.enabled(logger::LogLevel::Trace)) {
+            log_.trace() << connectionName << " MQTT: Send data (full message):\n" << toHexString(data);
         }
 
         mqttContext->send(data.data(), data.size());
@@ -225,9 +226,8 @@ namespace iot::mqtt {
         send(iot::mqtt::packets::Publish(packetIdentifier, topic, message, qoS, false, retain));
 
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   Topic: " << topic;
-        auto log = iot::mqtt::semantic::mqttLog();
-        if (log.enabled(logger::LogLevel::Trace)) {
-            log.trace() << connectionName << " MQTT:   Message:\n" << toHexString(message);
+        if (log_.enabled(logger::LogLevel::Trace)) {
+            log_.trace() << connectionName << " MQTT:   Message:\n" << toHexString(message);
         }
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(qoS);
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: " << packetIdentifier;
@@ -275,9 +275,8 @@ namespace iot::mqtt {
         bool deliver = true;
 
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   Topic: " << publish.getTopic();
-        auto log = iot::mqtt::semantic::mqttLog();
-        if (log.enabled(logger::LogLevel::Trace)) {
-            log.trace() << connectionName << " MQTT:   Message:\n" << toHexString(publish.getMessage());
+        if (log_.enabled(logger::LogLevel::Trace)) {
+            log_.trace() << connectionName << " MQTT:   Message:\n" << toHexString(publish.getMessage());
         }
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(publish.getQoS());
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT:   PacketIdentifier: " << publish.getPacketIdentifier();
@@ -415,19 +414,17 @@ namespace iot::mqtt {
     void Mqtt::printVP(const iot::mqtt::ControlPacket& packet) const {
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: " << packet.getName() << " received: " << clientId;
 
-        auto log = iot::mqtt::semantic::mqttLog();
-        if (log.enabled(logger::LogLevel::Trace)) {
+        if (log_.enabled(logger::LogLevel::Trace)) {
             const std::string hexString = toHexString(packet.serializeVP());
             if (!hexString.empty()) {
-                log.trace() << connectionName << " MQTT: Received data (variable header and payload):\n" << hexString;
+                log_.trace() << connectionName << " MQTT: Received data (variable header and payload):\n" << hexString;
             }
         }
     }
 
     void Mqtt::printFixedHeader(const FixedHeader& fixedHeader) const {
-        auto log = iot::mqtt::semantic::mqttLog();
-        if (log.enabled(logger::LogLevel::Trace)) {
-            log.trace() << connectionName << " MQTT: Received data (fixed header):\n" << toHexString(fixedHeader.serialize());
+        if (log_.enabled(logger::LogLevel::Trace)) {
+            log_.trace() << connectionName << " MQTT: Received data (fixed header):\n" << toHexString(fixedHeader.serialize());
         }
 
         iot::mqtt::semantic::mqttLog().debug() << connectionName << " MQTT: Fixed Header: PacketType: 0x" << std::hex << std::setfill('0')

--- a/src/iot/mqtt/Mqtt.h
+++ b/src/iot/mqtt/Mqtt.h
@@ -44,6 +44,7 @@
 
 #include "core/timer/Timer.h"     // IWYU pragma: export
 #include "iot/mqtt/FixedHeader.h" // IWYU pragma: export
+#include "log/SemanticLogger.h"
 
 namespace iot::mqtt {
     class ControlPacket;
@@ -151,6 +152,8 @@ namespace iot::mqtt {
         mutable uint16_t _packetIdentifier = 0;
 
         core::timer::Timer keepAliveTimer;
+
+        logger::BoundaryLogger log_;
 
         int state = 0;
 

--- a/src/iot/mqtt/server/broker/RetainTree.cpp
+++ b/src/iot/mqtt/server/broker/RetainTree.cpp
@@ -120,9 +120,9 @@ namespace iot::mqtt::server::broker {
         if (topic.empty()) {
             iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker: Retain:";
             iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Topic: " << message.getTopic();
-            if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Debug)) {
-                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Message:\n"
-                                                             << iot::mqtt::Mqtt::toHexString(message.getMessage());
+            auto log = iot::mqtt::semantic::mqttBrokerLog();
+            if (log.enabled(logger::LogLevel::Debug)) {
+                log.debug() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
             }
             iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
 
@@ -165,9 +165,9 @@ namespace iot::mqtt::server::broker {
             if (!message.getTopic().empty()) {
                 iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Retained Topic found:";
                 iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << message.getTopic();
-                if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Info)) {
-                    iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Message:\n"
-                                                                << iot::mqtt::Mqtt::toHexString(message.getMessage());
+                auto log = iot::mqtt::semantic::mqttBrokerLog();
+                if (log.enabled(logger::LogLevel::Info)) {
+                    log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
                 }
                 iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
                 iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Client:";
@@ -203,9 +203,9 @@ namespace iot::mqtt::server::broker {
         if (!message.getTopic().empty()) {
             iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Retained Topic found:";
             iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << message.getTopic();
-            if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Info)) {
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Message:\n"
-                                                            << iot::mqtt::Mqtt::toHexString(message.getMessage());
+            auto log = iot::mqtt::semantic::mqttBrokerLog();
+            if (log.enabled(logger::LogLevel::Info)) {
+                log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
             }
             iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
             iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Client:";

--- a/src/iot/mqtt/server/broker/Session.cpp
+++ b/src/iot/mqtt/server/broker/Session.cpp
@@ -66,9 +66,9 @@ namespace iot::mqtt::server::broker {
 
     void Session::sendPublish(Message& message, uint8_t qoS, bool retain) {
         iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:   TopicName: " << message.getTopic();
-        if (iot::mqtt::semantic::mqttSessionLog().enabled(logger::LogLevel::Info)) {
-            iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:   Message:\n"
-                                                         << iot::mqtt::Mqtt::toHexString(message.getMessage());
+        auto log = iot::mqtt::semantic::mqttSessionLog();
+        if (log.enabled(logger::LogLevel::Info)) {
+            log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
         }
         iot::mqtt::semantic::mqttSessionLog().debug() << "MQTT Broker:   QoS: " << static_cast<uint16_t>(std::min(qoS, message.getQoS()));
 

--- a/src/iot/mqtt/server/broker/SubscriptionTree.cpp
+++ b/src/iot/mqtt/server/broker/SubscriptionTree.cpp
@@ -170,9 +170,9 @@ namespace iot::mqtt::server::broker {
         if (topic.empty()) {
             iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Found match:";
             iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: '" << message.getTopic() << "';";
-            if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Info)) {
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Message:\n"
-                                                            << iot::mqtt::Mqtt::toHexString(message.getMessage());
+            auto log = iot::mqtt::semantic::mqttBrokerLog();
+            if (log.enabled(logger::LogLevel::Info)) {
+                log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
             }
 
             iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Distribute PUBLISH for match ...";
@@ -185,9 +185,9 @@ namespace iot::mqtt::server::broker {
             if (nextHashLevel != topicLevels.end()) {
                 iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Found parent match:";
                 iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
-                if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Info)) {
-                    iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Message:\n"
-                                                                << iot::mqtt::Mqtt::toHexString(message.getMessage());
+                auto log = iot::mqtt::semantic::mqttBrokerLog();
+                if (log.enabled(logger::LogLevel::Info)) {
+                    log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
                 }
 
                 iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Distribute PUBLISH for match ...";
@@ -215,9 +215,9 @@ namespace iot::mqtt::server::broker {
             if (foundNode != topicLevels.end()) {
                 iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Found match:";
                 iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
-                if (iot::mqtt::semantic::mqttBrokerLog().enabled(logger::LogLevel::Info)) {
-                    iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Message:\n"
-                                                                << iot::mqtt::Mqtt::toHexString(message.getMessage());
+                auto log = iot::mqtt::semantic::mqttBrokerLog();
+                if (log.enabled(logger::LogLevel::Info)) {
+                    log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
                 }
 
                 iot::mqtt::semantic::mqttBrokerLog().info()

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -167,6 +167,5 @@ snodec_set_source_policy_test_properties(SemanticCliSourcePolicyTest "unit;log;c
 snodec_add_test(SemanticCachedLoggerOverheadTest SemanticCachedLoggerOverheadTest.cpp)
 target_include_directories(SemanticCachedLoggerOverheadTest PRIVATE ${PROJECT_SOURCE_DIR})
 target_compile_features(SemanticCachedLoggerOverheadTest PRIVATE cxx_std_20)
-target_compile_definitions(SemanticCachedLoggerOverheadTest PRIVATE PROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}")
 target_link_libraries(SemanticCachedLoggerOverheadTest PRIVATE snodec-test-support snodec::logger)
-set_tests_properties(SemanticCachedLoggerOverheadTest PROPERTIES LABELS "unit;log;overhead")
+snodec_set_source_policy_test_properties(SemanticCachedLoggerOverheadTest "unit;log;overhead;source-policy")

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -163,3 +163,10 @@ target_include_directories(SemanticCliSourcePolicyTest PRIVATE ${PROJECT_SOURCE_
 target_compile_features(SemanticCliSourcePolicyTest PRIVATE cxx_std_20)
 target_link_libraries(SemanticCliSourcePolicyTest PRIVATE snodec-test-support)
 snodec_set_source_policy_test_properties(SemanticCliSourcePolicyTest "unit;log;cli;source-policy")
+
+snodec_add_test(SemanticCachedLoggerOverheadTest SemanticCachedLoggerOverheadTest.cpp)
+target_include_directories(SemanticCachedLoggerOverheadTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(SemanticCachedLoggerOverheadTest PRIVATE cxx_std_20)
+target_compile_definitions(SemanticCachedLoggerOverheadTest PRIVATE PROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}")
+target_link_libraries(SemanticCachedLoggerOverheadTest PRIVATE snodec-test-support snodec::logger)
+set_tests_properties(SemanticCachedLoggerOverheadTest PROPERTIES LABELS "unit;log;overhead")

--- a/tests/unit/log/SemanticCachedLoggerOverheadTest.cpp
+++ b/tests/unit/log/SemanticCachedLoggerOverheadTest.cpp
@@ -2,9 +2,9 @@
 #include "log/Logger.h"
 #include "log/SemanticLogger.h"
 #include "tests/support/TestResult.h"
+#include "tests/unit/log/SourcePolicyTestRoot.h"
 
 #include <filesystem>
-#include <fstream>
 #include <ostream>
 #include <string>
 #include <string_view>
@@ -34,14 +34,20 @@ namespace {
         }
     };
 
-    std::string readFile(const std::filesystem::path& path) {
-        std::ifstream input(path);
-        return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    bool containsRepeatedHelperGuard(const std::string& source) {
+        return source_policy::contains(source, "semantic::mqttBrokerLog().enabled") ||
+               source_policy::contains(source, "semantic::mqttSessionLog().enabled");
     }
 
-    bool containsRepeatedHelperGuard(const std::string& source) {
-        return source.find("semantic::mqttBrokerLog().enabled") != std::string::npos ||
-               source.find("semantic::mqttSessionLog().enabled") != std::string::npos;
+    bool containsDirectMqttLogSeverity(const std::string& source) {
+        constexpr std::string_view severities[] = {"trace", "debug", "info", "warn", "error", "critical"};
+        for (const std::string_view severity : severities) {
+            const std::string needle = std::string("iot::mqtt::semantic::mqttLog().") + std::string(severity) + "()";
+            if (source_policy::contains(source, needle)) {
+                return true;
+            }
+        }
+        return false;
     }
 } // namespace
 
@@ -86,11 +92,33 @@ int main() {
                           "copied cached logger keeps resolved threshold without re-resolution");
     }
 
+    const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
+    if (root.empty()) {
+        result.expectTrue(false, "sourcePolicyProjectRoot() must not return an empty path");
+        return result.processResult();
+    }
+
     {
-        const std::filesystem::path root = PROJECT_SOURCE_DIR;
-        const std::string retainTree = readFile(root / "src/iot/mqtt/server/broker/RetainTree.cpp");
-        const std::string subscriptionTree = readFile(root / "src/iot/mqtt/server/broker/SubscriptionTree.cpp");
-        const std::string session = readFile(root / "src/iot/mqtt/server/broker/Session.cpp");
+        const std::string mqttHeader = source_policy::readSourcePolicyFile(root / "src/iot/mqtt/Mqtt.h");
+        const std::string mqttSource = source_policy::readSourcePolicyFile(root / "src/iot/mqtt/Mqtt.cpp");
+
+        result.expectTrue(source_policy::contains(mqttHeader, "logger::BoundaryLogger log_"),
+                          "Mqtt.h contains cached BoundaryLogger member log_");
+        result.expectTrue(source_policy::contains(mqttSource, "log_(iot::mqtt::semantic::mqttLog())"),
+                          "Mqtt.cpp constructors initialize cached MQTT logger from mqttLog()");
+        result.expectTrue(!containsDirectMqttLogSeverity(mqttSource),
+                          "Mqtt.cpp uses cached log_ instead of direct same-scope mqttLog severity calls");
+        result.expectTrue(source_policy::contains(mqttSource, "log_.debug()"), "Mqtt.cpp contains cached debug logger usage");
+        result.expectTrue(source_policy::contains(mqttSource, "log_.info()"), "Mqtt.cpp contains cached info logger usage");
+        result.expectTrue(source_policy::contains(mqttSource, "log_.warn()"), "Mqtt.cpp contains cached warn logger usage");
+        result.expectTrue(source_policy::contains(mqttSource, "log_.error()"), "Mqtt.cpp contains cached error logger usage");
+        result.expectTrue(source_policy::contains(mqttSource, "log_.trace()"), "Mqtt.cpp contains cached trace logger usage");
+    }
+
+    {
+        const std::string retainTree = source_policy::readSourcePolicyFile(root / "src/iot/mqtt/server/broker/RetainTree.cpp");
+        const std::string subscriptionTree = source_policy::readSourcePolicyFile(root / "src/iot/mqtt/server/broker/SubscriptionTree.cpp");
+        const std::string session = source_policy::readSourcePolicyFile(root / "src/iot/mqtt/server/broker/Session.cpp");
 
         result.expectTrue(!containsRepeatedHelperGuard(retainTree), "RetainTree broker diagnostics use local bind-once guards");
         result.expectTrue(!containsRepeatedHelperGuard(subscriptionTree), "SubscriptionTree broker diagnostics use local bind-once guards");

--- a/tests/unit/log/SemanticCachedLoggerOverheadTest.cpp
+++ b/tests/unit/log/SemanticCachedLoggerOverheadTest.cpp
@@ -1,0 +1,101 @@
+#include "iot/mqtt/SemanticLog.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "tests/support/TestResult.h"
+
+#include <filesystem>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <string_view>
+
+namespace {
+    struct ExpensiveArgument {
+        int* counter;
+    };
+
+    std::ostream& operator<<(std::ostream& os, const ExpensiveArgument& value) {
+        ++*value.counter;
+        return os << "expensive";
+    }
+
+    class SemanticStateGuard {
+    public:
+        SemanticStateGuard() {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+        }
+
+        ~SemanticStateGuard() {
+            logger::Logger::init();
+            logger::LogManager::init();
+        }
+    };
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream input(path);
+        return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    }
+
+    bool containsRepeatedHelperGuard(const std::string& source) {
+        return source.find("semantic::mqttBrokerLog().enabled") != std::string::npos ||
+               source.find("semantic::mqttSessionLog().enabled") != std::string::npos;
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    {
+        SemanticStateGuard guard;
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Info);
+        logger::LogManager::freeze();
+
+        const auto cachedLog = iot::mqtt::semantic::mqttLog();
+        result.expectTrue(!cachedLog.enabled(logger::LogLevel::Debug), "cached MQTT logger honors global info threshold");
+
+        int counter = 0;
+        cachedLog.debug("value={}", ExpensiveArgument{&counter});
+        result.expectEqual(0, counter, "disabled cached MQTT logger does not format expensive arguments");
+    }
+
+    {
+        SemanticStateGuard guard;
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Info);
+        logger::LogManager::setComponentLevel("iot.mqtt", logger::LogLevel::Debug);
+        logger::LogManager::freeze();
+
+        const auto cachedLog = iot::mqtt::semantic::mqttLog();
+        result.expectTrue(cachedLog.enabled(logger::LogLevel::Debug), "cached MQTT logger honors component debug override");
+
+        int counter = 0;
+        cachedLog.debug("value={}", ExpensiveArgument{&counter});
+        result.expectEqual(1, counter, "enabled cached MQTT logger formats expensive arguments exactly once");
+    }
+
+    {
+        SemanticStateGuard guard;
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Warn);
+        logger::LogManager::freeze();
+
+        const auto cachedLog = iot::mqtt::semantic::mqttLog();
+        const auto copiedLog = cachedLog;
+        result.expectTrue(!copiedLog.enabled(logger::LogLevel::Info),
+                          "copied cached logger keeps resolved threshold without re-resolution");
+    }
+
+    {
+        const std::filesystem::path root = PROJECT_SOURCE_DIR;
+        const std::string retainTree = readFile(root / "src/iot/mqtt/server/broker/RetainTree.cpp");
+        const std::string subscriptionTree = readFile(root / "src/iot/mqtt/server/broker/SubscriptionTree.cpp");
+        const std::string session = readFile(root / "src/iot/mqtt/server/broker/Session.cpp");
+
+        result.expectTrue(!containsRepeatedHelperGuard(retainTree), "RetainTree broker diagnostics use local bind-once guards");
+        result.expectTrue(!containsRepeatedHelperGuard(subscriptionTree), "SubscriptionTree broker diagnostics use local bind-once guards");
+        result.expectTrue(!containsRepeatedHelperGuard(session), "Session broker diagnostics use local bind-once guards");
+    }
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation

- Reduce remaining per-call overhead where `mqttLog()`/`log()` re-resolve `LogManager::effectiveLevel(scope)` on every guarded diagnostic call in hot paths.
- Prove safe caching of the resolved `BoundaryLogger` (threshold included) for hot, stable-identity objects while preserving all existing logging semantics and overrides.
- Follow strict safety rules: only cache when identity is stable, construction is post-startup policy application, `LogManager::freeze()` has been applied (or construction is demonstrably post-freeze), and `BoundaryLogger` copy/value behavior is safe.

### Description

- Cache a resolved `logger::BoundaryLogger` as a member `log_` in `iot::mqtt::Mqtt`, initialized from `iot::mqtt::semantic::mqttLog()` in both constructors and used for hot trace guards (`log_.enabled(...)` / `log_.trace()`).
- Convert the remaining repeated-helper guarded sites in `src/iot/mqtt/server/broker/{RetainTree.cpp,SubscriptionTree.cpp,Session.cpp}` to local bind-once form (`auto log = ...`) before calling `enabled(...)` and expensive formatting.
- Add `tests/unit/log/SemanticCachedLoggerOverheadTest.cpp` and register it in `tests/unit/log/CMakeLists.txt` to validate cached logger behavior, expensive-argument suppression/format count, copy/value threshold stability, and the source-policy absence of repeated broker helper guards, and add `docs/logging/semantic-logger-cache-report.md` documenting safety reasoning and per-target construction-order verification.
- Verified `BoundaryLogger` value/copy safety (it stores an owned scope, sink, threshold and clock by value), verified MQTT construction path (socket-context factory creates MQTT runtime objects after root configuration applies policy and calls `LogManager::freeze()`), and left `SocketContext`/HTTP/WebSocket caching conditional and unchanged in this PR pending per-subclass verification.

### Testing

- Configured and built with `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build --parallel 2` successfully.
- Ran focused and full test sets with `ctest` (including the new `SemanticCachedLoggerOverheadTest`); all executed tests passed (observed run: 138/138 tests passed where non-applicable tests were skipped by their own conditions). The new test passed.
- Ran formatting (`clang-format -i` on touched files) and `git diff --check`; no formatting or whitespace issues reported.
- Automated test and build steps above completed successfully; no automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f46a56730832cba37b303770ddb54)