### PR TITLE
Add structured comment metadata to -s/--show-config output

### DIFF
--- a/docs/config-comment-metadata.md
+++ b/docs/config-comment-metadata.md
@@ -1,0 +1,64 @@
+# Configuration comment metadata
+
+`-s` / `--show-config` emits the canonical SNode.C configuration template as INI-compatible text. Version 1 now augments that template with structured metadata comments for tools such as `snodec-control` while keeping the real configuration lines unchanged.
+
+Metadata is carried only in comments with the reserved `#@` prefix:
+
+```ini
+#@ snodec.meta begin option
+#@ {
+#@   "schema": "snodec.config.comment-meta",
+#@   "version": 1,
+#@   "entity": "option",
+#@   "key": "echoserver.local.port"
+#@ }
+#@ snodec.meta end option
+# Port number
+#echoserver.local.port="<REQUIRED>"
+```
+
+Because each metadata line is a comment, CLI11/SNode.C config parsing ignores it. Existing config files without metadata remain valid, and generated templates can still be edited by changing only normal INI key/value lines.
+
+## Entities
+
+Version 1 emits four entity types:
+
+* `document` appears once at the beginning and describes the schema, application, output syntax (`ini-with-comment-metadata`), and scope (`configurable-options-only`).
+* `node` appears before each CLI11/SNode.C application or subcommand node represented by the output. Node kinds are inferred from the current CLI11 tree: root applications, `Instances`, `Sections`, anonymous empty-name nodes, other grouped categories, and fallback subcommands.
+* `group` appears before each CLI11 option group that contains configurable options. Group kind is inferred from the group name (`default`, `persistent`, `nonpersistent`, or `custom`).
+* `option` appears immediately before the option's human description and config/default line.
+
+Anonymous / empty-name subcommands are not collapsed into their parent. Their metadata path receives deterministic sibling-local generated segments such as `<anonymous-0>` while the `name` field preserves the actual CLI11 name, including the empty string.
+
+## Value fields
+
+Option metadata separates semantic values from INI literals:
+
+* `cppDefault`, `configured`, and `effective` are semantic values.
+* `cppDefaultLiteral`, `configuredLiteral`, and `effectiveLiteral` are the INI/config-file literal representations.
+* `source` reports `command-line-or-config`, `cpp-default`, `required-placeholder`, or `empty-default` according to current formatter-visible state.
+
+Version 1 exposes the current C++/CLI11 default as `cppDefault`. It does not expose the original registration-time default. `registrationDefault` is emitted as `null` with `registrationDefaultSource = "not-tracked"`.
+
+For multi-value options, version 1 may represent semantic values as deterministic space-joined strings and marks list-like options with `type.items = "list"`.
+
+## Required state
+
+This formatter-only metadata exposes only current CLI11 required state:
+
+```json
+"required": {
+  "effective": true,
+  "source": "cli11-current-state"
+}
+```
+
+Canonical required/needs state and disable/enable suppression semantics are not part of this formatter-only PR. Registration-default tracking is also deliberately left to a future option-metadata design.
+
+## Known limitations
+
+* The schema scope is `configurable-options-only`; non-configurable options are omitted from config output and metadata.
+* `registrationDefault` is not tracked in version 1.
+* `required.effective` reflects current CLI11 state only and is not a canonical registration-time value.
+* Relation metadata reports available CLI11 `needs` / `excludes` option names but does not restore or infer suppressed state.
+* No separate JSON config output mode is provided; JSON appears only inside INI comments.

--- a/docs/config-comment-metadata.md
+++ b/docs/config-comment-metadata.md
@@ -17,7 +17,7 @@ Metadata is carried only in comments with the reserved `#@` prefix:
 #echoserver.local.port="<REQUIRED>"
 ```
 
-Because each metadata line is a comment, CLI11/SNode.C config parsing ignores it. Existing config files without metadata remain valid, and generated templates can still be edited by changing only normal INI key/value lines.
+Because each metadata line is a comment, CLI11/SNode.C config parsing ignores it. Existing config files without metadata remain valid, and generated templates can still be edited by changing only normal INI key/value lines. No separate JSON output mode exists; JSON appears only as comment metadata inside the INI output. Metadata is emitted only when description/comment output is enabled (`write_description=true`, as used by `-s` / `--show-config`).
 
 ## Entities
 
@@ -28,7 +28,7 @@ Version 1 emits four entity types:
 * `group` appears before each CLI11 option group that contains configurable options. Group kind is inferred from the group name (`default`, `persistent`, `nonpersistent`, or `custom`).
 * `option` appears immediately before the option's human description and config/default line.
 
-Anonymous / empty-name subcommands are not collapsed into their parent. Their metadata path receives deterministic sibling-local generated segments such as `<anonymous-0>` while the `name` field preserves the actual CLI11 name, including the empty string.
+The root application has `path: []`. Child subcommands use paths relative to that root, for example `["outer"]` and `["outer", "inner"]`, so the application name does not look like part of the config-key hierarchy. Anonymous / empty-name subcommands are not collapsed into their parent. Their metadata path receives deterministic sibling-local generated segments such as `<anonymous-0>` while the `name` field preserves the actual CLI11 name, including the empty string. Option `key` remains the real config key; option `id` uses generated anonymous path segments where needed so sibling anonymous options can be distinguished, for example `<anonymous-0>.value`.
 
 ## Value fields
 
@@ -61,4 +61,6 @@ Canonical required/needs state and disable/enable suppression semantics are not 
 * `registrationDefault` is not tracked in version 1.
 * `required.effective` reflects current CLI11 state only and is not a canonical registration-time value.
 * Relation metadata reports available CLI11 `needs` / `excludes` option names but does not restore or infer suppressed state.
+* `constraints` is emitted as an empty array in version 1; validator and constraint metadata is not decomposed yet.
+* Metadata is suppressed when description/comment output is disabled.
 * No separate JSON config output mode is provided; JSON appears only inside INI comments.

--- a/src/utils/Formatter.cpp
+++ b/src/utils/Formatter.cpp
@@ -137,8 +137,55 @@ namespace CLI {
             return out.str();
         }
 
+        struct ConfigFormatSettings {
+            char commentChar{'#'};
+            char arrayStart{'['};
+            char arrayEnd{']'};
+            char arraySeparator{','};
+            char valueDelimiter{'='};
+            char stringQuote{'"'};
+            char literalQuote{'\''};
+            char parentSeparatorChar{'.'};
+        };
+
+        struct OptionMetaValue {
+            std::string cppDefaultSemantic{};
+            std::string configuredSemantic{};
+            std::string effectiveSemantic{};
+            std::string source{"empty-default"};
+            std::string cppDefaultLiteral{};
+            std::string configuredLiteral{};
+            std::string effectiveLiteral{};
+            bool hasCppDefault{false};
+            bool hasConfigured{false};
+            bool isCppDefault{false};
+            bool isMissingRequired{false};
+        };
+
         std::string optionKey(const std::string& prefix, const Option* opt) {
             return prefix + opt->get_single_name();
+        }
+
+        std::string joinSemanticValues(const results_t& values) {
+            std::ostringstream out;
+            for (std::size_t i = 0; i < values.size(); ++i) {
+                if (i > 0)
+                    out << ' ';
+                out << values[i];
+            }
+            return out.str();
+        }
+
+        std::string optionId(const std::vector<std::string>& path, const Option* opt) {
+            std::vector<std::string> idPath = path;
+            idPath.push_back(opt->get_single_name());
+            std::ostringstream out;
+            for (std::size_t i = 0; i < idPath.size(); ++i) {
+                if (i > 0)
+                    out << '.';
+                out << idPath[i];
+            }
+            return out.str();
         }
 
         std::vector<std::string> pathWith(const std::vector<std::string>& parentPath, const std::string& segment) {
@@ -167,12 +214,12 @@ namespace CLI {
         std::pair<std::string, std::string> nodeKind(const App* app) {
             if (app->get_parent() == nullptr)
                 return {"application", "root"};
-            if (app->get_name().empty())
-                return {"anonymous", "cli11-name"};
             if (app->get_group() == "Instances")
                 return {"instance", "cli11-group"};
             if (app->get_group() == "Sections")
                 return {"section", "cli11-group"};
+            if (app->get_name().empty())
+                return {"anonymous", "cli11-name"};
             if (!app->get_group().empty())
                 return {"category", "heuristic-cli11-group"};
             return {"subcommand", "fallback"};
@@ -244,12 +291,6 @@ namespace CLI {
             return "string";
         }
 
-        std::string semanticFromLiteral(const std::string& literal) {
-            if (literal.size() >= 2 && literal.front() == '"' && literal.back() == '"')
-                return literal.substr(1, literal.size() - 2);
-            return literal;
-        }
-
         void writeRelations(std::vector<std::string>& lines, const std::string& name, const std::set<Option*>& opts, bool comma) {
             lines.push_back("    \"" + name + "\": [");
             std::size_t idx = 0;
@@ -261,18 +302,11 @@ namespace CLI {
 
         void writeOptionMeta(std::ostream& out,
                              const Option* opt,
+                             const std::string& id,
                              const std::string& key,
                              const std::string& group,
                              const std::vector<std::string>& path,
-                             const std::string& defaultValue,
-                             const std::string& value) {
-            const bool explicitValue = opt->count() > 0;
-            const bool missingRequired =
-                opt->get_required() && (defaultValue == "\"<REQUIRED>\"" || (!explicitValue && opt->get_default_str().empty()));
-            const std::string effectiveLiteral = !value.empty() ? value : defaultValue;
-            const std::string source =
-                explicitValue ? "command-line-or-config"
-                              : (missingRequired ? "required-placeholder" : (!defaultValue.empty() ? "cpp-default" : "empty-default"));
+                             const OptionMetaValue& metaValue) {
             const std::string longName = opt->get_lnames().empty() ? "null" : quoteJson("--" + opt->get_lnames().front());
             const std::string shortName = opt->get_snames().empty() ? "null" : quoteJson("-" + opt->get_snames().front());
             const auto gk = groupKind(group);
@@ -281,7 +315,7 @@ namespace CLI {
                 "  \"schema\": " + quoteJson(MetaSchema) + ",",
                 "  \"version\": 1,",
                 "  \"entity\": \"option\",",
-                "  \"id\": " + quoteJson(key) + ",",
+                "  \"id\": " + quoteJson(id) + ",",
                 "  \"key\": " + quoteJson(key) + ",",
                 "  \"localName\": " + quoteJson(opt->get_single_name()) + ",",
                 "  \"displayName\": " + quoteJson(opt->get_single_name()) + ",",
@@ -315,29 +349,95 @@ namespace CLI {
                 "  \"relations\": {"};
             writeRelations(lines, "needs", opt->get_needs(), true);
             writeRelations(lines, "excludes", opt->get_excludes(), false);
-            lines.insert(lines.end(),
-                         {"  },",
-                          "  \"value\": {",
-                          "    \"registrationDefault\": null,",
-                          "    \"registrationDefaultSource\": \"not-tracked\",",
-                          "    \"cppDefault\": " + (defaultValue.empty() ? "null" : quoteJson(semanticFromLiteral(defaultValue))) + ",",
-                          "    \"configured\": " + (explicitValue && !value.empty() ? quoteJson(semanticFromLiteral(value)) : "null") + ",",
-                          "    \"effective\": " +
-                              (!effectiveLiteral.empty() ? quoteJson(semanticFromLiteral(effectiveLiteral)) : quoteJson("")) + ",",
-                          "    \"source\": " + quoteJson(source) + ",",
-                          std::string("    \"isCppDefault\": ") + (!explicitValue ? "true," : "false,"),
-                          std::string("    \"isExplicitlyConfigured\": ") + (explicitValue ? "true," : "false,"),
-                          std::string("    \"isMissingRequired\": ") + (missingRequired ? "true," : "false,"),
-                          "    \"registrationDefaultLiteral\": null,",
-                          "    \"cppDefaultLiteral\": " + (defaultValue.empty() ? "null" : quoteJson(defaultValue)) + ",",
-                          "    \"configuredLiteral\": " + (explicitValue && !value.empty() ? quoteJson(value) : "null") + ",",
-                          "    \"effectiveLiteral\": " + (!effectiveLiteral.empty() ? quoteJson(effectiveLiteral) : "null"),
-                          "  }",
-                          "}"});
+            lines.insert(
+                lines.end(),
+                {"  },",
+                 "  \"value\": {",
+                 "    \"registrationDefault\": null,",
+                 "    \"registrationDefaultSource\": \"not-tracked\",",
+                 "    \"cppDefault\": " + (metaValue.hasCppDefault ? quoteJson(metaValue.cppDefaultSemantic) : "null") + ",",
+                 "    \"configured\": " + (metaValue.hasConfigured ? quoteJson(metaValue.configuredSemantic) : "null") + ",",
+                 "    \"effective\": " + quoteJson(metaValue.effectiveSemantic) + ",",
+                 "    \"source\": " + quoteJson(metaValue.source) + ",",
+                 std::string("    \"isCppDefault\": ") + (metaValue.isCppDefault ? "true," : "false,"),
+                 std::string("    \"isExplicitlyConfigured\": ") + (metaValue.hasConfigured ? "true," : "false,"),
+                 std::string("    \"isMissingRequired\": ") + (metaValue.isMissingRequired ? "true," : "false,"),
+                 "    \"registrationDefaultLiteral\": null,",
+                 "    \"cppDefaultLiteral\": " + (metaValue.hasCppDefault ? quoteJson(metaValue.cppDefaultLiteral) : "null") + ",",
+                 "    \"configuredLiteral\": " + (metaValue.hasConfigured ? quoteJson(metaValue.configuredLiteral) : "null") + ",",
+                 "    \"effectiveLiteral\": " + (!metaValue.effectiveLiteral.empty() ? quoteJson(metaValue.effectiveLiteral) : "null"),
+                 "  }",
+                 "}"});
             writeMetaBlock(out, "option", lines);
         }
 
-        std::string toConfigWithMeta(const ConfigFormatter* formatter,
+        OptionMetaValue buildOptionMetaValue(const Option* opt, const ConfigFormatSettings& settings) {
+            OptionMetaValue meta;
+            meta.hasConfigured = opt->count() > 0;
+            if (meta.hasConfigured) {
+                try {
+                    const results_t configuredResults = opt->reduced_results();
+                    meta.configuredSemantic = joinSemanticValues(configuredResults);
+                    meta.configuredLiteral = detail::ini_join(configuredResults,
+                                                              settings.arraySeparator,
+                                                              settings.arrayStart,
+                                                              settings.arrayEnd,
+                                                              settings.stringQuote,
+                                                              settings.literalQuote);
+                } catch (CLI::ParseError&) {
+                    const auto& configuredResults = opt->results();
+                    meta.configuredSemantic = joinSemanticValues(configuredResults);
+                    meta.configuredLiteral = detail::ini_join(configuredResults,
+                                                              settings.arraySeparator,
+                                                              settings.arrayStart,
+                                                              settings.arrayEnd,
+                                                              settings.stringQuote,
+                                                              settings.literalQuote);
+                }
+            }
+
+            if (!opt->get_default_str().empty()) {
+                meta.hasCppDefault = true;
+                meta.cppDefaultSemantic = opt->get_default_str();
+                meta.cppDefaultLiteral =
+                    detail::convert_arg_for_ini(opt->get_default_str(), settings.stringQuote, settings.literalQuote, true);
+                if (meta.cppDefaultLiteral == "'\"\"'")
+                    meta.cppDefaultLiteral = "";
+            } else if (opt->get_run_callback_for_default()) {
+                meta.hasCppDefault = true;
+                meta.cppDefaultSemantic = "";
+                meta.cppDefaultLiteral = std::string{settings.stringQuote} + settings.stringQuote;
+            } else if (opt->get_required()) {
+                meta.hasCppDefault = true;
+                meta.cppDefaultSemantic = "<REQUIRED>";
+                meta.cppDefaultLiteral = std::string{settings.stringQuote} + "<REQUIRED>" + settings.stringQuote;
+                meta.isMissingRequired = !meta.hasConfigured;
+            } else if (opt->get_expected_min() == 0) {
+                meta.hasCppDefault = true;
+                meta.cppDefaultSemantic = "false";
+                meta.cppDefaultLiteral = "false";
+            } else {
+                meta.hasCppDefault = true;
+                meta.cppDefaultSemantic = "";
+                meta.cppDefaultLiteral = std::string{settings.stringQuote} + settings.stringQuote;
+            }
+
+            if (meta.hasConfigured) {
+                meta.effectiveSemantic = meta.configuredSemantic;
+                meta.effectiveLiteral = meta.configuredLiteral;
+                meta.source = "command-line-or-config";
+                meta.isCppDefault = false;
+            } else {
+                meta.effectiveSemantic = meta.cppDefaultSemantic;
+                meta.effectiveLiteral = meta.cppDefaultLiteral;
+                meta.source =
+                    meta.isMissingRequired ? "required-placeholder" : (!meta.cppDefaultSemantic.empty() ? "cpp-default" : "empty-default");
+                meta.isCppDefault = true;
+            }
+            return meta;
+        }
+
+        std::string toConfigWithMeta(const ConfigFormatSettings& settings,
                                      const App* app,
                                      bool default_also,
                                      bool write_description,
@@ -346,13 +446,16 @@ namespace CLI {
                                      bool root) {
             std::stringstream out;
             std::string commentLead;
-            commentLead.push_back('#');
+            commentLead.push_back(settings.commentChar);
             commentLead.push_back(' ');
-            if (root)
-                writeDocumentMeta(out, app);
-            writeNodeMeta(out, app, path, prefix);
-            if (write_description && !app->get_description().empty()) {
-                out << '#' << '#' << commentLead << detail::fix_newlines('#' + commentLead, app->get_description()) << '\n';
+            if (write_description) {
+                if (root)
+                    writeDocumentMeta(out, app);
+                writeNodeMeta(out, app, path, prefix);
+                if (!app->get_description().empty()) {
+                    out << settings.commentChar << settings.commentChar << commentLead
+                        << detail::fix_newlines(settings.commentChar + commentLead, app->get_description()) << '\n';
+                }
             }
 
             std::vector<std::string> groups = app->get_groups();
@@ -372,7 +475,7 @@ namespace CLI {
                 if (write_description && hasConfigurable) {
                     writeGroupMeta(out, group, path);
                     if (group != "Options" && !group.empty())
-                        out << '\n' << '#' << commentLead << group << "\n";
+                        out << '\n' << settings.commentChar << commentLead << group << "\n";
                 }
                 for (const Option* opt : app->get_options({})) {
                     if (!opt->get_configurable())
@@ -382,41 +485,51 @@ namespace CLI {
                     const std::string name = optionKey(prefix, opt);
                     std::string value;
                     try {
-                        value = detail::ini_join(opt->reduced_results(), ' ', '[', ']', '\"', '\'');
+                        value = detail::ini_join(opt->reduced_results(),
+                                                 settings.arraySeparator,
+                                                 settings.arrayStart,
+                                                 settings.arrayEnd,
+                                                 settings.stringQuote,
+                                                 settings.literalQuote);
                     } catch (CLI::ParseError& e) {
                         value = std::string{"<["} + Color::Code::FG_RED + e.get_name() + Color::Code::FG_DEFAULT + "] " + e.what() + ">";
                     }
                     std::string defaultValue{};
                     if (default_also) {
-                        if (!value.empty() && detail::convert_arg_for_ini(opt->get_default_str(), '\"', '\'', true) == "\"" + value + "\"")
+                        if (!value.empty() &&
+                            detail::convert_arg_for_ini(opt->get_default_str(), settings.stringQuote, settings.literalQuote, true) ==
+                                std::string{settings.stringQuote} + value + settings.stringQuote)
                             value.clear();
                         if (!opt->get_default_str().empty()) {
-                            defaultValue = detail::convert_arg_for_ini(opt->get_default_str(), '\"', '\'', true);
+                            defaultValue =
+                                detail::convert_arg_for_ini(opt->get_default_str(), settings.stringQuote, settings.literalQuote, true);
                             if (defaultValue == "'\"\"'")
                                 defaultValue = "";
-                        } else if (opt->get_required())
-                            defaultValue = "\"<REQUIRED>\"";
-                        else if (opt->get_run_callback_for_default())
-                            defaultValue = "\"\"";
+                        } else if (opt->get_run_callback_for_default())
+                            defaultValue = std::string{settings.stringQuote} + settings.stringQuote;
+                        else if (opt->get_required())
+                            defaultValue = std::string{settings.stringQuote} + "<REQUIRED>" + settings.stringQuote;
                         else if (opt->get_expected_min() == 0)
                             defaultValue = "false";
                         else
-                            defaultValue = "\"\"";
+                            defaultValue = std::string{settings.stringQuote} + settings.stringQuote;
                     }
-                    writeOptionMeta(out, opt, name, group, path, defaultValue, value);
+                    const OptionMetaValue metaValue = buildOptionMetaValue(opt, settings);
+                    if (write_description)
+                        writeOptionMeta(out, opt, optionId(path, opt), name, group, path, metaValue);
                     if (write_description && opt->has_description() && (default_also || !value.empty()))
                         out << commentLead << detail::fix_newlines(commentLead, opt->get_description()) << '\n';
                     if (default_also && !defaultValue.empty()) {
                         if (defaultValue == value)
                             value.clear();
-                        out << '#' << name << '=' << defaultValue << "\n";
+                        out << settings.commentChar << name << settings.valueDelimiter << defaultValue << "\n";
                     }
                     if (!value.empty()) {
                         if (!opt->get_fnames().empty())
                             value = opt->get_flag_value(name, value);
                         if (value == "\"default\"")
                             value = "default";
-                        out << name << '=' << value << "\n\n";
+                        out << name << settings.valueDelimiter << value << "\n\n";
                     } else
                         out << '\n';
                 }
@@ -430,7 +543,7 @@ namespace CLI {
             for (const App* subcom : subcommands) {
                 if (subcom->get_name().empty()) {
                     out << toConfigWithMeta(
-                        formatter, subcom, default_also, write_description, prefix, pathWith(path, anonymousSegments[subcom]), false);
+                        settings, subcom, default_also, write_description, prefix, pathWith(path, anonymousSegments[subcom]), false);
                 }
             }
             for (const App* subcom : subcommands) {
@@ -439,22 +552,22 @@ namespace CLI {
                         if (!prefix.empty() || app->get_parent() == nullptr)
                             out << '[' << prefix << subcom->get_name() << "]\n";
                         else {
-                            std::string subname = app->get_name() + '.' + subcom->get_name();
+                            std::string subname = app->get_name() + settings.parentSeparatorChar + subcom->get_name();
                             const auto* p = app->get_parent();
                             while (p->get_parent() != nullptr) {
-                                subname = p->get_name() + '.' + subname;
+                                subname = p->get_name() + settings.parentSeparatorChar + subname;
                                 p = p->get_parent();
                             }
                             out << '[' << subname << "]\n";
                         }
                         out << toConfigWithMeta(
-                            formatter, subcom, default_also, write_description, "", pathWith(path, subcom->get_name()), false);
+                            settings, subcom, default_also, write_description, "", pathWith(path, subcom->get_name()), false);
                     } else {
-                        out << toConfigWithMeta(formatter,
+                        out << toConfigWithMeta(settings,
                                                 subcom,
                                                 default_also,
                                                 write_description,
-                                                prefix + subcom->get_name() + '.',
+                                                prefix + subcom->get_name() + settings.parentSeparatorChar,
                                                 pathWith(path, subcom->get_name()),
                                                 false);
                     }
@@ -466,9 +579,11 @@ namespace CLI {
 
     CLI11_INLINE std::string
     ConfigFormatter::to_config(const App* app, bool default_also, bool write_description, std::string prefix) const {
-        const std::vector<std::string> path =
-            app->get_name().empty() ? std::vector<std::string>{} : std::vector<std::string>{app->get_name()};
-        return toConfigWithMeta(this, app, default_also, write_description, prefix, path, app->get_parent() == nullptr && prefix.empty());
+        const ConfigFormatSettings settings{
+            commentChar, arrayStart, arrayEnd, arraySeparator, valueDelimiter, stringQuote, literalQuote, parentSeparatorChar};
+        const std::vector<std::string> path{};
+        return toConfigWithMeta(
+            settings, app, default_also, write_description, prefix, path, app->get_parent() == nullptr && prefix.empty());
     }
 
 #ifndef CLI11_ORIGINAL_FORMATTER

--- a/src/utils/Formatter.cpp
+++ b/src/utils/Formatter.cpp
@@ -46,8 +46,10 @@
 #include "log/Logger.h"
 
 #include <algorithm>
+#include <cctype>
 #include <functional>
 #include <iomanip>
+#include <map>
 #include <set>
 #include <sstream>
 #include <vector>
@@ -63,130 +65,410 @@ namespace CLI {
     ConfigFormatter::~ConfigFormatter() {
     }
 
-    CLI11_INLINE std::string
-    ConfigFormatter::to_config(const App* app, bool default_also, bool write_description, std::string prefix) const {
-        std::stringstream out;
-        std::string commentLead;
-        commentLead.push_back(commentChar);
-        commentLead.push_back(' ');
+    namespace {
+        constexpr const char* MetaSchema = "snodec.config.comment-meta";
 
-        std::vector<std::string> groups = app->get_groups();
-        bool defaultUsed = false;
-        groups.insert(groups.begin(), std::string("Options"));
-        for (const auto& group : groups) {
-            if (group == "Options" || group.empty()) {
-                if (defaultUsed) {
-                    continue;
-                }
-                defaultUsed = true;
-            }
-            if (write_description && group != "Options" && !group.empty() &&
-                !app->get_options([group](const Option* opt) -> bool {
-                        return opt->get_group() == group && opt->get_configurable();
-                    })
-                     .empty()) {
-                out << '\n' << commentChar << commentLead << group << "\n";
-            }
-            for (const Option* opt : app->get_options({})) {
-                // Only process options that are configurable
-                if (opt->get_configurable()) {
-                    if (opt->get_group() != group) {
-                        if (!(group == "Options" && opt->get_group().empty())) {
-                            continue;
+        std::string jsonEscape(const std::string& input) {
+            std::string escaped;
+            for (const char ch : input) {
+                switch (ch) {
+                    case '\\':
+                        escaped += "\\\\";
+                        break;
+                    case '"':
+                        escaped += "\\\"";
+                        break;
+                    case '\b':
+                        escaped += "\\b";
+                        break;
+                    case '\f':
+                        escaped += "\\f";
+                        break;
+                    case '\n':
+                        escaped += "\\n";
+                        break;
+                    case '\r':
+                        escaped += "\\r";
+                        break;
+                    case '\t':
+                        escaped += "\\t";
+                        break;
+                    default:
+                        if (static_cast<unsigned char>(ch) < 0x20) {
+                            std::ostringstream hex;
+                            hex << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(ch);
+                            escaped += hex.str();
+                        } else {
+                            escaped.push_back(ch);
                         }
-                    }
-                    const std::string name = prefix + opt->get_single_name();
+                }
+            }
+            return escaped;
+        }
+
+        std::string quoteJson(const std::string& value) {
+            return "\"" + jsonEscape(value) + "\"";
+        }
+
+        std::string lower(std::string value) {
+            std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+                return static_cast<char>(std::tolower(c));
+            });
+            return value;
+        }
+
+        void writeMetaBlock(std::ostream& out, const std::string& entity, const std::vector<std::string>& lines) {
+            out << "#@ snodec.meta begin " << entity << '\n';
+            for (const auto& line : lines) {
+                out << "#@ " << line << '\n';
+            }
+            out << "#@ snodec.meta end " << entity << '\n';
+        }
+
+        std::string jsonStringArray(const std::vector<std::string>& values) {
+            std::ostringstream out;
+            out << '[';
+            for (std::size_t i = 0; i < values.size(); ++i) {
+                if (i > 0)
+                    out << ", ";
+                out << quoteJson(values[i]);
+            }
+            out << ']';
+            return out.str();
+        }
+
+        std::string optionKey(const std::string& prefix, const Option* opt) {
+            return prefix + opt->get_single_name();
+        }
+
+        std::vector<std::string> pathWith(const std::vector<std::string>& parentPath, const std::string& segment) {
+            auto path = parentPath;
+            if (!segment.empty())
+                path.push_back(segment);
+            return path;
+        }
+
+        void writeDocumentMeta(std::ostream& out, const App* app) {
+            writeMetaBlock(out,
+                           "document",
+                           {"{",
+                            "  \"schema\": " + quoteJson(MetaSchema) + ",",
+                            "  \"version\": 1,",
+                            "  \"entity\": \"document\",",
+                            "  \"application\": {",
+                            "    \"name\": " + quoteJson(app->get_name()) + ",",
+                            "    \"description\": " + quoteJson(app->get_description()),
+                            "  },",
+                            "  \"scope\": \"configurable-options-only\",",
+                            "  \"syntax\": \"ini-with-comment-metadata\"",
+                            "}"});
+        }
+
+        std::pair<std::string, std::string> nodeKind(const App* app) {
+            if (app->get_parent() == nullptr)
+                return {"application", "root"};
+            if (app->get_name().empty())
+                return {"anonymous", "cli11-name"};
+            if (app->get_group() == "Instances")
+                return {"instance", "cli11-group"};
+            if (app->get_group() == "Sections")
+                return {"section", "cli11-group"};
+            if (!app->get_group().empty())
+                return {"category", "heuristic-cli11-group"};
+            return {"subcommand", "fallback"};
+        }
+
+        void writeNodeMeta(std::ostream& out, const App* app, const std::vector<std::string>& path, const std::string& prefix) {
+            const auto [kind, kindSource] = nodeKind(app);
+            std::string display = app->get_name();
+            if (display.empty())
+                display = !app->get_group().empty() ? app->get_group()
+                                                    : (!app->get_description().empty() ? app->get_description() : "<anonymous>");
+            writeMetaBlock(out,
+                           "node",
+                           {"{",
+                            "  \"schema\": " + quoteJson(MetaSchema) + ",",
+                            "  \"version\": 1,",
+                            "  \"entity\": \"node\",",
+                            "  \"kind\": " + quoteJson(kind) + ",",
+                            "  \"kindSource\": " + quoteJson(kindSource) + ",",
+                            "  \"name\": " + quoteJson(app->get_name()) + ",",
+                            "  \"displayName\": " + quoteJson(display) + ",",
+                            "  \"path\": " + jsonStringArray(path) + ",",
+                            "  \"configPrefix\": " + quoteJson(prefix) + ",",
+                            "  \"group\": " + quoteJson(app->get_group()) + ",",
+                            "  \"description\": " + quoteJson(app->get_description()) + ",",
+                            std::string("  \"configurable\": ") + (app->get_configurable() ? "true," : "false,"),
+                            "  \"required\": {",
+                            std::string("    \"effective\": ") + (app->get_required() ? "true," : "false,"),
+                            "    \"source\": \"cli11-current-state\"",
+                            "  },",
+                            std::string("  \"disabled\": ") + (app->get_disabled() ? "true" : "false"),
+                            "}"});
+        }
+
+        std::pair<std::string, std::string> groupKind(const std::string& group) {
+            const std::string l = lower(group);
+            if (group.empty() || lower(group) == "options")
+                return {"default", "cli11-default-group"};
+            if (l.find("nonpersistent") != std::string::npos)
+                return {"nonpersistent", "heuristic-group-name"};
+            if (l.find("persistent") != std::string::npos)
+                return {"persistent", "heuristic-group-name"};
+            return {"custom", "heuristic-group-name"};
+        }
+
+        void writeGroupMeta(std::ostream& out, const std::string& group, const std::vector<std::string>& path) {
+            const auto [kind, source] = groupKind(group);
+            writeMetaBlock(out,
+                           "group",
+                           {"{",
+                            "  \"schema\": " + quoteJson(MetaSchema) + ",",
+                            "  \"version\": 1,",
+                            "  \"entity\": \"group\",",
+                            "  \"name\": " + quoteJson(group) + ",",
+                            "  \"kind\": " + quoteJson(kind) + ",",
+                            "  \"kindSource\": " + quoteJson(source) + ",",
+                            "  \"nodePath\": " + jsonStringArray(path),
+                            "}"});
+        }
+
+        std::string typeKind(const Option* opt) {
+            const std::string n = lower(opt->get_single_name() + " " + opt->get_type_name());
+            if (opt->get_expected_min() == 0)
+                return "boolean";
+            if (n.find("port") != std::string::npos || n.find("int") != std::string::npos || n.find("number") != std::string::npos)
+                return "integer";
+            if (n.find("float") != std::string::npos || n.find("double") != std::string::npos)
+                return "number";
+            return "string";
+        }
+
+        std::string semanticFromLiteral(const std::string& literal) {
+            if (literal.size() >= 2 && literal.front() == '"' && literal.back() == '"')
+                return literal.substr(1, literal.size() - 2);
+            return literal;
+        }
+
+        void writeRelations(std::vector<std::string>& lines, const std::string& name, const std::set<Option*>& opts, bool comma) {
+            lines.push_back("    \"" + name + "\": [");
+            std::size_t idx = 0;
+            for (const auto* rel : opts) {
+                lines.push_back("      " + quoteJson(rel->get_single_name()) + (++idx < opts.size() ? "," : ""));
+            }
+            lines.push_back(std::string("    ]") + (comma ? "," : ""));
+        }
+
+        void writeOptionMeta(std::ostream& out,
+                             const Option* opt,
+                             const std::string& key,
+                             const std::string& group,
+                             const std::vector<std::string>& path,
+                             const std::string& defaultValue,
+                             const std::string& value) {
+            const bool explicitValue = opt->count() > 0;
+            const bool missingRequired =
+                opt->get_required() && (defaultValue == "\"<REQUIRED>\"" || (!explicitValue && opt->get_default_str().empty()));
+            const std::string effectiveLiteral = !value.empty() ? value : defaultValue;
+            const std::string source =
+                explicitValue ? "command-line-or-config"
+                              : (missingRequired ? "required-placeholder" : (!defaultValue.empty() ? "cpp-default" : "empty-default"));
+            const std::string longName = opt->get_lnames().empty() ? "null" : quoteJson("--" + opt->get_lnames().front());
+            const std::string shortName = opt->get_snames().empty() ? "null" : quoteJson("-" + opt->get_snames().front());
+            const auto gk = groupKind(group);
+            std::vector<std::string> lines = {
+                "{",
+                "  \"schema\": " + quoteJson(MetaSchema) + ",",
+                "  \"version\": 1,",
+                "  \"entity\": \"option\",",
+                "  \"id\": " + quoteJson(key) + ",",
+                "  \"key\": " + quoteJson(key) + ",",
+                "  \"localName\": " + quoteJson(opt->get_single_name()) + ",",
+                "  \"displayName\": " + quoteJson(opt->get_single_name()) + ",",
+                "  \"nodePath\": " + jsonStringArray(path) + ",",
+                "  \"group\": " + quoteJson(group) + ",",
+                "  \"description\": " + quoteJson(opt->get_description()) + ",",
+                "  \"configurable\": true,",
+                "  \"required\": {",
+                std::string("    \"effective\": ") + (opt->get_required() ? "true," : "false,"),
+                "    \"source\": \"cli11-current-state\"",
+                "  },",
+                std::string("  \"persistent\": ") + (gk.first == "persistent" ? "true," : "false,"),
+                "  \"commandLine\": {",
+                "    \"long\": " + longName + ",",
+                "    \"short\": " + shortName + ",",
+                std::string("    \"takesValue\": ") + (opt->get_expected_min() != 0 ? "true," : "false,"),
+                std::string("    \"repeatable\": ") + (opt->get_expected_max() > 1 ? "true" : "false"),
+                "  },",
+                "  \"configFile\": {",
+                "    \"key\": " + quoteJson(key) + ",",
+                "    \"section\": null,",
+                "    \"writable\": true",
+                "  },",
+                "  \"type\": {",
+                "    \"name\": " + quoteJson(opt->get_type_name().empty() ? opt->get_single_name() : opt->get_type_name()) + ",",
+                "    \"kind\": " + quoteJson(typeKind(opt)) + ",",
+                "    \"kindSource\": \"heuristic-name\",",
+                std::string("    \"items\": ") + (opt->get_items_expected_max() > 1 ? "\"list\"" : "\"single\""),
+                "  },",
+                "  \"constraints\": [],",
+                "  \"relations\": {"};
+            writeRelations(lines, "needs", opt->get_needs(), true);
+            writeRelations(lines, "excludes", opt->get_excludes(), false);
+            lines.insert(lines.end(),
+                         {"  },",
+                          "  \"value\": {",
+                          "    \"registrationDefault\": null,",
+                          "    \"registrationDefaultSource\": \"not-tracked\",",
+                          "    \"cppDefault\": " + (defaultValue.empty() ? "null" : quoteJson(semanticFromLiteral(defaultValue))) + ",",
+                          "    \"configured\": " + (explicitValue && !value.empty() ? quoteJson(semanticFromLiteral(value)) : "null") + ",",
+                          "    \"effective\": " +
+                              (!effectiveLiteral.empty() ? quoteJson(semanticFromLiteral(effectiveLiteral)) : quoteJson("")) + ",",
+                          "    \"source\": " + quoteJson(source) + ",",
+                          std::string("    \"isCppDefault\": ") + (!explicitValue ? "true," : "false,"),
+                          std::string("    \"isExplicitlyConfigured\": ") + (explicitValue ? "true," : "false,"),
+                          std::string("    \"isMissingRequired\": ") + (missingRequired ? "true," : "false,"),
+                          "    \"registrationDefaultLiteral\": null,",
+                          "    \"cppDefaultLiteral\": " + (defaultValue.empty() ? "null" : quoteJson(defaultValue)) + ",",
+                          "    \"configuredLiteral\": " + (explicitValue && !value.empty() ? quoteJson(value) : "null") + ",",
+                          "    \"effectiveLiteral\": " + (!effectiveLiteral.empty() ? quoteJson(effectiveLiteral) : "null"),
+                          "  }",
+                          "}"});
+            writeMetaBlock(out, "option", lines);
+        }
+
+        std::string toConfigWithMeta(const ConfigFormatter* formatter,
+                                     const App* app,
+                                     bool default_also,
+                                     bool write_description,
+                                     const std::string& prefix,
+                                     const std::vector<std::string>& path,
+                                     bool root) {
+            std::stringstream out;
+            std::string commentLead;
+            commentLead.push_back('#');
+            commentLead.push_back(' ');
+            if (root)
+                writeDocumentMeta(out, app);
+            writeNodeMeta(out, app, path, prefix);
+            if (write_description && !app->get_description().empty()) {
+                out << '#' << '#' << commentLead << detail::fix_newlines('#' + commentLead, app->get_description()) << '\n';
+            }
+
+            std::vector<std::string> groups = app->get_groups();
+            bool defaultUsed = false;
+            groups.insert(groups.begin(), std::string("Options"));
+            for (const auto& group : groups) {
+                if (group == "Options" || group.empty()) {
+                    if (defaultUsed)
+                        continue;
+                    defaultUsed = true;
+                }
+                bool hasConfigurable = !app->get_options([group](const Option* opt) {
+                                               return opt->get_configurable() &&
+                                                      (opt->get_group() == group || (group == "Options" && opt->get_group().empty()));
+                                           })
+                                            .empty();
+                if (write_description && hasConfigurable) {
+                    writeGroupMeta(out, group, path);
+                    if (group != "Options" && !group.empty())
+                        out << '\n' << '#' << commentLead << group << "\n";
+                }
+                for (const Option* opt : app->get_options({})) {
+                    if (!opt->get_configurable())
+                        continue;
+                    if (opt->get_group() != group && !(group == "Options" && opt->get_group().empty()))
+                        continue;
+                    const std::string name = optionKey(prefix, opt);
                     std::string value;
                     try {
-                        value = detail::ini_join(opt->reduced_results(), arraySeparator, arrayStart, arrayEnd, stringQuote, literalQuote);
+                        value = detail::ini_join(opt->reduced_results(), ' ', '[', ']', '\"', '\'');
                     } catch (CLI::ParseError& e) {
                         value = std::string{"<["} + Color::Code::FG_RED + e.get_name() + Color::Code::FG_DEFAULT + "] " + e.what() + ">";
                     }
-
                     std::string defaultValue{};
                     if (default_also) {
-                        static_assert(std::string::npos + static_cast<std::string::size_type>(1) == 0,
-                                      "std::string::npos + static_cast<std::string::size_type>(1) != 0");
-                        if (!value.empty() &&
-                            detail::convert_arg_for_ini(opt->get_default_str(), stringQuote, literalQuote, true) == "\"" + value + "\"") {
+                        if (!value.empty() && detail::convert_arg_for_ini(opt->get_default_str(), '\"', '\'', true) == "\"" + value + "\"")
                             value.clear();
-                        }
                         if (!opt->get_default_str().empty()) {
-                            defaultValue = detail::convert_arg_for_ini(opt->get_default_str(), stringQuote, literalQuote, true);
-                            if (defaultValue == "'\"\"'") {
+                            defaultValue = detail::convert_arg_for_ini(opt->get_default_str(), '\"', '\'', true);
+                            if (defaultValue == "'\"\"'")
                                 defaultValue = "";
-                            }
-                        } else if (opt->get_run_callback_for_default()) {
-                            defaultValue = "\"\""; // empty string default value
-                        } else if (opt->get_required()) {
+                        } else if (opt->get_required())
                             defaultValue = "\"<REQUIRED>\"";
-                        } else if (opt->get_expected_min() == 0) {
-                            defaultValue = "false";
-                        } else {
+                        else if (opt->get_run_callback_for_default())
                             defaultValue = "\"\"";
-                        }
+                        else if (opt->get_expected_min() == 0)
+                            defaultValue = "false";
+                        else
+                            defaultValue = "\"\"";
                     }
-                    if (write_description && opt->has_description() && (default_also || !value.empty())) {
+                    writeOptionMeta(out, opt, name, group, path, defaultValue, value);
+                    if (write_description && opt->has_description() && (default_also || !value.empty()))
                         out << commentLead << detail::fix_newlines(commentLead, opt->get_description()) << '\n';
-                    }
                     if (default_also && !defaultValue.empty()) {
-                        if (defaultValue == value) {
+                        if (defaultValue == value)
                             value.clear();
-                        }
-                        out << commentChar << name << valueDelimiter << defaultValue << "\n";
+                        out << '#' << name << '=' << defaultValue << "\n";
                     }
                     if (!value.empty()) {
-                        if (!opt->get_fnames().empty()) {
+                        if (!opt->get_fnames().empty())
                             value = opt->get_flag_value(name, value);
-                        }
-                        if (value == "\"default\"") {
+                        if (value == "\"default\"")
                             value = "default";
-                        }
-                        out << name << valueDelimiter << value << "\n\n";
-                    } else {
+                        out << name << '=' << value << "\n\n";
+                    } else
                         out << '\n';
-                    }
                 }
             }
-        }
-        auto subcommands = app->get_subcommands({});
-        for (const App* subcom : subcommands) {
-            if (subcom->get_name().empty()) {
-                if (write_description && !subcom->get_group().empty()) {
-                    out << '\n' << commentLead << subcom->get_group() << " Options\n";
+            std::map<const App*, std::string> anonymousSegments;
+            std::size_t anon = 0;
+            auto subcommands = app->get_subcommands({});
+            for (const App* subcom : subcommands)
+                if (subcom->get_name().empty())
+                    anonymousSegments[subcom] = "<anonymous-" + std::to_string(anon++) + ">";
+            for (const App* subcom : subcommands) {
+                if (subcom->get_name().empty()) {
+                    out << toConfigWithMeta(
+                        formatter, subcom, default_also, write_description, prefix, pathWith(path, anonymousSegments[subcom]), false);
                 }
-                out << to_config(subcom, default_also, write_description, prefix);
             }
-        }
-
-        for (const App* subcom : subcommands) {
-            if (!subcom->get_name().empty()) {
-                if (subcom->get_configurable() && app->got_subcommand(subcom)) {
-                    if (!prefix.empty() || app->get_parent() == nullptr) {
-                        out << '[' << prefix << subcom->get_name() << "]\n";
-                    } else {
-                        std::string subname = app->get_name() + parentSeparatorChar + subcom->get_name();
-                        const auto* p = app->get_parent();
-                        while (p->get_parent() != nullptr) {
-                            subname = p->get_name() + parentSeparatorChar + subname;
-                            p = p->get_parent();
+            for (const App* subcom : subcommands) {
+                if (!subcom->get_name().empty()) {
+                    if (subcom->get_configurable() && app->got_subcommand(subcom)) {
+                        if (!prefix.empty() || app->get_parent() == nullptr)
+                            out << '[' << prefix << subcom->get_name() << "]\n";
+                        else {
+                            std::string subname = app->get_name() + '.' + subcom->get_name();
+                            const auto* p = app->get_parent();
+                            while (p->get_parent() != nullptr) {
+                                subname = p->get_name() + '.' + subname;
+                                p = p->get_parent();
+                            }
+                            out << '[' << subname << "]\n";
                         }
-                        out << '[' << subname << "]\n";
+                        out << toConfigWithMeta(
+                            formatter, subcom, default_also, write_description, "", pathWith(path, subcom->get_name()), false);
+                    } else {
+                        out << toConfigWithMeta(formatter,
+                                                subcom,
+                                                default_also,
+                                                write_description,
+                                                prefix + subcom->get_name() + '.',
+                                                pathWith(path, subcom->get_name()),
+                                                false);
                     }
-                    out << to_config(subcom, default_also, write_description, "");
-                } else {
-                    out << to_config(subcom, default_also, write_description, prefix + subcom->get_name() + parentSeparatorChar);
                 }
             }
+            return out.str();
         }
+    } // namespace
 
-        std::string outString;
-        if (write_description && !out.str().empty()) {
-            outString =
-                commentChar + std::string("#") + commentLead + detail::fix_newlines(commentChar + commentLead, app->get_description());
-        }
-
-        return outString + out.str();
+    CLI11_INLINE std::string
+    ConfigFormatter::to_config(const App* app, bool default_also, bool write_description, std::string prefix) const {
+        const std::vector<std::string> path =
+            app->get_name().empty() ? std::vector<std::string>{} : std::vector<std::string>{app->get_name()};
+        return toConfigWithMeta(this, app, default_also, write_description, prefix, path, app->get_parent() == nullptr && prefix.empty());
     }
 
 #ifndef CLI11_ORIGINAL_FORMATTER

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -45,3 +45,5 @@ add_subdirectory(net)
 add_subdirectory(http)
 
 add_subdirectory(log)
+
+add_subdirectory(utils)

--- a/tests/unit/utils/CMakeLists.txt
+++ b/tests/unit/utils/CMakeLists.txt
@@ -1,0 +1,3 @@
+snodec_add_test(ConfigFormatterCommentMetadataTest ConfigFormatterCommentMetadataTest.cpp)
+target_link_libraries(ConfigFormatterCommentMetadataTest PRIVATE snodec-test-support snodec::utils)
+set_tests_properties(ConfigFormatterCommentMetadataTest PROPERTIES LABELS "unit;utils;config;format" TIMEOUT 5)

--- a/tests/unit/utils/ConfigFormatterCommentMetadataTest.cpp
+++ b/tests/unit/utils/ConfigFormatterCommentMetadataTest.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -29,6 +30,12 @@ namespace {
         }
     }
 
+    void requireParseable(const std::string& config) {
+        CLI::ConfigINI parser;
+        std::istringstream input{config};
+        (void) parser.from_config(input);
+    }
+
 } // namespace
 
 int main() {
@@ -38,6 +45,7 @@ int main() {
 
     int port = 0;
     auto* portOpt = app.add_option("--port", port, "Port number")->required()->group("Options (persistent)");
+    portOpt->run_callback_for_default(false);
     std::string host = "localhost";
     auto* hostOpt = app.add_option("--host", host, "Host name")->default_str("localhost")->group("Custom Group");
     bool verbose = false;
@@ -45,6 +53,11 @@ int main() {
     auto* tokenOpt = app.add_option("--token", host, "Token value")->group("Custom Group");
     tokenOpt->needs(hostOpt);
     hostOpt->excludes(portOpt);
+    std::string callbackValue;
+    app.add_option("--callback-required", callbackValue, "Callback required")
+        ->required()
+        ->run_callback_for_default()
+        ->group("Custom Group");
 
     auto* anon = app.add_subcommand("", "Anonymous options");
     anon->group("Anonymous Group");
@@ -58,26 +71,44 @@ int main() {
     int depth = 3;
     inner->add_option("--depth", depth, "Nested depth")->default_str("3");
 
+    auto* instance = app.add_subcommand("", "Anonymous instance");
+    instance->group("Instances");
+    int instanceValue = 1;
+    instance->add_option("--instance-value", instanceValue, "Instance value")->default_str("1");
+
+    auto* section = app.add_subcommand("", "Anonymous section");
+    section->group("Sections");
+    int sectionValue = 2;
+    section->add_option("--section-value", sectionValue, "Section value")->default_str("2");
+
     const std::string config = app.config_to_str(true, true);
 
     requireContains(config, "#@ snodec.meta begin document\n#@ {\n#@   \"schema\": \"snodec.config.comment-meta\",");
     requireContains(config, "#@ snodec.meta begin node");
     requireContains(config, "#@   \"kind\": \"application\",");
-    requireContains(config, "#@   \"path\": [\"demo\"],");
+    requireContains(config, "#@   \"path\": [],");
+    requireContains(config, "#@   \"path\": [\"outer\"],");
+    requireContains(config, "#@   \"path\": [\"outer\", \"inner\"],");
     requireContains(config, "#@   \"kind\": \"category\",");
     requireContains(config, "#@   \"kind\": \"section\",");
-    requireContains(config, "#@   \"path\": [\"demo\", \"<anonymous-0>\"],");
+    requireContains(config, "#@   \"kind\": \"instance\",");
+    requireContains(config, "#@   \"path\": [\"<anonymous-0>\"],");
+    requireContains(config, "#@   \"path\": [\"<anonymous-1>\"],");
+    requireContains(config, "#@   \"path\": [\"<anonymous-2>\"],");
     requireContains(config, "#@ snodec.meta begin group");
     requireContains(config, "#@   \"name\": \"Options (persistent)\",");
     requireContains(config, "#@   \"kind\": \"persistent\",");
     requireContains(config, "#@   \"name\": \"Custom Group\",");
     requireContains(config, "#@   \"kind\": \"custom\",");
     requireContains(config, "#@ snodec.meta begin option");
+    requireContains(config, "#@   \"id\": \"port\",");
     requireContains(config, "#@   \"key\": \"port\",");
     requireContains(config, "#@     \"isMissingRequired\": true,");
     requireContains(config, "#@     \"cppDefault\": \"<REQUIRED>\",");
     requireContains(config, "#@     \"cppDefaultLiteral\": \"\\\"<REQUIRED>\\\"\",");
     requireContains(config, "#port=\"<REQUIRED>\"");
+    requireContains(config, "#callback-required=\"\"");
+    requireNotContains(config, "#callback-required=\"<REQUIRED>\"");
     requireContains(config, "#@     \"registrationDefault\": null,");
     requireContains(config, "#@     \"registrationDefaultSource\": \"not-tracked\",");
     requireNotContains(config, "apiDefault");
@@ -95,10 +126,65 @@ int main() {
                               "#@   \"version\": 1,\n"
                               "#@   \"entity\": \"document\",\n";
     requireContains(config, exact);
+    requireParseable(config);
 
-    CLI::ConfigINI parser;
-    std::istringstream input{config};
-    (void) parser.from_config(input);
+    const std::string noComments = app.config_to_str(true, false);
+    requireNotContains(noComments, "#@ snodec.meta");
+    requireNotContains(noComments, "Port number");
+    requireContains(noComments, "#port=\"<REQUIRED>\"");
+    requireParseable(noComments);
+
+    CLI::App configuredApp{"Configured default app"};
+    configuredApp.name("configured");
+    configuredApp.config_formatter(std::make_shared<CLI::ConfigFormatter>());
+    std::string mode = "default";
+    configuredApp.add_option("--mode", mode, "Mode value")->default_str("default");
+    configuredApp.parse("--mode default");
+    const std::string configuredConfig = configuredApp.config_to_str(true, true);
+    requireContains(configuredConfig, "#@   \"key\": \"mode\",");
+    requireContains(configuredConfig, "#@     \"configured\": \"default\",");
+    requireContains(configuredConfig, "#@     \"configuredLiteral\": \"\\\"default\\\"\",");
+    requireContains(configuredConfig, "#@     \"source\": \"command-line-or-config\",");
+    requireContains(configuredConfig, "#@     \"isExplicitlyConfigured\": true,");
+
+    CLI::App quotedApp{"Quoted value app"};
+    quotedApp.name("quoted");
+    quotedApp.config_formatter(std::make_shared<CLI::ConfigFormatter>());
+    std::string text;
+    const std::string configuredText = "a \"quoted\" value with \\ slash and spaces";
+    quotedApp.add_option("--text", text, "Text value")->default_str("default \"quoted\" \\ value");
+    quotedApp.parse(std::vector<std::string>{configuredText, "--text"});
+    const std::string quotedConfig = quotedApp.config_to_str(true, true);
+    requireContains(quotedConfig, "#@     \"configuredLiteral\": ");
+    requireContains(quotedConfig, "\\\\ slash and spaces");
+
+    CLI::App siblingApp{"Sibling anonymous app"};
+    siblingApp.name("siblings");
+    siblingApp.config_formatter(std::make_shared<CLI::ConfigFormatter>());
+    auto* anonA = siblingApp.add_subcommand("", "First anonymous");
+    anonA->group("Anon A");
+    int a = 1;
+    anonA->add_option("--value", a, "Shared value")->default_str("1");
+    auto* anonB = siblingApp.add_subcommand("", "Second anonymous");
+    anonB->group("Anon B");
+    int b = 2;
+    anonB->add_option("--value-b", b, "Shared value")->default_str("2");
+    const std::string siblingConfig = siblingApp.config_to_str(true, true);
+    requireContains(siblingConfig, "#@   \"id\": \"<anonymous-0>.value\",");
+    requireContains(siblingConfig, "#@   \"id\": \"<anonymous-1>.value-b\",");
+    requireContains(siblingConfig, "#@   \"key\": \"value\",");
+    requireContains(siblingConfig, "#@   \"key\": \"value-b\",");
+
+    CLI::App customFormatterApp{"Custom formatter app"};
+    customFormatterApp.name("custom-format");
+    auto customFormatter = std::make_shared<CLI::ConfigFormatter>();
+    customFormatter->comment(';')->valueSeparator(':')->quoteCharacter('`', '!');
+    customFormatterApp.config_formatter(customFormatter);
+    std::string custom = "hello world";
+    customFormatterApp.add_option("--custom", custom, "Custom value")->default_str("hello world");
+    const std::string customConfig = customFormatterApp.config_to_str(true, false);
+    requireContains(customConfig, ";custom:`hello world`");
+    requireNotContains(customConfig, "#custom=");
 
     return 0;
 }

--- a/tests/unit/utils/ConfigFormatterCommentMetadataTest.cpp
+++ b/tests/unit/utils/ConfigFormatterCommentMetadataTest.cpp
@@ -1,0 +1,104 @@
+#include "utils/Formatter.h"
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+    void requireContains(const std::string& text, const std::string& needle) {
+        if (text.find(needle) == std::string::npos) {
+            std::cerr << "Missing expected text:\n" << needle << "\n--- output ---\n" << text << std::endl;
+            std::abort();
+        }
+    }
+
+    void requireNotContains(const std::string& text, const std::string& needle) {
+        if (text.find(needle) != std::string::npos) {
+            std::cerr << "Unexpected text:\n" << needle << "\n--- output ---\n" << text << std::endl;
+            std::abort();
+        }
+    }
+
+    void requireBefore(const std::string& text, const std::string& first, const std::string& second) {
+        const auto a = text.find(first);
+        const auto b = text.find(second);
+        if (a == std::string::npos || b == std::string::npos || a >= b) {
+            std::cerr << "Ordering assertion failed:\n" << first << "\nbefore\n" << second << "\n--- output ---\n" << text << std::endl;
+            std::abort();
+        }
+    }
+
+} // namespace
+
+int main() {
+    CLI::App app{"Synthetic formatter app"};
+    app.name("demo");
+    app.config_formatter(std::make_shared<CLI::ConfigFormatter>());
+
+    int port = 0;
+    auto* portOpt = app.add_option("--port", port, "Port number")->required()->group("Options (persistent)");
+    std::string host = "localhost";
+    auto* hostOpt = app.add_option("--host", host, "Host name")->default_str("localhost")->group("Custom Group");
+    bool verbose = false;
+    app.add_flag("--verbose", verbose, "Verbose mode")->configurable(false);
+    auto* tokenOpt = app.add_option("--token", host, "Token value")->group("Custom Group");
+    tokenOpt->needs(hostOpt);
+    hostOpt->excludes(portOpt);
+
+    auto* anon = app.add_subcommand("", "Anonymous options");
+    anon->group("Anonymous Group");
+    int anonValue = 7;
+    anon->add_option("--anon-value", anonValue, "Anonymous value")->default_str("7");
+
+    auto* nested = app.add_subcommand("outer", "Outer node");
+    nested->group("Custom Nodes");
+    auto* inner = nested->add_subcommand("inner", "Inner node");
+    inner->group("Sections");
+    int depth = 3;
+    inner->add_option("--depth", depth, "Nested depth")->default_str("3");
+
+    const std::string config = app.config_to_str(true, true);
+
+    requireContains(config, "#@ snodec.meta begin document\n#@ {\n#@   \"schema\": \"snodec.config.comment-meta\",");
+    requireContains(config, "#@ snodec.meta begin node");
+    requireContains(config, "#@   \"kind\": \"application\",");
+    requireContains(config, "#@   \"path\": [\"demo\"],");
+    requireContains(config, "#@   \"kind\": \"category\",");
+    requireContains(config, "#@   \"kind\": \"section\",");
+    requireContains(config, "#@   \"path\": [\"demo\", \"<anonymous-0>\"],");
+    requireContains(config, "#@ snodec.meta begin group");
+    requireContains(config, "#@   \"name\": \"Options (persistent)\",");
+    requireContains(config, "#@   \"kind\": \"persistent\",");
+    requireContains(config, "#@   \"name\": \"Custom Group\",");
+    requireContains(config, "#@   \"kind\": \"custom\",");
+    requireContains(config, "#@ snodec.meta begin option");
+    requireContains(config, "#@   \"key\": \"port\",");
+    requireContains(config, "#@     \"isMissingRequired\": true,");
+    requireContains(config, "#@     \"cppDefault\": \"<REQUIRED>\",");
+    requireContains(config, "#@     \"cppDefaultLiteral\": \"\\\"<REQUIRED>\\\"\",");
+    requireContains(config, "#port=\"<REQUIRED>\"");
+    requireContains(config, "#@     \"registrationDefault\": null,");
+    requireContains(config, "#@     \"registrationDefaultSource\": \"not-tracked\",");
+    requireNotContains(config, "apiDefault");
+    requireContains(config, "#@       \"host\"");
+    requireContains(config, "#@       \"port\"");
+    requireContains(config, "#host=\"localhost\"");
+    requireContains(config, "#outer.inner.depth=3");
+    requireNotContains(config, "verbose=");
+    requireBefore(config, "#@   \"key\": \"port\",", "# Port number\n#port=\"<REQUIRED>\"");
+    requireBefore(config, "#@ snodec.meta begin group", "## Options (persistent)");
+
+    const std::string exact = "#@ snodec.meta begin document\n"
+                              "#@ {\n"
+                              "#@   \"schema\": \"snodec.config.comment-meta\",\n"
+                              "#@   \"version\": 1,\n"
+                              "#@   \"entity\": \"document\",\n";
+    requireContains(config, exact);
+
+    CLI::ConfigINI parser;
+    std::istringstream input{config};
+    (void) parser.from_config(input);
+
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Provide machine-readable structured metadata inside the existing INI-style `-s` / `--show-config` output while keeping the output valid INI and comment-only so existing config parsing is unaffected. 
- Expose document/node/group/option metadata blocks (schema v1) to enable future UI tooling (`snodec-control`) without changing runtime/registration semantics. 
- Keep this PR strictly formatter-only (no new JSON output modes, no changes to registration/canonical state). 

### Description
- Extended `ConfigFormatter::to_config()` (implemented in `src/utils/Formatter.cpp`) to emit `#@ snodec.meta begin/end` comment blocks and pretty-printed JSON lines for the `document`, `node`, `group`, and `option` entities using internal helpers (`writeMetaBlock`, `writeDocumentMeta`, `writeNodeMeta`, `writeGroupMeta`, `writeOptionMeta`) and a small internal JSON-quoting/formatting helper (no external dependency). 
- Option metadata contains `value` fields using `cppDefault` semantics, separates semantic values from INI literals, emits `registrationDefault: null` / `registrationDefaultSource: "not-tracked"`, reports current CLI11 `required.effective` state and `needs`/`excludes` relations, and preserves deterministic ordering and anonymous node ids (`<anonymous-N>`). 
- Group kind and node kind are inferred heuristically (rules implemented in the formatter) and metadata blocks are placed immediately before their human-readable headings per the placement rules. 
- Added unit test coverage and documentation: `tests/unit/utils/ConfigFormatterCommentMetadataTest.cpp` (registered in `tests/unit/utils/CMakeLists.txt` and `tests/unit/CMakeLists.txt`) validates document/node/group/option blocks, placement, literal vs semantic values, `cppDefault` usage, anonymous nodes, and that metadata lines begin with `#@`; and new docs file `docs/config-comment-metadata.md` documents the v1 format and known limitations.

### Testing
- Ran the new unit target build: `cmake --build build --target ConfigFormatterCommentMetadataTest` which completed successfully. 
- Ran the unit test: `ctest --test-dir build --output-on-failure -R ConfigFormatterCommentMetadataTest` and the test passed (validates many exact metadata substrings and parser compatibility). 
- Attempted a full build (`cmake --build build -j2`) and comprehensive `ctest`; an unrelated existing link failure in a websocket-client target prevented producing some unrelated executables and many unrelated tests were not run, but the formatter unit test passed and the formatter output was validated against a sample app `-s` run (metadata blocks present and INI lines preserved).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f545a32c0832c89c69e0883f40ef1)