### PR TITLE
Consolidate logging output behind spdlog backend

### DIFF
--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -65,9 +65,9 @@ FetchContent_MakeAvailable(spdlog)
 
 set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${TMP_CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
 
-set(LOGGER_CPP Logger.cpp SemanticLogger.cpp LogScopeOwner.cpp)
+set(LOGGER_CPP Logger.cpp SemanticLogger.cpp LogScopeOwner.cpp detail/SpdlogBackend.cpp)
 
-set(LOGGER_H Logger.h SemanticLogger.h LogScopeOwner.h)
+set(LOGGER_H Logger.h SemanticLogger.h LogScopeOwner.h detail/SpdlogBackend.h)
 
 set(TMP_CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
 unset(CMAKE_CXX_INCLUDE_WHAT_YOU_USE)

--- a/src/log/Logger.cpp
+++ b/src/log/Logger.cpp
@@ -44,281 +44,67 @@
 #include "log/Logger.h"
 
 #include "log/SemanticLogger.h"
+#include "log/detail/SpdlogBackend.h"
 
-#include <algorithm>
 #include <cerrno>
-#include <chrono>
-#include <cstring>
-#include <optional>
-#include <spdlog/logger.h>
-#include <spdlog/pattern_formatter.h>
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/rotating_file_sink.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <unistd.h>
+#include <string>
+#include <utility>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace {
-    std::shared_ptr<spdlog::sinks::stdout_color_sink_st> stdoutSink;
-    std::shared_ptr<spdlog::sinks::stdout_color_sink_st> semanticStdoutSink;
-    std::shared_ptr<spdlog::sinks::rotating_file_sink_st> fileSink;
-    std::shared_ptr<spdlog::sinks::rotating_file_sink_st> semanticFileSink;
-    std::shared_ptr<spdlog::logger> stdoutLogger;
-    std::shared_ptr<spdlog::logger> fileLogger;
-    std::shared_ptr<spdlog::logger> semanticStdoutLogger;
-    std::shared_ptr<spdlog::logger> semanticFileLogger;
-
-    int configuredLogLevel = 0;
-    int configuredVerboseLevel = 0;
-    bool quietMode = false;
-    logger::Logger::TickResolver tickResolver;
-
-    using Clock = std::chrono::steady_clock;
-    Clock::time_point startTime = Clock::now();
-
-    std::string defaultTick();
-
-    class TickFlagFormatter final : public spdlog::custom_flag_formatter {
-    public:
-        void format(const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override {
-            std::string tick = tickResolver ? tickResolver() : defaultTick();
-            dest.append(tick.data(), tick.data() + static_cast<std::ptrdiff_t>(tick.size()));
-        }
-
-        std::unique_ptr<custom_flag_formatter> clone() const override {
-            return spdlog::details::make_unique<TickFlagFormatter>();
-        }
-    };
-
-    std::string defaultTick() {
-        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - startTime).count();
-        std::string tick = std::to_string(elapsed);
-        if (tick.size() < 13) {
-            tick.insert(0, 13 - tick.size(), '0');
-        }
-        return tick;
-    }
-
-    std::string levelName(const logger::Level level) {
-        std::string result;
-
-        switch (level) {
-            case logger::Level::TRACE:
-                result = "TRACE  ";
-                break;
-            case logger::Level::DEBUG:
-                result = "DEBUG  ";
-                break;
-            case logger::Level::INFO:
-                result = "INFO   ";
-                break;
-            case logger::Level::WARNING:
-                result = "WARNING";
-                break;
-            case logger::Level::ERROR:
-                result = "ERROR  ";
-                break;
-            case logger::Level::FATAL:
-                result = "FATAL  ";
-                break;
-            case logger::Level::VERBOSE:
-                result = "VERBOSE";
-                break;
-        }
-
-        return result;
-    }
-
-    Color::Code levelColor(const logger::Level level) {
-        Color::Code color = Color::Code::FG_WHITE;
-
-        switch (level) {
-            case logger::Level::TRACE:
-                color = Color::Code::FG_MAGENTA; // +
-                break;
-            case logger::Level::DEBUG:
-                color = Color::Code::FG_LIGHT_GREEN; // +
-                break;
-            case logger::Level::INFO:
-                color = Color::Code::FG_LIGHT_YELLOW; // +
-                break;
-            case logger::Level::WARNING:
-                color = Color::Code::FG_YELLOW; // +
-                break;
-            case logger::Level::ERROR:
-                color = Color::Code::FG_RED; // +
-                break;
-            case logger::Level::FATAL:
-                color = Color::Code::FG_LIGHT_RED; // +
-                break;
-            case logger::Level::VERBOSE:
-                color = Color::Code::FG_WHITE;
-                break;
-        }
-
-        return color;
-    }
-
-    std::string colorizeLevel(const logger::Level level) {
-        std::string label = levelName(level);
-
-        if (!logger::Logger::getDisableColor()) {
-            label = Color::Code::FG_DEFAULT + (levelColor(level) + label) + Color::Code::FG_DEFAULT;
-        }
-
-        return label;
-    }
-
-    std::optional<logger::Level> mapSemanticLevel(const logger::LogLevel level) {
-        switch (level) {
-            case logger::LogLevel::Trace:
-                return logger::Level::TRACE;
-            case logger::LogLevel::Debug:
-                return logger::Level::DEBUG;
-            case logger::LogLevel::Info:
-                return logger::Level::INFO;
-            case logger::LogLevel::Warn:
-                return logger::Level::WARNING;
-            case logger::LogLevel::Error:
-                return logger::Level::ERROR;
-            case logger::LogLevel::Critical:
-                return logger::Level::FATAL;
-            case logger::LogLevel::Off:
-                return std::nullopt;
-        }
-        return std::nullopt;
-    }
-
-    bool shouldEmit(const logger::Level level) {
-        if (level == logger::Level::VERBOSE) {
-            return true;
-        }
-
-        switch (configuredLogLevel) {
-            case 6:
-                return true;
-            case 5:
-                return level != logger::Level::TRACE;
-            case 4:
-                return level == logger::Level::INFO || level == logger::Level::WARNING || level == logger::Level::ERROR ||
-                       level == logger::Level::FATAL;
-            case 3:
-                return level == logger::Level::WARNING || level == logger::Level::ERROR || level == logger::Level::FATAL;
-            case 2:
-                return level == logger::Level::ERROR || level == logger::Level::FATAL;
-            case 1:
-                return level == logger::Level::FATAL;
-            default:
-                return false;
-        }
+    logger::detail::SpdlogBackend& backend() {
+        static logger::detail::SpdlogBackend instance;
+        return instance;
     }
 } // namespace
 
 namespace logger {
 
     void Logger::init() {
-        startTime = Clock::now();
-        stdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
-        stdoutLogger = std::make_shared<spdlog::logger>("snodec-stdout", stdoutSink);
-        auto stdoutPattern = std::make_unique<spdlog::pattern_formatter>();
-        stdoutPattern->add_flag<TickFlagFormatter>('*').set_pattern("%Y-%m-%d %H:%M:%S %* %v");
-        stdoutLogger->set_formatter(std::move(stdoutPattern));
-        semanticStdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
-        semanticStdoutLogger = std::make_shared<spdlog::logger>("snodec-semantic-stdout", semanticStdoutSink);
-        semanticStdoutLogger->set_pattern("%v");
-
-        fileSink.reset();
-        semanticFileSink.reset();
-        fileLogger.reset();
-        semanticFileLogger.reset();
-        quietMode = false;
-        disableColorLog = ::isatty(::fileno(stdout)) == 0;
-        configuredVerboseLevel = 0;
-        configuredLogLevel = 0;
+        backend().init();
+        disableColorLog = backend().getDisableColor();
     }
 
     void Logger::setTickResolver(TickResolver resolver) {
-        tickResolver = std::move(resolver);
+        backend().setTickResolver(std::move(resolver));
     }
 
-    void Logger::setLogLevel(int level) {
-        configuredLogLevel = level;
+    void Logger::setLogLevel(const int level) {
+        backend().setLogLevel(level);
     }
 
-    void Logger::setVerboseLevel(int level) {
-        configuredVerboseLevel = std::max(0, level);
+    void Logger::setVerboseLevel(const int level) {
+        backend().setVerboseLevel(level);
     }
 
     void Logger::logToFile(const std::string& logFile) {
-        constexpr std::size_t maxSize = 2 * 1024 * 1024; // 2 MiB
-        constexpr std::size_t maxFiles = 3;              // keep log, log.1, log.2, log.3
-        fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
-        fileLogger = std::make_shared<spdlog::logger>("snodec-file", fileSink);
-        auto filePattern = std::make_unique<spdlog::pattern_formatter>();
-        filePattern->add_flag<TickFlagFormatter>('*').set_pattern("%Y-%m-%d %H:%M:%S %* %v");
-        fileLogger->set_formatter(std::move(filePattern));
-        semanticFileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
-        semanticFileLogger = std::make_shared<spdlog::logger>("snodec-semantic-file", semanticFileSink);
-        semanticFileLogger->set_pattern("%v");
+        backend().setLogFile(logFile);
     }
 
     void Logger::disableLogToFile() {
-        semanticFileLogger.reset();
-        semanticFileSink.reset();
-        fileLogger.reset();
-        fileSink.reset();
+        backend().disableLogFile();
     }
 
-    void Logger::setQuiet(bool quiet) {
-        quietMode = quiet;
+    void Logger::setQuiet(const bool quiet) {
+        backend().setQuiet(quiet);
     }
 
-    void Logger::setDisableColor(bool disableColor) {
+    void Logger::setDisableColor(const bool disableColor) {
+        backend().setDisableColor(disableColor);
         disableColorLog = disableColor;
     }
 
     bool Logger::getDisableColor() {
-        return disableColorLog;
+        return backend().getDisableColor();
     }
 
-    bool Logger::shouldLog(Level level) {
-        return shouldEmit(level);
+    bool Logger::shouldLog(const Level level) {
+        return backend().shouldLog(level);
     }
 
-    bool Logger::shouldVerbose(int verboseLevel) {
-        return verboseLevel >= 0 && verboseLevel <= configuredVerboseLevel;
-    }
-
-    static void emitFormattedLine(const std::string& line) {
-        if (!quietMode && semanticStdoutLogger) {
-            semanticStdoutLogger->log(spdlog::level::info, line);
-        }
-        if (semanticFileLogger) {
-            semanticFileLogger->log(spdlog::level::info, line);
-        }
-    }
-
-    static void emitLine(Level level, std::string message, const bool withErrno, const int errnoValue) {
-        if (!shouldEmit(level)) {
-            return;
-        }
-
-        if (withErrno) {
-            message += ": ";
-            message += std::strerror(errnoValue);
-        }
-
-        if (level != Level::VERBOSE) {
-            message = colorizeLevel(level) + " " + message;
-        }
-
-        if (!quietMode && stdoutLogger) {
-            stdoutLogger->log(spdlog::level::info, message);
-        }
-        if (fileLogger) {
-            fileLogger->log(spdlog::level::info, message);
-        }
+    bool Logger::shouldVerbose(const int verboseLevel) {
+        return backend().shouldVerbose(verboseLevel);
     }
 
     void Logger::emitSemantic(const LogRecord& record) {
@@ -326,11 +112,7 @@ namespace logger {
             return;
         }
 
-        if (!mapSemanticLevel(record.level)) {
-            return;
-        }
-
-        emitFormattedLine(LogManager::formatRecord(record));
+        backend().emitSemantic(record.level, LogManager::formatRecord(record));
     }
 
     BoundaryLogger::Sink Logger::semanticSink() {
@@ -351,7 +133,7 @@ namespace logger {
 
     LogMessage::~LogMessage() {
         if (enabled) {
-            emitLine(level, message.str(), withErrno, errnoValue);
+            backend().emitLegacy(level, message.str(), withErrno, errnoValue);
         }
     }
 

--- a/src/log/detail/SpdlogBackend.cpp
+++ b/src/log/detail/SpdlogBackend.cpp
@@ -1,0 +1,361 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include "log/detail/SpdlogBackend.h"
+
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <optional>
+#include <spdlog/logger.h>
+#include <spdlog/pattern_formatter.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <unistd.h>
+#include <utility>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+    using Clock = std::chrono::steady_clock;
+
+    std::string levelName(const logger::Level level) {
+        std::string result;
+
+        switch (level) {
+            case logger::Level::TRACE:
+                result = "TRACE  ";
+                break;
+            case logger::Level::DEBUG:
+                result = "DEBUG  ";
+                break;
+            case logger::Level::INFO:
+                result = "INFO   ";
+                break;
+            case logger::Level::WARNING:
+                result = "WARNING";
+                break;
+            case logger::Level::ERROR:
+                result = "ERROR  ";
+                break;
+            case logger::Level::FATAL:
+                result = "FATAL  ";
+                break;
+            case logger::Level::VERBOSE:
+                result = "VERBOSE";
+                break;
+        }
+
+        return result;
+    }
+
+    Color::Code levelColor(const logger::Level level) {
+        Color::Code color = Color::Code::FG_WHITE;
+
+        switch (level) {
+            case logger::Level::TRACE:
+                color = Color::Code::FG_MAGENTA;
+                break;
+            case logger::Level::DEBUG:
+                color = Color::Code::FG_LIGHT_GREEN;
+                break;
+            case logger::Level::INFO:
+                color = Color::Code::FG_LIGHT_YELLOW;
+                break;
+            case logger::Level::WARNING:
+                color = Color::Code::FG_YELLOW;
+                break;
+            case logger::Level::ERROR:
+                color = Color::Code::FG_RED;
+                break;
+            case logger::Level::FATAL:
+                color = Color::Code::FG_LIGHT_RED;
+                break;
+            case logger::Level::VERBOSE:
+                color = Color::Code::FG_WHITE;
+                break;
+        }
+
+        return color;
+    }
+
+    std::optional<spdlog::level::level_enum> toSpdlogLevel(const logger::Level level) {
+        switch (level) {
+            case logger::Level::TRACE:
+                return spdlog::level::trace;
+            case logger::Level::DEBUG:
+            case logger::Level::VERBOSE:
+                return spdlog::level::debug;
+            case logger::Level::INFO:
+                return spdlog::level::info;
+            case logger::Level::WARNING:
+                return spdlog::level::warn;
+            case logger::Level::ERROR:
+                return spdlog::level::err;
+            case logger::Level::FATAL:
+                return spdlog::level::critical;
+        }
+        return std::nullopt;
+    }
+
+    std::optional<spdlog::level::level_enum> toSpdlogLevel(const logger::LogLevel level) {
+        switch (level) {
+            case logger::LogLevel::Trace:
+                return spdlog::level::trace;
+            case logger::LogLevel::Debug:
+                return spdlog::level::debug;
+            case logger::LogLevel::Info:
+                return spdlog::level::info;
+            case logger::LogLevel::Warn:
+                return spdlog::level::warn;
+            case logger::LogLevel::Error:
+                return spdlog::level::err;
+            case logger::LogLevel::Critical:
+                return spdlog::level::critical;
+            case logger::LogLevel::Off:
+                return std::nullopt;
+        }
+        return std::nullopt;
+    }
+} // namespace
+
+namespace logger::detail {
+
+    class SpdlogBackend::Impl {
+    public:
+        class TickFlagFormatter final : public spdlog::custom_flag_formatter {
+        public:
+            explicit TickFlagFormatter(const Impl& backend)
+                : backend(backend) {
+            }
+
+            void format(const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override {
+                const std::string tick = backend.tick();
+                dest.append(tick.data(), tick.data() + static_cast<std::ptrdiff_t>(tick.size()));
+            }
+
+            std::unique_ptr<custom_flag_formatter> clone() const override {
+                return spdlog::details::make_unique<TickFlagFormatter>(backend);
+            }
+
+        private:
+            const Impl& backend;
+        };
+
+        void init() {
+            startTime = Clock::now();
+            stdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
+            stdoutLogger = std::make_shared<spdlog::logger>("snodec-stdout", stdoutSink);
+            stdoutLogger->set_level(spdlog::level::trace);
+            stdoutLogger->set_formatter(legacyFormatter());
+
+            semanticStdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
+            semanticStdoutLogger = std::make_shared<spdlog::logger>("snodec-semantic-stdout", semanticStdoutSink);
+            semanticStdoutLogger->set_level(spdlog::level::trace);
+            semanticStdoutLogger->set_pattern("%v");
+
+            disableLogFile();
+            quietMode = false;
+            disableColor = ::isatty(::fileno(stdout)) == 0;
+            configuredVerboseLevel = 0;
+            configuredLogLevel = 0;
+        }
+
+        void setLogFile(const std::string& logFile) {
+            constexpr std::size_t maxSize = 2 * 1024 * 1024;
+            constexpr std::size_t maxFiles = 3;
+
+            fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
+            fileLogger = std::make_shared<spdlog::logger>("snodec-file", fileSink);
+            fileLogger->set_level(spdlog::level::trace);
+            fileLogger->set_formatter(legacyFormatter());
+
+            semanticFileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
+            semanticFileLogger = std::make_shared<spdlog::logger>("snodec-semantic-file", semanticFileSink);
+            semanticFileLogger->set_level(spdlog::level::trace);
+            semanticFileLogger->set_pattern("%v");
+        }
+
+        void disableLogFile() {
+            semanticFileLogger.reset();
+            semanticFileSink.reset();
+            fileLogger.reset();
+            fileSink.reset();
+        }
+
+        bool shouldLog(const Level level) const {
+            if (level == Level::VERBOSE) {
+                return true;
+            }
+
+            switch (configuredLogLevel) {
+                case 6:
+                    return true;
+                case 5:
+                    return level != Level::TRACE;
+                case 4:
+                    return level == Level::INFO || level == Level::WARNING || level == Level::ERROR || level == Level::FATAL;
+                case 3:
+                    return level == Level::WARNING || level == Level::ERROR || level == Level::FATAL;
+                case 2:
+                    return level == Level::ERROR || level == Level::FATAL;
+                case 1:
+                    return level == Level::FATAL;
+                default:
+                    return false;
+            }
+        }
+
+        bool shouldVerbose(const int verboseLevel) const {
+            return verboseLevel >= 0 && verboseLevel <= configuredVerboseLevel;
+        }
+
+        void emitLegacy(const Level level, std::string message, const bool withErrno, const int errnoValue) {
+            if (!shouldLog(level)) {
+                return;
+            }
+
+            if (withErrno) {
+                message += ": ";
+                message += std::strerror(errnoValue);
+            }
+
+            if (level != Level::VERBOSE) {
+                message = colorizeLevel(level) + " " + message;
+            }
+
+            const auto spdlogLevel = toSpdlogLevel(level).value_or(spdlog::level::info);
+            emit(stdoutLogger, !quietMode, spdlogLevel, message);
+            emit(fileLogger, true, spdlogLevel, message);
+        }
+
+        void emitSemantic(const LogLevel level, const std::string& formattedRecord) {
+            const auto spdlogLevel = toSpdlogLevel(level);
+            if (!spdlogLevel) {
+                return;
+            }
+
+            emit(semanticStdoutLogger, !quietMode, *spdlogLevel, formattedRecord);
+            emit(semanticFileLogger, true, *spdlogLevel, formattedRecord);
+        }
+
+        std::string tick() const {
+            if (tickResolver) {
+                return tickResolver();
+            }
+
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - startTime).count();
+            std::string result = std::to_string(elapsed);
+            if (result.size() < 13) {
+                result.insert(0, 13 - result.size(), '0');
+            }
+            return result;
+        }
+
+        std::string colorizeLevel(const Level level) const {
+            std::string label = levelName(level);
+
+            if (!disableColor) {
+                label = Color::Code::FG_DEFAULT + (levelColor(level) + label) + Color::Code::FG_DEFAULT;
+            }
+
+            return label;
+        }
+
+        std::unique_ptr<spdlog::formatter> legacyFormatter() const {
+            auto formatter = std::make_unique<spdlog::pattern_formatter>();
+            formatter->add_flag<TickFlagFormatter>('*', *this).set_pattern("%Y-%m-%d %H:%M:%S %* %v");
+            return formatter;
+        }
+
+        template <typename LevelT>
+        void emit(const std::shared_ptr<spdlog::logger>& logger, const bool enabled, const LevelT level, const std::string& message) const {
+            if (enabled && logger) {
+                logger->log(level, message);
+            }
+        }
+
+        std::shared_ptr<spdlog::sinks::stdout_color_sink_st> stdoutSink;
+        std::shared_ptr<spdlog::sinks::stdout_color_sink_st> semanticStdoutSink;
+        std::shared_ptr<spdlog::sinks::rotating_file_sink_st> fileSink;
+        std::shared_ptr<spdlog::sinks::rotating_file_sink_st> semanticFileSink;
+        std::shared_ptr<spdlog::logger> stdoutLogger;
+        std::shared_ptr<spdlog::logger> fileLogger;
+        std::shared_ptr<spdlog::logger> semanticStdoutLogger;
+        std::shared_ptr<spdlog::logger> semanticFileLogger;
+        TickResolver tickResolver;
+        Clock::time_point startTime = Clock::now();
+        int configuredLogLevel = 0;
+        int configuredVerboseLevel = 0;
+        bool quietMode = false;
+        bool disableColor = false;
+    };
+
+    SpdlogBackend::SpdlogBackend()
+        : impl(std::make_unique<Impl>()) {
+    }
+
+    SpdlogBackend::~SpdlogBackend() = default;
+
+    void SpdlogBackend::init() {
+        impl->init();
+    }
+
+    void SpdlogBackend::setTickResolver(TickResolver resolver) {
+        impl->tickResolver = std::move(resolver);
+    }
+
+    void SpdlogBackend::setLogLevel(const int level) {
+        impl->configuredLogLevel = level;
+    }
+
+    void SpdlogBackend::setVerboseLevel(const int level) {
+        impl->configuredVerboseLevel = std::max(0, level);
+    }
+
+    void SpdlogBackend::setQuiet(const bool quiet) {
+        impl->quietMode = quiet;
+    }
+
+    void SpdlogBackend::setDisableColor(const bool disableColor) {
+        impl->disableColor = disableColor;
+    }
+
+    bool SpdlogBackend::getDisableColor() const {
+        return impl->disableColor;
+    }
+
+    void SpdlogBackend::setLogFile(const std::string& logFile) {
+        impl->setLogFile(logFile);
+    }
+
+    void SpdlogBackend::disableLogFile() {
+        impl->disableLogFile();
+    }
+
+    bool SpdlogBackend::shouldLog(const Level level) const {
+        return impl->shouldLog(level);
+    }
+
+    bool SpdlogBackend::shouldVerbose(const int verboseLevel) const {
+        return impl->shouldVerbose(verboseLevel);
+    }
+
+    void SpdlogBackend::emitLegacy(const Level level, std::string message, const bool withErrno, const int errnoValue) {
+        impl->emitLegacy(level, std::move(message), withErrno, errnoValue);
+    }
+
+    void SpdlogBackend::emitSemantic(const LogLevel level, const std::string& formattedRecord) {
+        impl->emitSemantic(level, formattedRecord);
+    }
+
+} // namespace logger::detail

--- a/src/log/detail/SpdlogBackend.h
+++ b/src/log/detail/SpdlogBackend.h
@@ -1,0 +1,63 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ */
+
+#ifndef LOGGER_DETAIL_SPDLOGBACKEND_H
+#define LOGGER_DETAIL_SPDLOGBACKEND_H
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace logger {
+
+    enum class Level;
+    enum class LogLevel;
+
+    namespace detail {
+
+        class SpdlogBackend {
+        public:
+            using TickResolver = std::function<std::string()>;
+
+            SpdlogBackend();
+            ~SpdlogBackend();
+
+            SpdlogBackend(const SpdlogBackend&) = delete;
+            SpdlogBackend& operator=(const SpdlogBackend&) = delete;
+            SpdlogBackend(SpdlogBackend&&) = delete;
+            SpdlogBackend& operator=(SpdlogBackend&&) = delete;
+
+            void init();
+            void setTickResolver(TickResolver resolver);
+            void setLogLevel(int level);
+            void setVerboseLevel(int level);
+            void setQuiet(bool quiet);
+            void setDisableColor(bool disableColor);
+            bool getDisableColor() const;
+
+            void setLogFile(const std::string& logFile);
+            void disableLogFile();
+
+            bool shouldLog(Level level) const;
+            bool shouldVerbose(int verboseLevel) const;
+
+            void emitLegacy(Level level, std::string message, bool withErrno, int errnoValue);
+            void emitSemantic(LogLevel level, const std::string& formattedRecord);
+
+        private:
+            class Impl;
+
+            std::unique_ptr<Impl> impl;
+        };
+
+    } // namespace detail
+} // namespace logger
+
+#endif // LOGGER_DETAIL_SPDLOGBACKEND_H


### PR DESCRIPTION
### Motivation
- SNode.C already uses `spdlog`, but `Logger.cpp` mixed backend state and sink setup with the semantic and legacy logging facade making the implementation hard to maintain.
- Introduce a clear backend boundary so `spdlog` owns how/where already-formatted lines are emitted while SNode.C keeps owning semantic policy, formatting and public API.

### Description
- Added an internal backend abstraction `logger::detail::SpdlogBackend` (header + implementation) and moved stdout/file sinks, rotating file setup, tick formatting, quiet/color state, and backend logger ownership into it (`src/log/detail/SpdlogBackend.h`, `src/log/detail/SpdlogBackend.cpp`).
- Simplified `Logger.cpp` into a stable facade that delegates initialization, tick resolver, quiet/color toggles, file enable/disable, legacy emission and level/verbose checks to the backend while preserving `LogManager`/`LogRecord` semantics and public APIs.
- Preserved semantic behavior by keeping `LogManager::shouldEmit()` and `LogManager::formatRecord()` in the semantic layer and passing the already-formatted semantic line to the backend for emission.
- Updated `src/log/CMakeLists.txt` to compile and install the new backend source/header and retained synchronous emission (no async mode introduced). 

### Testing
- Ran `cmake -S . -B cmake-build` which configured the project successfully. 
- Ran `cmake --build cmake-build --parallel 2` which built the project successfully. 
- Ran `ctest --test-dir cmake-build -R "Log|Semantic" --output-on-failure` which executed and reported `No tests were found!!!` for the focused logging regex. 
- Ran `ctest --test-dir cmake-build --output-on-failure` which executed and reported `No tests were found!!!` for the full test run in this build tree. 
- Ran `git diff --check` to validate whitespace and patch issues and it returned clean. 
- Ran `clang-format -i src/log/Logger.cpp src/log/detail/SpdlogBackend.cpp src/log/detail/SpdlogBackend.h` to format touched files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fc6f69e44832ca47dd3ae87aea119)