### PR TITLE
Consolidate logging output behind spdlog backend

### DIFF
--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -65,9 +65,9 @@ FetchContent_MakeAvailable(spdlog)
 
 set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${TMP_CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
 
-set(LOGGER_CPP Logger.cpp SemanticLogger.cpp LogScopeOwner.cpp)
+set(LOGGER_CPP Logger.cpp SemanticLogger.cpp LogScopeOwner.cpp detail/SpdlogBackend.cpp)
 
-set(LOGGER_H Logger.h SemanticLogger.h LogScopeOwner.h)
+set(LOGGER_H Logger.h SemanticLogger.h LogScopeOwner.h detail/SpdlogBackend.h)
 
 set(TMP_CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
 unset(CMAKE_CXX_INCLUDE_WHAT_YOU_USE)

--- a/src/log/Logger.cpp
+++ b/src/log/Logger.cpp
@@ -44,281 +44,63 @@
 #include "log/Logger.h"
 
 #include "log/SemanticLogger.h"
+#include "log/detail/SpdlogBackend.h"
 
-#include <algorithm>
 #include <cerrno>
-#include <chrono>
-#include <cstring>
-#include <optional>
-#include <spdlog/logger.h>
-#include <spdlog/pattern_formatter.h>
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/rotating_file_sink.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <unistd.h>
+#include <utility>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace {
-    std::shared_ptr<spdlog::sinks::stdout_color_sink_st> stdoutSink;
-    std::shared_ptr<spdlog::sinks::stdout_color_sink_st> semanticStdoutSink;
-    std::shared_ptr<spdlog::sinks::rotating_file_sink_st> fileSink;
-    std::shared_ptr<spdlog::sinks::rotating_file_sink_st> semanticFileSink;
-    std::shared_ptr<spdlog::logger> stdoutLogger;
-    std::shared_ptr<spdlog::logger> fileLogger;
-    std::shared_ptr<spdlog::logger> semanticStdoutLogger;
-    std::shared_ptr<spdlog::logger> semanticFileLogger;
-
-    int configuredLogLevel = 0;
-    int configuredVerboseLevel = 0;
-    bool quietMode = false;
-    logger::Logger::TickResolver tickResolver;
-
-    using Clock = std::chrono::steady_clock;
-    Clock::time_point startTime = Clock::now();
-
-    std::string defaultTick();
-
-    class TickFlagFormatter final : public spdlog::custom_flag_formatter {
-    public:
-        void format(const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override {
-            std::string tick = tickResolver ? tickResolver() : defaultTick();
-            dest.append(tick.data(), tick.data() + static_cast<std::ptrdiff_t>(tick.size()));
-        }
-
-        std::unique_ptr<custom_flag_formatter> clone() const override {
-            return spdlog::details::make_unique<TickFlagFormatter>();
-        }
-    };
-
-    std::string defaultTick() {
-        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - startTime).count();
-        std::string tick = std::to_string(elapsed);
-        if (tick.size() < 13) {
-            tick.insert(0, 13 - tick.size(), '0');
-        }
-        return tick;
-    }
-
-    std::string levelName(const logger::Level level) {
-        std::string result;
-
-        switch (level) {
-            case logger::Level::TRACE:
-                result = "TRACE  ";
-                break;
-            case logger::Level::DEBUG:
-                result = "DEBUG  ";
-                break;
-            case logger::Level::INFO:
-                result = "INFO   ";
-                break;
-            case logger::Level::WARNING:
-                result = "WARNING";
-                break;
-            case logger::Level::ERROR:
-                result = "ERROR  ";
-                break;
-            case logger::Level::FATAL:
-                result = "FATAL  ";
-                break;
-            case logger::Level::VERBOSE:
-                result = "VERBOSE";
-                break;
-        }
-
-        return result;
-    }
-
-    Color::Code levelColor(const logger::Level level) {
-        Color::Code color = Color::Code::FG_WHITE;
-
-        switch (level) {
-            case logger::Level::TRACE:
-                color = Color::Code::FG_MAGENTA; // +
-                break;
-            case logger::Level::DEBUG:
-                color = Color::Code::FG_LIGHT_GREEN; // +
-                break;
-            case logger::Level::INFO:
-                color = Color::Code::FG_LIGHT_YELLOW; // +
-                break;
-            case logger::Level::WARNING:
-                color = Color::Code::FG_YELLOW; // +
-                break;
-            case logger::Level::ERROR:
-                color = Color::Code::FG_RED; // +
-                break;
-            case logger::Level::FATAL:
-                color = Color::Code::FG_LIGHT_RED; // +
-                break;
-            case logger::Level::VERBOSE:
-                color = Color::Code::FG_WHITE;
-                break;
-        }
-
-        return color;
-    }
-
-    std::string colorizeLevel(const logger::Level level) {
-        std::string label = levelName(level);
-
-        if (!logger::Logger::getDisableColor()) {
-            label = Color::Code::FG_DEFAULT + (levelColor(level) + label) + Color::Code::FG_DEFAULT;
-        }
-
-        return label;
-    }
-
-    std::optional<logger::Level> mapSemanticLevel(const logger::LogLevel level) {
-        switch (level) {
-            case logger::LogLevel::Trace:
-                return logger::Level::TRACE;
-            case logger::LogLevel::Debug:
-                return logger::Level::DEBUG;
-            case logger::LogLevel::Info:
-                return logger::Level::INFO;
-            case logger::LogLevel::Warn:
-                return logger::Level::WARNING;
-            case logger::LogLevel::Error:
-                return logger::Level::ERROR;
-            case logger::LogLevel::Critical:
-                return logger::Level::FATAL;
-            case logger::LogLevel::Off:
-                return std::nullopt;
-        }
-        return std::nullopt;
-    }
-
-    bool shouldEmit(const logger::Level level) {
-        if (level == logger::Level::VERBOSE) {
-            return true;
-        }
-
-        switch (configuredLogLevel) {
-            case 6:
-                return true;
-            case 5:
-                return level != logger::Level::TRACE;
-            case 4:
-                return level == logger::Level::INFO || level == logger::Level::WARNING || level == logger::Level::ERROR ||
-                       level == logger::Level::FATAL;
-            case 3:
-                return level == logger::Level::WARNING || level == logger::Level::ERROR || level == logger::Level::FATAL;
-            case 2:
-                return level == logger::Level::ERROR || level == logger::Level::FATAL;
-            case 1:
-                return level == logger::Level::FATAL;
-            default:
-                return false;
-        }
-    }
+    logger::detail::SpdlogBackend backend;
 } // namespace
 
 namespace logger {
 
     void Logger::init() {
-        startTime = Clock::now();
-        stdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
-        stdoutLogger = std::make_shared<spdlog::logger>("snodec-stdout", stdoutSink);
-        auto stdoutPattern = std::make_unique<spdlog::pattern_formatter>();
-        stdoutPattern->add_flag<TickFlagFormatter>('*').set_pattern("%Y-%m-%d %H:%M:%S %* %v");
-        stdoutLogger->set_formatter(std::move(stdoutPattern));
-        semanticStdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
-        semanticStdoutLogger = std::make_shared<spdlog::logger>("snodec-semantic-stdout", semanticStdoutSink);
-        semanticStdoutLogger->set_pattern("%v");
-
-        fileSink.reset();
-        semanticFileSink.reset();
-        fileLogger.reset();
-        semanticFileLogger.reset();
-        quietMode = false;
-        disableColorLog = ::isatty(::fileno(stdout)) == 0;
-        configuredVerboseLevel = 0;
-        configuredLogLevel = 0;
+        backend.init();
+        disableColorLog = backend.getDisableColor();
     }
 
     void Logger::setTickResolver(TickResolver resolver) {
-        tickResolver = std::move(resolver);
+        backend.setTickResolver(std::move(resolver));
     }
 
     void Logger::setLogLevel(int level) {
-        configuredLogLevel = level;
+        backend.setLogLevel(level);
     }
 
     void Logger::setVerboseLevel(int level) {
-        configuredVerboseLevel = std::max(0, level);
+        backend.setVerboseLevel(level);
     }
 
     void Logger::logToFile(const std::string& logFile) {
-        constexpr std::size_t maxSize = 2 * 1024 * 1024; // 2 MiB
-        constexpr std::size_t maxFiles = 3;              // keep log, log.1, log.2, log.3
-        fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
-        fileLogger = std::make_shared<spdlog::logger>("snodec-file", fileSink);
-        auto filePattern = std::make_unique<spdlog::pattern_formatter>();
-        filePattern->add_flag<TickFlagFormatter>('*').set_pattern("%Y-%m-%d %H:%M:%S %* %v");
-        fileLogger->set_formatter(std::move(filePattern));
-        semanticFileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
-        semanticFileLogger = std::make_shared<spdlog::logger>("snodec-semantic-file", semanticFileSink);
-        semanticFileLogger->set_pattern("%v");
+        backend.setLogFile(logFile);
     }
 
     void Logger::disableLogToFile() {
-        semanticFileLogger.reset();
-        semanticFileSink.reset();
-        fileLogger.reset();
-        fileSink.reset();
+        backend.disableLogFile();
     }
 
     void Logger::setQuiet(bool quiet) {
-        quietMode = quiet;
+        backend.setQuiet(quiet);
     }
 
     void Logger::setDisableColor(bool disableColor) {
+        backend.setDisableColor(disableColor);
         disableColorLog = disableColor;
     }
 
     bool Logger::getDisableColor() {
-        return disableColorLog;
+        return backend.getDisableColor();
     }
 
     bool Logger::shouldLog(Level level) {
-        return shouldEmit(level);
+        return backend.shouldLog(level);
     }
 
     bool Logger::shouldVerbose(int verboseLevel) {
-        return verboseLevel >= 0 && verboseLevel <= configuredVerboseLevel;
-    }
-
-    static void emitFormattedLine(const std::string& line) {
-        if (!quietMode && semanticStdoutLogger) {
-            semanticStdoutLogger->log(spdlog::level::info, line);
-        }
-        if (semanticFileLogger) {
-            semanticFileLogger->log(spdlog::level::info, line);
-        }
-    }
-
-    static void emitLine(Level level, std::string message, const bool withErrno, const int errnoValue) {
-        if (!shouldEmit(level)) {
-            return;
-        }
-
-        if (withErrno) {
-            message += ": ";
-            message += std::strerror(errnoValue);
-        }
-
-        if (level != Level::VERBOSE) {
-            message = colorizeLevel(level) + " " + message;
-        }
-
-        if (!quietMode && stdoutLogger) {
-            stdoutLogger->log(spdlog::level::info, message);
-        }
-        if (fileLogger) {
-            fileLogger->log(spdlog::level::info, message);
-        }
+        return backend.shouldVerbose(verboseLevel);
     }
 
     void Logger::emitSemantic(const LogRecord& record) {
@@ -326,11 +108,7 @@ namespace logger {
             return;
         }
 
-        if (!mapSemanticLevel(record.level)) {
-            return;
-        }
-
-        emitFormattedLine(LogManager::formatRecord(record));
+        backend.emitSemantic(record.level, LogManager::formatRecord(record));
     }
 
     BoundaryLogger::Sink Logger::semanticSink() {
@@ -351,7 +129,7 @@ namespace logger {
 
     LogMessage::~LogMessage() {
         if (enabled) {
-            emitLine(level, message.str(), withErrno, errnoValue);
+            backend.emitLegacy(level, message.str(), withErrno, errnoValue);
         }
     }
 

--- a/src/log/detail/SpdlogBackend.cpp
+++ b/src/log/detail/SpdlogBackend.cpp
@@ -1,0 +1,267 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include "log/detail/SpdlogBackend.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <optional>
+#include <spdlog/logger.h>
+#include <spdlog/pattern_formatter.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <unistd.h>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace {
+    using Clock = std::chrono::steady_clock;
+    Clock::time_point startTime = Clock::now();
+    ::logger::detail::SpdlogBackend* activeBackend = nullptr;
+
+    std::string defaultTick() {
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - startTime).count();
+        std::string tick = std::to_string(elapsed);
+        if (tick.size() < 13) {
+            tick.insert(0, 13 - tick.size(), '0');
+        }
+        return tick;
+    }
+
+    class TickFlagFormatter final : public spdlog::custom_flag_formatter {
+    public:
+        void format(const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override {
+            std::string tick = activeBackend != nullptr ? activeBackend->resolveTick() : defaultTick();
+            dest.append(tick.data(), tick.data() + static_cast<std::ptrdiff_t>(tick.size()));
+        }
+
+        std::unique_ptr<custom_flag_formatter> clone() const override {
+            return spdlog::details::make_unique<TickFlagFormatter>();
+        }
+    };
+
+    std::string levelName(const ::logger::Level level) {
+        switch (level) {
+            case ::logger::Level::TRACE:
+                return "TRACE  ";
+            case ::logger::Level::DEBUG:
+                return "DEBUG  ";
+            case ::logger::Level::INFO:
+                return "INFO   ";
+            case ::logger::Level::WARNING:
+                return "WARNING";
+            case ::logger::Level::ERROR:
+                return "ERROR  ";
+            case ::logger::Level::FATAL:
+                return "FATAL  ";
+            case ::logger::Level::VERBOSE:
+                return "VERBOSE";
+        }
+        return "";
+    }
+
+    Color::Code levelColor(const ::logger::Level level) {
+        switch (level) {
+            case ::logger::Level::TRACE:
+                return Color::Code::FG_MAGENTA;
+            case ::logger::Level::DEBUG:
+                return Color::Code::FG_LIGHT_GREEN;
+            case ::logger::Level::INFO:
+                return Color::Code::FG_LIGHT_YELLOW;
+            case ::logger::Level::WARNING:
+                return Color::Code::FG_YELLOW;
+            case ::logger::Level::ERROR:
+                return Color::Code::FG_RED;
+            case ::logger::Level::FATAL:
+                return Color::Code::FG_LIGHT_RED;
+            case ::logger::Level::VERBOSE:
+                return Color::Code::FG_WHITE;
+        }
+        return Color::Code::FG_WHITE;
+    }
+
+    spdlog::level::level_enum mapLegacyLevel(const ::logger::Level level) {
+        switch (level) {
+            case ::logger::Level::TRACE:
+                return spdlog::level::trace;
+            case ::logger::Level::DEBUG:
+                return spdlog::level::debug;
+            case ::logger::Level::INFO:
+                return spdlog::level::info;
+            case ::logger::Level::WARNING:
+                return spdlog::level::warn;
+            case ::logger::Level::ERROR:
+                return spdlog::level::err;
+            case ::logger::Level::FATAL:
+                return spdlog::level::critical;
+            case ::logger::Level::VERBOSE:
+                return spdlog::level::info;
+        }
+        return spdlog::level::info;
+    }
+
+    std::optional<spdlog::level::level_enum> mapSemanticLevel(const ::logger::LogLevel level) {
+        switch (level) {
+            case ::logger::LogLevel::Trace:
+                return spdlog::level::trace;
+            case ::logger::LogLevel::Debug:
+                return spdlog::level::debug;
+            case ::logger::LogLevel::Info:
+                return spdlog::level::info;
+            case ::logger::LogLevel::Warn:
+                return spdlog::level::warn;
+            case ::logger::LogLevel::Error:
+                return spdlog::level::err;
+            case ::logger::LogLevel::Critical:
+                return spdlog::level::critical;
+            case ::logger::LogLevel::Off:
+                return std::nullopt;
+        }
+        return std::nullopt;
+    }
+} // namespace
+
+namespace logger::detail {
+
+    void SpdlogBackend::init() {
+        activeBackend = this;
+        startTime = Clock::now();
+        stdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
+        stdoutLogger = std::make_shared<spdlog::logger>("snodec-stdout", stdoutSink);
+        stdoutLogger->set_level(spdlog::level::trace);
+        auto stdoutPattern = std::make_unique<spdlog::pattern_formatter>();
+        stdoutPattern->add_flag<TickFlagFormatter>('*').set_pattern("%Y-%m-%d %H:%M:%S %* %v");
+        stdoutLogger->set_formatter(std::move(stdoutPattern));
+
+        semanticStdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
+        semanticStdoutLogger = std::make_shared<spdlog::logger>("snodec-semantic-stdout", semanticStdoutSink);
+        semanticStdoutLogger->set_level(spdlog::level::trace);
+        semanticStdoutLogger->set_pattern("%v");
+
+        disableLogFile();
+        quietMode = false;
+        disableColor = ::isatty(::fileno(stdout)) == 0;
+        configuredVerboseLevel = 0;
+        configuredLogLevel = 0;
+    }
+
+    void SpdlogBackend::setQuiet(const bool quiet) {
+        quietMode = quiet;
+    }
+    void SpdlogBackend::setDisableColor(const bool disableColorValue) {
+        disableColor = disableColorValue;
+    }
+    bool SpdlogBackend::getDisableColor() const {
+        return disableColor;
+    }
+    void SpdlogBackend::setTickResolver(Logger::TickResolver resolver) {
+        tickResolver = std::move(resolver);
+    }
+    void SpdlogBackend::setLogLevel(const int level) {
+        configuredLogLevel = level;
+    }
+    void SpdlogBackend::setVerboseLevel(const int level) {
+        configuredVerboseLevel = std::max(0, level);
+    }
+    std::string SpdlogBackend::resolveTick() const {
+        return tickResolver ? tickResolver() : defaultTick();
+    }
+
+    void SpdlogBackend::setLogFile(const std::string& logFile) {
+        constexpr std::size_t maxSize = 2 * 1024 * 1024;
+        constexpr std::size_t maxFiles = 3;
+        fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
+        fileLogger = std::make_shared<spdlog::logger>("snodec-file", fileSink);
+        fileLogger->set_level(spdlog::level::trace);
+        auto filePattern = std::make_unique<spdlog::pattern_formatter>();
+        filePattern->add_flag<TickFlagFormatter>('*').set_pattern("%Y-%m-%d %H:%M:%S %* %v");
+        fileLogger->set_formatter(std::move(filePattern));
+
+        semanticFileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
+        semanticFileLogger = std::make_shared<spdlog::logger>("snodec-semantic-file", semanticFileSink);
+        semanticFileLogger->set_level(spdlog::level::trace);
+        semanticFileLogger->set_pattern("%v");
+    }
+
+    void SpdlogBackend::disableLogFile() {
+        semanticFileLogger.reset();
+        semanticFileSink.reset();
+        fileLogger.reset();
+        fileSink.reset();
+    }
+
+    bool SpdlogBackend::shouldLog(const Level level) const {
+        if (level == Level::VERBOSE) {
+            return true;
+        }
+        switch (configuredLogLevel) {
+            case 6:
+                return true;
+            case 5:
+                return level != Level::TRACE;
+            case 4:
+                return level == Level::INFO || level == Level::WARNING || level == Level::ERROR || level == Level::FATAL;
+            case 3:
+                return level == Level::WARNING || level == Level::ERROR || level == Level::FATAL;
+            case 2:
+                return level == Level::ERROR || level == Level::FATAL;
+            case 1:
+                return level == Level::FATAL;
+            default:
+                return false;
+        }
+    }
+
+    bool SpdlogBackend::shouldVerbose(const int verboseLevel) const {
+        return verboseLevel >= 0 && verboseLevel <= configuredVerboseLevel;
+    }
+
+    void SpdlogBackend::emitLegacy(const Level level, std::string message, const bool withErrno, const int errnoValue) {
+        if (!shouldLog(level)) {
+            return;
+        }
+        if (withErrno) {
+            message += ": ";
+            message += std::strerror(errnoValue);
+        }
+        if (level != Level::VERBOSE) {
+            std::string label = levelName(level);
+            if (!disableColor) {
+                label = Color::Code::FG_DEFAULT + (levelColor(level) + label) + Color::Code::FG_DEFAULT;
+            }
+            message = label + " " + message;
+        }
+        const auto spdlogLevel = mapLegacyLevel(level);
+        if (!quietMode && stdoutLogger) {
+            stdoutLogger->log(spdlogLevel, message);
+        }
+        if (fileLogger) {
+            fileLogger->log(spdlogLevel, message);
+        }
+    }
+
+    void SpdlogBackend::emitSemantic(const LogLevel level, const std::string& formattedRecord) {
+        const auto spdlogLevel = mapSemanticLevel(level);
+        if (!spdlogLevel) {
+            return;
+        }
+        if (!quietMode && semanticStdoutLogger) {
+            semanticStdoutLogger->log(*spdlogLevel, formattedRecord);
+        }
+        if (semanticFileLogger) {
+            semanticFileLogger->log(*spdlogLevel, formattedRecord);
+        }
+    }
+
+} // namespace logger::detail

--- a/src/log/detail/SpdlogBackend.cpp
+++ b/src/log/detail/SpdlogBackend.cpp
@@ -22,34 +22,12 @@
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <unistd.h>
+#include <utility>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace {
     using Clock = std::chrono::steady_clock;
-    Clock::time_point startTime = Clock::now();
-    ::logger::detail::SpdlogBackend* activeBackend = nullptr;
-
-    std::string defaultTick() {
-        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - startTime).count();
-        std::string tick = std::to_string(elapsed);
-        if (tick.size() < 13) {
-            tick.insert(0, 13 - tick.size(), '0');
-        }
-        return tick;
-    }
-
-    class TickFlagFormatter final : public spdlog::custom_flag_formatter {
-    public:
-        void format(const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override {
-            std::string tick = activeBackend != nullptr ? activeBackend->resolveTick() : defaultTick();
-            dest.append(tick.data(), tick.data() + static_cast<std::ptrdiff_t>(tick.size()));
-        }
-
-        std::unique_ptr<custom_flag_formatter> clone() const override {
-            return spdlog::details::make_unique<TickFlagFormatter>();
-        }
-    };
 
     std::string levelName(const ::logger::Level level) {
         switch (level) {
@@ -134,134 +112,247 @@ namespace {
 
 namespace logger::detail {
 
+    class SpdlogBackend::Impl {
+    public:
+        class TickFlagFormatter final : public spdlog::custom_flag_formatter {
+        public:
+            explicit TickFlagFormatter(const Impl& backend)
+                : backend(backend) {
+            }
+
+            void format(const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override {
+                const std::string tick = backend.tick();
+                dest.append(tick.data(), tick.data() + static_cast<std::ptrdiff_t>(tick.size()));
+            }
+
+            std::unique_ptr<custom_flag_formatter> clone() const override {
+                return spdlog::details::make_unique<TickFlagFormatter>(backend);
+            }
+
+        private:
+            const Impl& backend;
+        };
+
+        void init() {
+            startTime = Clock::now();
+            stdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
+            stdoutLogger = std::make_shared<spdlog::logger>("snodec-stdout", stdoutSink);
+            stdoutLogger->set_level(spdlog::level::trace);
+            stdoutLogger->set_formatter(legacyFormatter());
+
+            semanticStdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
+            semanticStdoutLogger = std::make_shared<spdlog::logger>("snodec-semantic-stdout", semanticStdoutSink);
+            semanticStdoutLogger->set_level(spdlog::level::trace);
+            semanticStdoutLogger->set_pattern("%v");
+
+            disableLogFile();
+            quietMode = false;
+            disableColor = ::isatty(::fileno(stdout)) == 0;
+            configuredVerboseLevel = 0;
+            configuredLogLevel = 0;
+        }
+
+        void setQuiet(const bool quiet) {
+            quietMode = quiet;
+        }
+
+        void setDisableColor(const bool disableColorValue) {
+            disableColor = disableColorValue;
+        }
+
+        bool getDisableColor() const {
+            return disableColor;
+        }
+
+        void setTickResolver(Logger::TickResolver resolver) {
+            tickResolver = std::move(resolver);
+        }
+
+        void setLogLevel(const int level) {
+            configuredLogLevel = level;
+        }
+
+        void setVerboseLevel(const int level) {
+            configuredVerboseLevel = std::max(0, level);
+        }
+
+        void setLogFile(const std::string& logFile) {
+            constexpr std::size_t maxSize = 2 * 1024 * 1024;
+            constexpr std::size_t maxFiles = 3;
+            fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
+            fileLogger = std::make_shared<spdlog::logger>("snodec-file", fileSink);
+            fileLogger->set_level(spdlog::level::trace);
+            fileLogger->set_formatter(legacyFormatter());
+
+            semanticFileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
+            semanticFileLogger = std::make_shared<spdlog::logger>("snodec-semantic-file", semanticFileSink);
+            semanticFileLogger->set_level(spdlog::level::trace);
+            semanticFileLogger->set_pattern("%v");
+        }
+
+        void disableLogFile() {
+            semanticFileLogger.reset();
+            semanticFileSink.reset();
+            fileLogger.reset();
+            fileSink.reset();
+        }
+
+        bool shouldLog(const Level level) const {
+            if (level == Level::VERBOSE) {
+                return true;
+            }
+            switch (configuredLogLevel) {
+                case 6:
+                    return true;
+                case 5:
+                    return level != Level::TRACE;
+                case 4:
+                    return level == Level::INFO || level == Level::WARNING || level == Level::ERROR || level == Level::FATAL;
+                case 3:
+                    return level == Level::WARNING || level == Level::ERROR || level == Level::FATAL;
+                case 2:
+                    return level == Level::ERROR || level == Level::FATAL;
+                case 1:
+                    return level == Level::FATAL;
+                default:
+                    return false;
+            }
+        }
+
+        bool shouldVerbose(const int verboseLevel) const {
+            return verboseLevel >= 0 && verboseLevel <= configuredVerboseLevel;
+        }
+
+        void emitLegacy(const Level level, std::string message, const bool withErrno, const int errnoValue) {
+            if (!shouldLog(level)) {
+                return;
+            }
+            if (withErrno) {
+                message += ": ";
+                message += std::strerror(errnoValue);
+            }
+            if (level != Level::VERBOSE) {
+                std::string label = levelName(level);
+                if (!disableColor) {
+                    label = Color::Code::FG_DEFAULT + (levelColor(level) + label) + Color::Code::FG_DEFAULT;
+                }
+                message = label + " " + message;
+            }
+            const auto spdlogLevel = mapLegacyLevel(level);
+            if (!quietMode && stdoutLogger) {
+                stdoutLogger->log(spdlogLevel, message);
+            }
+            if (fileLogger) {
+                fileLogger->log(spdlogLevel, message);
+            }
+        }
+
+        void emitSemantic(const LogLevel level, const std::string& formattedRecord) {
+            const auto spdlogLevel = mapSemanticLevel(level);
+            if (!spdlogLevel) {
+                return;
+            }
+            if (!quietMode && semanticStdoutLogger) {
+                semanticStdoutLogger->log(*spdlogLevel, formattedRecord);
+            }
+            if (semanticFileLogger) {
+                semanticFileLogger->log(*spdlogLevel, formattedRecord);
+            }
+        }
+
+        std::string tick() const {
+            if (tickResolver) {
+                return tickResolver();
+            }
+
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - startTime).count();
+            std::string tick = std::to_string(elapsed);
+            if (tick.size() < 13) {
+                tick.insert(0, 13 - tick.size(), '0');
+            }
+            return tick;
+        }
+
+        std::unique_ptr<spdlog::formatter> legacyFormatter() const {
+            auto formatter = std::make_unique<spdlog::pattern_formatter>();
+            formatter->add_flag<TickFlagFormatter>('*', *this).set_pattern("%Y-%m-%d %H:%M:%S %* %v");
+            return formatter;
+        }
+
+    private:
+        std::shared_ptr<spdlog::sinks::stdout_color_sink_st> stdoutSink;
+        std::shared_ptr<spdlog::sinks::stdout_color_sink_st> semanticStdoutSink;
+        std::shared_ptr<spdlog::sinks::rotating_file_sink_st> fileSink;
+        std::shared_ptr<spdlog::sinks::rotating_file_sink_st> semanticFileSink;
+        std::shared_ptr<spdlog::logger> stdoutLogger;
+        std::shared_ptr<spdlog::logger> fileLogger;
+        std::shared_ptr<spdlog::logger> semanticStdoutLogger;
+        std::shared_ptr<spdlog::logger> semanticFileLogger;
+
+        Logger::TickResolver tickResolver;
+        Clock::time_point startTime = Clock::now();
+        int configuredLogLevel = 0;
+        int configuredVerboseLevel = 0;
+        bool quietMode = false;
+        bool disableColor = false;
+    };
+
+    SpdlogBackend::SpdlogBackend()
+        : impl_(std::make_unique<Impl>()) {
+    }
+
+    SpdlogBackend::~SpdlogBackend() = default;
+
     void SpdlogBackend::init() {
-        activeBackend = this;
-        startTime = Clock::now();
-        stdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
-        stdoutLogger = std::make_shared<spdlog::logger>("snodec-stdout", stdoutSink);
-        stdoutLogger->set_level(spdlog::level::trace);
-        auto stdoutPattern = std::make_unique<spdlog::pattern_formatter>();
-        stdoutPattern->add_flag<TickFlagFormatter>('*').set_pattern("%Y-%m-%d %H:%M:%S %* %v");
-        stdoutLogger->set_formatter(std::move(stdoutPattern));
-
-        semanticStdoutSink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
-        semanticStdoutLogger = std::make_shared<spdlog::logger>("snodec-semantic-stdout", semanticStdoutSink);
-        semanticStdoutLogger->set_level(spdlog::level::trace);
-        semanticStdoutLogger->set_pattern("%v");
-
-        disableLogFile();
-        quietMode = false;
-        disableColor = ::isatty(::fileno(stdout)) == 0;
-        configuredVerboseLevel = 0;
-        configuredLogLevel = 0;
+        impl_->init();
     }
 
     void SpdlogBackend::setQuiet(const bool quiet) {
-        quietMode = quiet;
+        impl_->setQuiet(quiet);
     }
-    void SpdlogBackend::setDisableColor(const bool disableColorValue) {
-        disableColor = disableColorValue;
+
+    void SpdlogBackend::setDisableColor(const bool disableColor) {
+        impl_->setDisableColor(disableColor);
     }
+
     bool SpdlogBackend::getDisableColor() const {
-        return disableColor;
+        return impl_->getDisableColor();
     }
+
     void SpdlogBackend::setTickResolver(Logger::TickResolver resolver) {
-        tickResolver = std::move(resolver);
-    }
-    void SpdlogBackend::setLogLevel(const int level) {
-        configuredLogLevel = level;
-    }
-    void SpdlogBackend::setVerboseLevel(const int level) {
-        configuredVerboseLevel = std::max(0, level);
-    }
-    std::string SpdlogBackend::resolveTick() const {
-        return tickResolver ? tickResolver() : defaultTick();
+        impl_->setTickResolver(std::move(resolver));
     }
 
     void SpdlogBackend::setLogFile(const std::string& logFile) {
-        constexpr std::size_t maxSize = 2 * 1024 * 1024;
-        constexpr std::size_t maxFiles = 3;
-        fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
-        fileLogger = std::make_shared<spdlog::logger>("snodec-file", fileSink);
-        fileLogger->set_level(spdlog::level::trace);
-        auto filePattern = std::make_unique<spdlog::pattern_formatter>();
-        filePattern->add_flag<TickFlagFormatter>('*').set_pattern("%Y-%m-%d %H:%M:%S %* %v");
-        fileLogger->set_formatter(std::move(filePattern));
-
-        semanticFileSink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(logFile, maxSize, maxFiles);
-        semanticFileLogger = std::make_shared<spdlog::logger>("snodec-semantic-file", semanticFileSink);
-        semanticFileLogger->set_level(spdlog::level::trace);
-        semanticFileLogger->set_pattern("%v");
+        impl_->setLogFile(logFile);
     }
 
     void SpdlogBackend::disableLogFile() {
-        semanticFileLogger.reset();
-        semanticFileSink.reset();
-        fileLogger.reset();
-        fileSink.reset();
-    }
-
-    bool SpdlogBackend::shouldLog(const Level level) const {
-        if (level == Level::VERBOSE) {
-            return true;
-        }
-        switch (configuredLogLevel) {
-            case 6:
-                return true;
-            case 5:
-                return level != Level::TRACE;
-            case 4:
-                return level == Level::INFO || level == Level::WARNING || level == Level::ERROR || level == Level::FATAL;
-            case 3:
-                return level == Level::WARNING || level == Level::ERROR || level == Level::FATAL;
-            case 2:
-                return level == Level::ERROR || level == Level::FATAL;
-            case 1:
-                return level == Level::FATAL;
-            default:
-                return false;
-        }
-    }
-
-    bool SpdlogBackend::shouldVerbose(const int verboseLevel) const {
-        return verboseLevel >= 0 && verboseLevel <= configuredVerboseLevel;
+        impl_->disableLogFile();
     }
 
     void SpdlogBackend::emitLegacy(const Level level, std::string message, const bool withErrno, const int errnoValue) {
-        if (!shouldLog(level)) {
-            return;
-        }
-        if (withErrno) {
-            message += ": ";
-            message += std::strerror(errnoValue);
-        }
-        if (level != Level::VERBOSE) {
-            std::string label = levelName(level);
-            if (!disableColor) {
-                label = Color::Code::FG_DEFAULT + (levelColor(level) + label) + Color::Code::FG_DEFAULT;
-            }
-            message = label + " " + message;
-        }
-        const auto spdlogLevel = mapLegacyLevel(level);
-        if (!quietMode && stdoutLogger) {
-            stdoutLogger->log(spdlogLevel, message);
-        }
-        if (fileLogger) {
-            fileLogger->log(spdlogLevel, message);
-        }
+        impl_->emitLegacy(level, std::move(message), withErrno, errnoValue);
     }
 
     void SpdlogBackend::emitSemantic(const LogLevel level, const std::string& formattedRecord) {
-        const auto spdlogLevel = mapSemanticLevel(level);
-        if (!spdlogLevel) {
-            return;
-        }
-        if (!quietMode && semanticStdoutLogger) {
-            semanticStdoutLogger->log(*spdlogLevel, formattedRecord);
-        }
-        if (semanticFileLogger) {
-            semanticFileLogger->log(*spdlogLevel, formattedRecord);
-        }
+        impl_->emitSemantic(level, formattedRecord);
+    }
+
+    bool SpdlogBackend::shouldLog(const Level level) const {
+        return impl_->shouldLog(level);
+    }
+
+    bool SpdlogBackend::shouldVerbose(const int verboseLevel) const {
+        return impl_->shouldVerbose(verboseLevel);
+    }
+
+    void SpdlogBackend::setLogLevel(const int level) {
+        impl_->setLogLevel(level);
+    }
+
+    void SpdlogBackend::setVerboseLevel(const int level) {
+        impl_->setVerboseLevel(level);
     }
 
 } // namespace logger::detail

--- a/src/log/detail/SpdlogBackend.h
+++ b/src/log/detail/SpdlogBackend.h
@@ -17,19 +17,22 @@
 #include "log/Logger.h"
 
 #include <memory>
-#include <spdlog/sinks/sink.h>
 #include <string>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
-
-namespace spdlog {
-    class logger;
-} // namespace spdlog
 
 namespace logger::detail {
 
     class SpdlogBackend {
     public:
+        SpdlogBackend();
+        ~SpdlogBackend();
+
+        SpdlogBackend(const SpdlogBackend&) = delete;
+        SpdlogBackend& operator=(const SpdlogBackend&) = delete;
+        SpdlogBackend(SpdlogBackend&&) = delete;
+        SpdlogBackend& operator=(SpdlogBackend&&) = delete;
+
         void init();
 
         void setQuiet(bool quiet);
@@ -49,23 +52,10 @@ namespace logger::detail {
 
         void setLogLevel(int level);
         void setVerboseLevel(int level);
-        std::string resolveTick() const;
 
     private:
-        std::shared_ptr<spdlog::sinks::sink> stdoutSink;
-        std::shared_ptr<spdlog::sinks::sink> semanticStdoutSink;
-        std::shared_ptr<spdlog::sinks::sink> fileSink;
-        std::shared_ptr<spdlog::sinks::sink> semanticFileSink;
-        std::shared_ptr<spdlog::logger> stdoutLogger;
-        std::shared_ptr<spdlog::logger> fileLogger;
-        std::shared_ptr<spdlog::logger> semanticStdoutLogger;
-        std::shared_ptr<spdlog::logger> semanticFileLogger;
-
-        Logger::TickResolver tickResolver;
-        int configuredLogLevel = 0;
-        int configuredVerboseLevel = 0;
-        bool quietMode = false;
-        bool disableColor = false;
+        class Impl;
+        std::unique_ptr<Impl> impl_;
     };
 
 } // namespace logger::detail

--- a/src/log/detail/SpdlogBackend.h
+++ b/src/log/detail/SpdlogBackend.h
@@ -1,0 +1,73 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *               2020, 2021, 2022, 2023, 2024, 2025, 2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef LOGGER_DETAIL_SPDLOGBACKEND_H
+#define LOGGER_DETAIL_SPDLOGBACKEND_H
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#include "log/Logger.h"
+
+#include <memory>
+#include <spdlog/sinks/sink.h>
+#include <string>
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+namespace spdlog {
+    class logger;
+} // namespace spdlog
+
+namespace logger::detail {
+
+    class SpdlogBackend {
+    public:
+        void init();
+
+        void setQuiet(bool quiet);
+        void setDisableColor(bool disableColor);
+        bool getDisableColor() const;
+
+        void setTickResolver(Logger::TickResolver resolver);
+
+        void setLogFile(const std::string& logFile);
+        void disableLogFile();
+
+        void emitLegacy(Level level, std::string message, bool withErrno, int errnoValue);
+        void emitSemantic(LogLevel level, const std::string& formattedRecord);
+
+        bool shouldLog(Level level) const;
+        bool shouldVerbose(int verboseLevel) const;
+
+        void setLogLevel(int level);
+        void setVerboseLevel(int level);
+        std::string resolveTick() const;
+
+    private:
+        std::shared_ptr<spdlog::sinks::sink> stdoutSink;
+        std::shared_ptr<spdlog::sinks::sink> semanticStdoutSink;
+        std::shared_ptr<spdlog::sinks::sink> fileSink;
+        std::shared_ptr<spdlog::sinks::sink> semanticFileSink;
+        std::shared_ptr<spdlog::logger> stdoutLogger;
+        std::shared_ptr<spdlog::logger> fileLogger;
+        std::shared_ptr<spdlog::logger> semanticStdoutLogger;
+        std::shared_ptr<spdlog::logger> semanticFileLogger;
+
+        Logger::TickResolver tickResolver;
+        int configuredLogLevel = 0;
+        int configuredVerboseLevel = 0;
+        bool quietMode = false;
+        bool disableColor = false;
+    };
+
+} // namespace logger::detail
+
+#endif // LOGGER_DETAIL_SPDLOGBACKEND_H


### PR DESCRIPTION
### Motivation
- SNode.C already uses spdlog but `Logger.cpp` mixed backend state with the semantic/legacy facade logic; this change makes spdlog the explicit backend layer while preserving SNode.C's semantic logging API and behavior.
- Centralize stdout/file sink ownership, quiet/color policy and rotating-file setup behind a single internal backend to reduce scattered global state and simplify `Logger.cpp` without changing public APIs or semantic policy.

### Description
- Added an internal backend `logger::detail::SpdlogBackend` (`src/log/detail/SpdlogBackend.h/.cpp`) which owns spdlog sinks, backend loggers, tick resolution, quiet/color state, file setup, and legacy/semantic emission logic.
- Simplified `src/log/Logger.cpp` so the public facade delegates to the backend for initialization, tick resolver, log-level/verbose controls, file controls, quiet/color toggles, and emission (`emitSemantic` still uses `LogManager::formatRecord` and `LogManager::shouldEmit`).
- Preserved SNode.C semantic/legacy responsibilities: `LogRecord` formatting remains in `LogManager`, numeric legacy-level and `VLOG/PLOG/LOG` behavior remain unchanged, and `PLOG()` still captures `errno` at message construction time.
- Registered the new backend sources in `src/log/CMakeLists.txt` and formatted touched files with `clang-format`.

### Testing
- Configured the project with tests/apps enabled: `rm -rf cmake-build && cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON`; initial configure failed due to missing `nlohmann_json` and was resolved by installing the package `nlohmann-json3-dev` via `apt-get install -y nlohmann-json3-dev`.
- Built the project: `cmake --build cmake-build --parallel 2` and the build completed successfully (logger target and tests built).
- Ran focused logging/semantic tests: `ctest --test-dir cmake-build -R "Log|Semantic|Logger" --output-on-failure` — result: all focused tests passed (17/17).
- Ran the full test suite: `ctest --test-dir cmake-build --output-on-failure` — result: all reported tests passed (141/141); CTest reported a number of environment-gated/long-running component tests as skipped which is expected in this run.
- Ran formatting/checks: `clang-format -i src/log/Logger.cpp src/log/detail/SpdlogBackend.h src/log/detail/SpdlogBackend.cpp` and `git diff --check` — no whitespace/format issues.

Files changed or added (key):
- Modified: `src/log/Logger.cpp`, `src/log/CMakeLists.txt`.
- Added: `src/log/detail/SpdlogBackend.h`, `src/log/detail/SpdlogBackend.cpp`.

This PR focuses only on consolidating spdlog backend ownership and reducing backend glue inside `Logger.cpp`; it does not change the public semantic logging API, semantic formatting policy, legacy level precedence, or introduce async logging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fe3b68a0c832c826f9e869db26d1e)