### PR TITLE
Clean semantic log identity and improve text output

### DIFF
--- a/docs/logging/semantic-identity-message-cleanup-report.md
+++ b/docs/logging/semantic-identity-message-cleanup-report.md
@@ -1,0 +1,71 @@
+# Semantic identity message cleanup report
+
+## Scope
+
+This PR completed Phase 1 only. Phase 2 text formatting and terminal coloring were intentionally deferred because the identity audit found enough call-site cleanup to keep this PR focused and reviewable.
+
+## Searches performed
+
+The audit was started before editing with these repository-wide searches:
+
+```sh
+rg -n "getConnectionName|getInstanceName" src tests/unit/log
+rg -n "<<.*get(Connection|Instance)Name\(" src
+rg -n "get(Connection|Instance)Name\(\).*<<" src
+rg -n "(frameworkLog|\blog\(|appLog|expressLog|httpLog|httpClientLog|webSocketLog|websocketLog|mqttLog|mqttBrokerLog|mqttSessionLog|mqttWebSocketLog|coreSocketLog|tlsConfigLog).*get(Connection|Instance)Name" src
+rg -n "(getSocketConnection\(\)->getConnectionName|getSocketConnection\(\)->getInstanceName|socketConnection->getConnectionName|socketConnection->getInstanceName|config->getInstanceName|Super::getConnectionName|Super::getInstanceName)" src
+```
+
+The first pass found 268 broad identity-name occurrences in `src` and `tests/unit/log`, with the concentrated duplicated semantic-message prefixes in HTTP socket contexts and TLS stream wrappers.
+
+## Files audited
+
+The audit covered the requested production and logging-test areas:
+
+- `src/core/socket`
+- `src/core/socket/stream`
+- `src/core/socket/stream/tls`
+- `src/web/http`
+- `src/web/http/client/tools`
+- `src/web/websocket`
+- `src/iot/mqtt`
+- `src/express`
+- `src/apps`
+- `tests/unit/log`
+
+## Files changed
+
+- `src/web/http/client/SocketContext.cpp`
+- `src/web/http/server/SocketContext.cpp`
+- `src/core/socket/stream/tls/SocketAcceptor.hpp`
+- `src/core/socket/stream/tls/SocketConnector.hpp`
+- `src/core/socket/stream/tls/SocketConnection.hpp`
+- `tests/unit/log/SemanticIdentityMessagePolicyTest.cpp`
+- `tests/unit/log/CMakeLists.txt`
+- `docs/logging/semantic-identity-message-cleanup-report.md`
+
+## Removed duplicated identity prefixes
+
+Removed current connection prefixes from `frameworkLog()` message text in the HTTP client/server socket contexts. Those loggers are created by `core::socket::stream::SocketContext` with concrete `inst=` and `conn=` fields from the owning socket connection, so the free-text message no longer needs `getSocketConnection()->getConnectionName()`.
+
+Removed current instance prefixes from TLS socket acceptor/connector `this->log()` messages. Those object loggers inherit the stream connector/acceptor instance scope, so `config->getInstanceName()` was duplicated when used as a leading `{}` argument.
+
+Removed current connection prefixes from TLS socket connection shutdown messages emitted through the scoped stream socket connection logger. That logger carries the concrete socket `conn=` field, so leading `Super::getConnectionName()` format arguments were duplicated.
+
+## Remaining identity-name uses intentionally kept
+
+Remaining `getConnectionName()` / `getInstanceName()` uses were kept by class:
+
+- Log scope construction in socket connections, contexts, clients, servers, acceptors, connectors, and configuration objects. These are the structured identity source and must remain.
+- Non-logging logic, including event receiver names, flow controller names, request construction, OpenSSL ex-data, TLS handshake/shutdown helper names, SNI lookup messages, and user-facing request/response objects.
+- Static helper semantic logs such as `coreSocketLog()`, `httpClientLog()`, `webSocketLog()`, `mqttWebSocketLog()`, `expressLog()`, and `tlsConfigLog()` where the helper itself does not carry the concrete current `conn=`/`inst=` value. These may still need a name in the message until those helpers are redesigned or wrapped with object scopes.
+- Application/demo code under `src/apps`, where output is intentionally user-facing and may name the connection or instance explicitly.
+- Tests and source-policy checks under `tests/unit/log`, where identity names are used to verify scope construction and expected propagation.
+
+## Static-helper follow-up
+
+Static semantic helper logs still produce component/boundary records without a concrete connection or instance in many call sites. This PR does not redesign those helpers, convert them to object-bound loggers, or strip identity in the formatter. A future PR can decide whether specific static-helper surfaces should grow object-owned scopes; until then, keeping explicit names in those messages is intentional.
+
+## Phase 2 status
+
+Semantic text format and terminal coloring were not changed in this PR. JSON output was not changed.

--- a/src/core/socket/stream/tls/SocketAcceptor.hpp
+++ b/src/core/socket/stream/tls/SocketAcceptor.hpp
@@ -141,17 +141,17 @@ namespace core::socket::stream::tls {
     template <typename PhysicalSocketServer, typename Config>
     void SocketAcceptor<PhysicalSocketServer, Config>::init() {
         if (core::eventLoopState() == core::State::RUNNING && !config->getDisabled()) {
-            this->log().trace("{} SSL/TLS: SSL_CTX creating ...", config->getInstanceName());
+            this->log().trace("SSL/TLS: SSL_CTX creating ...");
             SSL_CTX* sslCtx = config->getSslCtx();
 
             if (sslCtx != nullptr) {
-                this->log().debug("{} SSL/TLS: SSL_CTX created", config->getInstanceName());
+                this->log().debug("SSL/TLS: SSL_CTX created");
 
                 SSL_CTX_set_client_hello_cb(sslCtx, clientHelloCallback, nullptr);
 
                 Super::init();
             } else {
-                this->log().error("{} SSL/TLS: SSL/TLS creation failed", config->getInstanceName());
+                this->log().error("SSL/TLS: SSL/TLS creation failed");
 
                 Super::onStatus(Super::config->Local::getSocketAddress(), core::socket::STATE_ERROR);
                 Super::destruct();

--- a/src/core/socket/stream/tls/SocketConnection.hpp
+++ b/src/core/socket/stream/tls/SocketConnection.hpp
@@ -166,10 +166,9 @@ namespace core::socket::stream::tls {
                     SocketWriter::resume();
                 }
                 if (SSL_get_shutdown(ssl) == (SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN)) {
-                    core::socket::stream::SocketConnection::log().debug("{} SSL/TLS: Passive close_notify received and sent",
-                                                                        Super::getConnectionName());
+                    core::socket::stream::SocketConnection::log().debug("SSL/TLS: Passive close_notify received and sent");
                 } else {
-                    core::socket::stream::SocketConnection::log().debug("{} SSL/TLS: Active close_notify sent", Super::getConnectionName());
+                    core::socket::stream::SocketConnection::log().debug("SSL/TLS: Active close_notify sent");
                 }
             },
             [this, resumeSocketReader, resumeSocketWriter]() { // onTimeout
@@ -179,7 +178,7 @@ namespace core::socket::stream::tls {
                 if (resumeSocketWriter) {
                     SocketWriter::resume();
                 }
-                core::socket::stream::SocketConnection::log().error("{} SSL/TLS: Shutdown handshake timed out", Super::getConnectionName());
+                core::socket::stream::SocketConnection::log().error("SSL/TLS: Shutdown handshake timed out");
                 Super::doWriteShutdown([this]() {
                     SocketConnection::close();
                 });
@@ -203,21 +202,19 @@ namespace core::socket::stream::tls {
     void SocketConnection<PhysicalSocket, Config>::onReadShutdown() {
         if ((SSL_get_shutdown(ssl) & SSL_RECEIVED_SHUTDOWN) != 0) {
             if ((SSL_get_shutdown(ssl) & SSL_SENT_SHUTDOWN) != 0) {
-                core::socket::stream::SocketConnection::log().debug("{} SSL/TLS: Active close_notify sent and received",
-                                                                    Super::getConnectionName());
+                core::socket::stream::SocketConnection::log().debug("SSL/TLS: Active close_notify sent and received");
                 SocketWriter::shutdownInProgress = false;
 
                 if (closeNotifyIsEOF) {
                     this->onReadError(0);
                 }
             } else {
-                core::socket::stream::SocketConnection::log().debug(
-                    "{} SSL/TLS: Passive close_notify received, answering with close_notify", Super::getConnectionName());
+                core::socket::stream::SocketConnection::log().debug("SSL/TLS: Passive close_notify received, answering with close_notify");
 
                 doSSLShutdown();
             }
         } else {
-            core::socket::stream::SocketConnection::log().error("{} SSL/TLS: Unexpected EOF error", Super::getConnectionName());
+            core::socket::stream::SocketConnection::log().error("SSL/TLS: Unexpected EOF error");
 
             SocketWriter::shutdownInProgress = false;
             SSL_set_shutdown(ssl, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
@@ -227,7 +224,7 @@ namespace core::socket::stream::tls {
     template <typename PhysicalSocket, typename Config>
     void SocketConnection<PhysicalSocket, Config>::doWriteShutdown(const std::function<void()>& onShutdown) {
         if ((SSL_get_shutdown(ssl) & SSL_SENT_SHUTDOWN) == 0) {
-            core::socket::stream::SocketConnection::log().debug("{} SSL/TLS: Active send close_notify", Super::getConnectionName());
+            core::socket::stream::SocketConnection::log().debug("SSL/TLS: Active send close_notify");
 
             doSSLShutdown();
         } else {

--- a/src/core/socket/stream/tls/SocketConnector.hpp
+++ b/src/core/socket/stream/tls/SocketConnector.hpp
@@ -144,14 +144,14 @@ namespace core::socket::stream::tls {
     template <typename PhysicalSocketClient, typename Config>
     void SocketConnector<PhysicalSocketClient, Config>::init() {
         if (core::eventLoopState() == core::State::RUNNING && !config->getDisabled()) {
-            this->log().trace("{} SSL/TLS: SSL_CTX creating ...", config->getInstanceName());
+            this->log().trace("SSL/TLS: SSL_CTX creating ...");
 
             if (config->getSslCtx() != nullptr) {
-                this->log().debug("{} SSL/TLS: SSL_CTX created", config->getInstanceName());
+                this->log().debug("SSL/TLS: SSL_CTX created");
 
                 Super::init();
             } else {
-                this->log().error("{} SSL/TLS: SSL_CTX creation failed", config->getInstanceName());
+                this->log().error("SSL/TLS: SSL_CTX creation failed");
 
                 Super::onStatus(config->Remote::getSocketAddress(), core::socket::STATE_FATAL);
                 Super::destruct();

--- a/src/web/http/client/SocketContext.cpp
+++ b/src/web/http/client/SocketContext.cpp
@@ -87,7 +87,7 @@ namespace web::http::client {
 
     SocketContext::~SocketContext() {
         if (!deliveredRequests.empty()) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Responses missed";
+            frameworkLog().debug() << "HTTP: Responses missed";
             for (const std::shared_ptr<MasterRequest>& request : deliveredRequests) {
                 frameworkLog().debug() << "  " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
                                        << request->httpMinor;
@@ -95,7 +95,7 @@ namespace web::http::client {
         }
 
         if (!pendingRequests.empty()) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Requests ignored";
+            frameworkLog().debug() << "HTTP: Requests ignored";
             for (const std::shared_ptr<MasterRequest>& request : pendingRequests) {
                 frameworkLog().debug() << "  " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
                                        << request->httpMinor;
@@ -114,8 +114,7 @@ namespace web::http::client {
 
         if ((flags == Flags::NONE || (flags & Flags::HTTP11) == Flags::HTTP11 || (flags & Flags::KEEPALIVE) == Flags::KEEPALIVE) &&
             (flags & Flags::CLOSE) != Flags::CLOSE) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                   << ") accepted: " << requestLine;
+            frameworkLog().debug() << "HTTP: Request (" << request->count << ") accepted: " << requestLine;
             flags = (flags & Flags::HTTP11) | ((request->httpMajor == 1 && request->httpMinor == 1) ? Flags::HTTP11 : Flags::NONE);
             flags = (flags & Flags::HTTP10) | ((request->httpMajor == 1 && request->httpMinor == 0) ? Flags::HTTP10 : Flags::NONE);
             flags = (flags & Flags::KEEPALIVE) |
@@ -124,16 +123,15 @@ namespace web::http::client {
 
             pendingRequests.push_back(request);
 
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                   << ") queued: " << requestLine << " - QueueSize = " << pendingRequests.size() << " - Flags: " << flags
-                                   << " - " << web::http::ciContains(request->header("Connection"), "close");
+            frameworkLog().debug() << "HTTP: Request (" << request->count << ") queued: " << requestLine
+                                   << " - QueueSize = " << pendingRequests.size() << " - Flags: " << flags << " - "
+                                   << web::http::ciContains(request->header("Connection"), "close");
 
             if (pendingRequests.size() == 1 && (deliveredRequests.empty() || pipelinedRequests)) {
                 initiateRequest();
             }
         } else {
-            frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                  << ") rejected: " << requestLine;
+            frameworkLog().warn() << "HTTP: Request (" << request->count << ") rejected: " << requestLine;
 
             auto log = frameworkLog();
             if (log.enabled(logger::LogLevel::Trace)) {
@@ -161,12 +159,10 @@ namespace web::http::client {
                                                 .append(".")
                                                 .append(std::to_string(request->httpMinor));
 
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                   << ") start: " << requestLine;
+            frameworkLog().debug() << "HTTP: Request (" << request->count << ") start: " << requestLine;
 
             if (!request->initiate(request)) {
-                frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                      << ") delivering failed: " << requestLine;
+                frameworkLog().warn() << "HTTP: Request (" << request->count << ") delivering failed: " << requestLine;
 
                 core::EventReceiver::atNextTick([masterRequest = std::weak_ptr(masterRequest)]() {
                     if (!masterRequest.expired()) {
@@ -178,9 +174,8 @@ namespace web::http::client {
                                 const std::shared_ptr<Request>& request = socketContext->pendingRequests.front();
 
                                 socketContext->frameworkLog().debug()
-                                    << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                    << ") dequeued: " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
-                                    << request->httpMinor;
+                                    << "HTTP: Request (" << request->count << ") dequeued: " << request->method << " " << request->url
+                                    << " HTTP/" << request->httpMajor << "." << request->httpMinor;
 
                                 socketContext->initiateRequest();
                             }
@@ -204,8 +199,8 @@ namespace web::http::client {
                                             .append(std::to_string(currentRequest->httpMinor));
 
         if (success) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << currentRequest->count
-                                   << ") delivered: " << requestLine << " " << pendingRequests.size();
+            frameworkLog().debug() << "HTTP: Request (" << currentRequest->count << ") delivered: " << requestLine << " "
+                                   << pendingRequests.size();
 
             deliveredRequests.push_back(currentRequest);
 
@@ -218,9 +213,8 @@ namespace web::http::client {
                             const std::shared_ptr<Request>& request = socketContext->pendingRequests.front();
 
                             socketContext->frameworkLog().debug()
-                                << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                << ") dequeued: " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
-                                << request->httpMinor;
+                                << "HTTP: Request (" << request->count << ") dequeued: " << request->method << " " << request->url
+                                << " HTTP/" << request->httpMajor << "." << request->httpMinor;
 
                             socketContext->initiateRequest();
                         }
@@ -228,8 +222,7 @@ namespace web::http::client {
                 });
             }
         } else {
-            frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << currentRequest->count
-                                  << ") deliver failed: " << requestLine;
+            frameworkLog().warn() << "HTTP: Request (" << currentRequest->count << ") deliver failed: " << requestLine;
 
             shutdownWrite();
         }
@@ -237,7 +230,7 @@ namespace web::http::client {
 
     void SocketContext::responseStarted() {
         if (deliveredRequests.empty()) {
-            frameworkLog().error() << getSocketConnection()->getConnectionName() << " HTTP: Response without delivered request";
+            frameworkLog().error() << "HTTP: Response without delivered request";
 
             close();
         }
@@ -255,16 +248,14 @@ namespace web::http::client {
                                             .append(".")
                                             .append(std::to_string(request->httpMinor));
 
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Response received for request (" << request->count
-                               << "): " << requestLine;
+        frameworkLog().debug() << "HTTP: Response received for request (" << request->count << "): " << requestLine;
 
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << "   HTTP/" << response->httpMajor << "."
-                               << response->httpMinor << " " << response->statusCode << " " << response->reason;
+        frameworkLog().debug() << "  HTTP/" << response->httpMajor << "." << response->httpMinor << " " << response->statusCode << " "
+                               << response->reason;
 
         request->deliverResponse(request, response);
 
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                               << ") completed: " << requestLine;
+        frameworkLog().debug() << "HTTP: Request (" << request->count << ") completed: " << requestLine;
 
         requestCompleted(response);
     }
@@ -281,8 +272,8 @@ namespace web::http::client {
                                             .append(".")
                                             .append(std::to_string(request->httpMinor));
 
-        frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Response parse error: " << reason << " (" << status
-                              << ") for request (" << request->count << "): " << requestLine
+        frameworkLog().warn() << "HTTP: Response parse error: " << reason << " (" << status << ") for request (" << request->count
+                              << "): " << requestLine
                               << std::string(request->method)
                                      .append(" ")
                                      .append(request->url)
@@ -302,11 +293,11 @@ namespace web::http::client {
                      ((response->httpMajor == 0 && response->httpMinor == 0) || (response->httpMajor == 1 && response->httpMinor == 0)));
 
         if (httpClose) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Close";
+            frameworkLog().debug() << "HTTP: Connection = Close";
 
             shutdownWrite();
         } else {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Keep-Alive";
+            frameworkLog().debug() << "HTTP: Connection = Keep-Alive";
 
             if (!pipelinedRequests && !pendingRequests.empty()) {
                 core::EventReceiver::atNextTick([masterRequest = std::weak_ptr(masterRequest)]() {
@@ -317,9 +308,8 @@ namespace web::http::client {
                             const std::shared_ptr<Request>& request = socketContext->pendingRequests.front();
 
                             socketContext->frameworkLog().debug()
-                                << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Initiating request ("
-                                << request->count << "): " << request->method << " " << request->url << " HTTP/" << request->httpMajor
-                                << "." << request->httpMinor;
+                                << "HTTP: Initiating request (" << request->count << "): " << request->method << " " << request->url
+                                << " HTTP/" << request->httpMajor << "." << request->httpMinor;
 
                             socketContext->initiateRequest();
                         }
@@ -336,7 +326,7 @@ namespace web::http::client {
     }
 
     void SocketContext::onConnected() {
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connected";
+        frameworkLog().debug() << "HTTP: Connected";
 
         onHttpConnected(masterRequest);
     }
@@ -370,11 +360,11 @@ namespace web::http::client {
         masterRequest->disconnect();
         onHttpDisconnected(masterRequest);
 
-        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received disconnect";
+        frameworkLog().info() << "HTTP: Received disconnect";
     }
 
     bool SocketContext::onSignal([[maybe_unused]] int signum) {
-        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received signal " << signum;
+        frameworkLog().info() << "HTTP: Received signal " << signum;
 
         return true;
     }

--- a/src/web/http/server/SocketContext.cpp
+++ b/src/web/http/server/SocketContext.cpp
@@ -67,11 +67,11 @@ namespace web::http::server {
         , parser(
               this,
               [this]() {
-                  frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request start";
+                  frameworkLog().debug() << "HTTP: Request start";
               },
               [this](web::http::server::Request&& request) {
-                  frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request parse success: " << request.method
-                                         << " " << request.url << " HTTP/" << request.httpMajor << "." << request.httpMinor;
+                  frameworkLog().debug() << "HTTP: Request parse success: " << request.method << " " << request.url << " HTTP/"
+                                         << request.httpMajor << "." << request.httpMinor;
 
                   pendingRequests.emplace_back(std::make_shared<Request>(std::move(request)));
 
@@ -80,8 +80,7 @@ namespace web::http::server {
                   }
               },
               [this](int status, const std::string& reason) {
-                  frameworkLog().error() << getSocketConnection()->getConnectionName() << " HTTP: Request parse error: " << reason << " ("
-                                         << status << ") ";
+                  frameworkLog().error() << "HTTP: Request parse error: " << reason << " (" << status << ") ";
                   shutdownRead();
 
                   pendingRequests.emplace_back(std::make_shared<Request>(Request(status, reason)));
@@ -109,9 +108,8 @@ namespace web::http::server {
             const std::shared_ptr<Request>& pendingRequest = pendingRequests.front();
 
             if (pendingRequest->status == 0) {
-                frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request deliver: " << pendingRequest->method
-                                       << " " << pendingRequest->url << " HTTP/" << pendingRequest->httpMajor << "."
-                                       << pendingRequest->httpMinor;
+                frameworkLog().debug() << "HTTP: Request deliver: " << pendingRequest->method << " " << pendingRequest->url << " HTTP/"
+                                       << pendingRequest->httpMajor << "." << pendingRequest->httpMinor;
 
                 masterResponse->init();
                 masterResponse->requestMethod = pendingRequest->method;
@@ -135,7 +133,7 @@ namespace web::http::server {
                 masterResponse->status(pendingRequest->status).send(pendingRequest->reason);
             }
         } else {
-            frameworkLog().trace() << getSocketConnection()->getConnectionName() << " HTTP: No more pending request";
+            frameworkLog().trace() << "HTTP: No more pending request";
         }
     }
 
@@ -149,10 +147,9 @@ namespace web::http::server {
                 getSocketConnection()->setReadTimeout(0);
             }
 
-            frameworkLog().debug() << getSocketConnection()->getConnectionName()
-                                   << " HTTP: Response start for request: " << pendingRequest->method << " " << pendingRequest->url
+            frameworkLog().debug() << " HTTP: Response start for request: " << pendingRequest->method << " " << pendingRequest->url
                                    << " HTTP/" << pendingRequest->httpMajor << "." << pendingRequest->httpMinor;
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << "   "
+            frameworkLog().debug() << "  "
                                    << "HTTP/" + std::to_string(response.httpMajor)
                                                     .append(".")
                                                     .append(std::to_string(response.httpMinor))
@@ -167,8 +164,7 @@ namespace web::http::server {
         if (success) {
             requestCompleted(response);
         } else {
-            frameworkLog().warn() << getSocketConnection()->getConnectionName()
-                                  << " HTTP: Response completed with error: " << response.statusCode << " "
+            frameworkLog().warn() << " HTTP: Response completed with error: " << response.statusCode << " "
                                   << StatusCode::reason(response.statusCode);
 
             close();
@@ -179,9 +175,9 @@ namespace web::http::server {
         const std::shared_ptr<Request> request = std::move(pendingRequests.front());
         pendingRequests.pop_front();
 
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Response completed for request: " << request->method
-                               << " " << request->url << " HTTP/" << request->httpMajor << "." << request->httpMinor;
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << "   "
+        frameworkLog().debug() << "HTTP: Response completed for request: " << request->method << " " << request->url << " HTTP/"
+                               << request->httpMajor << "." << request->httpMinor;
+        frameworkLog().debug() << "  "
                                << "HTTP/" + std::to_string(response.httpMajor)
                                                 .append(".")
                                                 .append(std::to_string(response.httpMinor))
@@ -195,11 +191,11 @@ namespace web::http::server {
                      ((response.httpMajor == 0 && response.httpMinor == 9) || (response.httpMajor == 1 && response.httpMinor == 0)));
 
         if (httpClose) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Close";
+            frameworkLog().debug() << "HTTP: Connection = Close";
 
             shutdownWrite();
         } else {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Keep-Alive";
+            frameworkLog().debug() << "HTTP: Connection = Keep-Alive";
 
             if (!pendingRequests.empty()) {
                 core::EventReceiver::atNextTick([response = std::weak_ptr<Response>(masterResponse)]() {
@@ -216,7 +212,7 @@ namespace web::http::server {
     }
 
     void SocketContext::onConnected() {
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connected";
+        frameworkLog().debug() << "HTTP: Connected";
 
         for (const auto& onConnectEventReceiver : onConnectEventReceiverList) {
             onConnectEventReceiver();
@@ -236,7 +232,7 @@ namespace web::http::server {
     void SocketContext::onDisconnected() {
         masterResponse->disconnect();
 
-        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received disconnect";
+        frameworkLog().info() << "HTTP: Received disconnect";
 
         for (const auto& onDisconnectEventReceiver : onDisconnectEventReceiverList) {
             onDisconnectEventReceiver();
@@ -244,7 +240,7 @@ namespace web::http::server {
     }
 
     bool SocketContext::onSignal(int signum) {
-        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received signal " << signum;
+        frameworkLog().info() << "HTTP: Received signal " << signum;
 
         return true;
     }

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -158,6 +158,13 @@ target_compile_features(SemanticCliIntegrationTest PRIVATE cxx_std_20)
 target_link_libraries(SemanticCliIntegrationTest PRIVATE snodec-test-support snodec::utils snodec::logger)
 set_tests_properties(SemanticCliIntegrationTest PROPERTIES LABELS "unit;log;cli")
 
+
+snodec_add_test(SemanticIdentityMessagePolicyTest SemanticIdentityMessagePolicyTest.cpp)
+target_include_directories(SemanticIdentityMessagePolicyTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(SemanticIdentityMessagePolicyTest PRIVATE cxx_std_20)
+target_link_libraries(SemanticIdentityMessagePolicyTest PRIVATE snodec-test-support)
+snodec_set_source_policy_test_properties(SemanticIdentityMessagePolicyTest "unit;log;identity;source-policy")
+
 snodec_add_test(SemanticCliSourcePolicyTest SemanticCliSourcePolicyTest.cpp)
 target_include_directories(SemanticCliSourcePolicyTest PRIVATE ${PROJECT_SOURCE_DIR})
 target_compile_features(SemanticCliSourcePolicyTest PRIVATE cxx_std_20)

--- a/tests/unit/log/SemanticIdentityMessagePolicyTest.cpp
+++ b/tests/unit/log/SemanticIdentityMessagePolicyTest.cpp
@@ -1,0 +1,106 @@
+#include "tests/support/TestResult.h"
+#include "tests/unit/log/SourcePolicyTestRoot.h"
+
+#include <filesystem>
+#include <fstream>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+    struct Pattern {
+        std::string name;
+        std::regex expression;
+    };
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream input(path);
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        return buffer.str();
+    }
+
+    bool isProductionSource(const std::filesystem::path& path) {
+        const std::string ext = path.extension().string();
+        return ext == ".cpp" || ext == ".h" || ext == ".hpp";
+    }
+
+    bool isScopedSemanticLoggerSurface(const std::filesystem::path& relative) {
+        const std::string path = relative.generic_string();
+        return path == "src/core/socket/stream/SocketContext.cpp" || path == "src/core/socket/stream/SocketConnection.cpp" ||
+               path == "src/core/socket/stream/SocketConnection.hpp" || path == "src/core/socket/stream/SocketClient.h" ||
+               path == "src/core/socket/stream/SocketServer.h" || path == "src/core/socket/stream/tls/SocketAcceptor.hpp" ||
+               path == "src/core/socket/stream/tls/SocketConnector.hpp" || path == "src/core/socket/stream/tls/SocketConnection.hpp" ||
+               path == "src/web/http/client/SocketContext.cpp" || path == "src/web/http/server/SocketContext.cpp";
+    }
+
+    std::string lineForOffset(const std::string& text, std::size_t offset) {
+        std::size_t line = 1;
+        for (std::size_t i = 0; i < offset && i < text.size(); ++i) {
+            if (text[i] == '\n') {
+                ++line;
+            }
+        }
+        return std::to_string(line);
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+    const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
+    if (root.empty()) {
+        result.expectTrue(false, "sourcePolicyProjectRoot() must not return an empty path");
+        return result.processResult();
+    }
+
+    const std::vector<Pattern> patterns = {
+        {"frameworkLog stream prepends socket connection identity",
+         std::regex(
+             R"(frameworkLog\s*\(\s*\)\s*\.\s*(trace|debug|info|warn|error|critical)\s*\(\s*\)\s*<<\s*(this->)?getSocketConnection\s*\(\s*\)\s*->\s*getConnectionName\s*\()")},
+        {"captured frameworkLog stream prepends socket connection identity",
+         std::regex(
+             R"(([A-Za-z_][A-Za-z0-9_]*->)?frameworkLog\s*\(\s*\)\s*\.\s*(trace|debug|info|warn|error|critical)\s*\(\s*\)\s*<<\s*([A-Za-z_][A-Za-z0-9_]*->)?getSocketConnection\s*\(\s*\)\s*->\s*getConnectionName\s*\()")},
+        {"object log stream prepends current connection identity",
+         std::regex(
+             R"((^|[^A-Za-z0-9_:])log\s*\(\s*\)\s*\.\s*(trace|debug|info|warn|error|critical)\s*\(\s*\)\s*<<\s*(this->)?getConnectionName\s*\()")},
+        {"object log stream prepends current instance identity",
+         std::regex(
+             R"((^|[^A-Za-z0-9_:])log\s*\(\s*\)\s*\.\s*(trace|debug|info|warn|error|critical)\s*\(\s*\)\s*<<\s*(this->)?getInstanceName\s*\()")},
+        {"object log format prepends current connection identity",
+         std::regex(
+             R"((this->)?log\s*\(\s*\)\s*\.\s*(trace|debug|info|warn|error|critical)\s*\(\s*"\{\}[^"\n]*"\s*,\s*(this->)?getConnectionName\s*\()")},
+        {"object log format prepends current instance identity",
+         std::regex(
+             R"((this->)?log\s*\(\s*\)\s*\.\s*(trace|debug|info|warn|error|critical)\s*\(\s*"\{\}[^"\n]*"\s*,\s*(config->|this->)?getInstanceName\s*\()")},
+        {"SocketConnection scoped log format prepends Super connection identity",
+         std::regex(
+             R"(SocketConnection::log\s*\(\s*\)\s*\.\s*(trace|debug|info|warn|error|critical)\s*\(\s*"\{\}[^"\n]*"\s*,\s*Super::getConnectionName\s*\()")},
+        {"local frameworkLog variable prepends socket connection identity",
+         std::regex(
+             R"(auto\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*frameworkLog\s*\(\s*\)\s*;[\s\S]{0,400}\b\1\s*\.\s*(trace|debug|info|warn|error|critical)\s*\(\s*\)\s*<<\s*(this->)?getSocketConnection\s*\(\s*\)\s*->\s*getConnectionName\s*\()")},
+    };
+
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(root / "src")) {
+        if (!entry.is_regular_file() || !isProductionSource(entry.path())) {
+            continue;
+        }
+
+        const std::filesystem::path relative = std::filesystem::relative(entry.path(), root);
+        if (!isScopedSemanticLoggerSurface(relative)) {
+            continue;
+        }
+
+        const std::string text = readFile(entry.path());
+        for (const Pattern& pattern : patterns) {
+            std::smatch match;
+            if (std::regex_search(text, match, pattern.expression)) {
+                result.expectTrue(false,
+                                  relative.generic_string() + ":" + lineForOffset(text, static_cast<std::size_t>(match.position())) + ": " +
+                                      pattern.name);
+            }
+        }
+    }
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation

- Remove duplicated connection/instance identity prefixes from semantic log message text where the logger scope already supplies `inst=`/`conn=` identity.
- Keep changes focused on Phase 1 (identity cleanup) to avoid the scope creep experienced in prior work, and defer Phase 2 (text formatting & coloring) until identity cleanup is fully scoped and tested.
- Provide an automated, honest source-policy test to catch future regressions where identity prefixes are prepended to messages emitted from object-scoped semantic loggers.

### Description

- Removed duplicated identity prefixes from HTTP socket contexts so `frameworkLog()` messages no longer prepend `getSocketConnection()->getConnectionName()` and now log the human message text only; changes are in `src/web/http/client/SocketContext.cpp` and `src/web/http/server/SocketContext.cpp`.
- Removed duplicated instance prefixes and duplicated `{}` format arguments from TLS acceptor/connector and connection shutdown messages so object-scoped `this->log()` / `SocketConnection::log()` messages do not pass `config->getInstanceName()` / `Super::getConnectionName()` as leading message text; changes are in `src/core/socket/stream/tls/SocketAcceptor.hpp`, `src/core/socket/stream/tls/SocketConnector.hpp`, and `src/core/socket/stream/tls/SocketConnection.hpp`.
- Added a focused source-policy unit test `SemanticIdentityMessagePolicyTest` under `tests/unit/log/SemanticIdentityMessagePolicyTest.cpp` and registered it in the log test `CMakeLists.txt` to detect obvious duplicated identity prefixes on known object-scoped semantic logger surfaces.
- Added `docs/logging/semantic-identity-message-cleanup-report.md` that records the searches performed, files audited, files changed, prefixes removed, intentionally retained occurrences, and follow-up notes about static helper logs.

### Testing

- Configured and built with tests and apps enabled using `cmake -S . -B cmake-build -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build cmake-build --parallel 2`.
- Ran targeted unit tests with `ctest --test-dir cmake-build -R "SemanticIdentityMessagePolicyTest|Log|Semantic|Logger" --output-on-failure` and then the full test set with `ctest --test-dir cmake-build --output-on-failure`, both completed successfully for the tests that ran in this environment.
- The new `SemanticIdentityMessagePolicyTest` passed; the full CTest run reported many repository-gated component tests as `Skipped` per existing test gating but overall the executed tests passed.
- Verified `git diff --check` (no whitespace/check failures) and formatted touched files with `clang-format` where appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50b6872924832ca9e3ebbf3737d9e1)