### PR TITLE
Structurally cache semantic loggers in hot framework paths

### DIFF
--- a/docs/logging/semantic-structural-cache-report.md
+++ b/docs/logging/semantic-structural-cache-report.md
@@ -24,6 +24,15 @@ For real structural optimization, stable framework objects now keep cached `Boun
 
 A cached `BoundaryLogger` captures the threshold selected when it is constructed. Caching is safe only when semantic identity is stable and policy has already frozen, or when the accessor keeps a pre-freeze dynamic fallback and populates the cache only after `LogManager::isFrozen()`.
 
+
+## Generation-safe structural caches
+
+`LogManager::generation()` invalidates lazy structural caches after `LogManager::init()` by giving long-lived objects a cheap way to detect policy reinitialization. `EventLoop`, `SocketConnection`, and `SocketContext` keep their existing lazy post-freeze generation-aware caches so pre-freeze calls remain dynamically resolved and post-freeze calls reuse a resolved threshold only for the current policy generation.
+
+`Mqtt`, WebSocket `Receiver`/`Transmitter`, and MQTT broker/tree/session caches were also made generation-aware. These classes now avoid direct non-refreshable `BoundaryLogger` members and instead store optional cached loggers plus a generation value, refreshing from the semantic helper when the generation changes.
+
+`EventLoop` still cannot cache in its constructor because it may be created before `Config::bootstrap()` freezes semantic logging policy. `Broker::instance()` can return a long-lived singleton broker, so it must not hold a stale direct `BoundaryLogger` across a `LogManager::init()` in tests or embedded reuse. The source-policy test now checks generation-aware structure for these long-lived caches, and it includes a behavioral EventLoop generation-invalidation check that proves a cached accessor refreshes when the policy generation changes.
+
 ## EventLoop special case
 
 `EventLoop` is a Meyers singleton and can be initialized before configuration bootstrap freezes logging policy. It therefore does not cache in its constructor. Its default `log()` accessor remains dynamic before freeze and lazily caches the resolved semantic logger after freeze.
@@ -42,11 +51,11 @@ HTTP client/server socket contexts call `frameworkLog()` in request/response lif
 
 ## WebSocket frame cache
 
-`Receiver` and `Transmitter` now cache `webSocketFrameLog()` as `frameLog_`. `readPayload()` and `sendFrame()` no longer create a fresh frame logger per payload chunk/frame, while `hexDump()` remains guarded by the trace-enabled check.
+`Receiver` and `Transmitter` now cache `webSocketFrameLog()` through generation-aware `frameLog()` accessors. `readPayload()` and `sendFrame()` no longer create a fresh frame logger per payload chunk/frame, while `hexDump()` remains guarded by the trace-enabled check.
 
 ## MQTT broker/session/tree cache
 
-`Broker`, `RetainTree`, `RetainTree::TopicLevel`, `SubscriptionTree`, `SubscriptionTree::TopicLevel`, and `Session` now keep cached MQTT broker/session loggers. Hot publish, retain, subscription, and queued-session paths use those cached members rather than direct helper resolution.
+`Broker`, `RetainTree`, `RetainTree::TopicLevel`, `SubscriptionTree`, `SubscriptionTree::TopicLevel`, and `Session` now keep generation-aware cached MQTT broker/session loggers. Hot publish, retain, subscription, and queued-session paths use those cached members rather than direct helper resolution.
 
 ## Files inspected
 
@@ -61,7 +70,7 @@ The audit covered `src/core`, `src/core/socket`, `src/web/http`, `src/web/websoc
 
 ## Where caching was added
 
-Caching was added to EventLoop, SocketConnection, SocketContext, WebSocket Receiver/Transmitter, MQTT Broker, RetainTree, SubscriptionTree, their hot nested topic levels, and Session.
+Generation-aware caching was added to EventLoop, SocketConnection, SocketContext, Mqtt, WebSocket Receiver/Transmitter, MQTT Broker, RetainTree, SubscriptionTree, their hot nested topic levels, and Session.
 
 ## Where caching was deliberately not added and why
 
@@ -69,7 +78,7 @@ Free functions, semantic helper definitions, and sink-taking overloads were not 
 
 ## Tests added/updated
 
-Added `SemanticStructuralLoggerCacheTest` and registered it in the log unit test CMake file. The test checks source structure, macro non-introduction, threshold/override behavior, and disabled/ enabled formatting behavior.
+Added `SemanticStructuralLoggerCacheTest` and registered it in the log unit test CMake file. The test checks source structure, generation-aware cache invalidation, macro non-introduction, threshold/override behavior, and disabled/enabled formatting behavior.
 
 ## Search commands run
 

--- a/docs/logging/semantic-structural-cache-report.md
+++ b/docs/logging/semantic-structural-cache-report.md
@@ -1,0 +1,92 @@
+# Semantic structural logger cache report
+
+## Problem summary
+
+Several hot framework paths still resolved semantic loggers repeatedly. Each direct helper call or uncached accessor created a fresh `BoundaryLogger`, forcing effective-level lookup work before discovering that a message was disabled.
+
+## What #175 fixed
+
+#175 reduced disabled semantic logging overhead by moving expensive formatting behind enabled checks and by introducing local bind-once guard patterns where immediate structural ownership was not yet available.
+
+## What #176 fixed
+
+#176 structurally cached the stable `iot::mqtt::Mqtt` semantic logger and completed the direct same-scope cleanup in `Mqtt.cpp`.
+
+## Why bind-once was not enough
+
+A local `auto log = ...Log()` avoids repeated helper calls within one block, but it still resolves the effective level every time the function is entered. Hot objects with stable semantic identity need a member cache so repeated runtime calls reuse an already-resolved threshold.
+
+## For real structural optimization
+
+For real structural optimization, stable framework objects now keep cached `BoundaryLogger` members or lazy post-freeze cached accessors. Disabled logging follows the cheap shape: check `cachedLog.enabled(level)` first, then format only inside the enabled path.
+
+## Safety model
+
+A cached `BoundaryLogger` captures the threshold selected when it is constructed. Caching is safe only when semantic identity is stable and policy has already frozen, or when the accessor keeps a pre-freeze dynamic fallback and populates the cache only after `LogManager::isFrozen()`.
+
+## EventLoop special case
+
+`EventLoop` is a Meyers singleton and can be initialized before configuration bootstrap freezes logging policy. It therefore does not cache in its constructor. Its default `log()` accessor remains dynamic before freeze and lazily caches the resolved semantic logger after freeze.
+
+## SocketConnection cache
+
+`SocketConnection` now stores a lazy cached logger. The accessor preserves dynamic behavior before freeze and reuses the cached logger after freeze for shutdown, close, read/write error, and context-switch diagnostics.
+
+## SocketContext cache
+
+`SocketContext` now stores separate lazy cached application and framework loggers. `log()` and `frameworkLog()` retain sink-taking overloads for tests/custom capture while avoiding repeated effective-level resolution on post-freeze hot paths.
+
+## HTTP client/server impact
+
+HTTP client/server socket contexts call `frameworkLog()` in request/response lifecycle paths. Those call sites now benefit from the core `SocketContext` structural cache without logging wording or protocol behavior changes.
+
+## WebSocket frame cache
+
+`Receiver` and `Transmitter` now cache `webSocketFrameLog()` as `frameLog_`. `readPayload()` and `sendFrame()` no longer create a fresh frame logger per payload chunk/frame, while `hexDump()` remains guarded by the trace-enabled check.
+
+## MQTT broker/session/tree cache
+
+`Broker`, `RetainTree`, `RetainTree::TopicLevel`, `SubscriptionTree`, `SubscriptionTree::TopicLevel`, and `Session` now keep cached MQTT broker/session loggers. Hot publish, retain, subscription, and queued-session paths use those cached members rather than direct helper resolution.
+
+## Files inspected
+
+The audit covered `src/core`, `src/core/socket`, `src/web/http`, `src/web/websocket`, `src/iot/mqtt`, existing logging tests, and prior logging reports.
+
+## Implementation summary
+
+- Added lazy post-freeze caches to `EventLoop`, `SocketConnection`, and `SocketContext`.
+- Added frame logger members to WebSocket receiver/transmitter.
+- Added broker/session logger members to MQTT broker tree/session classes.
+- Added a source-policy and behavioral regression test for structural caching.
+
+## Where caching was added
+
+Caching was added to EventLoop, SocketConnection, SocketContext, WebSocket Receiver/Transmitter, MQTT Broker, RetainTree, SubscriptionTree, their hot nested topic levels, and Session.
+
+## Where caching was deliberately not added and why
+
+Free functions, semantic helper definitions, and sink-taking overloads were not converted because they either do not own stable semantic identity or intentionally support tests/custom capture. EventLoop constructor caching was deliberately avoided because initialization can happen before policy freeze.
+
+## Tests added/updated
+
+Added `SemanticStructuralLoggerCacheTest` and registered it in the log unit test CMake file. The test checks source structure, macro non-introduction, threshold/override behavior, and disabled/ enabled formatting behavior.
+
+## Search commands run
+
+- `rg -n "[A-Za-z0-9_:]*Log\\(\\)\\.(trace|debug|info|warn|error|critical|enabled)|\\.log\\(\\)\\.(trace|debug|info|warn|error|critical|enabled)|frameworkLog\\(\\)\\.(trace|debug|info|warn|error|critical|enabled)" src -g '*.h' -g '*.hpp' -g '*.cpp'`
+- `rg -n "return .*LogScope.*\\.logger\\(logger::Logger::semanticSink\\(\\)\\)|return .*logScope\\.logger\\(logger::Logger::semanticSink\\(\\)\\)|return .*LogScopeOwner.*logger\\(logger::Logger::semanticSink\\(\\)\\)" src -g '*.h' -g '*.hpp' -g '*.cpp'`
+- `rg -n "hexDump|toHexString|httputils::toString|dump\\(|payload|body|header|packet|buffer|retain|subscription|route" src -g '*.h' -g '*.hpp' -g '*.cpp'`
+- `rg -n "logger::BoundaryLogger .*log_|std::optional<logger::BoundaryLogger>|cached.*BoundaryLogger|refresh.*Log|cache.*Log" src tests docs -g '*.h' -g '*.hpp' -g '*.cpp' -g '*.md'`
+- `rg -n "auto log = .*Log\\(\\)|auto log = .*frameworkLog\\(\\)|auto log = .*\\.log\\(\\)" src/iot/mqtt src/web/http src/web/websocket src/core/socket src/core -g '*.h' -g '*.hpp' -g '*.cpp'`
+
+## Tests run
+
+The implementation was validated with configure, build, focused tests, source searches, formatting, and diff checks as recorded in the PR summary.
+
+## Known follow-ups
+
+1. PR G.2 — ConfigInstance instance-scoped --log-level.
+2. Optional measurements/callgrind benchmark.
+3. Optional async logging backend only if accepted-log sink I/O becomes the bottleneck.
+4. Final macro removal/source gate.
+5. Round 10 book integration.

--- a/docs/logging/semantic-structural-cache-report.md
+++ b/docs/logging/semantic-structural-cache-report.md
@@ -33,6 +33,23 @@ A cached `BoundaryLogger` captures the threshold selected when it is constructed
 
 `EventLoop` still cannot cache in its constructor because it may be created before `Config::bootstrap()` freezes semantic logging policy. `Broker::instance()` can return a long-lived singleton broker, so it must not hold a stale direct `BoundaryLogger` across a `LogManager::init()` in tests or embedded reuse. The source-policy test now checks generation-aware structure for these long-lived caches, and it includes a behavioral EventLoop generation-invalidation check that proves a cached accessor refreshes when the policy generation changes.
 
+## Generation-aware cache versus pre-freeze-safe cache
+
+`LogManager::generation()` changes when `LogManager::init()` resets the semantic policy. It does not change for every `setGlobalLevel()`, `setComponentLevel()`, `setInstanceLevel()`, or `freeze()` call. Therefore, generation-aware caching alone is not automatically safe for objects that can log during the policy-building window before freeze.
+
+Current class policy:
+
+- **EventLoop:** uses an `isFrozen()` fallback because it can be touched before `Config::bootstrap()` and `LogManager::freeze()`. Pre-freeze log calls continue to resolve dynamically, and only post-freeze calls populate the generation-aware cache.
+- **SocketConnection and SocketContext:** use lazy post-freeze generation-aware caches. This is conservative and safe for framework code that may be constructed near connection setup boundaries while still preserving dynamic behavior before freeze.
+- **Broker / RetainTree / SubscriptionTree / Session:** use private generation-aware accessors. This is safe for the current code because their log accessors are private and call sites are enumerable. If any broker-family logger accessor becomes public or is called from application-controlled pre-freeze setup code, it must gain an `isFrozen()` fallback.
+- **Mqtt / WebSocket Receiver / WebSocket Transmitter:** use generation-aware caches. This is acceptable because these are runtime protocol objects constructed and used through framework-controlled connection/context paths.
+
+Future rule:
+
+- If an object can log before `LogManager::freeze()`, use an `isFrozen()` fallback.
+- If an object is runtime-only or has private, enumerable post-freeze logging call sites, generation-aware caching is sufficient.
+- If unsure, use the `isFrozen()` fallback.
+
 ## EventLoop special case
 
 `EventLoop` is a Meyers singleton and can be initialized before configuration bootstrap freezes logging policy. It therefore does not cache in its constructor. Its default `log()` accessor remains dynamic before freeze and lazily caches the resolved semantic logger after freeze.

--- a/src/core/EventLoop.cpp
+++ b/src/core/EventLoop.cpp
@@ -134,6 +134,15 @@ namespace core {
     }
 
     logger::BoundaryLogger EventLoop::log() const {
+        if (logger::LogManager::isFrozen()) {
+            const unsigned long generation = logger::LogManager::generation();
+            if (!cachedLog_ || cachedLogGeneration_ != generation) {
+                cachedLogGeneration_ = generation;
+                cachedLog_.emplace(logScope.logger(logger::Logger::semanticSink()));
+            }
+            return *cachedLog_;
+        }
+
         return logScope.logger(logger::Logger::semanticSink());
     }
 

--- a/src/core/EventLoop.h
+++ b/src/core/EventLoop.h
@@ -45,6 +45,7 @@
 #include "core/State.h" // IWYU pragma: export
 #include "core/TickStatus.h"
 #include "log/LogScopeOwner.h"
+#include "log/SemanticLogger.h"
 
 namespace core {
     class EventMultiplexer;
@@ -96,6 +97,8 @@ namespace core {
 
         core::EventMultiplexer& eventMultiplexer;
         logger::LogScopeOwner logScope;
+        mutable std::optional<logger::BoundaryLogger> cachedLog_;
+        mutable unsigned long cachedLogGeneration_ = 0;
 
         static int stopsig;
 

--- a/src/core/socket/stream/SocketConnection.cpp
+++ b/src/core/socket/stream/SocketConnection.cpp
@@ -121,9 +121,17 @@ namespace core::socket::stream {
     }
 
     logger::BoundaryLogger SocketConnection::log() const {
-        // Round 6 backend-backed default semantic logger.
         // The sink-taking overload remains available for tests and custom capture.
-        // Production default logger uses the frozen startup semantic policy as its local threshold.
+        // Before freeze this remains dynamic; after freeze it reuses the cached semantic threshold.
+        if (logger::LogManager::isFrozen()) {
+            const unsigned long generation = logger::LogManager::generation();
+            if (!cachedLog_ || cachedLogGeneration_ != generation) {
+                cachedLogGeneration_ = generation;
+                cachedLog_.emplace(logScope.logger(logger::Logger::semanticSink()));
+            }
+            return *cachedLog_;
+        }
+
         return logScope.logger(logger::Logger::semanticSink());
     }
 

--- a/src/core/socket/stream/SocketConnection.h
+++ b/src/core/socket/stream/SocketConnection.h
@@ -43,6 +43,7 @@
 #define CORE_SOCKET_STREAM_SOCKETCONNECTION_H
 
 #include "log/LogScopeOwner.h"
+#include "log/SemanticLogger.h"
 
 namespace core {
     namespace pipe {
@@ -72,6 +73,7 @@ namespace utils {
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector> // IWYU pragma: keep
 
@@ -153,6 +155,8 @@ namespace core::socket::stream {
         std::string instanceName;
         std::string connectionName;
         logger::LogScopeOwner logScope;
+        mutable std::optional<logger::BoundaryLogger> cachedLog_;
+        mutable unsigned long cachedLogGeneration_ = 0;
 
         std::chrono::time_point<std::chrono::system_clock> onlineSinceTimePoint;
 

--- a/src/core/socket/stream/SocketContext.cpp
+++ b/src/core/socket/stream/SocketContext.cpp
@@ -83,9 +83,17 @@ namespace core::socket::stream {
     }
 
     logger::BoundaryLogger SocketContext::log() const {
-        // Round 6 backend-backed default semantic logger.
         // The sink-taking overload remains available for tests and custom capture.
-        // Production default logger uses the frozen startup semantic policy as its local threshold.
+        // Before freeze this remains dynamic; after freeze it reuses the cached semantic threshold.
+        if (logger::LogManager::isFrozen()) {
+            const unsigned long generation = logger::LogManager::generation();
+            if (!applicationLog_ || applicationLogGeneration_ != generation) {
+                applicationLogGeneration_ = generation;
+                applicationLog_.emplace(applicationLogScope.logger(logger::Logger::semanticSink()));
+            }
+            return *applicationLog_;
+        }
+
         return applicationLogScope.logger(logger::Logger::semanticSink());
     }
 
@@ -95,9 +103,17 @@ namespace core::socket::stream {
     }
 
     logger::BoundaryLogger SocketContext::frameworkLog() const {
-        // Round 6 backend-backed default semantic logger.
         // The sink-taking overload remains available for tests and custom capture.
-        // Production default logger uses the frozen startup semantic policy as its local threshold.
+        // Before freeze this remains dynamic; after freeze it reuses the cached semantic threshold.
+        if (logger::LogManager::isFrozen()) {
+            const unsigned long generation = logger::LogManager::generation();
+            if (!frameworkLog_ || frameworkLogGeneration_ != generation) {
+                frameworkLogGeneration_ = generation;
+                frameworkLog_.emplace(frameworkLogScope.logger(logger::Logger::semanticSink()));
+            }
+            return *frameworkLog_;
+        }
+
         return frameworkLogScope.logger(logger::Logger::semanticSink());
     }
 

--- a/src/core/socket/stream/SocketContext.h
+++ b/src/core/socket/stream/SocketContext.h
@@ -44,6 +44,7 @@
 
 #include "core/socket/SocketContext.h"
 #include "log/LogScopeOwner.h"
+#include "log/SemanticLogger.h"
 
 namespace core::pipe {
     class Source;
@@ -58,6 +59,7 @@ namespace core::socket::stream {
 
 #include <chrono>
 #include <cstddef>
+#include <optional>
 #include <string>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -129,6 +131,10 @@ namespace core::socket::stream {
         core::socket::stream::SocketConnection* socketConnection;
         logger::LogScopeOwner applicationLogScope;
         logger::LogScopeOwner frameworkLogScope;
+        mutable std::optional<logger::BoundaryLogger> applicationLog_;
+        mutable std::optional<logger::BoundaryLogger> frameworkLog_;
+        mutable unsigned long applicationLogGeneration_ = 0;
+        mutable unsigned long frameworkLogGeneration_ = 0;
 
         std::string onlineSince;
         std::size_t alreadyTotalQueued = 0;

--- a/src/iot/mqtt/Mqtt.cpp
+++ b/src/iot/mqtt/Mqtt.cpp
@@ -67,14 +67,21 @@
 namespace iot::mqtt {
 
     Mqtt::Mqtt(const std::string& connectionName)
-        : connectionName(connectionName)
-        , log_(iot::mqtt::semantic::mqttLog()) {
+        : connectionName(connectionName) {
     }
 
     Mqtt::Mqtt(const std::string& connectionName, const std::string& clientId)
         : connectionName(connectionName)
-        , clientId(clientId)
-        , log_(iot::mqtt::semantic::mqttLog()) {
+        , clientId(clientId) {
+    }
+
+    const logger::BoundaryLogger& Mqtt::log() const {
+        const unsigned long generation = logger::LogManager::generation();
+        if (!log_ || logGeneration_ != generation) {
+            logGeneration_ = generation;
+            log_.emplace(iot::mqtt::semantic::mqttLog());
+        }
+        return *log_;
     }
 
     Mqtt::~Mqtt() {
@@ -95,7 +102,7 @@ namespace iot::mqtt {
     }
 
     void Mqtt::onConnected() {
-        log_.info() << "MQTT: Connected";
+        log().info() << "MQTT: Connected";
     }
 
     std::size_t Mqtt::onReceivedFromPeer() {
@@ -119,13 +126,13 @@ namespace iot::mqtt {
                 fixedHeader.reset();
 
                 if (controlPacketDeserializer == nullptr) {
-                    log_.debug() << connectionName << " MQTT: Received packet-type is unavailable ... closing connection";
+                    log().debug() << connectionName << " MQTT: Received packet-type is unavailable ... closing connection";
 
                     mqttContext->close();
                     break;
                 }
                 if (controlPacketDeserializer->isError()) {
-                    log_.debug() << connectionName << " MQTT: Fixed header has error ... closing connection";
+                    log().debug() << connectionName << " MQTT: Fixed header has error ... closing connection";
 
                     delete controlPacketDeserializer;
                     controlPacketDeserializer = nullptr;
@@ -141,7 +148,7 @@ namespace iot::mqtt {
                 consumed += controlPacketDeserializer->deserialize(mqttContext);
 
                 if (controlPacketDeserializer->isError()) {
-                    log_.debug() << connectionName << " MQTT: Control packet has error ... closing connection";
+                    log().debug() << connectionName << " MQTT: Control packet has error ... closing connection";
                     mqttContext->close();
 
                     delete controlPacketDeserializer;
@@ -166,7 +173,7 @@ namespace iot::mqtt {
     }
 
     void Mqtt::onDisconnected() {
-        log_.info() << connectionName << " MQTT: Disconnected";
+        log().info() << connectionName << " MQTT: Disconnected";
     }
 
     const std::string& Mqtt::getConnectionName() const {
@@ -177,13 +184,13 @@ namespace iot::mqtt {
         this->session = session;
 
         for (const auto& [packetIdentifier, publish] : session->outgoingPublishMap) {
-            log_.debug() << connectionName << " MQTT: PUBLISH Resend";
+            log().debug() << connectionName << " MQTT: PUBLISH Resend";
 
             send(publish);
         }
 
         for (const uint16_t packetIdentifier : session->pubrelPacketIdentifierSet) {
-            log_.debug() << connectionName << " MQTT: PUBREL Resend";
+            log().debug() << connectionName << " MQTT: PUBREL Resend";
 
             sendPubrel(packetIdentifier);
         }
@@ -191,11 +198,11 @@ namespace iot::mqtt {
         if (keepAlive > 0) {
             keepAlive *= 1.5;
 
-            log_.info() << connectionName << " MQTT: Keep alive initialized with: " << keepAlive;
+            log().info() << connectionName << " MQTT: Keep alive initialized with: " << keepAlive;
 
             keepAliveTimer = core::timer::Timer::singleshotTimer(
                 [this, keepAlive]() {
-                    log_.error() << connectionName << " MQTT: Keep-alive timer expired. Interval was: " << keepAlive;
+                    log().error() << connectionName << " MQTT: Keep-alive timer expired. Interval was: " << keepAlive;
                     mqttContext->close();
                 },
                 keepAlive);
@@ -205,14 +212,14 @@ namespace iot::mqtt {
     }
 
     void Mqtt::send(const ControlPacket& controlPacket) const {
-        log_.debug() << connectionName << " MQTT: " << controlPacket.getName() << " send: " << clientId;
+        log().debug() << connectionName << " MQTT: " << controlPacket.getName() << " send: " << clientId;
 
         send(controlPacket.serialize());
     }
 
     void Mqtt::send(const std::vector<char>& data) const {
-        if (log_.enabled(logger::LogLevel::Trace)) {
-            log_.trace() << connectionName << " MQTT: Send data (full message):\n" << toHexString(data);
+        if (log().enabled(logger::LogLevel::Trace)) {
+            log().trace() << connectionName << " MQTT: Send data (full message):\n" << toHexString(data);
         }
 
         mqttContext->send(data.data(), data.size());
@@ -223,14 +230,14 @@ namespace iot::mqtt {
 
         send(iot::mqtt::packets::Publish(packetIdentifier, topic, message, qoS, false, retain));
 
-        log_.debug() << connectionName << " MQTT:   Topic: " << topic;
-        if (log_.enabled(logger::LogLevel::Trace)) {
-            log_.trace() << connectionName << " MQTT:   Message:\n" << toHexString(message);
+        log().debug() << connectionName << " MQTT:   Topic: " << topic;
+        if (log().enabled(logger::LogLevel::Trace)) {
+            log().trace() << connectionName << " MQTT:   Message:\n" << toHexString(message);
         }
-        log_.debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(qoS);
-        log_.debug() << connectionName << " MQTT:   PacketIdentifier: " << packetIdentifier;
-        log_.debug() << connectionName << " MQTT:   DUP: " << false;
-        log_.debug() << connectionName << " MQTT:   Retain: " << retain;
+        log().debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(qoS);
+        log().debug() << connectionName << " MQTT:   PacketIdentifier: " << packetIdentifier;
+        log().debug() << connectionName << " MQTT:   DUP: " << false;
+        log().debug() << connectionName << " MQTT:   Retain: " << retain;
 
         if (qoS >= 1) {
             session->outgoingPublishMap.insert_or_assign(packetIdentifier,
@@ -272,25 +279,25 @@ namespace iot::mqtt {
     bool Mqtt::_onPublish(const iot::mqtt::packets::Publish& publish) {
         bool deliver = true;
 
-        log_.debug() << connectionName << " MQTT:   Topic: " << publish.getTopic();
-        if (log_.enabled(logger::LogLevel::Trace)) {
-            log_.trace() << connectionName << " MQTT:   Message:\n" << toHexString(publish.getMessage());
+        log().debug() << connectionName << " MQTT:   Topic: " << publish.getTopic();
+        if (log().enabled(logger::LogLevel::Trace)) {
+            log().trace() << connectionName << " MQTT:   Message:\n" << toHexString(publish.getMessage());
         }
-        log_.debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(publish.getQoS());
-        log_.debug() << connectionName << " MQTT:   PacketIdentifier: " << publish.getPacketIdentifier();
-        log_.debug() << connectionName << " MQTT:   DUP: " << publish.getDup();
-        log_.debug() << connectionName << " MQTT:   Retain: " << publish.getRetain();
+        log().debug() << connectionName << " MQTT:   QoS: " << static_cast<uint16_t>(publish.getQoS());
+        log().debug() << connectionName << " MQTT:   PacketIdentifier: " << publish.getPacketIdentifier();
+        log().debug() << connectionName << " MQTT:   DUP: " << publish.getDup();
+        log().debug() << connectionName << " MQTT:   Retain: " << publish.getRetain();
 
         if (publish.getQoS() > 2) {
-            log_.error() << connectionName << " MQTT:   Received invalid QoS: " << publish.getQoS();
+            log().error() << connectionName << " MQTT:   Received invalid QoS: " << publish.getQoS();
             mqttContext->close();
             deliver = false;
         } else if (publish.getPacketIdentifier() == 0 && publish.getQoS() > 0) {
-            log_.error() << connectionName << " MQTT:   Received QoS > 0 but no PackageIdentifier present";
+            log().error() << connectionName << " MQTT:   Received QoS > 0 but no PackageIdentifier present";
             mqttContext->close();
             deliver = false;
         } else if (publish.getQoS() == 0 && publish.getDup()) {
-            log_.error() << connectionName << " MQTT:   Received QoS == 0 but dup is set";
+            log().error() << connectionName << " MQTT:   Received QoS == 0 but dup is set";
             mqttContext->close();
             deliver = false;
         } else {
@@ -310,13 +317,13 @@ namespace iot::mqtt {
                         if (!publish.getDup()) {
                             session->pubcompPacketIdentifierSet.erase(pid);
                         } else {
-                            log_.warn() << connectionName << " MQTT:   Duplicate QoS2 PUBLISH after PUBCOMP for PacketIdentifier: " << pid;
+                            log().warn() << connectionName << " MQTT:   Duplicate QoS2 PUBLISH after PUBCOMP for PacketIdentifier: " << pid;
                             break;
                         }
                     }
 
                     if (session->incomingPublishMap.contains(pid)) {
-                        log_.debug() << connectionName << " MQTT:   Duplicate QoS2 PUBLISH suppressed for PacketIdentifier: " << pid;
+                        log().debug() << connectionName << " MQTT:   Duplicate QoS2 PUBLISH suppressed for PacketIdentifier: " << pid;
                     } else {
                         session->incomingPublishMap.emplace(pid, publish);
                     }
@@ -330,11 +337,11 @@ namespace iot::mqtt {
 
     void Mqtt::_onPuback(const iot::mqtt::packets::Puback& puback) {
         if (puback.getPacketIdentifier() == 0) {
-            log_.error() << connectionName << " MQTT:   PackageIdentifier missing";
+            log().error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            log_.debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                         << puback.getPacketIdentifier() << std::dec;
+            log().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
+                          << puback.getPacketIdentifier() << std::dec;
 
             session->outgoingPublishMap.erase(puback.getPacketIdentifier());
         }
@@ -344,11 +351,11 @@ namespace iot::mqtt {
 
     void Mqtt::_onPubrec(const iot::mqtt::packets::Pubrec& pubrec) {
         if (pubrec.getPacketIdentifier() == 0) {
-            log_.error() << connectionName << " MQTT:   PackageIdentifier missing";
+            log().error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            log_.debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                         << pubrec.getPacketIdentifier() << std::dec;
+            log().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
+                          << pubrec.getPacketIdentifier() << std::dec;
 
             session->outgoingPublishMap.erase(pubrec.getPacketIdentifier());
             session->pubrelPacketIdentifierSet.insert(pubrec.getPacketIdentifier());
@@ -361,25 +368,25 @@ namespace iot::mqtt {
 
     void Mqtt::_onPubrel(const iot::mqtt::packets::Pubrel& pubrel) {
         if (pubrel.getPacketIdentifier() == 0) {
-            log_.error() << connectionName << " MQTT:   PackageIdentifier missing";
+            log().error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            log_.debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                         << pubrel.getPacketIdentifier() << std::dec;
+            log().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
+                          << pubrel.getPacketIdentifier() << std::dec;
 
             const uint16_t pid = pubrel.getPacketIdentifier();
 
             if (session->incomingPublishMap.contains(pid)) {
-                log_.debug() << connectionName << " MQTT:   QoS2 PUBREL received. Deliver publish: " << pid;
+                log().debug() << connectionName << " MQTT:   QoS2 PUBREL received. Deliver publish: " << pid;
 
                 distributePublish(session->incomingPublishMap[pid]);
 
                 session->incomingPublishMap.erase(pid);
                 session->pubcompPacketIdentifierSet.insert(pid);
             } else if (session->pubcompPacketIdentifierSet.contains(pid)) {
-                log_.debug() << connectionName << " MQTT:   Duplicate QoS2 PUBREL for completed PacketIdentifier: " << pid;
+                log().debug() << connectionName << " MQTT:   Duplicate QoS2 PUBREL for completed PacketIdentifier: " << pid;
             } else {
-                log_.warn() << connectionName << " MQTT:   QoS2 PUBREL received for unknown PacketIdentifier: " << pid;
+                log().warn() << connectionName << " MQTT:   QoS2 PUBREL received for unknown PacketIdentifier: " << pid;
 
                 session->pubcompPacketIdentifierSet.insert(pid);
             }
@@ -392,11 +399,11 @@ namespace iot::mqtt {
 
     void Mqtt::_onPubcomp(const iot::mqtt::packets::Pubcomp& pubcomp) {
         if (pubcomp.getPacketIdentifier() == 0) {
-            log_.error() << connectionName << " MQTT:   PackageIdentifier missing";
+            log().error() << connectionName << " MQTT:   PackageIdentifier missing";
             mqttContext->close();
         } else {
-            log_.debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
-                         << pubcomp.getPacketIdentifier() << std::dec;
+            log().debug() << connectionName << " MQTT:   PacketIdentifier: 0x" << std::hex << std::setfill('0') << std::setw(4)
+                          << pubcomp.getPacketIdentifier() << std::dec;
 
             session->outgoingPublishMap.erase(pubcomp.getPacketIdentifier());
             session->pubrelPacketIdentifierSet.erase(pubcomp.getPacketIdentifier());
@@ -406,27 +413,27 @@ namespace iot::mqtt {
     }
 
     void Mqtt::printVP(const iot::mqtt::ControlPacket& packet) const {
-        log_.debug() << connectionName << " MQTT: " << packet.getName() << " received: " << clientId;
+        log().debug() << connectionName << " MQTT: " << packet.getName() << " received: " << clientId;
 
-        if (log_.enabled(logger::LogLevel::Trace)) {
+        if (log().enabled(logger::LogLevel::Trace)) {
             const std::string hexString = toHexString(packet.serializeVP());
             if (!hexString.empty()) {
-                log_.trace() << connectionName << " MQTT: Received data (variable header and payload):\n" << hexString;
+                log().trace() << connectionName << " MQTT: Received data (variable header and payload):\n" << hexString;
             }
         }
     }
 
     void Mqtt::printFixedHeader(const FixedHeader& fixedHeader) const {
-        if (log_.enabled(logger::LogLevel::Trace)) {
-            log_.trace() << connectionName << " MQTT: Received data (fixed header):\n" << toHexString(fixedHeader.serialize());
+        if (log().enabled(logger::LogLevel::Trace)) {
+            log().trace() << connectionName << " MQTT: Received data (fixed header):\n" << toHexString(fixedHeader.serialize());
         }
 
-        log_.debug() << connectionName << " MQTT: Fixed Header: PacketType: 0x" << std::hex << std::setfill('0') << std::setw(2)
-                     << static_cast<uint16_t>(fixedHeader.getType()) << " (" << iot::mqtt::mqttPackageName[fixedHeader.getType()] << ")"
-                     << std::dec;
-        log_.debug() << connectionName << " MQTT:   PacketFlags: 0x" << std::hex << std::setfill('0') << std::setw(2)
-                     << static_cast<uint16_t>(fixedHeader.getFlags()) << std::dec;
-        log_.debug() << connectionName << " MQTT:   RemainingLength: " << fixedHeader.getRemainingLength();
+        log().debug() << connectionName << " MQTT: Fixed Header: PacketType: 0x" << std::hex << std::setfill('0') << std::setw(2)
+                      << static_cast<uint16_t>(fixedHeader.getType()) << " (" << iot::mqtt::mqttPackageName[fixedHeader.getType()] << ")"
+                      << std::dec;
+        log().debug() << connectionName << " MQTT:   PacketFlags: 0x" << std::hex << std::setfill('0') << std::setw(2)
+                      << static_cast<uint16_t>(fixedHeader.getFlags()) << std::dec;
+        log().debug() << connectionName << " MQTT:   RemainingLength: " << fixedHeader.getRemainingLength();
     }
 
     std::string Mqtt::toHexString(const std::vector<char>& data) {

--- a/src/iot/mqtt/Mqtt.h
+++ b/src/iot/mqtt/Mqtt.h
@@ -65,6 +65,7 @@ namespace iot::mqtt {
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -137,6 +138,7 @@ namespace iot::mqtt {
 
     private:
         void send(const std::vector<char>& data) const;
+        const logger::BoundaryLogger& log() const;
 
     protected:
         void printVP(const iot::mqtt::ControlPacket& packet) const;
@@ -153,7 +155,8 @@ namespace iot::mqtt {
 
         core::timer::Timer keepAliveTimer;
 
-        logger::BoundaryLogger log_;
+        mutable std::optional<logger::BoundaryLogger> log_;
+        mutable unsigned long logGeneration_ = 0;
 
         int state = 0;
 

--- a/src/iot/mqtt/server/broker/Broker.cpp
+++ b/src/iot/mqtt/server/broker/Broker.cpp
@@ -64,8 +64,7 @@ namespace iot::mqtt::server::broker {
         : sessionStoreFileName(sessionStoreFileName)
         , maxQoS(maxQoS)
         , subscriptionTree(this)
-        , retainTree(this)
-        , log_(iot::mqtt::semantic::mqttBrokerLog()) {
+        , retainTree(this) {
         if (!sessionStoreFileName.empty()) {
             std::ifstream sessionStoreFile(sessionStoreFileName);
 
@@ -81,10 +80,10 @@ namespace iot::mqtt::server::broker {
                     retainTree.fromJson(sessionStoreJson["retain_tree"]);
                     subscriptionTree.fromJson(sessionStoreJson["subscription_tree"]);
 
-                    log_.info() << "MQTT Broker: Persistent session data loaded successful";
+                    log().info() << "MQTT Broker: Persistent session data loaded successful";
                 } catch (const nlohmann::json::exception&) {
-                    log_.info() << "MQTT Broker: Starting with empty session: Session store '" << sessionStoreFileName
-                                << "' empty or corrupted";
+                    log().info() << "MQTT Broker: Starting with empty session: Session store '" << sessionStoreFileName
+                                 << "' empty or corrupted";
 
                     sessionStore.clear();
                     retainTree.clear();
@@ -94,14 +93,23 @@ namespace iot::mqtt::server::broker {
                 sessionStoreFile.close();
                 std::remove(sessionStoreFileName.data()); // NOLINT
 
-                log_.info() << "MQTT Broker: Restoring saved session done";
+                log().info() << "MQTT Broker: Restoring saved session done";
             } else {
                 const int errnum = errno;
-                log_.sysError(logger::LogLevel::Warn, errnum, "MQTT Broker: Could not read session store '{}'", sessionStoreFileName);
+                log().sysError(logger::LogLevel::Warn, errnum, "MQTT Broker: Could not read session store '{}'", sessionStoreFileName);
             }
         } else {
-            log_.info() << "MQTT Broker: Session not reloaded: Session store filename empty";
+            log().info() << "MQTT Broker: Session not reloaded: Session store filename empty";
         }
+    }
+
+    const logger::BoundaryLogger& Broker::log() const {
+        const unsigned long generation = logger::LogManager::generation();
+        if (!log_ || logGeneration_ != generation) {
+            logGeneration_ = generation;
+            log_.emplace(iot::mqtt::semantic::mqttBrokerLog());
+        }
+        return *log_;
     }
 
     Broker::~Broker() {
@@ -133,13 +141,13 @@ namespace iot::mqtt::server::broker {
 
                 sessionStoreFile.close();
 
-                log_.info() << "MQTT Broker: Session store written '" << sessionStoreFileName << "'";
+                log().info() << "MQTT Broker: Session store written '" << sessionStoreFileName << "'";
             } else {
                 const int errnum = errno;
-                log_.sysError(logger::LogLevel::Error, errnum, "MQTT Broker: Could not write session store '{}'", sessionStoreFileName);
+                log().sysError(logger::LogLevel::Error, errnum, "MQTT Broker: Could not write session store '{}'", sessionStoreFileName);
             }
         } else {
-            log_.info() << "MQTT Broker: Session not saved: Session store filename empty";
+            log().info() << "MQTT Broker: Session not saved: Session store filename empty";
         }
     }
 
@@ -169,10 +177,10 @@ namespace iot::mqtt::server::broker {
     }
 
     void Broker::restartSession(const std::string& clientId) {
-        log_.info() << "MQTT Broker:   Retained: Send PUBLISH: " << clientId;
+        log().info() << "MQTT Broker:   Retained: Send PUBLISH: " << clientId;
         subscriptionTree.appear(clientId);
 
-        log_.info() << "MQTT Broker:   Queued: Send PUBLISH: " << clientId;
+        log().info() << "MQTT Broker:   Queued: Send PUBLISH: " << clientId;
         sessionStore[clientId].publishQueued();
     }
 
@@ -241,7 +249,7 @@ namespace iot::mqtt::server::broker {
     }
 
     void Broker::sendPublish(const std::string& clientId, Message& message, uint8_t qoS, bool retain) {
-        log_.info() << "MQTT Broker: Send PUBLISH: " << clientId;
+        log().info() << "MQTT Broker: Send PUBLISH: " << clientId;
 
         sessionStore[clientId].sendPublish(message, qoS, retain);
     }

--- a/src/iot/mqtt/server/broker/Broker.cpp
+++ b/src/iot/mqtt/server/broker/Broker.cpp
@@ -64,7 +64,8 @@ namespace iot::mqtt::server::broker {
         : sessionStoreFileName(sessionStoreFileName)
         , maxQoS(maxQoS)
         , subscriptionTree(this)
-        , retainTree(this) {
+        , retainTree(this)
+        , log_(iot::mqtt::semantic::mqttBrokerLog()) {
         if (!sessionStoreFileName.empty()) {
             std::ifstream sessionStoreFile(sessionStoreFileName);
 
@@ -80,10 +81,10 @@ namespace iot::mqtt::server::broker {
                     retainTree.fromJson(sessionStoreJson["retain_tree"]);
                     subscriptionTree.fromJson(sessionStoreJson["subscription_tree"]);
 
-                    iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Persistent session data loaded successful";
+                    log_.info() << "MQTT Broker: Persistent session data loaded successful";
                 } catch (const nlohmann::json::exception&) {
-                    iot::mqtt::semantic::mqttBrokerLog().info()
-                        << "MQTT Broker: Starting with empty session: Session store '" << sessionStoreFileName << "' empty or corrupted";
+                    log_.info() << "MQTT Broker: Starting with empty session: Session store '" << sessionStoreFileName
+                                << "' empty or corrupted";
 
                     sessionStore.clear();
                     retainTree.clear();
@@ -93,14 +94,13 @@ namespace iot::mqtt::server::broker {
                 sessionStoreFile.close();
                 std::remove(sessionStoreFileName.data()); // NOLINT
 
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Restoring saved session done";
+                log_.info() << "MQTT Broker: Restoring saved session done";
             } else {
                 const int errnum = errno;
-                iot::mqtt::semantic::mqttBrokerLog().sysError(
-                    logger::LogLevel::Warn, errnum, "MQTT Broker: Could not read session store '{}'", sessionStoreFileName);
+                log_.sysError(logger::LogLevel::Warn, errnum, "MQTT Broker: Could not read session store '{}'", sessionStoreFileName);
             }
         } else {
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Session not reloaded: Session store filename empty";
+            log_.info() << "MQTT Broker: Session not reloaded: Session store filename empty";
         }
     }
 
@@ -133,14 +133,13 @@ namespace iot::mqtt::server::broker {
 
                 sessionStoreFile.close();
 
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Session store written '" << sessionStoreFileName << "'";
+                log_.info() << "MQTT Broker: Session store written '" << sessionStoreFileName << "'";
             } else {
                 const int errnum = errno;
-                iot::mqtt::semantic::mqttBrokerLog().sysError(
-                    logger::LogLevel::Error, errnum, "MQTT Broker: Could not write session store '{}'", sessionStoreFileName);
+                log_.sysError(logger::LogLevel::Error, errnum, "MQTT Broker: Could not write session store '{}'", sessionStoreFileName);
             }
         } else {
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Session not saved: Session store filename empty";
+            log_.info() << "MQTT Broker: Session not saved: Session store filename empty";
         }
     }
 
@@ -170,10 +169,10 @@ namespace iot::mqtt::server::broker {
     }
 
     void Broker::restartSession(const std::string& clientId) {
-        iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Retained: Send PUBLISH: " << clientId;
+        log_.info() << "MQTT Broker:   Retained: Send PUBLISH: " << clientId;
         subscriptionTree.appear(clientId);
 
-        iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Queued: Send PUBLISH: " << clientId;
+        log_.info() << "MQTT Broker:   Queued: Send PUBLISH: " << clientId;
         sessionStore[clientId].publishQueued();
     }
 
@@ -242,7 +241,7 @@ namespace iot::mqtt::server::broker {
     }
 
     void Broker::sendPublish(const std::string& clientId, Message& message, uint8_t qoS, bool retain) {
-        iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Send PUBLISH: " << clientId;
+        log_.info() << "MQTT Broker: Send PUBLISH: " << clientId;
 
         sessionStore[clientId].sendPublish(message, qoS, retain);
     }

--- a/src/iot/mqtt/server/broker/Broker.h
+++ b/src/iot/mqtt/server/broker/Broker.h
@@ -58,6 +58,7 @@ namespace iot::mqtt::server {
 #include <list>
 #include <map> // IWYU pragma: keep
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -107,6 +108,8 @@ namespace iot::mqtt::server::broker {
         void sendPublish(const std::string& clientId, Message& message, uint8_t qoS, bool retain);
 
     private:
+        const logger::BoundaryLogger& log() const;
+
         std::string sessionStoreFileName;
         uint8_t maxQoS;
 
@@ -115,7 +118,8 @@ namespace iot::mqtt::server::broker {
 
         std::map<std::string, iot::mqtt::server::broker::Session> sessionStore;
 
-        logger::BoundaryLogger log_;
+        mutable std::optional<logger::BoundaryLogger> log_;
+        mutable unsigned long logGeneration_ = 0;
     };
 
 } // namespace iot::mqtt::server::broker

--- a/src/iot/mqtt/server/broker/Broker.h
+++ b/src/iot/mqtt/server/broker/Broker.h
@@ -52,6 +52,8 @@ namespace iot::mqtt::server {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/SemanticLogger.h"
+
 #include <cstdint>
 #include <list>
 #include <map> // IWYU pragma: keep
@@ -112,6 +114,8 @@ namespace iot::mqtt::server::broker {
         iot::mqtt::server::broker::RetainTree retainTree;
 
         std::map<std::string, iot::mqtt::server::broker::Session> sessionStore;
+
+        logger::BoundaryLogger log_;
     };
 
 } // namespace iot::mqtt::server::broker

--- a/src/iot/mqtt/server/broker/RetainTree.cpp
+++ b/src/iot/mqtt/server/broker/RetainTree.cpp
@@ -60,8 +60,16 @@
 namespace iot::mqtt::server::broker {
 
     RetainTree::RetainTree(Broker* broker)
-        : head(broker)
-        , log_(iot::mqtt::semantic::mqttBrokerLog()) {
+        : head(broker) {
+    }
+
+    const logger::BoundaryLogger& RetainTree::log() const {
+        const unsigned long generation = logger::LogManager::generation();
+        if (!log_ || logGeneration_ != generation) {
+            logGeneration_ = generation;
+            log_.emplace(iot::mqtt::semantic::mqttBrokerLog());
+        }
+        return *log_;
     }
 
     void RetainTree::retain(Message&& message) {
@@ -101,8 +109,16 @@ namespace iot::mqtt::server::broker {
     }
 
     RetainTree::TopicLevel::TopicLevel(iot::mqtt::server::broker::Broker* broker)
-        : broker(broker)
-        , log_(iot::mqtt::semantic::mqttBrokerLog()) {
+        : broker(broker) {
+    }
+
+    const logger::BoundaryLogger& RetainTree::TopicLevel::log() const {
+        const unsigned long generation = logger::LogManager::generation();
+        if (!log_ || logGeneration_ != generation) {
+            logGeneration_ = generation;
+            log_.emplace(iot::mqtt::semantic::mqttBrokerLog());
+        }
+        return *log_;
     }
 
     RetainTree::TopicLevel& RetainTree::TopicLevel::fromJson(const nlohmann::json& json) {
@@ -119,14 +135,14 @@ namespace iot::mqtt::server::broker {
         return *this;
     }
     void RetainTree::TopicLevel::retain(const Message& message, std::string topic) {
+        const auto& log = this->log();
         if (topic.empty()) {
-            log_.debug() << "MQTT Broker: Retain:";
-            log_.debug() << "MQTT Broker:   Topic: " << message.getTopic();
-            const auto& log = log_;
+            log.debug() << "MQTT Broker: Retain:";
+            log.debug() << "MQTT Broker:   Topic: " << message.getTopic();
             if (log.enabled(logger::LogLevel::Debug)) {
                 log.debug() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
             }
-            log_.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
+            log.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
 
             this->message = message;
         } else {
@@ -140,8 +156,8 @@ namespace iot::mqtt::server::broker {
 
     bool RetainTree::TopicLevel::release(std::string topic) {
         if (topic.empty()) {
-            log_.debug() << "MQTT Broker: Release retained:";
-            log_.debug() << "MQTT Broker:   Topic: " << message.getTopic();
+            log().debug() << "MQTT Broker: Release retained:";
+            log().debug() << "MQTT Broker:   Topic: " << message.getTopic();
 
             message = Message();
         } else {
@@ -152,7 +168,7 @@ namespace iot::mqtt::server::broker {
                 topic.erase(0, topicLevel.size() + 1);
 
                 if (it->second.release(topic)) {
-                    log_.debug() << "               Erase: " << topicLevel;
+                    log().debug() << "               Erase: " << topicLevel;
 
                     subTopicLevels.erase(it);
                 }
@@ -163,21 +179,21 @@ namespace iot::mqtt::server::broker {
     }
 
     void RetainTree::TopicLevel::appear(const std::string& clientId, std::string topic, uint8_t qoS) {
+        const auto& log = this->log();
         if (topic.empty()) {
             if (!message.getTopic().empty()) {
-                log_.info() << "MQTT Broker: Retained Topic found:";
-                log_.info() << "MQTT Broker:   Topic: " << message.getTopic();
-                const auto& log = log_;
+                log.info() << "MQTT Broker: Retained Topic found:";
+                log.info() << "MQTT Broker:   Topic: " << message.getTopic();
                 if (log.enabled(logger::LogLevel::Info)) {
                     log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
                 }
-                log_.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
-                log_.debug() << "MQTT Broker:   Client:";
-                log_.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(qoS);
+                log.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
+                log.debug() << "MQTT Broker:   Client:";
+                log.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(qoS);
 
-                log_.info() << "MQTT Broker: Distributing message ...";
+                log.info() << "MQTT Broker: Distributing message ...";
                 broker->sendPublish(clientId, message, std::min(message.getQoS(), qoS), true);
-                log_.info() << "MQTT Broker: ... distributing message completed";
+                log.info() << "MQTT Broker: ... distributing message completed";
             }
         } else {
             const std::string topicLevel = topic.substr(0, topic.find('/'));
@@ -202,20 +218,20 @@ namespace iot::mqtt::server::broker {
     }
 
     void RetainTree::TopicLevel::appear(const std::string& clientId, uint8_t clientQoS) {
+        const auto& log = this->log();
         if (!message.getTopic().empty()) {
-            log_.info() << "MQTT Broker: Retained Topic found:";
-            log_.info() << "MQTT Broker:   Topic: " << message.getTopic();
-            const auto& log = log_;
+            log.info() << "MQTT Broker: Retained Topic found:";
+            log.info() << "MQTT Broker:   Topic: " << message.getTopic();
             if (log.enabled(logger::LogLevel::Info)) {
                 log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
             }
-            log_.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
-            log_.debug() << "MQTT Broker:   Client:";
-            log_.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(clientQoS);
+            log.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
+            log.debug() << "MQTT Broker:   Client:";
+            log.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(clientQoS);
 
-            log_.info() << "MQTT Broker: Distributing message ...";
+            log.info() << "MQTT Broker: Distributing message ...";
             broker->sendPublish(clientId, message, std::min(message.getQoS(), clientQoS), true);
-            log_.info() << "MQTT Broker: ... distributing message completed";
+            log.info() << "MQTT Broker: ... distributing message completed";
         }
 
         for (auto& [topicLevel, subTopicLevel] : subTopicLevels) {

--- a/src/iot/mqtt/server/broker/RetainTree.cpp
+++ b/src/iot/mqtt/server/broker/RetainTree.cpp
@@ -60,7 +60,8 @@
 namespace iot::mqtt::server::broker {
 
     RetainTree::RetainTree(Broker* broker)
-        : head(broker) {
+        : head(broker)
+        , log_(iot::mqtt::semantic::mqttBrokerLog()) {
     }
 
     void RetainTree::retain(Message&& message) {
@@ -100,7 +101,8 @@ namespace iot::mqtt::server::broker {
     }
 
     RetainTree::TopicLevel::TopicLevel(iot::mqtt::server::broker::Broker* broker)
-        : broker(broker) {
+        : broker(broker)
+        , log_(iot::mqtt::semantic::mqttBrokerLog()) {
     }
 
     RetainTree::TopicLevel& RetainTree::TopicLevel::fromJson(const nlohmann::json& json) {
@@ -118,13 +120,13 @@ namespace iot::mqtt::server::broker {
     }
     void RetainTree::TopicLevel::retain(const Message& message, std::string topic) {
         if (topic.empty()) {
-            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker: Retain:";
-            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Topic: " << message.getTopic();
-            auto log = iot::mqtt::semantic::mqttBrokerLog();
+            log_.debug() << "MQTT Broker: Retain:";
+            log_.debug() << "MQTT Broker:   Topic: " << message.getTopic();
+            const auto& log = log_;
             if (log.enabled(logger::LogLevel::Debug)) {
                 log.debug() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
             }
-            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
+            log_.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
 
             this->message = message;
         } else {
@@ -138,8 +140,8 @@ namespace iot::mqtt::server::broker {
 
     bool RetainTree::TopicLevel::release(std::string topic) {
         if (topic.empty()) {
-            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker: Release retained:";
-            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Topic: " << message.getTopic();
+            log_.debug() << "MQTT Broker: Release retained:";
+            log_.debug() << "MQTT Broker:   Topic: " << message.getTopic();
 
             message = Message();
         } else {
@@ -150,7 +152,7 @@ namespace iot::mqtt::server::broker {
                 topic.erase(0, topicLevel.size() + 1);
 
                 if (it->second.release(topic)) {
-                    iot::mqtt::semantic::mqttBrokerLog().debug() << "               Erase: " << topicLevel;
+                    log_.debug() << "               Erase: " << topicLevel;
 
                     subTopicLevels.erase(it);
                 }
@@ -163,19 +165,19 @@ namespace iot::mqtt::server::broker {
     void RetainTree::TopicLevel::appear(const std::string& clientId, std::string topic, uint8_t qoS) {
         if (topic.empty()) {
             if (!message.getTopic().empty()) {
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Retained Topic found:";
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << message.getTopic();
-                auto log = iot::mqtt::semantic::mqttBrokerLog();
+                log_.info() << "MQTT Broker: Retained Topic found:";
+                log_.info() << "MQTT Broker:   Topic: " << message.getTopic();
+                const auto& log = log_;
                 if (log.enabled(logger::LogLevel::Info)) {
                     log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
                 }
-                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
-                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Client:";
-                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(qoS);
+                log_.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
+                log_.debug() << "MQTT Broker:   Client:";
+                log_.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(qoS);
 
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Distributing message ...";
+                log_.info() << "MQTT Broker: Distributing message ...";
                 broker->sendPublish(clientId, message, std::min(message.getQoS(), qoS), true);
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: ... distributing message completed";
+                log_.info() << "MQTT Broker: ... distributing message completed";
             }
         } else {
             const std::string topicLevel = topic.substr(0, topic.find('/'));
@@ -201,19 +203,19 @@ namespace iot::mqtt::server::broker {
 
     void RetainTree::TopicLevel::appear(const std::string& clientId, uint8_t clientQoS) {
         if (!message.getTopic().empty()) {
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Retained Topic found:";
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << message.getTopic();
-            auto log = iot::mqtt::semantic::mqttBrokerLog();
+            log_.info() << "MQTT Broker: Retained Topic found:";
+            log_.info() << "MQTT Broker:   Topic: " << message.getTopic();
+            const auto& log = log_;
             if (log.enabled(logger::LogLevel::Info)) {
                 log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
             }
-            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
-            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Client:";
-            iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(clientQoS);
+            log_.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(message.getQoS());
+            log_.debug() << "MQTT Broker:   Client:";
+            log_.debug() << "MQTT Broker:     QoS: " << static_cast<uint16_t>(clientQoS);
 
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Distributing message ...";
+            log_.info() << "MQTT Broker: Distributing message ...";
             broker->sendPublish(clientId, message, std::min(message.getQoS(), clientQoS), true);
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: ... distributing message completed";
+            log_.info() << "MQTT Broker: ... distributing message completed";
         }
 
         for (auto& [topicLevel, subTopicLevel] : subTopicLevels) {

--- a/src/iot/mqtt/server/broker/RetainTree.h
+++ b/src/iot/mqtt/server/broker/RetainTree.h
@@ -50,6 +50,8 @@ namespace iot::mqtt::server::broker {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/SemanticLogger.h"
+
 #include <cstdint>
 #include <iterator>
 #include <list>
@@ -106,9 +108,11 @@ namespace iot::mqtt::server::broker {
             std::map<std::string, TopicLevel> subTopicLevels;
 
             iot::mqtt::server::broker::Broker* broker = nullptr;
+            logger::BoundaryLogger log_;
         };
 
         TopicLevel head;
+        logger::BoundaryLogger log_;
     };
 
 } // namespace iot::mqtt::server::broker

--- a/src/iot/mqtt/server/broker/RetainTree.h
+++ b/src/iot/mqtt/server/broker/RetainTree.h
@@ -57,6 +57,7 @@ namespace iot::mqtt::server::broker {
 #include <list>
 #include <map>
 #include <nlohmann/json_fwd.hpp>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -98,6 +99,8 @@ namespace iot::mqtt::server::broker {
             void clear();
 
         private:
+            const logger::BoundaryLogger& log() const;
+
             void appear(const std::string& clientId, uint8_t clientQoS);
 
             std::list<std::pair<std::string, std::pair<std::string, uint8_t>>>
@@ -108,11 +111,15 @@ namespace iot::mqtt::server::broker {
             std::map<std::string, TopicLevel> subTopicLevels;
 
             iot::mqtt::server::broker::Broker* broker = nullptr;
-            logger::BoundaryLogger log_;
+            mutable std::optional<logger::BoundaryLogger> log_;
+            mutable unsigned long logGeneration_ = 0;
         };
 
+        const logger::BoundaryLogger& log() const;
+
         TopicLevel head;
-        logger::BoundaryLogger log_;
+        mutable std::optional<logger::BoundaryLogger> log_;
+        mutable unsigned long logGeneration_ = 0;
     };
 
 } // namespace iot::mqtt::server::broker

--- a/src/iot/mqtt/server/broker/Session.cpp
+++ b/src/iot/mqtt/server/broker/Session.cpp
@@ -60,21 +60,26 @@
 
 namespace iot::mqtt::server::broker {
 
+    Session::Session()
+        : log_(iot::mqtt::semantic::mqttSessionLog()) {
+    }
+
     Session::Session(iot::mqtt::server::Mqtt* mqtt)
-        : mqtt(mqtt) {
+        : mqtt(mqtt)
+        , log_(iot::mqtt::semantic::mqttSessionLog()) {
     }
 
     void Session::sendPublish(Message& message, uint8_t qoS, bool retain) {
-        iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:   TopicName: " << message.getTopic();
-        auto log = iot::mqtt::semantic::mqttSessionLog();
+        log_.info() << "MQTT Broker:   TopicName: " << message.getTopic();
+        const auto& log = log_;
         if (log.enabled(logger::LogLevel::Info)) {
             log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
         }
-        iot::mqtt::semantic::mqttSessionLog().debug() << "MQTT Broker:   QoS: " << static_cast<uint16_t>(std::min(qoS, message.getQoS()));
+        log_.debug() << "MQTT Broker:   QoS: " << static_cast<uint16_t>(std::min(qoS, message.getQoS()));
 
         if (isActive()) {
-            iot::mqtt::semantic::mqttSessionLog().debug() << "MQTT Broker:   ClientId: " << mqtt->getClientId();
-            iot::mqtt::semantic::mqttSessionLog().debug() << "MQTT Broker:   OriginClientId: " << message.getOriginClientId();
+            log_.debug() << "MQTT Broker:   ClientId: " << mqtt->getClientId();
+            log_.debug() << "MQTT Broker:   OriginClientId: " << message.getOriginClientId();
 
             if ((mqtt->getReflect() || mqtt->getClientId() != message.getOriginClientId())) {
                 mqtt->sendPublish(message.getTopic(),
@@ -82,7 +87,7 @@ namespace iot::mqtt::server::broker {
                                   std::min(message.getQoS(), qoS),
                                   !mqtt->getReflect() ? message.getOriginRetain() || retain : retain);
             } else {
-                iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:     Suppress reflection to origin to avoid message looping";
+                log_.info() << "MQTT Broker:     Suppress reflection to origin to avoid message looping";
             }
         } else {
             // Offline session behavior:
@@ -93,17 +98,17 @@ namespace iot::mqtt::server::broker {
                 message.setQoS(effectiveQoS);
                 messageQueue.emplace_back(message);
             } else {
-                iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:     Drop QoS0 message for inactive session";
+                log_.info() << "MQTT Broker:     Drop QoS0 message for inactive session";
             }
         }
     }
 
     void Session::publishQueued() {
-        iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:     send queued messages ...";
+        log_.info() << "MQTT Broker:     send queued messages ...";
         for (iot::mqtt::server::broker::Message& message : messageQueue) {
             sendPublish(message, message.getQoS(), false);
         }
-        iot::mqtt::semantic::mqttSessionLog().info() << "MQTT Broker:     ... done";
+        log_.info() << "MQTT Broker:     ... done";
 
         messageQueue.clear();
     }

--- a/src/iot/mqtt/server/broker/Session.cpp
+++ b/src/iot/mqtt/server/broker/Session.cpp
@@ -60,26 +60,33 @@
 
 namespace iot::mqtt::server::broker {
 
-    Session::Session()
-        : log_(iot::mqtt::semantic::mqttSessionLog()) {
+    Session::Session() {
     }
 
     Session::Session(iot::mqtt::server::Mqtt* mqtt)
-        : mqtt(mqtt)
-        , log_(iot::mqtt::semantic::mqttSessionLog()) {
+        : mqtt(mqtt) {
+    }
+
+    const logger::BoundaryLogger& Session::log() const {
+        const unsigned long generation = logger::LogManager::generation();
+        if (!log_ || logGeneration_ != generation) {
+            logGeneration_ = generation;
+            log_.emplace(iot::mqtt::semantic::mqttSessionLog());
+        }
+        return *log_;
     }
 
     void Session::sendPublish(Message& message, uint8_t qoS, bool retain) {
-        log_.info() << "MQTT Broker:   TopicName: " << message.getTopic();
-        const auto& log = log_;
+        const auto& log = this->log();
+        log.info() << "MQTT Broker:   TopicName: " << message.getTopic();
         if (log.enabled(logger::LogLevel::Info)) {
             log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
         }
-        log_.debug() << "MQTT Broker:   QoS: " << static_cast<uint16_t>(std::min(qoS, message.getQoS()));
+        log.debug() << "MQTT Broker:   QoS: " << static_cast<uint16_t>(std::min(qoS, message.getQoS()));
 
         if (isActive()) {
-            log_.debug() << "MQTT Broker:   ClientId: " << mqtt->getClientId();
-            log_.debug() << "MQTT Broker:   OriginClientId: " << message.getOriginClientId();
+            log.debug() << "MQTT Broker:   ClientId: " << mqtt->getClientId();
+            log.debug() << "MQTT Broker:   OriginClientId: " << message.getOriginClientId();
 
             if ((mqtt->getReflect() || mqtt->getClientId() != message.getOriginClientId())) {
                 mqtt->sendPublish(message.getTopic(),
@@ -87,7 +94,7 @@ namespace iot::mqtt::server::broker {
                                   std::min(message.getQoS(), qoS),
                                   !mqtt->getReflect() ? message.getOriginRetain() || retain : retain);
             } else {
-                log_.info() << "MQTT Broker:     Suppress reflection to origin to avoid message looping";
+                log.info() << "MQTT Broker:     Suppress reflection to origin to avoid message looping";
             }
         } else {
             // Offline session behavior:
@@ -98,17 +105,17 @@ namespace iot::mqtt::server::broker {
                 message.setQoS(effectiveQoS);
                 messageQueue.emplace_back(message);
             } else {
-                log_.info() << "MQTT Broker:     Drop QoS0 message for inactive session";
+                log.info() << "MQTT Broker:     Drop QoS0 message for inactive session";
             }
         }
     }
 
     void Session::publishQueued() {
-        log_.info() << "MQTT Broker:     send queued messages ...";
+        log().info() << "MQTT Broker:     send queued messages ...";
         for (iot::mqtt::server::broker::Message& message : messageQueue) {
             sendPublish(message, message.getQoS(), false);
         }
-        log_.info() << "MQTT Broker:     ... done";
+        log().info() << "MQTT Broker:     ... done";
 
         messageQueue.clear();
     }

--- a/src/iot/mqtt/server/broker/Session.h
+++ b/src/iot/mqtt/server/broker/Session.h
@@ -56,6 +56,7 @@ namespace iot::mqtt::server {
 #include <cstdint>
 #include <deque>
 #include <nlohmann/json_fwd.hpp>
+#include <optional>
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
@@ -81,10 +82,13 @@ namespace iot::mqtt::server::broker {
         void fromJson(const nlohmann::json& json);
 
     private:
+        const logger::BoundaryLogger& log() const;
+
         iot::mqtt::server::Mqtt* mqtt = nullptr;
 
         std::deque<Message> messageQueue;
-        logger::BoundaryLogger log_;
+        mutable std::optional<logger::BoundaryLogger> log_;
+        mutable unsigned long logGeneration_ = 0;
     };
 
 } // namespace iot::mqtt::server::broker

--- a/src/iot/mqtt/server/broker/Session.h
+++ b/src/iot/mqtt/server/broker/Session.h
@@ -51,6 +51,8 @@ namespace iot::mqtt::server {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/SemanticLogger.h"
+
 #include <cstdint>
 #include <deque>
 #include <nlohmann/json_fwd.hpp>
@@ -61,7 +63,7 @@ namespace iot::mqtt::server::broker {
 
     class Session : public iot::mqtt::Session {
     public:
-        Session() = default;
+        Session();
         explicit Session(iot::mqtt::server::Mqtt* mqtt);
 
         void sendPublish(iot::mqtt::server::broker::Message& message, uint8_t qoS, bool retain);
@@ -82,6 +84,7 @@ namespace iot::mqtt::server::broker {
         iot::mqtt::server::Mqtt* mqtt = nullptr;
 
         std::deque<Message> messageQueue;
+        logger::BoundaryLogger log_;
     };
 
 } // namespace iot::mqtt::server::broker

--- a/src/iot/mqtt/server/broker/SubscriptionTree.cpp
+++ b/src/iot/mqtt/server/broker/SubscriptionTree.cpp
@@ -60,7 +60,8 @@
 namespace iot::mqtt::server::broker {
 
     SubscriptionTree::SubscriptionTree(iot::mqtt::server::broker::Broker* broker)
-        : head(broker, "") {
+        : head(broker, "")
+        , log_(iot::mqtt::semantic::mqttBrokerLog()) {
     }
 
     void SubscriptionTree::appear(const std::string& clientId) {
@@ -76,7 +77,7 @@ namespace iot::mqtt::server::broker {
 
             success = true;
         } else {
-            iot::mqtt::semantic::mqttBrokerLog().error() << "MQTT Broker: Subscribe: Wrong '#' placement: " << topic;
+            log_.error() << "MQTT Broker: Subscribe: Wrong '#' placement: " << topic;
         }
 
         return success;
@@ -87,7 +88,7 @@ namespace iot::mqtt::server::broker {
         if (!message.getTopic().empty() && (hashCount == 0 || (hashCount == 1 && message.getTopic().ends_with('#')))) {
             head.publish(message, message.getTopic());
         } else {
-            iot::mqtt::semantic::mqttBrokerLog().error() << "MQTT Broker: Publish: Wrong '#' placement: " << message.getTopic();
+            log_.error() << "MQTT Broker: Publish: Wrong '#' placement: " << message.getTopic();
         }
     }
 
@@ -96,7 +97,7 @@ namespace iot::mqtt::server::broker {
         if (!topic.empty() && (hashCount == 0 || (hashCount == 1 && topic.ends_with('#')))) {
             head.unsubscribe(clientId, topic);
         } else {
-            iot::mqtt::semantic::mqttBrokerLog().error() << "MQTT Broker: Unsubscribe: Wrong '#' placement: " << topic;
+            log_.error() << "MQTT Broker: Unsubscribe: Wrong '#' placement: " << topic;
         }
     }
 
@@ -128,7 +129,8 @@ namespace iot::mqtt::server::broker {
 
     SubscriptionTree::TopicLevel::TopicLevel(Broker* broker, const std::string& topicLevel)
         : broker(broker)
-        , topicLevel(topicLevel) {
+        , topicLevel(topicLevel)
+        , log_(iot::mqtt::semantic::mqttBrokerLog()) {
     }
 
     void SubscriptionTree::TopicLevel::appear(const std::string& clientId, const std::string& topic) {
@@ -143,8 +145,8 @@ namespace iot::mqtt::server::broker {
 
     bool SubscriptionTree::TopicLevel::subscribe(const std::string& clientId, uint8_t qoS, std::string topic) {
         if (topic.empty()) {
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Subscribe";
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   ClientId: " << clientId;
+            log_.info() << "MQTT Broker: Subscribe";
+            log_.info() << "MQTT Broker:   ClientId: " << clientId;
 
             clientIds[clientId] = qoS;
         } else {
@@ -155,11 +157,11 @@ namespace iot::mqtt::server::broker {
             const auto& [it, inserted] = topicLevels.insert({topicLevel, SubscriptionTree::TopicLevel(broker, topicLevel)});
 
             if (!it->second.subscribe(clientId, qoS, topic)) {
-                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Erase topic: " << topicLevel << " /" << topic;
+                log_.debug() << "MQTT Broker:   Erase topic: " << topicLevel << " /" << topic;
 
                 topicLevels.erase(it);
             } else {
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << topicLevel << " /" << topic;
+                log_.info() << "MQTT Broker:   Topic: " << topicLevel << " /" << topic;
             }
         }
 
@@ -168,33 +170,33 @@ namespace iot::mqtt::server::broker {
 
     void SubscriptionTree::TopicLevel::publish(Message& message, std::string topic) {
         if (topic.empty()) {
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Found match:";
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: '" << message.getTopic() << "';";
-            auto log = iot::mqtt::semantic::mqttBrokerLog();
+            log_.info() << "MQTT Broker: Found match:";
+            log_.info() << "MQTT Broker:   Topic: '" << message.getTopic() << "';";
+            const auto& log = log_;
             if (log.enabled(logger::LogLevel::Info)) {
                 log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
             }
 
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Distribute PUBLISH for match ...";
+            log_.info() << "MQTT Broker: Distribute PUBLISH for match ...";
             for (auto& [clientId, clientQoS] : clientIds) {
                 broker->sendPublish(clientId, message, clientQoS, false);
             }
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: ... distributing PUBLISH for match completed";
+            log_.info() << "MQTT Broker: ... distributing PUBLISH for match completed";
 
             const auto nextHashLevel = topicLevels.find("#");
             if (nextHashLevel != topicLevels.end()) {
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Found parent match:";
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
-                auto log = iot::mqtt::semantic::mqttBrokerLog();
+                log_.info() << "MQTT Broker: Found parent match:";
+                log_.info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
+                const auto& log = log_;
                 if (log.enabled(logger::LogLevel::Info)) {
                     log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
                 }
 
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Distribute PUBLISH for match ...";
+                log_.info() << "MQTT Broker: Distribute PUBLISH for match ...";
                 for (auto& [clientId, clientQoS] : nextHashLevel->second.clientIds) {
                     broker->sendPublish(clientId, message, clientQoS, false);
                 }
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: ... distributing PUBLISH for match completed";
+                log_.info() << "MQTT Broker: ... distributing PUBLISH for match completed";
             }
         } else {
             const std::string topicLevel = topic.substr(0, topic.find('/'));
@@ -213,19 +215,18 @@ namespace iot::mqtt::server::broker {
 
             foundNode = topicLevels.find("#");
             if (foundNode != topicLevels.end()) {
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Found match:";
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
-                auto log = iot::mqtt::semantic::mqttBrokerLog();
+                log_.info() << "MQTT Broker: Found match:";
+                log_.info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
+                const auto& log = log_;
                 if (log.enabled(logger::LogLevel::Info)) {
                     log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
                 }
 
-                iot::mqtt::semantic::mqttBrokerLog().info()
-                    << "MQTT Broker: Distribute PUBLISH for match '" << message.getTopic() << "' ...";
+                log_.info() << "MQTT Broker: Distribute PUBLISH for match '" << message.getTopic() << "' ...";
                 for (auto& [clientId, clientQoS] : foundNode->second.clientIds) {
                     broker->sendPublish(clientId, message, clientQoS, false);
                 }
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: ... distributing PUBLISH for match completed";
+                log_.info() << "MQTT Broker: ... distributing PUBLISH for match completed";
             }
         }
     }
@@ -233,9 +234,9 @@ namespace iot::mqtt::server::broker {
     bool SubscriptionTree::TopicLevel::unsubscribe(const std::string& clientId, std::string topic) {
         if (topic.empty()) {
             if (clientIds.erase(clientId) != 0) {
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Unsubscribe";
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   ClientId: " << clientId;
-                iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << topicLevel;
+                log_.info() << "MQTT Broker: Unsubscribe";
+                log_.info() << "MQTT Broker:   ClientId: " << clientId;
+                log_.info() << "MQTT Broker:   Topic: " << topicLevel;
             }
         } else {
             const std::string topicLevel = topic.substr(0, topic.find('/'));
@@ -245,7 +246,7 @@ namespace iot::mqtt::server::broker {
                 topic.erase(0, topicLevel.size() + 1);
 
                 if (it->second.unsubscribe(clientId, topic)) {
-                    iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Erase Topic: " << it->first;
+                    log_.debug() << "MQTT Broker:   Erase Topic: " << it->first;
 
                     topicLevels.erase(it);
                 }
@@ -257,14 +258,14 @@ namespace iot::mqtt::server::broker {
 
     bool SubscriptionTree::TopicLevel::unsubscribe(const std::string& clientId) {
         if (clientIds.erase(clientId) != 0) {
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker: Unsubscribe";
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   ClientId: " << clientId;
-            iot::mqtt::semantic::mqttBrokerLog().info() << "MQTT Broker:   Topic: " << topicLevel;
+            log_.info() << "MQTT Broker: Unsubscribe";
+            log_.info() << "MQTT Broker:   ClientId: " << clientId;
+            log_.info() << "MQTT Broker:   Topic: " << topicLevel;
         }
 
         for (auto it = topicLevels.begin(); it != topicLevels.end();) {
             if (it->second.unsubscribe(clientId)) {
-                iot::mqtt::semantic::mqttBrokerLog().debug() << "MQTT Broker:   Erase Topic: " << it->first;
+                log_.debug() << "MQTT Broker:   Erase Topic: " << it->first;
 
                 it = topicLevels.erase(it);
             } else {

--- a/src/iot/mqtt/server/broker/SubscriptionTree.cpp
+++ b/src/iot/mqtt/server/broker/SubscriptionTree.cpp
@@ -60,8 +60,16 @@
 namespace iot::mqtt::server::broker {
 
     SubscriptionTree::SubscriptionTree(iot::mqtt::server::broker::Broker* broker)
-        : head(broker, "")
-        , log_(iot::mqtt::semantic::mqttBrokerLog()) {
+        : head(broker, "") {
+    }
+
+    const logger::BoundaryLogger& SubscriptionTree::log() const {
+        const unsigned long generation = logger::LogManager::generation();
+        if (!log_ || logGeneration_ != generation) {
+            logGeneration_ = generation;
+            log_.emplace(iot::mqtt::semantic::mqttBrokerLog());
+        }
+        return *log_;
     }
 
     void SubscriptionTree::appear(const std::string& clientId) {
@@ -77,7 +85,7 @@ namespace iot::mqtt::server::broker {
 
             success = true;
         } else {
-            log_.error() << "MQTT Broker: Subscribe: Wrong '#' placement: " << topic;
+            log().error() << "MQTT Broker: Subscribe: Wrong '#' placement: " << topic;
         }
 
         return success;
@@ -88,7 +96,7 @@ namespace iot::mqtt::server::broker {
         if (!message.getTopic().empty() && (hashCount == 0 || (hashCount == 1 && message.getTopic().ends_with('#')))) {
             head.publish(message, message.getTopic());
         } else {
-            log_.error() << "MQTT Broker: Publish: Wrong '#' placement: " << message.getTopic();
+            log().error() << "MQTT Broker: Publish: Wrong '#' placement: " << message.getTopic();
         }
     }
 
@@ -97,7 +105,7 @@ namespace iot::mqtt::server::broker {
         if (!topic.empty() && (hashCount == 0 || (hashCount == 1 && topic.ends_with('#')))) {
             head.unsubscribe(clientId, topic);
         } else {
-            log_.error() << "MQTT Broker: Unsubscribe: Wrong '#' placement: " << topic;
+            log().error() << "MQTT Broker: Unsubscribe: Wrong '#' placement: " << topic;
         }
     }
 
@@ -129,8 +137,16 @@ namespace iot::mqtt::server::broker {
 
     SubscriptionTree::TopicLevel::TopicLevel(Broker* broker, const std::string& topicLevel)
         : broker(broker)
-        , topicLevel(topicLevel)
-        , log_(iot::mqtt::semantic::mqttBrokerLog()) {
+        , topicLevel(topicLevel) {
+    }
+
+    const logger::BoundaryLogger& SubscriptionTree::TopicLevel::log() const {
+        const unsigned long generation = logger::LogManager::generation();
+        if (!log_ || logGeneration_ != generation) {
+            logGeneration_ = generation;
+            log_.emplace(iot::mqtt::semantic::mqttBrokerLog());
+        }
+        return *log_;
     }
 
     void SubscriptionTree::TopicLevel::appear(const std::string& clientId, const std::string& topic) {
@@ -145,8 +161,8 @@ namespace iot::mqtt::server::broker {
 
     bool SubscriptionTree::TopicLevel::subscribe(const std::string& clientId, uint8_t qoS, std::string topic) {
         if (topic.empty()) {
-            log_.info() << "MQTT Broker: Subscribe";
-            log_.info() << "MQTT Broker:   ClientId: " << clientId;
+            log().info() << "MQTT Broker: Subscribe";
+            log().info() << "MQTT Broker:   ClientId: " << clientId;
 
             clientIds[clientId] = qoS;
         } else {
@@ -157,11 +173,11 @@ namespace iot::mqtt::server::broker {
             const auto& [it, inserted] = topicLevels.insert({topicLevel, SubscriptionTree::TopicLevel(broker, topicLevel)});
 
             if (!it->second.subscribe(clientId, qoS, topic)) {
-                log_.debug() << "MQTT Broker:   Erase topic: " << topicLevel << " /" << topic;
+                log().debug() << "MQTT Broker:   Erase topic: " << topicLevel << " /" << topic;
 
                 topicLevels.erase(it);
             } else {
-                log_.info() << "MQTT Broker:   Topic: " << topicLevel << " /" << topic;
+                log().info() << "MQTT Broker:   Topic: " << topicLevel << " /" << topic;
             }
         }
 
@@ -169,34 +185,33 @@ namespace iot::mqtt::server::broker {
     }
 
     void SubscriptionTree::TopicLevel::publish(Message& message, std::string topic) {
+        const auto& log = this->log();
         if (topic.empty()) {
-            log_.info() << "MQTT Broker: Found match:";
-            log_.info() << "MQTT Broker:   Topic: '" << message.getTopic() << "';";
-            const auto& log = log_;
+            log.info() << "MQTT Broker: Found match:";
+            log.info() << "MQTT Broker:   Topic: '" << message.getTopic() << "';";
             if (log.enabled(logger::LogLevel::Info)) {
                 log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
             }
 
-            log_.info() << "MQTT Broker: Distribute PUBLISH for match ...";
+            log.info() << "MQTT Broker: Distribute PUBLISH for match ...";
             for (auto& [clientId, clientQoS] : clientIds) {
                 broker->sendPublish(clientId, message, clientQoS, false);
             }
-            log_.info() << "MQTT Broker: ... distributing PUBLISH for match completed";
+            log.info() << "MQTT Broker: ... distributing PUBLISH for match completed";
 
             const auto nextHashLevel = topicLevels.find("#");
             if (nextHashLevel != topicLevels.end()) {
-                log_.info() << "MQTT Broker: Found parent match:";
-                log_.info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
-                const auto& log = log_;
+                log.info() << "MQTT Broker: Found parent match:";
+                log.info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
                 if (log.enabled(logger::LogLevel::Info)) {
                     log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
                 }
 
-                log_.info() << "MQTT Broker: Distribute PUBLISH for match ...";
+                log.info() << "MQTT Broker: Distribute PUBLISH for match ...";
                 for (auto& [clientId, clientQoS] : nextHashLevel->second.clientIds) {
                     broker->sendPublish(clientId, message, clientQoS, false);
                 }
-                log_.info() << "MQTT Broker: ... distributing PUBLISH for match completed";
+                log.info() << "MQTT Broker: ... distributing PUBLISH for match completed";
             }
         } else {
             const std::string topicLevel = topic.substr(0, topic.find('/'));
@@ -215,18 +230,17 @@ namespace iot::mqtt::server::broker {
 
             foundNode = topicLevels.find("#");
             if (foundNode != topicLevels.end()) {
-                log_.info() << "MQTT Broker: Found match:";
-                log_.info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
-                const auto& log = log_;
+                log.info() << "MQTT Broker: Found match:";
+                log.info() << "MQTT Broker:   Topic: '" << message.getTopic() << "'";
                 if (log.enabled(logger::LogLevel::Info)) {
                     log.info() << "MQTT Broker:   Message:\n" << iot::mqtt::Mqtt::toHexString(message.getMessage());
                 }
 
-                log_.info() << "MQTT Broker: Distribute PUBLISH for match '" << message.getTopic() << "' ...";
+                log.info() << "MQTT Broker: Distribute PUBLISH for match '" << message.getTopic() << "' ...";
                 for (auto& [clientId, clientQoS] : foundNode->second.clientIds) {
                     broker->sendPublish(clientId, message, clientQoS, false);
                 }
-                log_.info() << "MQTT Broker: ... distributing PUBLISH for match completed";
+                log.info() << "MQTT Broker: ... distributing PUBLISH for match completed";
             }
         }
     }
@@ -234,9 +248,9 @@ namespace iot::mqtt::server::broker {
     bool SubscriptionTree::TopicLevel::unsubscribe(const std::string& clientId, std::string topic) {
         if (topic.empty()) {
             if (clientIds.erase(clientId) != 0) {
-                log_.info() << "MQTT Broker: Unsubscribe";
-                log_.info() << "MQTT Broker:   ClientId: " << clientId;
-                log_.info() << "MQTT Broker:   Topic: " << topicLevel;
+                log().info() << "MQTT Broker: Unsubscribe";
+                log().info() << "MQTT Broker:   ClientId: " << clientId;
+                log().info() << "MQTT Broker:   Topic: " << topicLevel;
             }
         } else {
             const std::string topicLevel = topic.substr(0, topic.find('/'));
@@ -246,7 +260,7 @@ namespace iot::mqtt::server::broker {
                 topic.erase(0, topicLevel.size() + 1);
 
                 if (it->second.unsubscribe(clientId, topic)) {
-                    log_.debug() << "MQTT Broker:   Erase Topic: " << it->first;
+                    log().debug() << "MQTT Broker:   Erase Topic: " << it->first;
 
                     topicLevels.erase(it);
                 }
@@ -258,14 +272,14 @@ namespace iot::mqtt::server::broker {
 
     bool SubscriptionTree::TopicLevel::unsubscribe(const std::string& clientId) {
         if (clientIds.erase(clientId) != 0) {
-            log_.info() << "MQTT Broker: Unsubscribe";
-            log_.info() << "MQTT Broker:   ClientId: " << clientId;
-            log_.info() << "MQTT Broker:   Topic: " << topicLevel;
+            log().info() << "MQTT Broker: Unsubscribe";
+            log().info() << "MQTT Broker:   ClientId: " << clientId;
+            log().info() << "MQTT Broker:   Topic: " << topicLevel;
         }
 
         for (auto it = topicLevels.begin(); it != topicLevels.end();) {
             if (it->second.unsubscribe(clientId)) {
-                log_.debug() << "MQTT Broker:   Erase Topic: " << it->first;
+                log().debug() << "MQTT Broker:   Erase Topic: " << it->first;
 
                 it = topicLevels.erase(it);
             } else {

--- a/src/iot/mqtt/server/broker/SubscriptionTree.h
+++ b/src/iot/mqtt/server/broker/SubscriptionTree.h
@@ -49,6 +49,8 @@ namespace iot::mqtt::server::broker {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/SemanticLogger.h"
+
 #include <cstdint>
 #include <list>
 #include <map>
@@ -117,9 +119,11 @@ namespace iot::mqtt::server::broker {
             std::map<std::string, TopicLevel> topicLevels;
 
             std::string topicLevel;
+            logger::BoundaryLogger log_;
         };
 
         TopicLevel head;
+        logger::BoundaryLogger log_;
     };
 
 } // namespace iot::mqtt::server::broker

--- a/src/iot/mqtt/server/broker/SubscriptionTree.h
+++ b/src/iot/mqtt/server/broker/SubscriptionTree.h
@@ -55,6 +55,7 @@ namespace iot::mqtt::server::broker {
 #include <list>
 #include <map>
 #include <nlohmann/json_fwd.hpp>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -109,6 +110,8 @@ namespace iot::mqtt::server::broker {
             void clear();
 
         private:
+            const logger::BoundaryLogger& log() const;
+
             std::list<std::string> getSubscriptions(const std::string& absoluteTopicLevel, const std::string& clientId) const;
             std::map<std::string, std::list<std::pair<std::string, uint8_t>>>
             getSubscriptionTree(const std::string& absoluteTopicLevel) const;
@@ -119,11 +122,15 @@ namespace iot::mqtt::server::broker {
             std::map<std::string, TopicLevel> topicLevels;
 
             std::string topicLevel;
-            logger::BoundaryLogger log_;
+            mutable std::optional<logger::BoundaryLogger> log_;
+            mutable unsigned long logGeneration_ = 0;
         };
 
+        const logger::BoundaryLogger& log() const;
+
         TopicLevel head;
-        logger::BoundaryLogger log_;
+        mutable std::optional<logger::BoundaryLogger> log_;
+        mutable unsigned long logGeneration_ = 0;
     };
 
 } // namespace iot::mqtt::server::broker

--- a/src/log/SemanticLogger.cpp
+++ b/src/log/SemanticLogger.cpp
@@ -105,6 +105,7 @@ namespace logger {
             std::map<std::string, LogLevel> instanceLevels;
             LogManager::Format format = LogManager::Format::Text;
             bool frozen = false;
+            unsigned long generation = 0;
         };
 
         SemanticPolicy& policy() {
@@ -149,7 +150,9 @@ namespace logger {
     }
 
     void LogManager::init() {
+        const unsigned long nextGeneration = policy().generation + 1;
         policy() = SemanticPolicy{};
+        policy().generation = nextGeneration;
     }
 
     void LogManager::setGlobalLevel(LogLevel level) {
@@ -190,6 +193,10 @@ namespace logger {
 
     bool LogManager::isFrozen() {
         return policy().frozen;
+    }
+
+    unsigned long LogManager::generation() {
+        return policy().generation;
     }
 
     LogLevel LogManager::effectiveLevel(const LogScope& scope) {

--- a/src/log/SemanticLogger.h
+++ b/src/log/SemanticLogger.h
@@ -128,6 +128,7 @@ namespace logger {
         static void setFormat(Format format);
         static void freeze();
         static bool isFrozen();
+        static unsigned long generation();
 
         static LogLevel effectiveLevel(const LogScope& scope);
         static LogLevel effectiveLevel(const LogRecord& record);

--- a/src/web/websocket/Receiver.cpp
+++ b/src/web/websocket/Receiver.cpp
@@ -60,7 +60,8 @@
 namespace web::websocket {
 
     Receiver::Receiver(bool maskingExpected)
-        : maskingExpected(maskingExpected) {
+        : maskingExpected(maskingExpected)
+        , frameLog_(semantic::webSocketFrameLog()) {
     }
 
     Receiver::~Receiver() {
@@ -129,7 +130,7 @@ namespace web::websocket {
             } else {
                 parserState = ParserState::ERROR;
                 errorState = 1002;
-                semantic::webSocketFrameLog().error() << "WebSocket: Error opcode in continuation frame";
+                frameLog_.error() << "WebSocket: Error opcode in continuation frame";
             }
             continuation = !fin;
         }
@@ -283,9 +284,8 @@ namespace web::websocket {
                 }
             }
 
-            auto log = semantic::webSocketFrameLog();
-            if (log.enabled(logger::LogLevel::Trace)) {
-                log.trace("WebSocket receive: Frame data\n{}", utils::hexDump(payloadChunk, payloadChunkLen, 32, true));
+            if (frameLog_.enabled(logger::LogLevel::Trace)) {
+                frameLog_.trace("WebSocket receive: Frame data\n{}", utils::hexDump(payloadChunk, payloadChunkLen, 32, true));
             }
 
             onMessageData(payloadChunk, payloadChunkLen);

--- a/src/web/websocket/Receiver.cpp
+++ b/src/web/websocket/Receiver.cpp
@@ -60,8 +60,16 @@
 namespace web::websocket {
 
     Receiver::Receiver(bool maskingExpected)
-        : maskingExpected(maskingExpected)
-        , frameLog_(semantic::webSocketFrameLog()) {
+        : maskingExpected(maskingExpected) {
+    }
+
+    const logger::BoundaryLogger& Receiver::frameLog() const {
+        const unsigned long generation = logger::LogManager::generation();
+        if (!frameLog_ || frameLogGeneration_ != generation) {
+            frameLogGeneration_ = generation;
+            frameLog_.emplace(semantic::webSocketFrameLog());
+        }
+        return *frameLog_;
     }
 
     Receiver::~Receiver() {
@@ -130,7 +138,7 @@ namespace web::websocket {
             } else {
                 parserState = ParserState::ERROR;
                 errorState = 1002;
-                frameLog_.error() << "WebSocket: Error opcode in continuation frame";
+                frameLog().error() << "WebSocket: Error opcode in continuation frame";
             }
             continuation = !fin;
         }
@@ -284,8 +292,8 @@ namespace web::websocket {
                 }
             }
 
-            if (frameLog_.enabled(logger::LogLevel::Trace)) {
-                frameLog_.trace("WebSocket receive: Frame data\n{}", utils::hexDump(payloadChunk, payloadChunkLen, 32, true));
+            if (frameLog().enabled(logger::LogLevel::Trace)) {
+                frameLog().trace("WebSocket receive: Frame data\n{}", utils::hexDump(payloadChunk, payloadChunkLen, 32, true));
             }
 
             onMessageData(payloadChunk, payloadChunkLen);

--- a/src/web/websocket/Receiver.h
+++ b/src/web/websocket/Receiver.h
@@ -48,6 +48,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -74,6 +75,8 @@ namespace web::websocket {
         std::size_t readELength();
         std::size_t readMaskingKey();
         std::size_t readPayload();
+
+        const logger::BoundaryLogger& frameLog() const;
 
         std::size_t readELength2();
         std::size_t readELength8();
@@ -121,7 +124,8 @@ namespace web::websocket {
 
         uint16_t errorState = 0;
 
-        logger::BoundaryLogger frameLog_;
+        mutable std::optional<logger::BoundaryLogger> frameLog_;
+        mutable unsigned long frameLogGeneration_ = 0;
 
         std::size_t payloadTotalRead = 0;
     };

--- a/src/web/websocket/Receiver.h
+++ b/src/web/websocket/Receiver.h
@@ -44,6 +44,8 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/SemanticLogger.h"
+
 #include <cstddef>
 #include <cstdint>
 
@@ -118,6 +120,8 @@ namespace web::websocket {
         uint8_t maskingKeyNumBytesLeft = 4;
 
         uint16_t errorState = 0;
+
+        logger::BoundaryLogger frameLog_;
 
         std::size_t payloadTotalRead = 0;
     };

--- a/src/web/websocket/Transmitter.cpp
+++ b/src/web/websocket/Transmitter.cpp
@@ -61,7 +61,8 @@
 namespace web::websocket {
 
     Transmitter::Transmitter(bool masking)
-        : masking(masking) {
+        : masking(masking)
+        , frameLog_(semantic::webSocketFrameLog()) {
     }
 
     Transmitter::~Transmitter() {
@@ -141,9 +142,8 @@ namespace web::websocket {
         MaskingKey maskingKeyAsArray = {.keyAsValue = distribution(randomDevice)};
 
         if (payloadLength > 0) {
-            auto log = semantic::webSocketFrameLog();
-            if (log.enabled(logger::LogLevel::Trace)) {
-                log.trace("WebSocket send: Frame data\n{}", utils::hexDump(payload, payloadLength, 32, true));
+            if (frameLog_.enabled(logger::LogLevel::Trace)) {
+                frameLog_.trace("WebSocket send: Frame data\n{}", utils::hexDump(payload, payloadLength, 32, true));
             }
         }
 

--- a/src/web/websocket/Transmitter.cpp
+++ b/src/web/websocket/Transmitter.cpp
@@ -61,8 +61,16 @@
 namespace web::websocket {
 
     Transmitter::Transmitter(bool masking)
-        : masking(masking)
-        , frameLog_(semantic::webSocketFrameLog()) {
+        : masking(masking) {
+    }
+
+    const logger::BoundaryLogger& Transmitter::frameLog() const {
+        const unsigned long generation = logger::LogManager::generation();
+        if (!frameLog_ || frameLogGeneration_ != generation) {
+            frameLogGeneration_ = generation;
+            frameLog_.emplace(semantic::webSocketFrameLog());
+        }
+        return *frameLog_;
     }
 
     Transmitter::~Transmitter() {
@@ -142,8 +150,8 @@ namespace web::websocket {
         MaskingKey maskingKeyAsArray = {.keyAsValue = distribution(randomDevice)};
 
         if (payloadLength > 0) {
-            if (frameLog_.enabled(logger::LogLevel::Trace)) {
-                frameLog_.trace("WebSocket send: Frame data\n{}", utils::hexDump(payload, payloadLength, 32, true));
+            if (frameLog().enabled(logger::LogLevel::Trace)) {
+                frameLog().trace("WebSocket send: Frame data\n{}", utils::hexDump(payload, payloadLength, 32, true));
             }
         }
 

--- a/src/web/websocket/Transmitter.h
+++ b/src/web/websocket/Transmitter.h
@@ -44,6 +44,8 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include "log/SemanticLogger.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <random>
@@ -94,6 +96,8 @@ namespace web::websocket {
         bool closeSent = false;
 
     private:
+        logger::BoundaryLogger frameLog_;
+
         std::size_t payloadTotalSent = 0;
     };
 

--- a/src/web/websocket/Transmitter.h
+++ b/src/web/websocket/Transmitter.h
@@ -48,6 +48,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <random>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -79,6 +80,8 @@ namespace web::websocket {
 
         void sendFrame(bool fin, uint8_t opCode, const char* payload, uint64_t payloadLength);
 
+        const logger::BoundaryLogger& frameLog() const;
+
         void sendFrameData(uint8_t data) const;
         void sendFrameData(uint16_t data) const;
         void sendFrameData(uint32_t data) const;
@@ -96,7 +99,8 @@ namespace web::websocket {
         bool closeSent = false;
 
     private:
-        logger::BoundaryLogger frameLog_;
+        mutable std::optional<logger::BoundaryLogger> frameLog_;
+        mutable unsigned long frameLogGeneration_ = 0;
 
         std::size_t payloadTotalSent = 0;
     };

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -173,5 +173,5 @@ snodec_set_source_policy_test_properties(SemanticCachedLoggerOverheadTest "unit;
 snodec_add_test(SemanticStructuralLoggerCacheTest SemanticStructuralLoggerCacheTest.cpp)
 target_include_directories(SemanticStructuralLoggerCacheTest PRIVATE ${PROJECT_SOURCE_DIR})
 target_compile_features(SemanticStructuralLoggerCacheTest PRIVATE cxx_std_20)
-target_link_libraries(SemanticStructuralLoggerCacheTest PRIVATE snodec-test-support snodec::logger)
+target_link_libraries(SemanticStructuralLoggerCacheTest PRIVATE snodec-test-support snodec::core snodec::logger)
 snodec_set_source_policy_test_properties(SemanticStructuralLoggerCacheTest "unit;log;structural-cache")

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -169,3 +169,9 @@ target_include_directories(SemanticCachedLoggerOverheadTest PRIVATE ${PROJECT_SO
 target_compile_features(SemanticCachedLoggerOverheadTest PRIVATE cxx_std_20)
 target_link_libraries(SemanticCachedLoggerOverheadTest PRIVATE snodec-test-support snodec::logger)
 snodec_set_source_policy_test_properties(SemanticCachedLoggerOverheadTest "unit;log;overhead;source-policy")
+
+snodec_add_test(SemanticStructuralLoggerCacheTest SemanticStructuralLoggerCacheTest.cpp)
+target_include_directories(SemanticStructuralLoggerCacheTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(SemanticStructuralLoggerCacheTest PRIVATE cxx_std_20)
+target_link_libraries(SemanticStructuralLoggerCacheTest PRIVATE snodec-test-support snodec::logger)
+snodec_set_source_policy_test_properties(SemanticStructuralLoggerCacheTest "unit;log;structural-cache")

--- a/tests/unit/log/SemanticCachedLoggerOverheadTest.cpp
+++ b/tests/unit/log/SemanticCachedLoggerOverheadTest.cpp
@@ -102,17 +102,17 @@ int main() {
         const std::string mqttHeader = source_policy::readSourcePolicyFile(root / "src/iot/mqtt/Mqtt.h");
         const std::string mqttSource = source_policy::readSourcePolicyFile(root / "src/iot/mqtt/Mqtt.cpp");
 
-        result.expectTrue(source_policy::contains(mqttHeader, "logger::BoundaryLogger log_"),
-                          "Mqtt.h contains cached BoundaryLogger member log_");
-        result.expectTrue(source_policy::contains(mqttSource, "log_(iot::mqtt::semantic::mqttLog())"),
-                          "Mqtt.cpp constructors initialize cached MQTT logger from mqttLog()");
+        result.expectTrue(source_policy::contains(mqttHeader, "std::optional<logger::BoundaryLogger> log_"),
+                          "Mqtt.h contains generation-refreshable cached BoundaryLogger member log_");
+        result.expectTrue(source_policy::contains(mqttSource, "log_.emplace(iot::mqtt::semantic::mqttLog())"),
+                          "Mqtt.cpp lazily initializes cached MQTT logger from mqttLog()");
         result.expectTrue(!containsDirectMqttLogSeverity(mqttSource),
                           "Mqtt.cpp uses cached log_ instead of direct same-scope mqttLog severity calls");
-        result.expectTrue(source_policy::contains(mqttSource, "log_.debug()"), "Mqtt.cpp contains cached debug logger usage");
-        result.expectTrue(source_policy::contains(mqttSource, "log_.info()"), "Mqtt.cpp contains cached info logger usage");
-        result.expectTrue(source_policy::contains(mqttSource, "log_.warn()"), "Mqtt.cpp contains cached warn logger usage");
-        result.expectTrue(source_policy::contains(mqttSource, "log_.error()"), "Mqtt.cpp contains cached error logger usage");
-        result.expectTrue(source_policy::contains(mqttSource, "log_.trace()"), "Mqtt.cpp contains cached trace logger usage");
+        result.expectTrue(source_policy::contains(mqttSource, "log().debug()"), "Mqtt.cpp contains cached debug logger usage");
+        result.expectTrue(source_policy::contains(mqttSource, "log().info()"), "Mqtt.cpp contains cached info logger usage");
+        result.expectTrue(source_policy::contains(mqttSource, "log().warn()"), "Mqtt.cpp contains cached warn logger usage");
+        result.expectTrue(source_policy::contains(mqttSource, "log().error()"), "Mqtt.cpp contains cached error logger usage");
+        result.expectTrue(source_policy::contains(mqttSource, "log().trace()"), "Mqtt.cpp contains cached trace logger usage");
     }
 
     {

--- a/tests/unit/log/SemanticStructuralLoggerCacheTest.cpp
+++ b/tests/unit/log/SemanticStructuralLoggerCacheTest.cpp
@@ -1,3 +1,4 @@
+#include "core/EventLoop.h"
 #include "log/LogScopeOwner.h"
 #include "log/Logger.h"
 #include "log/SemanticLogger.h"
@@ -122,6 +123,20 @@ int main() {
         result.expectTrue(cachedLog.enabled(logger::LogLevel::Trace), "cached logger honors instance override");
     }
 
+    {
+        SemanticStateGuard guard;
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Info);
+        logger::LogManager::freeze();
+        result.expectTrue(!core::EventLoop::instance().log().enabled(logger::LogLevel::Debug),
+                          "EventLoop cached logger honors initial info generation");
+
+        logger::LogManager::init();
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::freeze();
+        result.expectTrue(core::EventLoop::instance().log().enabled(logger::LogLevel::Debug),
+                          "EventLoop cached logger refreshes after LogManager generation changes");
+    }
+
     const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
     if (root.empty()) {
         result.expectTrue(false, "sourcePolicyProjectRoot() must not return an empty path");
@@ -153,13 +168,32 @@ int main() {
                           source_policy::contains(socketContextSource, "frameworkLog_.emplace"),
                       "SocketContext lazily populates both cached loggers");
 
+    const std::string mqttHeader = source_policy::readSourcePolicyFile(root / "src/iot/mqtt/Mqtt.h");
+    const std::string mqttSource = source_policy::readSourcePolicyFile(root / "src/iot/mqtt/Mqtt.cpp");
+    result.expectTrue(source_policy::contains(mqttHeader, "std::optional<logger::BoundaryLogger> log_") &&
+                          source_policy::contains(mqttHeader, "logGeneration_"),
+                      "Mqtt cache is optional and generation-tracked");
+    result.expectTrue(source_policy::contains(mqttSource, "logger::LogManager::generation()") &&
+                          source_policy::contains(mqttSource, "log_.emplace(iot::mqtt::semantic::mqttLog())"),
+                      "Mqtt cache refreshes from mqttLog when the generation changes");
+    result.expectTrue(!source_policy::contains(mqttHeader, "logger::BoundaryLogger log_;"),
+                      "Mqtt does not use a direct non-refreshable BoundaryLogger member");
+
     const std::string receiverHeader = source_policy::readSourcePolicyFile(root / "src/web/websocket/Receiver.h");
     const std::string receiverSource = source_policy::readSourcePolicyFile(root / "src/web/websocket/Receiver.cpp");
     const std::string transmitterHeader = source_policy::readSourcePolicyFile(root / "src/web/websocket/Transmitter.h");
     const std::string transmitterSource = source_policy::readSourcePolicyFile(root / "src/web/websocket/Transmitter.cpp");
-    result.expectTrue(source_policy::contains(receiverHeader, "logger::BoundaryLogger frameLog_") &&
-                          source_policy::contains(transmitterHeader, "logger::BoundaryLogger frameLog_"),
-                      "WebSocket Receiver and Transmitter cache frame loggers");
+    result.expectTrue(source_policy::contains(receiverHeader, "std::optional<logger::BoundaryLogger> frameLog_") &&
+                          source_policy::contains(receiverHeader, "frameLogGeneration_") &&
+                          source_policy::contains(transmitterHeader, "std::optional<logger::BoundaryLogger> frameLog_") &&
+                          source_policy::contains(transmitterHeader, "frameLogGeneration_"),
+                      "WebSocket Receiver and Transmitter use generation-tracked frame logger caches");
+    result.expectTrue(source_policy::contains(receiverSource, "logger::LogManager::generation()") &&
+                          source_policy::contains(transmitterSource, "logger::LogManager::generation()"),
+                      "WebSocket frame caches check LogManager generation");
+    result.expectTrue(!source_policy::contains(receiverHeader, "logger::BoundaryLogger frameLog_;") &&
+                          !source_policy::contains(transmitterHeader, "logger::BoundaryLogger frameLog_;"),
+                      "WebSocket frame caches are not direct non-refreshable BoundaryLogger members");
     result.expectTrue(!containsDirectWebSocketFrameHotCall(receiverSource) && !containsDirectWebSocketFrameHotCall(transmitterSource),
                       "WebSocket hot paths no longer call webSocketFrameLog directly");
 
@@ -168,13 +202,20 @@ int main() {
                             "src/iot/mqtt/server/broker/SubscriptionTree.h",
                             "src/iot/mqtt/server/broker/Session.h"}) {
         const std::string source = source_policy::readSourcePolicyFile(root / file);
-        result.expectTrue(source_policy::contains(source, "logger::BoundaryLogger log_"), std::string(file) + " caches a BoundaryLogger");
+        result.expectTrue(source_policy::contains(source, "std::optional<logger::BoundaryLogger> log_") &&
+                              source_policy::contains(source, "logGeneration_") &&
+                              !source_policy::contains(source, "logger::BoundaryLogger log_;"),
+                          std::string(file) + " caches a generation-tracked optional BoundaryLogger");
     }
     for (const auto file : {"src/iot/mqtt/server/broker/Broker.cpp",
                             "src/iot/mqtt/server/broker/RetainTree.cpp",
                             "src/iot/mqtt/server/broker/SubscriptionTree.cpp",
                             "src/iot/mqtt/server/broker/Session.cpp"}) {
         const std::string source = source_policy::readSourcePolicyFile(root / file);
+        result.expectTrue(source_policy::contains(source, "logger::LogManager::generation()"),
+                          std::string(file) + " uses LogManager generation for cached logger refresh");
+        result.expectTrue(!source_policy::contains(source, "const auto& log = log_"),
+                          std::string(file) + " has no transitional direct-member logger aliases");
         result.expectTrue(!containsDirectMqttBrokerOrSessionSeverity(source),
                           std::string(file) + " hot diagnostics use cached MQTT loggers");
     }

--- a/tests/unit/log/SemanticStructuralLoggerCacheTest.cpp
+++ b/tests/unit/log/SemanticStructuralLoggerCacheTest.cpp
@@ -63,6 +63,12 @@ namespace {
         }
         return false;
     }
+
+    bool containsOnlyPrivateLogAccessors(std::string_view source) {
+        return source_policy::contains(source, "const logger::BoundaryLogger& log() const;") &&
+               !source_policy::contains(source, "public:\n        const logger::BoundaryLogger& log() const;") &&
+               !source_policy::contains(source, "public:\n            const logger::BoundaryLogger& log() const;");
+    }
 } // namespace
 
 int main() {
@@ -143,6 +149,7 @@ int main() {
         return result.processResult();
     }
 
+    // Pre-freeze-capable objects must keep an isFrozen() fallback; generation() alone only invalidates caches after LogManager::init().
     const std::string eventLoopHeader = source_policy::readSourcePolicyFile(root / "src/core/EventLoop.h");
     const std::string eventLoopSource = source_policy::readSourcePolicyFile(root / "src/core/EventLoop.cpp");
     result.expectTrue(source_policy::contains(eventLoopHeader, "std::optional<logger::BoundaryLogger> cachedLog_"),
@@ -197,6 +204,7 @@ int main() {
     result.expectTrue(!containsDirectWebSocketFrameHotCall(receiverSource) && !containsDirectWebSocketFrameHotCall(transmitterSource),
                       "WebSocket hot paths no longer call webSocketFrameLog directly");
 
+    // Broker-family caches intentionally rely on private, enumerable runtime call sites plus generation-aware refresh.
     for (const auto file : {"src/iot/mqtt/server/broker/Broker.h",
                             "src/iot/mqtt/server/broker/RetainTree.h",
                             "src/iot/mqtt/server/broker/SubscriptionTree.h",
@@ -206,6 +214,7 @@ int main() {
                               source_policy::contains(source, "logGeneration_") &&
                               !source_policy::contains(source, "logger::BoundaryLogger log_;"),
                           std::string(file) + " caches a generation-tracked optional BoundaryLogger");
+        result.expectTrue(containsOnlyPrivateLogAccessors(source), std::string(file) + " keeps the broker-family logger accessor private");
     }
     for (const auto file : {"src/iot/mqtt/server/broker/Broker.cpp",
                             "src/iot/mqtt/server/broker/RetainTree.cpp",

--- a/tests/unit/log/SemanticStructuralLoggerCacheTest.cpp
+++ b/tests/unit/log/SemanticStructuralLoggerCacheTest.cpp
@@ -10,6 +10,7 @@
 #include <ostream>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace {
     struct ExpensiveArgument {
@@ -64,10 +65,48 @@ namespace {
         return false;
     }
 
-    bool containsOnlyPrivateLogAccessors(std::string_view source) {
-        return source_policy::contains(source, "const logger::BoundaryLogger& log() const;") &&
-               !source_policy::contains(source, "public:\n        const logger::BoundaryLogger& log() const;") &&
-               !source_policy::contains(source, "public:\n            const logger::BoundaryLogger& log() const;");
+    bool isDeclaredAfterNearestPrivateSpecifier(std::string_view source, std::size_t declarationPos) {
+        enum class AccessSpecifier { None, Public, Protected, Private };
+
+        std::size_t nearestPos = 0;
+        AccessSpecifier nearestAccessSpecifier = AccessSpecifier::None;
+
+        const auto consider = [&](std::string_view specifier, AccessSpecifier accessSpecifier) {
+            const std::size_t pos = source.rfind(specifier, declarationPos);
+            if (pos != std::string_view::npos && (nearestAccessSpecifier == AccessSpecifier::None || pos > nearestPos)) {
+                nearestPos = pos;
+                nearestAccessSpecifier = accessSpecifier;
+            }
+        };
+
+        consider("public:", AccessSpecifier::Public);
+        consider("protected:", AccessSpecifier::Protected);
+        consider("private:", AccessSpecifier::Private);
+
+        return nearestAccessSpecifier == AccessSpecifier::Private;
+    }
+
+    bool isDeclaredAfterNearestPrivateSpecifier(std::string_view source, std::string_view declaration) {
+        const std::size_t declarationPos = source.find(declaration);
+        return declarationPos != std::string_view::npos && isDeclaredAfterNearestPrivateSpecifier(source, declarationPos);
+    }
+
+    bool allDeclarationsAfterNearestPrivateSpecifier(std::string_view source, std::string_view declaration, std::size_t expectedCount) {
+        std::size_t count = 0;
+        std::size_t searchPos = 0;
+        while (true) {
+            const std::size_t declarationPos = source.find(declaration, searchPos);
+            if (declarationPos == std::string_view::npos) {
+                break;
+            }
+            ++count;
+            if (!isDeclaredAfterNearestPrivateSpecifier(source, declarationPos)) {
+                return false;
+            }
+            searchPos = declarationPos + declaration.size();
+        }
+
+        return count == expectedCount;
     }
 } // namespace
 
@@ -143,6 +182,35 @@ int main() {
                           "EventLoop cached logger refreshes after LogManager generation changes");
     }
 
+    constexpr std::string_view brokerLogDeclaration = "const logger::BoundaryLogger& log() const;";
+
+    const std::string publicAccessor = R"cpp(
+class Example {
+public:
+    void foo();
+
+    const logger::BoundaryLogger& log() const;
+
+private:
+    int value = 0;
+};
+)cpp";
+    const std::string privateAccessor = R"cpp(
+class Example {
+public:
+    void foo();
+
+private:
+    const logger::BoundaryLogger& log() const;
+
+    int value = 0;
+};
+)cpp";
+    result.expectTrue(!isDeclaredAfterNearestPrivateSpecifier(publicAccessor, brokerLogDeclaration),
+                      "privacy helper rejects public logger accessor placement");
+    result.expectTrue(isDeclaredAfterNearestPrivateSpecifier(privateAccessor, brokerLogDeclaration),
+                      "privacy helper accepts private logger accessor placement");
+
     const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
     if (root.empty()) {
         result.expectTrue(false, "sourcePolicyProjectRoot() must not return an empty path");
@@ -205,16 +273,17 @@ int main() {
                       "WebSocket hot paths no longer call webSocketFrameLog directly");
 
     // Broker-family caches intentionally rely on private, enumerable runtime call sites plus generation-aware refresh.
-    for (const auto file : {"src/iot/mqtt/server/broker/Broker.h",
-                            "src/iot/mqtt/server/broker/RetainTree.h",
-                            "src/iot/mqtt/server/broker/SubscriptionTree.h",
-                            "src/iot/mqtt/server/broker/Session.h"}) {
+    for (const auto [file, expectedLogAccessorCount] : {std::pair{"src/iot/mqtt/server/broker/Broker.h", std::size_t{1}},
+                                                        std::pair{"src/iot/mqtt/server/broker/RetainTree.h", std::size_t{2}},
+                                                        std::pair{"src/iot/mqtt/server/broker/SubscriptionTree.h", std::size_t{2}},
+                                                        std::pair{"src/iot/mqtt/server/broker/Session.h", std::size_t{1}}}) {
         const std::string source = source_policy::readSourcePolicyFile(root / file);
         result.expectTrue(source_policy::contains(source, "std::optional<logger::BoundaryLogger> log_") &&
                               source_policy::contains(source, "logGeneration_") &&
                               !source_policy::contains(source, "logger::BoundaryLogger log_;"),
                           std::string(file) + " caches a generation-tracked optional BoundaryLogger");
-        result.expectTrue(containsOnlyPrivateLogAccessors(source), std::string(file) + " keeps the broker-family logger accessor private");
+        result.expectTrue(allDeclarationsAfterNearestPrivateSpecifier(source, brokerLogDeclaration, expectedLogAccessorCount),
+                          std::string(file) + " keeps every broker-family logger accessor private");
     }
     for (const auto file : {"src/iot/mqtt/server/broker/Broker.cpp",
                             "src/iot/mqtt/server/broker/RetainTree.cpp",

--- a/tests/unit/log/SemanticStructuralLoggerCacheTest.cpp
+++ b/tests/unit/log/SemanticStructuralLoggerCacheTest.cpp
@@ -1,0 +1,189 @@
+#include "log/LogScopeOwner.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "tests/support/TestResult.h"
+#include "tests/unit/log/SourcePolicyTestRoot.h"
+
+#include <filesystem>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <string_view>
+
+namespace {
+    struct ExpensiveArgument {
+        int* counter;
+    };
+
+    std::ostream& operator<<(std::ostream& os, const ExpensiveArgument& value) {
+        ++*value.counter;
+        return os << "expensive";
+    }
+
+    class SemanticStateGuard {
+    public:
+        SemanticStateGuard() {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+        }
+
+        ~SemanticStateGuard() {
+            logger::Logger::init();
+            logger::LogManager::init();
+        }
+    };
+
+    bool containsAny(std::string_view source, std::initializer_list<std::string_view> needles) {
+        for (const auto needle : needles) {
+            if (source_policy::contains(source, needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool containsDirectWebSocketFrameHotCall(std::string_view source) {
+        return source_policy::contains(source, "auto log = semantic::webSocketFrameLog()") ||
+               source_policy::contains(source, "semantic::webSocketFrameLog().enabled") ||
+               source_policy::contains(source, "semantic::webSocketFrameLog().trace");
+    }
+
+    bool containsDirectMqttBrokerOrSessionSeverity(std::string_view source) {
+        constexpr std::string_view prefixes[] = {"iot::mqtt::semantic::mqttBrokerLog().", "iot::mqtt::semantic::mqttSessionLog()."};
+        constexpr std::string_view severities[] = {"trace", "debug", "info", "warn", "error", "critical", "enabled", "sysError"};
+        for (const auto prefix : prefixes) {
+            for (const auto severity : severities) {
+                if (source_policy::contains(source, std::string(prefix) + std::string(severity))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    {
+        SemanticStateGuard guard;
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Info);
+        logger::LogManager::freeze();
+
+        logger::LogScopeOwner scope(logger::LogOrigin::Framework,
+                                    logger::LogBoundary::Connection,
+                                    "core.socket.stream",
+                                    "unit-instance",
+                                    std::nullopt,
+                                    "unit-connection");
+        const auto cachedLog = scope.logger(logger::Logger::semanticSink());
+        result.expectTrue(!cachedLog.enabled(logger::LogLevel::Debug), "cached logger honors global threshold");
+
+        int counter = 0;
+        cachedLog.debug("value={}", ExpensiveArgument{&counter});
+        result.expectEqual(0, counter, "disabled cached logger does not format expensive arguments");
+    }
+
+    {
+        SemanticStateGuard guard;
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Warn);
+        logger::LogManager::setComponentLevel("core.socket.stream", logger::LogLevel::Debug);
+        logger::LogManager::freeze();
+
+        logger::LogScopeOwner scope(logger::LogOrigin::Framework,
+                                    logger::LogBoundary::Connection,
+                                    "core.socket.stream",
+                                    std::nullopt,
+                                    std::nullopt,
+                                    "unit-connection");
+        const auto cachedLog = scope.logger(logger::Logger::semanticSink());
+        result.expectTrue(cachedLog.enabled(logger::LogLevel::Debug), "cached logger honors component override");
+
+        int counter = 0;
+        cachedLog.debug("value={}", ExpensiveArgument{&counter});
+        result.expectEqual(1, counter, "enabled cached logger formats expensive arguments exactly once");
+    }
+
+    {
+        SemanticStateGuard guard;
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Warn);
+        logger::LogManager::setInstanceLevel("unit-instance", logger::LogLevel::Trace);
+        logger::LogManager::freeze();
+
+        logger::LogScopeOwner scope(logger::LogOrigin::Framework,
+                                    logger::LogBoundary::Context,
+                                    "core.socket.context",
+                                    "unit-instance",
+                                    std::nullopt,
+                                    "unit-connection");
+        const auto cachedLog = scope.logger(logger::Logger::semanticSink());
+        result.expectTrue(cachedLog.enabled(logger::LogLevel::Trace), "cached logger honors instance override");
+    }
+
+    const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
+    if (root.empty()) {
+        result.expectTrue(false, "sourcePolicyProjectRoot() must not return an empty path");
+        return result.processResult();
+    }
+
+    const std::string eventLoopHeader = source_policy::readSourcePolicyFile(root / "src/core/EventLoop.h");
+    const std::string eventLoopSource = source_policy::readSourcePolicyFile(root / "src/core/EventLoop.cpp");
+    result.expectTrue(source_policy::contains(eventLoopHeader, "std::optional<logger::BoundaryLogger> cachedLog_"),
+                      "EventLoop has a lazy cached logger member");
+    result.expectTrue(source_policy::contains(eventLoopSource, "logger::LogManager::isFrozen()"),
+                      "EventLoop gates cached logger use on post-freeze state");
+    result.expectTrue(!source_policy::contains(eventLoopSource, ", cachedLog_"),
+                      "EventLoop does not initialize the semantic logger in the constructor");
+
+    const std::string socketConnectionHeader = source_policy::readSourcePolicyFile(root / "src/core/socket/stream/SocketConnection.h");
+    const std::string socketConnectionSource = source_policy::readSourcePolicyFile(root / "src/core/socket/stream/SocketConnection.cpp");
+    result.expectTrue(source_policy::contains(socketConnectionHeader, "std::optional<logger::BoundaryLogger> cachedLog_"),
+                      "SocketConnection has a cached logger member");
+    result.expectTrue(source_policy::contains(socketConnectionSource, "if (logger::LogManager::isFrozen())"),
+                      "SocketConnection uses lazy post-freeze caching");
+
+    const std::string socketContextHeader = source_policy::readSourcePolicyFile(root / "src/core/socket/stream/SocketContext.h");
+    const std::string socketContextSource = source_policy::readSourcePolicyFile(root / "src/core/socket/stream/SocketContext.cpp");
+    result.expectTrue(source_policy::contains(socketContextHeader, "applicationLog_") &&
+                          source_policy::contains(socketContextHeader, "frameworkLog_"),
+                      "SocketContext has cached application and framework logger members");
+    result.expectTrue(source_policy::contains(socketContextSource, "applicationLog_.emplace") &&
+                          source_policy::contains(socketContextSource, "frameworkLog_.emplace"),
+                      "SocketContext lazily populates both cached loggers");
+
+    const std::string receiverHeader = source_policy::readSourcePolicyFile(root / "src/web/websocket/Receiver.h");
+    const std::string receiverSource = source_policy::readSourcePolicyFile(root / "src/web/websocket/Receiver.cpp");
+    const std::string transmitterHeader = source_policy::readSourcePolicyFile(root / "src/web/websocket/Transmitter.h");
+    const std::string transmitterSource = source_policy::readSourcePolicyFile(root / "src/web/websocket/Transmitter.cpp");
+    result.expectTrue(source_policy::contains(receiverHeader, "logger::BoundaryLogger frameLog_") &&
+                          source_policy::contains(transmitterHeader, "logger::BoundaryLogger frameLog_"),
+                      "WebSocket Receiver and Transmitter cache frame loggers");
+    result.expectTrue(!containsDirectWebSocketFrameHotCall(receiverSource) && !containsDirectWebSocketFrameHotCall(transmitterSource),
+                      "WebSocket hot paths no longer call webSocketFrameLog directly");
+
+    for (const auto file : {"src/iot/mqtt/server/broker/Broker.h",
+                            "src/iot/mqtt/server/broker/RetainTree.h",
+                            "src/iot/mqtt/server/broker/SubscriptionTree.h",
+                            "src/iot/mqtt/server/broker/Session.h"}) {
+        const std::string source = source_policy::readSourcePolicyFile(root / file);
+        result.expectTrue(source_policy::contains(source, "logger::BoundaryLogger log_"), std::string(file) + " caches a BoundaryLogger");
+    }
+    for (const auto file : {"src/iot/mqtt/server/broker/Broker.cpp",
+                            "src/iot/mqtt/server/broker/RetainTree.cpp",
+                            "src/iot/mqtt/server/broker/SubscriptionTree.cpp",
+                            "src/iot/mqtt/server/broker/Session.cpp"}) {
+        const std::string source = source_policy::readSourcePolicyFile(root / file);
+        result.expectTrue(!containsDirectMqttBrokerOrSessionSeverity(source),
+                          std::string(file) + " hot diagnostics use cached MQTT loggers");
+    }
+
+    const std::string allTouchedPolicy = eventLoopHeader + eventLoopSource + socketConnectionHeader + socketConnectionSource +
+                                         socketContextHeader + socketContextSource + receiverHeader + receiverSource + transmitterHeader +
+                                         transmitterSource;
+    result.expectTrue(!containsAny(allTouchedPolicy, {"LOG_IF", "TRACE_IF", "DEBUG_IF", "IF_ENABLED"}),
+                      "No new macro guard API was introduced in structural cache paths");
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation
- Hot framework paths repeatedly reconstructed `BoundaryLogger` instances which re-ran `LogManager::effectiveLevel()` on every call, adding map/key/temporary-string overhead in high-frequency code paths. 
- `EventLoop` is a Meyers singleton initialized before `Config::bootstrap()` and `LogManager::freeze()`, so it must not cache a resolved logger in its constructor but can safely perform a post-freeze/lazy cache. 
- Prior PRs (#175/#176) left remaining repeated helper resolutions; this PR finishes the work with repository-wide structural caches where objects have stable semantic identity.

### Description
- Added lazy post-freeze caches using `std::optional<logger::BoundaryLogger>` and generation checks to `EventLoop`, `SocketConnection`, and `SocketContext` so `log()`/`frameworkLog()` reuse a resolved `BoundaryLogger` after `LogManager::isFrozen()` without changing semantics. 
- Cached WebSocket frame logger as a member `frameLog_` in `Receiver`/`Transmitter` and replaced hot-path helper calls so heavy `hexDump()` is executed only when `frameLog_.enabled(...)` is true. 
- Introduced member-cached `logger::BoundaryLogger log_` in MQTT broker-side types (`Broker`, `RetainTree`, `SubscriptionTree`, `Session`) and updated publish/retain/session hot paths to use the cached logger instead of repeated `mqttBrokerLog()`/`mqttSessionLog()` helper calls. 
- Added a lightweight policy generation API to `logger::LogManager` (`generation()`) to invalidate lazy caches safely across `LogManager::init()`/reinitialization; added `tests/unit/log/SemanticStructuralLoggerCacheTest.cpp`, CMake registration, and `docs/logging/semantic-structural-cache-report.md` documenting safety, scope, and searches. 

### Testing
- Configured and built with `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build --parallel 2`, which completed successfully. 
- Ran the unit test set with `ctest` including focused/coverage targets and the full test suite; all selected tests, including the new `SemanticStructuralLoggerCacheTest`, passed in the CI run reported here. 
- The new `SemanticStructuralLoggerCacheTest` verifies source-policy structure, instance/component override behavior, disabled/ enabled formatting behaviour, and confirms no new macro guard APIs were introduced. 
- Ran formatting (`clang-format -i` on touched files) and `git diff --check` to ensure style and whitespace checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f67dccb30832cbbcc6132b6fcd182)