### PR TITLE
Preserve canonical config requirement state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: cmake --build build --parallel 2
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --output-on-failure -L unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/ci.yml'
 
 jobs:
-  gcc-debug:
+  gcc-debug-unit:
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -36,5 +36,26 @@ jobs:
       - name: Build
         run: cmake --build build --parallel 2
 
-      - name: Test
+      - name: Unit tests
         run: ctest --test-dir build --output-on-failure -L unit
+
+  gcc-debug-component:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ pkg-config libssl-dev nlohmann-json3-dev
+
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON
+
+      - name: Build
+        run: cmake --build build --parallel 2
+
+      - name: Component tests
+        run: ctest --test-dir build --output-on-failure -L component

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,28 +18,7 @@ on:
       - '.github/workflows/ci.yml'
 
 jobs:
-  gcc-debug-unit:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake g++ pkg-config libssl-dev nlohmann-json3-dev
-
-      - name: Configure
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=OFF
-
-      - name: Build
-        run: cmake --build build --parallel 2
-
-      - name: Unit tests
-        run: ctest --test-dir build --output-on-failure -L unit
-
-  gcc-debug-component:
+  gcc-debug:
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -57,5 +36,5 @@ jobs:
       - name: Build
         run: cmake --build build --parallel 2
 
-      - name: Component tests
-        run: ctest --test-dir build --output-on-failure -L component
+      - name: Tests
+        run: ctest --test-dir build --output-on-failure

--- a/src/net/config/ConfigInstance.cpp
+++ b/src/net/config/ConfigInstance.cpp
@@ -85,7 +85,7 @@ namespace net::config {
         , disableOpt(setConfigurable(addFlagFunction(
                                          "--disabled{true}",
                                          [this]() {
-                                             forceUnrequired(disableOpt->as<bool>());
+                                             suppressRequirements(utils::ConfigSuppressionReason::Disabled, disableOpt->as<bool>());
                                          },
                                          "Disable this instance",
                                          "BOOL",
@@ -138,7 +138,7 @@ namespace net::config {
     ConfigInstance* ConfigInstance::setDisabled(bool disabled) {
         setDefaultValue(disableOpt, disabled ? "true" : "false");
 
-        this->forceUnrequired(disabled);
+        suppressRequirements(utils::ConfigSuppressionReason::Disabled, disabled);
 
         return this;
     }

--- a/src/utils/SubCommand.cpp
+++ b/src/utils/SubCommand.cpp
@@ -212,10 +212,15 @@ namespace utils {
     }
 
     SubCommand* SubCommand::forceUnrequired(bool unrequired) {
+        requiredForced = unrequired;
+
+        return suppressRequirements(ConfigSuppressionReason::ForceUnrequired, requiredForced);
+    }
+
+    SubCommand* SubCommand::suppressRequirements(ConfigSuppressionReason reason, bool suppressed) {
         const bool previousEffectiveRequired = subCommandApp->effectiveRequired();
 
-        requiredForced = unrequired;
-        subCommandApp->setSuppressionRecursive(ConfigSuppressionReason::ForceUnrequired, requiredForced);
+        subCommandApp->setSuppressionRecursive(reason, suppressed);
 
         applyEffectiveRequiredContribution(previousEffectiveRequired, subCommandApp->effectiveRequired());
 
@@ -235,7 +240,6 @@ namespace utils {
         }
         const bool countedRequired = requiredCount > 0;
         const bool effectivelyCountedRequired = effectiveRequiredCount > 0;
-        subCommandApp->ignore_case(countedRequired);
         subCommandApp->setCanonicalRequired(countedRequired);
         subCommandApp->setEffectiveRequiredBase(effectivelyCountedRequired);
         subCommandApp->setSuppression(ConfigSuppressionReason::ForceUnrequired, requiredForced);
@@ -289,7 +293,6 @@ namespace utils {
             }
 
             const bool parentCanonicalRequired = requiredCount > 0;
-            subCommandApp->ignore_case(parentCanonicalRequired);
             subCommandApp->setCanonicalRequired(parentCanonicalRequired);
             subCommandApp->setEffectiveRequiredBase(effectiveRequiredCount > 0);
 
@@ -313,7 +316,6 @@ namespace utils {
                 parent->effectiveRequiredCount = parent->effectiveRequiredCount > 0 ? parent->effectiveRequiredCount - 1 : 0;
             }
             parent->subCommandApp->setEffectiveRequiredBase(parent->effectiveRequiredCount > 0);
-            parent->subCommandApp->setEffectiveNeed(subCommandApp, effectiveRequired);
 
             parent->applyEffectiveRequiredContribution(previousParentEffectiveRequired, parent->subCommandApp->effectiveRequired());
         }
@@ -580,16 +582,6 @@ namespace utils {
         applyEffectiveState();
     }
 
-    void AppWithPtr::setEffectiveNeed(CLI::App* app, bool needed) {
-        if (needed && configState.canonicalNeeds.contains(app) && configState.required.suppressions.empty()) {
-            needs(app);
-            configState.effectiveNeeds.insert(app);
-        } else {
-            remove_needs(app);
-            configState.effectiveNeeds.erase(app);
-        }
-    }
-
     bool AppWithPtr::canonicalRequired() const {
         return configState.required.canonicalRequired;
     }
@@ -637,6 +629,8 @@ namespace utils {
     }
 
     void AppWithPtr::applyEffectiveState() {
+        const bool previousEffectiveRequired = configState.required.effectiveRequired;
+
         configState.required.effectiveRequired =
             configState.required.canonicalRequired && configState.required.effectiveRequiredBase && configState.required.suppressions.empty();
         required(configState.required.effectiveRequired);
@@ -668,10 +662,16 @@ namespace utils {
 
             for (const CLI::App* app : configState.canonicalNeeds) {
                 const auto* appWithPtr = dynamic_cast<const AppWithPtr*>(app);
-                if (appWithPtr == nullptr || appWithPtr->configState.required.suppressions.empty()) {
+                if (appWithPtr == nullptr || appWithPtr->effectiveRequired()) {
                     needs(const_cast<CLI::App*>(app));
                     configState.effectiveNeeds.insert(app);
                 }
+            }
+        }
+
+        if (previousEffectiveRequired != configState.required.effectiveRequired) {
+            if (auto* parent = dynamic_cast<AppWithPtr*>(get_parent()); parent != nullptr) {
+                parent->applyEffectiveState();
             }
         }
     }

--- a/src/utils/SubCommand.cpp
+++ b/src/utils/SubCommand.cpp
@@ -224,9 +224,15 @@ namespace utils {
 
     SubCommand* SubCommand::required(bool required) {
         const bool previousCanonicalRequired = requiredCount > 0;
+        const bool previousEffectiveRequired = subCommandApp->effectiveRequired();
 
-        requiredCount += required ? 1 : -1;
-        effectiveRequiredCount += required ? 1 : -1;
+        if (required) {
+            requiredCount++;
+            effectiveRequiredCount++;
+        } else {
+            requiredCount = requiredCount > 0 ? requiredCount - 1 : 0;
+            effectiveRequiredCount = effectiveRequiredCount > 0 ? effectiveRequiredCount - 1 : 0;
+        }
         const bool countedRequired = requiredCount > 0;
         const bool effectivelyCountedRequired = effectiveRequiredCount > 0;
         subCommandApp->ignore_case(countedRequired);
@@ -239,8 +245,10 @@ namespace utils {
             SubCommand* parent = getParent();
 
             parent->needs(this, countedRequired);
-            parent->required(effectiveRequired);
+            parent->applyCanonicalRequiredContribution(previousCanonicalRequired, countedRequired);
         }
+
+        applyEffectiveRequiredContribution(previousEffectiveRequired, effectiveRequired);
 
         return this;
     }
@@ -270,12 +278,40 @@ namespace utils {
         return this;
     }
 
+    void SubCommand::applyCanonicalRequiredContribution(bool previousCanonicalRequired, bool canonicalRequired) {
+        if (previousCanonicalRequired != canonicalRequired) {
+            const bool previousParentCanonicalRequired = requiredCount > 0;
+
+            if (canonicalRequired) {
+                requiredCount++;
+            } else {
+                requiredCount = requiredCount > 0 ? requiredCount - 1 : 0;
+            }
+
+            const bool parentCanonicalRequired = requiredCount > 0;
+            subCommandApp->ignore_case(parentCanonicalRequired);
+            subCommandApp->setCanonicalRequired(parentCanonicalRequired);
+            subCommandApp->setEffectiveRequiredBase(effectiveRequiredCount > 0);
+
+            if (hasParent() && previousParentCanonicalRequired != parentCanonicalRequired) {
+                SubCommand* parent = getParent();
+
+                parent->needs(this, parentCanonicalRequired);
+                parent->applyCanonicalRequiredContribution(previousParentCanonicalRequired, parentCanonicalRequired);
+            }
+        }
+    }
+
     void SubCommand::applyEffectiveRequiredContribution(bool previousEffectiveRequired, bool effectiveRequired) {
         if (hasParent() && previousEffectiveRequired != effectiveRequired) {
             SubCommand* parent = getParent();
             const bool previousParentEffectiveRequired = parent->subCommandApp->effectiveRequired();
 
-            parent->effectiveRequiredCount += effectiveRequired ? 1 : -1;
+            if (effectiveRequired) {
+                parent->effectiveRequiredCount++;
+            } else {
+                parent->effectiveRequiredCount = parent->effectiveRequiredCount > 0 ? parent->effectiveRequiredCount - 1 : 0;
+            }
             parent->subCommandApp->setEffectiveRequiredBase(parent->effectiveRequiredCount > 0);
             parent->subCommandApp->setEffectiveNeed(subCommandApp, effectiveRequired);
 

--- a/src/utils/SubCommand.cpp
+++ b/src/utils/SubCommand.cpp
@@ -197,6 +197,14 @@ namespace utils {
         return parent;
     }
 
+    const AppWithPtr* SubCommand::getAppWithPtr() const {
+        return subCommandApp;
+    }
+
+    AppWithPtr* SubCommand::getAppWithPtr() {
+        return subCommandApp;
+    }
+
     SubCommand* SubCommand::allowExtras(bool allow) {
         subCommandApp->allow_extras(allow);
 
@@ -204,26 +212,33 @@ namespace utils {
     }
 
     SubCommand* SubCommand::forceUnrequired(bool unrequired) {
+        const bool previousEffectiveRequired = subCommandApp->effectiveRequired();
+
         requiredForced = unrequired;
         subCommandApp->setSuppressionRecursive(ConfigSuppressionReason::ForceUnrequired, requiredForced);
+
+        applyEffectiveRequiredContribution(previousEffectiveRequired, subCommandApp->effectiveRequired());
 
         return this;
     }
 
     SubCommand* SubCommand::required(bool required) {
-        const bool previousEffectiveRequired = subCommandApp->effectiveRequired();
+        const bool previousCanonicalRequired = requiredCount > 0;
 
         requiredCount += required ? 1 : -1;
+        effectiveRequiredCount += required ? 1 : -1;
         const bool countedRequired = requiredCount > 0;
+        const bool effectivelyCountedRequired = effectiveRequiredCount > 0;
         subCommandApp->ignore_case(countedRequired);
         subCommandApp->setCanonicalRequired(countedRequired);
+        subCommandApp->setEffectiveRequiredBase(effectivelyCountedRequired);
         subCommandApp->setSuppression(ConfigSuppressionReason::ForceUnrequired, requiredForced);
         const bool effectiveRequired = subCommandApp->effectiveRequired();
 
-        if (hasParent() && previousEffectiveRequired != effectiveRequired) {
+        if (hasParent() && previousCanonicalRequired != countedRequired) {
             SubCommand* parent = getParent();
 
-            parent->needs(this, effectiveRequired);
+            parent->needs(this, countedRequired);
             parent->required(effectiveRequired);
         }
 
@@ -253,6 +268,19 @@ namespace utils {
         subCommandApp->setCanonicalNeed(subCommand->subCommandApp, needs);
 
         return this;
+    }
+
+    void SubCommand::applyEffectiveRequiredContribution(bool previousEffectiveRequired, bool effectiveRequired) {
+        if (hasParent() && previousEffectiveRequired != effectiveRequired) {
+            SubCommand* parent = getParent();
+            const bool previousParentEffectiveRequired = parent->subCommandApp->effectiveRequired();
+
+            parent->effectiveRequiredCount += effectiveRequired ? 1 : -1;
+            parent->subCommandApp->setEffectiveRequiredBase(parent->effectiveRequiredCount > 0);
+            parent->subCommandApp->setEffectiveNeed(subCommandApp, effectiveRequired);
+
+            parent->applyEffectiveRequiredContribution(previousParentEffectiveRequired, parent->subCommandApp->effectiveRequired());
+        }
     }
 
     SubCommand* SubCommand::setRequireCallback(const std::function<void()>& callback) {
@@ -441,6 +469,12 @@ namespace utils {
 
     void AppWithPtr::setCanonicalRequired(bool required) {
         configState.required.canonicalRequired = required;
+        configState.required.effectiveRequiredBase = required;
+        applyEffectiveState();
+    }
+
+    void AppWithPtr::setEffectiveRequiredBase(bool required) {
+        configState.required.effectiveRequiredBase = required;
         applyEffectiveState();
     }
 
@@ -510,6 +544,16 @@ namespace utils {
         applyEffectiveState();
     }
 
+    void AppWithPtr::setEffectiveNeed(CLI::App* app, bool needed) {
+        if (needed && configState.canonicalNeeds.contains(app) && configState.required.suppressions.empty()) {
+            needs(app);
+            configState.effectiveNeeds.insert(app);
+        } else {
+            remove_needs(app);
+            configState.effectiveNeeds.erase(app);
+        }
+    }
+
     bool AppWithPtr::canonicalRequired() const {
         return configState.required.canonicalRequired;
     }
@@ -557,7 +601,8 @@ namespace utils {
     }
 
     void AppWithPtr::applyEffectiveState() {
-        configState.required.effectiveRequired = configState.required.canonicalRequired && configState.required.suppressions.empty();
+        configState.required.effectiveRequired =
+            configState.required.canonicalRequired && configState.required.effectiveRequiredBase && configState.required.suppressions.empty();
         required(configState.required.effectiveRequired);
 
         for (auto& [option, state] : optionConfigStates) {

--- a/src/utils/SubCommand.cpp
+++ b/src/utils/SubCommand.cpp
@@ -48,6 +48,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <vector>
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
@@ -203,36 +204,21 @@ namespace utils {
     }
 
     SubCommand* SubCommand::forceUnrequired(bool unrequired) {
-        const bool previouslyRequired = subCommandApp->get_required();
-        const bool countedRequired = subCommandApp->get_ignore_case();
-
         requiredForced = unrequired;
-
-        const bool effectiveRequired = requiredForced ? false : countedRequired;
-        if (previouslyRequired != effectiveRequired) {
-            subCommandApp->required(effectiveRequired);
-
-            if (hasParent()) {
-                SubCommand* parent = getParent();
-                parent->needs(this, effectiveRequired);
-                parent->required(effectiveRequired);
-            }
-        }
+        subCommandApp->setSuppressionRecursive(ConfigSuppressionReason::ForceUnrequired, requiredForced);
 
         return this;
     }
 
     SubCommand* SubCommand::required(bool required) {
-        const bool previousEffectiveRequired = subCommandApp->get_required();
+        const bool previousEffectiveRequired = subCommandApp->effectiveRequired();
 
         requiredCount += required ? 1 : -1;
         const bool countedRequired = requiredCount > 0;
-        const bool effectiveRequired = requiredForced ? false : countedRequired;
-
         subCommandApp->ignore_case(countedRequired);
-        if (subCommandApp->get_required() != effectiveRequired) {
-            subCommandApp->required(effectiveRequired);
-        }
+        subCommandApp->setCanonicalRequired(countedRequired);
+        subCommandApp->setSuppression(ConfigSuppressionReason::ForceUnrequired, requiredForced);
+        const bool effectiveRequired = subCommandApp->effectiveRequired();
 
         if (hasParent() && previousEffectiveRequired != effectiveRequired) {
             SubCommand* parent = getParent();
@@ -245,14 +231,12 @@ namespace utils {
     }
 
     SubCommand* SubCommand::required(CLI::Option* option, bool required) {
-        if (option->get_required() != required) {
-            option->required(required);
+        if (subCommandApp->canonicalRequired(option) != required) {
+            subCommandApp->setCanonicalRequired(option, required);
+            subCommandApp->setCanonicalNeed(option, required);
 
             if (required) {
-                subCommandApp->needs(option);
                 option->default_str("");
-            } else {
-                subCommandApp->remove_needs(option);
             }
 
             this->required(required);
@@ -266,11 +250,7 @@ namespace utils {
     }
 
     SubCommand* SubCommand::needs(SubCommand* subCommand, bool needs) {
-        if (needs) {
-            subCommandApp->needs(subCommand->subCommandApp);
-        } else {
-            subCommandApp->remove_needs(subCommand->subCommandApp);
-        }
+        subCommandApp->setCanonicalNeed(subCommand->subCommandApp, needs);
 
         return this;
     }
@@ -447,6 +427,172 @@ namespace utils {
         }
 
         return help_ptr_;
+    }
+
+    ConfigOptionState& AppWithPtr::optionState(const CLI::Option* option) {
+        return optionConfigStates[option];
+    }
+
+    const ConfigOptionState* AppWithPtr::findOptionState(const CLI::Option* option) const {
+        const auto stateIt = optionConfigStates.find(option);
+
+        return stateIt != optionConfigStates.end() ? &stateIt->second : nullptr;
+    }
+
+    void AppWithPtr::setCanonicalRequired(bool required) {
+        configState.required.canonicalRequired = required;
+        applyEffectiveState();
+    }
+
+    void AppWithPtr::setCanonicalRequired(CLI::Option* option, bool required) {
+        optionState(option).required.canonicalRequired = required;
+        applyEffectiveState();
+    }
+
+    void AppWithPtr::setSuppression(ConfigSuppressionReason reason, bool suppressed) {
+        if (suppressed) {
+            configState.required.suppressions.insert(reason);
+        } else {
+            configState.required.suppressions.erase(reason);
+        }
+
+        applyEffectiveState();
+    }
+
+    void AppWithPtr::setSuppression(CLI::Option* option, ConfigSuppressionReason reason, bool suppressed) {
+        ConfigOptionState& state = optionState(option);
+        if (suppressed) {
+            state.required.suppressions.insert(reason);
+        } else {
+            state.required.suppressions.erase(reason);
+        }
+
+        applyEffectiveState();
+    }
+
+    void AppWithPtr::setSuppressionRecursive(ConfigSuppressionReason reason, bool suppressed) {
+        setSuppression(reason, suppressed);
+
+        for (CLI::Option* option : get_options([](CLI::Option*) {
+                 return true;
+             })) {
+            setSuppression(option, reason, suppressed);
+        }
+
+        for (CLI::App* subCommand : get_subcommands([](CLI::App*) {
+                 return true;
+             })) {
+            if (auto* appWithPtr = dynamic_cast<AppWithPtr*>(subCommand); appWithPtr != nullptr) {
+                appWithPtr->setSuppressionRecursive(reason, suppressed);
+            }
+        }
+
+        applyEffectiveState();
+    }
+
+    void AppWithPtr::setCanonicalNeed(CLI::Option* option, bool needed) {
+        if (needed) {
+            configState.canonicalOptionNeeds.insert(option);
+        } else {
+            configState.canonicalOptionNeeds.erase(option);
+        }
+
+        applyEffectiveState();
+    }
+
+    void AppWithPtr::setCanonicalNeed(CLI::App* app, bool needed) {
+        if (needed) {
+            configState.canonicalNeeds.insert(app);
+        } else {
+            configState.canonicalNeeds.erase(app);
+        }
+
+        applyEffectiveState();
+    }
+
+    bool AppWithPtr::canonicalRequired() const {
+        return configState.required.canonicalRequired;
+    }
+
+    bool AppWithPtr::effectiveRequired() const {
+        return configState.required.effectiveRequired;
+    }
+
+    bool AppWithPtr::canonicalRequired(const CLI::Option* option) const {
+        const ConfigOptionState* state = findOptionState(option);
+
+        return state != nullptr && state->required.canonicalRequired;
+    }
+
+    bool AppWithPtr::effectiveRequired(const CLI::Option* option) const {
+        const ConfigOptionState* state = findOptionState(option);
+
+        return state != nullptr && state->required.effectiveRequired;
+    }
+
+    bool AppWithPtr::hasSuppression(ConfigSuppressionReason reason) const {
+        return configState.required.suppressions.contains(reason);
+    }
+
+    bool AppWithPtr::hasSuppression(const CLI::Option* option, ConfigSuppressionReason reason) const {
+        const ConfigOptionState* state = findOptionState(option);
+
+        return state != nullptr && state->required.suppressions.contains(reason);
+    }
+
+    bool AppWithPtr::canonicalNeeds(const CLI::Option* option) const {
+        return configState.canonicalOptionNeeds.contains(option);
+    }
+
+    bool AppWithPtr::effectiveNeeds(const CLI::Option* option) const {
+        return configState.effectiveOptionNeeds.contains(option);
+    }
+
+    bool AppWithPtr::canonicalNeeds(const CLI::App* app) const {
+        return configState.canonicalNeeds.contains(app);
+    }
+
+    bool AppWithPtr::effectiveNeeds(const CLI::App* app) const {
+        return configState.effectiveNeeds.contains(app);
+    }
+
+    void AppWithPtr::applyEffectiveState() {
+        configState.required.effectiveRequired = configState.required.canonicalRequired && configState.required.suppressions.empty();
+        required(configState.required.effectiveRequired);
+
+        for (auto& [option, state] : optionConfigStates) {
+            state.required.effectiveRequired = state.required.canonicalRequired && state.required.suppressions.empty();
+            const_cast<CLI::Option*>(option)->required(state.required.effectiveRequired);
+        }
+
+        for (const CLI::Option* option : configState.effectiveOptionNeeds) {
+            remove_needs(const_cast<CLI::Option*>(option));
+        }
+        configState.effectiveOptionNeeds.clear();
+
+        std::set<const CLI::App*> previousEffectiveApps;
+        previousEffectiveApps.swap(configState.effectiveNeeds);
+        for (const CLI::App* app : previousEffectiveApps) {
+            remove_needs(const_cast<CLI::App*>(app));
+        }
+
+        if (configState.required.suppressions.empty()) {
+            for (const CLI::Option* option : configState.canonicalOptionNeeds) {
+                const ConfigOptionState* optionRequirementState = findOptionState(option);
+                if (optionRequirementState == nullptr || optionRequirementState->required.suppressions.empty()) {
+                    needs(const_cast<CLI::Option*>(option));
+                    configState.effectiveOptionNeeds.insert(option);
+                }
+            }
+
+            for (const CLI::App* app : configState.canonicalNeeds) {
+                const auto* appWithPtr = dynamic_cast<const AppWithPtr*>(app);
+                if (appWithPtr == nullptr || appWithPtr->configState.required.suppressions.empty()) {
+                    needs(const_cast<CLI::App*>(app));
+                    configState.effectiveNeeds.insert(app);
+                }
+            }
+        }
     }
 
     std::map<std::string, std::string> SubCommand::aliases;

--- a/src/utils/SubCommand.cpp
+++ b/src/utils/SubCommand.cpp
@@ -629,8 +629,6 @@ namespace utils {
     }
 
     void AppWithPtr::applyEffectiveState() {
-        const bool previousEffectiveRequired = configState.required.effectiveRequired;
-
         configState.required.effectiveRequired =
             configState.required.canonicalRequired && configState.required.effectiveRequiredBase && configState.required.suppressions.empty();
         required(configState.required.effectiveRequired);
@@ -669,11 +667,6 @@ namespace utils {
             }
         }
 
-        if (previousEffectiveRequired != configState.required.effectiveRequired) {
-            if (auto* parent = dynamic_cast<AppWithPtr*>(get_parent()); parent != nullptr) {
-                parent->applyEffectiveState();
-            }
-        }
     }
 
     std::map<std::string, std::string> SubCommand::aliases;

--- a/src/utils/SubCommand.h
+++ b/src/utils/SubCommand.h
@@ -87,6 +87,7 @@ namespace utils {
 
     struct ConfigRequirementState {
         bool canonicalRequired = false;
+        bool effectiveRequiredBase = false;
         bool effectiveRequired = false;
         std::set<ConfigSuppressionReason> suppressions;
     };
@@ -118,6 +119,7 @@ namespace utils {
         set_help_flag(std::string flag_name, std::function<void(std::size_t)> help_callback, const std::string& help_description);
 
         void setCanonicalRequired(bool required);
+        void setEffectiveRequiredBase(bool required);
         void setCanonicalRequired(CLI::Option* option, bool required);
         void setSuppression(ConfigSuppressionReason reason, bool suppressed);
         void setSuppression(CLI::Option* option, ConfigSuppressionReason reason, bool suppressed);
@@ -125,6 +127,7 @@ namespace utils {
 
         void setCanonicalNeed(CLI::Option* option, bool needed);
         void setCanonicalNeed(CLI::App* app, bool needed);
+        void setEffectiveNeed(CLI::App* app, bool needed);
 
         bool canonicalRequired() const;
         bool effectiveRequired() const;
@@ -180,6 +183,8 @@ namespace utils {
 
         bool hasParent() const;
         SubCommand* getParent() const;
+        const AppWithPtr* getAppWithPtr() const;
+        AppWithPtr* getAppWithPtr();
 
         SubCommand* allowExtras(bool allow = true);
 
@@ -296,6 +301,8 @@ namespace utils {
         static CLI::App* commandlineTriggerApp;
 
     private:
+        void applyEffectiveRequiredContribution(bool previousEffectiveRequired, bool effectiveRequired);
+
         CLI::Option* initialize(CLI::Option* option, const std::string& typeName, const CLI::Validator& validator, bool configurable) const;
 
         AppWithPtr* subCommandApp;
@@ -315,6 +322,7 @@ namespace utils {
         std::set<SubCommand*> childSubCommands;
 
         int requiredCount = 0;
+        int effectiveRequiredCount = 0;
         bool requiredForced = false;
 
         bool final;

--- a/src/utils/SubCommand.h
+++ b/src/utils/SubCommand.h
@@ -94,8 +94,6 @@ namespace utils {
 
     struct ConfigOptionState {
         ConfigRequirementState required;
-        std::set<const CLI::Option*> canonicalNeeds;
-        std::set<const CLI::Option*> effectiveNeeds;
     };
 
     struct ConfigNodeState {
@@ -127,7 +125,6 @@ namespace utils {
 
         void setCanonicalNeed(CLI::Option* option, bool needed);
         void setCanonicalNeed(CLI::App* app, bool needed);
-        void setEffectiveNeed(CLI::App* app, bool needed);
 
         bool canonicalRequired() const;
         bool effectiveRequired() const;
@@ -211,6 +208,8 @@ namespace utils {
         RequestedSubCommand* getSubCommand() const;
 
     protected:
+        SubCommand* suppressRequirements(ConfigSuppressionReason reason, bool suppressed);
+
         CLI::Option* addConfigFlag(const std::string& defaultConfigFile) const;
         CLI::Option* addLogFileFlag(const std::string& defaultLogFile) const;
         CLI::Option* addVersionFlag(const std::string& version) const;

--- a/src/utils/SubCommand.h
+++ b/src/utils/SubCommand.h
@@ -322,6 +322,9 @@ namespace utils {
         std::set<SubCommand*> childSubCommands;
 
         int requiredCount = 0;
+        // Effective contribution counting stays in SubCommand because required(bool)
+        // is a counted API and not every config child is owned in childSubCommands.
+        // AppWithPtr derives/applies only the local effective CLI11 state from this base.
         int effectiveRequiredCount = 0;
         bool requiredForced = false;
 

--- a/src/utils/SubCommand.h
+++ b/src/utils/SubCommand.h
@@ -301,6 +301,7 @@ namespace utils {
         static CLI::App* commandlineTriggerApp;
 
     private:
+        void applyCanonicalRequiredContribution(bool previousCanonicalRequired, bool canonicalRequired);
         void applyEffectiveRequiredContribution(bool previousEffectiveRequired, bool effectiveRequired);
 
         CLI::Option* initialize(CLI::Option* option, const std::string& typeName, const CLI::Validator& validator, bool configurable) const;

--- a/src/utils/SubCommand.h
+++ b/src/utils/SubCommand.h
@@ -80,6 +80,31 @@
 namespace utils {
     class SubCommand;
 
+    enum class ConfigSuppressionReason {
+        Disabled,
+        ForceUnrequired
+    };
+
+    struct ConfigRequirementState {
+        bool canonicalRequired = false;
+        bool effectiveRequired = false;
+        std::set<ConfigSuppressionReason> suppressions;
+    };
+
+    struct ConfigOptionState {
+        ConfigRequirementState required;
+        std::set<const CLI::Option*> canonicalNeeds;
+        std::set<const CLI::Option*> effectiveNeeds;
+    };
+
+    struct ConfigNodeState {
+        ConfigRequirementState required;
+        std::set<const CLI::Option*> canonicalOptionNeeds;
+        std::set<const CLI::Option*> effectiveOptionNeeds;
+        std::set<const CLI::App*> canonicalNeeds;
+        std::set<const CLI::App*> effectiveNeeds;
+    };
+
     class AppWithPtr : public CLI::App {
     public:
         AppWithPtr(const std::string& description, const std::string& name, SubCommand* t);
@@ -92,8 +117,34 @@ namespace utils {
         CLI11_INLINE CLI::Option*
         set_help_flag(std::string flag_name, std::function<void(std::size_t)> help_callback, const std::string& help_description);
 
+        void setCanonicalRequired(bool required);
+        void setCanonicalRequired(CLI::Option* option, bool required);
+        void setSuppression(ConfigSuppressionReason reason, bool suppressed);
+        void setSuppression(CLI::Option* option, ConfigSuppressionReason reason, bool suppressed);
+        void setSuppressionRecursive(ConfigSuppressionReason reason, bool suppressed);
+
+        void setCanonicalNeed(CLI::Option* option, bool needed);
+        void setCanonicalNeed(CLI::App* app, bool needed);
+
+        bool canonicalRequired() const;
+        bool effectiveRequired() const;
+        bool canonicalRequired(const CLI::Option* option) const;
+        bool effectiveRequired(const CLI::Option* option) const;
+        bool hasSuppression(ConfigSuppressionReason reason) const;
+        bool hasSuppression(const CLI::Option* option, ConfigSuppressionReason reason) const;
+        bool canonicalNeeds(const CLI::Option* option) const;
+        bool effectiveNeeds(const CLI::Option* option) const;
+        bool canonicalNeeds(const CLI::App* app) const;
+        bool effectiveNeeds(const CLI::App* app) const;
+
     private:
+        ConfigOptionState& optionState(const CLI::Option* option);
+        const ConfigOptionState* findOptionState(const CLI::Option* option) const;
+        void applyEffectiveState();
+
         SubCommand* ptr;
+        ConfigNodeState configState;
+        std::map<const CLI::Option*, ConfigOptionState> optionConfigStates;
     };
 
     class SubCommand {

--- a/tests/unit/utils/CMakeLists.txt
+++ b/tests/unit/utils/CMakeLists.txt
@@ -3,5 +3,5 @@ target_link_libraries(ConfigFormatterCommentMetadataTest PRIVATE snodec-test-sup
 set_tests_properties(ConfigFormatterCommentMetadataTest PROPERTIES LABELS "unit;utils;config;format" TIMEOUT 5)
 
 snodec_add_test(ConfigRequirementStateTest ConfigRequirementStateTest.cpp)
-target_link_libraries(ConfigRequirementStateTest PRIVATE snodec-test-support snodec::utils)
+target_link_libraries(ConfigRequirementStateTest PRIVATE snodec-test-support snodec::utils snodec::net)
 set_tests_properties(ConfigRequirementStateTest PROPERTIES LABELS "unit;utils;config" TIMEOUT 5)

--- a/tests/unit/utils/CMakeLists.txt
+++ b/tests/unit/utils/CMakeLists.txt
@@ -1,3 +1,7 @@
 snodec_add_test(ConfigFormatterCommentMetadataTest ConfigFormatterCommentMetadataTest.cpp)
 target_link_libraries(ConfigFormatterCommentMetadataTest PRIVATE snodec-test-support snodec::utils)
 set_tests_properties(ConfigFormatterCommentMetadataTest PROPERTIES LABELS "unit;utils;config;format" TIMEOUT 5)
+
+snodec_add_test(ConfigRequirementStateTest ConfigRequirementStateTest.cpp)
+target_link_libraries(ConfigRequirementStateTest PRIVATE snodec-test-support snodec::utils)
+set_tests_properties(ConfigRequirementStateTest PROPERTIES LABELS "unit;utils;config" TIMEOUT 5)

--- a/tests/unit/utils/ConfigRequirementStateTest.cpp
+++ b/tests/unit/utils/ConfigRequirementStateTest.cpp
@@ -228,5 +228,37 @@ int main() {
     require(utils::Config::configRoot.getAppWithPtr()->effectiveNeeds(instance.getAppWithPtr()),
             "ConfigInstance re-enable did not restore parent effective need");
 
+    instance.setDisabled(true);
+    require(instance.getAppWithPtr()->hasSuppression(utils::ConfigSuppressionReason::Disabled),
+            "ConfigInstance setDisabled(true) did not apply Disabled suppression");
+    require(!instance.getAppWithPtr()->hasSuppression(utils::ConfigSuppressionReason::ForceUnrequired),
+            "ConfigInstance setDisabled(true) incorrectly applied ForceUnrequired suppression");
+    instance.forceUnrequired(true);
+    require(instance.getAppWithPtr()->hasSuppression(utils::ConfigSuppressionReason::Disabled),
+            "layered ConfigInstance suppression lost Disabled suppression");
+    require(instance.getAppWithPtr()->hasSuppression(utils::ConfigSuppressionReason::ForceUnrequired),
+            "layered ConfigInstance suppression did not apply ForceUnrequired suppression");
+    instance.setDisabled(false);
+    require(!instance.getAppWithPtr()->hasSuppression(utils::ConfigSuppressionReason::Disabled),
+            "ConfigInstance setDisabled(false) did not clear Disabled suppression");
+    require(instance.getAppWithPtr()->hasSuppression(utils::ConfigSuppressionReason::ForceUnrequired),
+            "ConfigInstance setDisabled(false) cleared ForceUnrequired suppression");
+    require(instance.getAppWithPtr()->canonicalRequired(), "layered ConfigInstance suppression erased canonical required state");
+    require(!instance.getAppWithPtr()->effectiveRequired(),
+            "layered ConfigInstance suppression restored effective required while ForceUnrequired remained active");
+    require(utils::Config::configRoot.getAppWithPtr()->canonicalNeeds(instance.getAppWithPtr()),
+            "layered ConfigInstance suppression erased parent canonical need");
+    require(!utils::Config::configRoot.getAppWithPtr()->effectiveNeeds(instance.getAppWithPtr()),
+            "layered ConfigInstance suppression restored parent effective need while ForceUnrequired remained active");
+    instance.forceUnrequired(false);
+    require(!instance.getAppWithPtr()->hasSuppression(utils::ConfigSuppressionReason::Disabled),
+            "clearing final layered suppression restored Disabled suppression");
+    require(!instance.getAppWithPtr()->hasSuppression(utils::ConfigSuppressionReason::ForceUnrequired),
+            "forceUnrequired(false) did not clear ForceUnrequired suppression");
+    require(instance.getAppWithPtr()->effectiveRequired(),
+            "layered ConfigInstance suppression did not restore effective required after final suppression cleared");
+    require(utils::Config::configRoot.getAppWithPtr()->effectiveNeeds(instance.getAppWithPtr()),
+            "layered ConfigInstance suppression did not restore parent effective need after final suppression cleared");
+
     return 0;
 }

--- a/tests/unit/utils/ConfigRequirementStateTest.cpp
+++ b/tests/unit/utils/ConfigRequirementStateTest.cpp
@@ -150,6 +150,65 @@ int main() {
     child.forceUnrequired(false);
     require(child.getAppWithPtr()->effectiveRequired(), "mixed SubCommand suppressions did not restore effective required state");
 
+    TestSubCommand suppressedRoot{nullptr, "suppressed-root"};
+    TestSubCommand suppressedChild{&suppressedRoot, "suppressed-child"};
+    suppressedChild.forceUnrequired(true);
+    suppressedChild.required(true);
+    require(suppressedChild.getAppWithPtr()->canonicalRequired(), "required while suppressed did not record child canonical required");
+    require(!suppressedChild.getAppWithPtr()->effectiveRequired(), "required while suppressed restored child effective required too early");
+    require(suppressedRoot.getAppWithPtr()->canonicalNeeds(suppressedChild.getAppWithPtr()),
+            "required while suppressed did not record parent canonical need");
+    require(!suppressedRoot.getAppWithPtr()->effectiveNeeds(suppressedChild.getAppWithPtr()),
+            "required while suppressed applied parent effective need too early");
+    require(suppressedRoot.getAppWithPtr()->canonicalRequired(), "required while suppressed did not record parent canonical contribution");
+    require(!suppressedRoot.getAppWithPtr()->effectiveRequired(), "required while suppressed applied parent effective contribution too early");
+
+    TestSubCommand removeRoot{nullptr, "remove-root"};
+    TestSubCommand removeChild{&removeRoot, "remove-child"};
+    removeChild.required(true);
+    removeChild.forceUnrequired(true);
+    removeChild.required(false);
+    require(!removeChild.getAppWithPtr()->canonicalRequired(), "required(false) while suppressed left child canonical required");
+    require(!removeChild.getAppWithPtr()->effectiveRequired(), "required(false) while suppressed left child effective required");
+    require(!removeRoot.getAppWithPtr()->canonicalNeeds(removeChild.getAppWithPtr()),
+            "required(false) while suppressed left parent canonical need");
+    require(!removeRoot.getAppWithPtr()->effectiveNeeds(removeChild.getAppWithPtr()),
+            "required(false) while suppressed left parent effective need");
+    require(!removeRoot.getAppWithPtr()->canonicalRequired(), "required(false) while suppressed left parent canonical contribution");
+    require(!removeRoot.getAppWithPtr()->effectiveRequired(), "required(false) while suppressed decremented/restored parent effective contribution incorrectly");
+    removeChild.forceUnrequired(false);
+    require(!removeChild.getAppWithPtr()->canonicalRequired(), "restore after suppressed removal changed child canonical required");
+    require(!removeChild.getAppWithPtr()->effectiveRequired(), "restore after suppressed removal changed child effective required");
+    require(!removeRoot.getAppWithPtr()->canonicalNeeds(removeChild.getAppWithPtr()),
+            "restore after suppressed removal restored parent canonical need");
+    require(!removeRoot.getAppWithPtr()->effectiveNeeds(removeChild.getAppWithPtr()),
+            "restore after suppressed removal restored parent effective need");
+    require(!removeRoot.getAppWithPtr()->effectiveRequired(), "restore after suppressed removal corrupted parent effective count");
+
+    TestSubCommand countedRoot{nullptr, "counted-root"};
+    TestSubCommand countedChild{&countedRoot, "counted-child"};
+    countedChild.required(true);
+    countedChild.required(true);
+    countedChild.forceUnrequired(true);
+    countedChild.required(false);
+    require(countedChild.getAppWithPtr()->canonicalRequired(), "balanced counted sequence removed child canonical required too early");
+    require(!countedChild.getAppWithPtr()->effectiveRequired(), "balanced counted sequence restored child effective while still suppressed");
+    require(countedRoot.getAppWithPtr()->canonicalNeeds(countedChild.getAppWithPtr()),
+            "balanced counted sequence removed parent canonical need too early");
+    require(!countedRoot.getAppWithPtr()->effectiveNeeds(countedChild.getAppWithPtr()),
+            "balanced counted sequence restored parent effective need while child still suppressed");
+    countedChild.forceUnrequired(false);
+    require(countedChild.getAppWithPtr()->effectiveRequired(), "balanced counted sequence did not restore child effective required");
+    require(countedRoot.getAppWithPtr()->effectiveRequired(), "balanced counted sequence did not restore parent effective required");
+    countedChild.required(false);
+    require(!countedChild.getAppWithPtr()->canonicalRequired(), "balanced counted sequence left child canonical required");
+    require(!countedChild.getAppWithPtr()->effectiveRequired(), "balanced counted sequence left child effective required");
+    require(!countedRoot.getAppWithPtr()->canonicalNeeds(countedChild.getAppWithPtr()),
+            "balanced counted sequence left parent canonical need");
+    require(!countedRoot.getAppWithPtr()->effectiveNeeds(countedChild.getAppWithPtr()),
+            "balanced counted sequence left parent effective need");
+    require(!countedRoot.getAppWithPtr()->effectiveRequired(), "balanced counted sequence left parent effective required");
+
     TestConfigInstance instance;
     instance.required(true);
     require(utils::Config::configRoot.getAppWithPtr()->canonicalNeeds(instance.getAppWithPtr()),

--- a/tests/unit/utils/ConfigRequirementStateTest.cpp
+++ b/tests/unit/utils/ConfigRequirementStateTest.cpp
@@ -1,5 +1,8 @@
 #include "utils/SubCommand.h"
 
+#include "net/config/ConfigInstance.h"
+#include "utils/Config.h"
+
 #include <cstdlib>
 #include <iostream>
 #include <memory>
@@ -13,6 +16,22 @@ namespace {
             std::abort();
         }
     }
+
+    class TestSubCommand : public utils::SubCommand {
+    public:
+        TestSubCommand(utils::SubCommand* parent, const std::string& name)
+            : utils::SubCommand(parent, std::make_shared<utils::AppWithPtr>("test command", name, this), "Tests") {
+        }
+    };
+
+    class TestConfigInstance : public net::config::ConfigInstance {
+    public:
+        TestConfigInstance()
+            : net::config::ConfigInstance("unit-instance", net::config::ConfigInstance::Role::SERVER) {
+        }
+
+        ~TestConfigInstance() override = default;
+    };
 
 } // namespace
 
@@ -53,28 +72,28 @@ int main() {
     require(requiredOpt->get_required(), "removing final suppression did not restore CLI11 option required state");
 
     utils::AppWithPtr parent{"Parent app", "parent", nullptr};
-    auto child = std::make_shared<utils::AppWithPtr>("Child section", "section", nullptr);
-    parent.add_subcommand(child);
-    parent.setCanonicalNeed(child.get(), true);
-    child->setCanonicalRequired(true);
-    require(child->canonicalRequired(), "child canonical required state was not recorded");
-    require(child->effectiveRequired(), "child effective required state was not applied initially");
-    require(child->get_required(), "CLI11 child required state was not applied initially");
-    require(parent.canonicalNeeds(child.get()), "child canonical need was not recorded");
-    require(parent.effectiveNeeds(child.get()), "child effective need was not applied initially");
+    auto appChild = std::make_shared<utils::AppWithPtr>("Child section", "section", nullptr);
+    parent.add_subcommand(appChild);
+    parent.setCanonicalNeed(appChild.get(), true);
+    appChild->setCanonicalRequired(true);
+    require(appChild->canonicalRequired(), "child canonical required state was not recorded");
+    require(appChild->effectiveRequired(), "child effective required state was not applied initially");
+    require(appChild->get_required(), "CLI11 child required state was not applied initially");
+    require(parent.canonicalNeeds(appChild.get()), "child canonical need was not recorded");
+    require(parent.effectiveNeeds(appChild.get()), "child effective need was not applied initially");
 
     parent.setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, true);
-    require(child->canonicalRequired(), "disabled suppression erased child canonical required state");
-    require(!child->effectiveRequired(), "disabled suppression did not clear child effective required state");
-    require(!child->get_required(), "disabled suppression did not clear CLI11 child required state");
-    require(parent.canonicalNeeds(child.get()), "disabled suppression erased child canonical need");
-    require(!parent.effectiveNeeds(child.get()), "disabled suppression did not clear child effective need");
+    require(appChild->canonicalRequired(), "disabled suppression erased child canonical required state");
+    require(!appChild->effectiveRequired(), "disabled suppression did not clear child effective required state");
+    require(!appChild->get_required(), "disabled suppression did not clear CLI11 child required state");
+    require(parent.canonicalNeeds(appChild.get()), "disabled suppression erased child canonical need");
+    require(!parent.effectiveNeeds(appChild.get()), "disabled suppression did not clear child effective need");
 
     parent.setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, false);
-    require(child->canonicalRequired(), "re-enable erased child canonical required state");
-    require(child->effectiveRequired(), "re-enable did not restore child effective required state");
-    require(child->get_required(), "re-enable did not restore CLI11 child required state");
-    require(parent.effectiveNeeds(child.get()), "re-enable did not restore child effective need");
+    require(appChild->canonicalRequired(), "re-enable erased child canonical required state");
+    require(appChild->effectiveRequired(), "re-enable did not restore child effective required state");
+    require(appChild->get_required(), "re-enable did not restore CLI11 child required state");
+    require(parent.effectiveNeeds(appChild.get()), "re-enable did not restore child effective need");
 
     std::string defaulted = "from-api";
     auto* defaultedOpt = app.add_option("--defaulted", defaulted, "Defaulted required value")->default_str(defaulted);
@@ -86,6 +105,69 @@ int main() {
     require(!requiredOpt->get_required(), "disabled owner still requires nested option");
     app.setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, false);
     require(requiredOpt->get_required(), "re-enabled owner left stale non-required CLI11 state");
+
+    TestSubCommand root{nullptr, "root"};
+    TestSubCommand child{&root, "child"};
+
+    child.required(true);
+    require(child.getAppWithPtr()->canonicalRequired(), "SubCommand child canonical required state was not recorded");
+    require(child.getAppWithPtr()->effectiveRequired(), "SubCommand child effective required state was not applied");
+    require(root.getAppWithPtr()->canonicalNeeds(child.getAppWithPtr()), "SubCommand parent canonical need was not recorded");
+    require(root.getAppWithPtr()->effectiveNeeds(child.getAppWithPtr()), "SubCommand parent effective need was not applied");
+    require(root.getAppWithPtr()->effectiveRequired(), "SubCommand parent effective required state did not reflect child requirement");
+
+    child.forceUnrequired(true);
+    require(child.getAppWithPtr()->canonicalRequired(), "forceUnrequired erased SubCommand child canonical required state");
+    require(!child.getAppWithPtr()->effectiveRequired(), "forceUnrequired did not suppress SubCommand child effective required state");
+    require(root.getAppWithPtr()->canonicalNeeds(child.getAppWithPtr()), "forceUnrequired erased SubCommand parent canonical need");
+    require(!root.getAppWithPtr()->effectiveNeeds(child.getAppWithPtr()), "forceUnrequired did not suppress SubCommand parent effective need");
+    require(!root.getAppWithPtr()->effectiveRequired(), "forceUnrequired left stale SubCommand parent effective required state");
+
+    child.forceUnrequired(false);
+    require(child.getAppWithPtr()->canonicalRequired(), "forceUnrequired(false) erased SubCommand child canonical required state");
+    require(child.getAppWithPtr()->effectiveRequired(), "forceUnrequired(false) did not restore SubCommand child effective required state");
+    require(root.getAppWithPtr()->canonicalNeeds(child.getAppWithPtr()), "forceUnrequired(false) erased SubCommand parent canonical need");
+    require(root.getAppWithPtr()->effectiveNeeds(child.getAppWithPtr()), "forceUnrequired(false) did not restore SubCommand parent effective need");
+    require(root.getAppWithPtr()->effectiveRequired(), "forceUnrequired(false) did not restore SubCommand parent effective required state");
+
+    auto* childOption = child.addOption("--child-option", "Child option", "INT", CLI::NonNegativeNumber);
+    child.required(childOption, true);
+    require(child.getAppWithPtr()->canonicalRequired(childOption), "SubCommand option canonical required state was not recorded");
+    require(child.getAppWithPtr()->effectiveRequired(childOption), "SubCommand option effective required state was not applied");
+    require(childOption->get_required(), "CLI11 SubCommand option required state was not applied");
+    child.forceUnrequired(true);
+    require(child.getAppWithPtr()->canonicalRequired(childOption), "forceUnrequired erased SubCommand option canonical required state");
+    require(!child.getAppWithPtr()->effectiveRequired(childOption), "forceUnrequired did not suppress SubCommand option effective required state");
+    require(!childOption->get_required(), "forceUnrequired did not suppress CLI11 option required state");
+    child.forceUnrequired(false);
+    require(child.getAppWithPtr()->effectiveRequired(childOption), "forceUnrequired(false) did not restore SubCommand option effective required state");
+    require(childOption->get_required(), "forceUnrequired(false) did not restore CLI11 option required state");
+
+    child.getAppWithPtr()->setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, true);
+    child.forceUnrequired(true);
+    child.getAppWithPtr()->setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, false);
+    require(!child.getAppWithPtr()->effectiveRequired(), "mixed SubCommand suppressions restored effective required state too early");
+    child.forceUnrequired(false);
+    require(child.getAppWithPtr()->effectiveRequired(), "mixed SubCommand suppressions did not restore effective required state");
+
+    TestConfigInstance instance;
+    instance.required(true);
+    require(utils::Config::configRoot.getAppWithPtr()->canonicalNeeds(instance.getAppWithPtr()),
+            "ConfigInstance parent canonical need was not recorded");
+    require(utils::Config::configRoot.getAppWithPtr()->effectiveNeeds(instance.getAppWithPtr()),
+            "ConfigInstance parent effective need was not applied");
+    instance.setDisabled(true);
+    require(instance.getAppWithPtr()->canonicalRequired(), "ConfigInstance disable erased canonical required state");
+    require(!instance.getAppWithPtr()->effectiveRequired(), "ConfigInstance disable did not suppress effective required state");
+    require(utils::Config::configRoot.getAppWithPtr()->canonicalNeeds(instance.getAppWithPtr()),
+            "ConfigInstance disable erased parent canonical need");
+    require(!utils::Config::configRoot.getAppWithPtr()->effectiveNeeds(instance.getAppWithPtr()),
+            "ConfigInstance disable did not suppress parent effective need");
+    instance.setDisabled(false);
+    require(instance.getAppWithPtr()->canonicalRequired(), "ConfigInstance re-enable erased canonical required state");
+    require(instance.getAppWithPtr()->effectiveRequired(), "ConfigInstance re-enable did not restore effective required state");
+    require(utils::Config::configRoot.getAppWithPtr()->effectiveNeeds(instance.getAppWithPtr()),
+            "ConfigInstance re-enable did not restore parent effective need");
 
     return 0;
 }

--- a/tests/unit/utils/ConfigRequirementStateTest.cpp
+++ b/tests/unit/utils/ConfigRequirementStateTest.cpp
@@ -1,0 +1,91 @@
+#include "utils/SubCommand.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+
+    void require(bool condition, const std::string& message) {
+        if (!condition) {
+            std::cerr << message << std::endl;
+            std::abort();
+        }
+    }
+
+} // namespace
+
+int main() {
+    utils::AppWithPtr app{"Synthetic app", "demo", nullptr};
+    int requiredValue = 0;
+    auto* requiredOpt = app.add_option("--required", requiredValue, "Required value");
+
+    app.setCanonicalRequired(requiredOpt, true);
+    app.setCanonicalNeed(requiredOpt, true);
+    require(app.canonicalRequired(requiredOpt), "option canonical required state was not recorded");
+    require(app.effectiveRequired(requiredOpt), "option effective required state was not applied initially");
+    require(requiredOpt->get_required(), "CLI11 option required state was not applied initially");
+    require(app.canonicalNeeds(requiredOpt), "option canonical need was not recorded");
+    require(app.effectiveNeeds(requiredOpt), "option effective need was not applied initially");
+
+    app.setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, true);
+    require(app.canonicalRequired(requiredOpt), "disabled suppression erased option canonical required state");
+    require(!app.effectiveRequired(requiredOpt), "disabled suppression did not clear option effective required state");
+    require(!requiredOpt->get_required(), "disabled suppression did not clear CLI11 option required state");
+    require(app.canonicalNeeds(requiredOpt), "disabled suppression erased option canonical need");
+    require(!app.effectiveNeeds(requiredOpt), "disabled suppression did not clear option effective need");
+
+    app.setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, false);
+    require(app.canonicalRequired(requiredOpt), "re-enable erased option canonical required state");
+    require(app.effectiveRequired(requiredOpt), "re-enable did not restore option effective required state");
+    require(requiredOpt->get_required(), "re-enable did not restore CLI11 option required state");
+    require(app.effectiveNeeds(requiredOpt), "re-enable did not restore option effective need");
+
+    app.setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, true);
+    app.setSuppressionRecursive(utils::ConfigSuppressionReason::ForceUnrequired, true);
+    app.setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, false);
+    require(app.canonicalRequired(requiredOpt), "multiple suppressions erased canonical option required state");
+    require(!app.effectiveRequired(requiredOpt), "removing one of two suppressions restored option effective required state too early");
+    require(!requiredOpt->get_required(), "removing one of two suppressions restored CLI11 option required state too early");
+    app.setSuppressionRecursive(utils::ConfigSuppressionReason::ForceUnrequired, false);
+    require(app.effectiveRequired(requiredOpt), "removing final suppression did not restore option effective required state");
+    require(requiredOpt->get_required(), "removing final suppression did not restore CLI11 option required state");
+
+    utils::AppWithPtr parent{"Parent app", "parent", nullptr};
+    auto child = std::make_shared<utils::AppWithPtr>("Child section", "section", nullptr);
+    parent.add_subcommand(child);
+    parent.setCanonicalNeed(child.get(), true);
+    child->setCanonicalRequired(true);
+    require(child->canonicalRequired(), "child canonical required state was not recorded");
+    require(child->effectiveRequired(), "child effective required state was not applied initially");
+    require(child->get_required(), "CLI11 child required state was not applied initially");
+    require(parent.canonicalNeeds(child.get()), "child canonical need was not recorded");
+    require(parent.effectiveNeeds(child.get()), "child effective need was not applied initially");
+
+    parent.setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, true);
+    require(child->canonicalRequired(), "disabled suppression erased child canonical required state");
+    require(!child->effectiveRequired(), "disabled suppression did not clear child effective required state");
+    require(!child->get_required(), "disabled suppression did not clear CLI11 child required state");
+    require(parent.canonicalNeeds(child.get()), "disabled suppression erased child canonical need");
+    require(!parent.effectiveNeeds(child.get()), "disabled suppression did not clear child effective need");
+
+    parent.setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, false);
+    require(child->canonicalRequired(), "re-enable erased child canonical required state");
+    require(child->effectiveRequired(), "re-enable did not restore child effective required state");
+    require(child->get_required(), "re-enable did not restore CLI11 child required state");
+    require(parent.effectiveNeeds(child.get()), "re-enable did not restore child effective need");
+
+    std::string defaulted = "from-api";
+    auto* defaultedOpt = app.add_option("--defaulted", defaulted, "Defaulted required value")->default_str(defaulted);
+    app.setCanonicalRequired(defaultedOpt, true);
+    require(app.canonicalRequired(defaultedOpt), "C++ default erased canonical required state");
+    require(app.effectiveRequired(defaultedOpt), "C++ default erased effective required state");
+
+    app.setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, true);
+    require(!requiredOpt->get_required(), "disabled owner still requires nested option");
+    app.setSuppressionRecursive(utils::ConfigSuppressionReason::Disabled, false);
+    require(requiredOpt->get_required(), "re-enabled owner left stale non-required CLI11 state");
+
+    return 0;
+}

--- a/tests/unit/utils/ConfigRequirementStateTest.cpp
+++ b/tests/unit/utils/ConfigRequirementStateTest.cpp
@@ -74,8 +74,8 @@ int main() {
     utils::AppWithPtr parent{"Parent app", "parent", nullptr};
     auto appChild = std::make_shared<utils::AppWithPtr>("Child section", "section", nullptr);
     parent.add_subcommand(appChild);
-    parent.setCanonicalNeed(appChild.get(), true);
     appChild->setCanonicalRequired(true);
+    parent.setCanonicalNeed(appChild.get(), true);
     require(appChild->canonicalRequired(), "child canonical required state was not recorded");
     require(appChild->effectiveRequired(), "child effective required state was not applied initially");
     require(appChild->get_required(), "CLI11 child required state was not applied initially");


### PR DESCRIPTION
### Motivation
- Prevent CLI11 mutations from destroying SNode.C’s canonical required/needs model so requirements suppressed while instances are disabled can be restored later. 
- Record a stable SNode.C-declared (canonical) state separate from the mutable CLI11-applied (effective) state and support multiple suppression reasons such as `Disabled` and `ForceUnrequired`.
- Keep the change scoped to internal state and runtime behavior without touching formatter metadata schema or command-line surface.

### Description
- Add typed suppression reasons and a compact canonical/effective state model attached to `utils::AppWithPtr` with `ConfigRequirementState`, `ConfigOptionState`, and `ConfigNodeState` structs (see `src/utils/SubCommand.h`).
- Introduce `AppWithPtr` APIs to record canonical state and suppressions: `setCanonicalRequired`, `setCanonicalRequired(CLI::Option*)`, `setCanonicalNeed`, `setSuppression`, `setSuppressionRecursive`, and query helpers such as `canonicalRequired(...)` and `effectiveRequired(...)` (implemented in `src/utils/SubCommand.cpp`).
- Centralize recomputation/apply logic in `AppWithPtr::applyEffectiveState()` so effective `required` and `needs` are derived from canonical state and active suppressions and applied to CLI11 in one place.
- Route SNode.C requirement/needs flows through the new canonical helpers by updating `SubCommand::required`, `SubCommand::required(CLI::Option*)`, `SubCommand::needs`, and `SubCommand::forceUnrequired` to record canonical state & suppressions and then recompute effective state (changes in `src/utils/SubCommand.cpp`).
- Add a focused unit test `tests/unit/utils/ConfigRequirementStateTest.cpp` and register it in `tests/unit/utils/CMakeLists.txt` to exercise option/node required restoration, needs restoration, C++ default preservation, disabled suppression, stale-state restoration, and multiple suppression reasons.
- Keep formatter output, schema, and CLI surface unchanged as required by the PR scope.

### Testing
- Built the project and the new test: `cmake -S . -B build -DSNODEC_BUILD_TESTS=ON` and `cmake --build build -j2`, and the targeted unit: `cmake --build build --target ConfigRequirementStateTest -j2`, which succeeded.
- Ran the focused unit test via CTest: `ctest --test-dir build --output-on-failure -R ConfigRequirementStateTest`, which passed.
- Performed a full build and test run: `cmake --build build -j2` and `ctest --test-dir build --output-on-failure`, and the test suite completed successfully in this environment (reported tests ran/passed; skipped tests are environment/test-policy skips).
- Verifications confirm canonical state survives suppression, effective state is suppressed and restored correctly, and multiple suppression reasons are handled (removing one reason does not prematurely restore effective requiredness).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f67b5ec40832c979602dda9ccee25)