### PR TITLE
Remove duplicated HTTP SocketContext log identity prefixes

### DIFF
--- a/src/web/http/client/SocketContext.cpp
+++ b/src/web/http/client/SocketContext.cpp
@@ -87,7 +87,7 @@ namespace web::http::client {
 
     SocketContext::~SocketContext() {
         if (!deliveredRequests.empty()) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Responses missed";
+            frameworkLog().debug() << "HTTP: Responses missed";
             for (const std::shared_ptr<MasterRequest>& request : deliveredRequests) {
                 frameworkLog().debug() << "  " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
                                        << request->httpMinor;
@@ -95,7 +95,7 @@ namespace web::http::client {
         }
 
         if (!pendingRequests.empty()) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Requests ignored";
+            frameworkLog().debug() << "HTTP: Requests ignored";
             for (const std::shared_ptr<MasterRequest>& request : pendingRequests) {
                 frameworkLog().debug() << "  " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
                                        << request->httpMinor;
@@ -114,8 +114,7 @@ namespace web::http::client {
 
         if ((flags == Flags::NONE || (flags & Flags::HTTP11) == Flags::HTTP11 || (flags & Flags::KEEPALIVE) == Flags::KEEPALIVE) &&
             (flags & Flags::CLOSE) != Flags::CLOSE) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                   << ") accepted: " << requestLine;
+            frameworkLog().debug() << "HTTP: Request (" << request->count << ") accepted: " << requestLine;
             flags = (flags & Flags::HTTP11) | ((request->httpMajor == 1 && request->httpMinor == 1) ? Flags::HTTP11 : Flags::NONE);
             flags = (flags & Flags::HTTP10) | ((request->httpMajor == 1 && request->httpMinor == 0) ? Flags::HTTP10 : Flags::NONE);
             flags = (flags & Flags::KEEPALIVE) |
@@ -124,16 +123,15 @@ namespace web::http::client {
 
             pendingRequests.push_back(request);
 
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                   << ") queued: " << requestLine << " - QueueSize = " << pendingRequests.size() << " - Flags: " << flags
-                                   << " - " << web::http::ciContains(request->header("Connection"), "close");
+            frameworkLog().debug() << "HTTP: Request (" << request->count << ") queued: " << requestLine
+                                   << " - QueueSize = " << pendingRequests.size() << " - Flags: " << flags << " - "
+                                   << web::http::ciContains(request->header("Connection"), "close");
 
             if (pendingRequests.size() == 1 && (deliveredRequests.empty() || pipelinedRequests)) {
                 initiateRequest();
             }
         } else {
-            frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                  << ") rejected: " << requestLine;
+            frameworkLog().warn() << "HTTP: Request (" << request->count << ") rejected: " << requestLine;
 
             auto log = frameworkLog();
             if (log.enabled(logger::LogLevel::Trace)) {
@@ -161,12 +159,10 @@ namespace web::http::client {
                                                 .append(".")
                                                 .append(std::to_string(request->httpMinor));
 
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                   << ") start: " << requestLine;
+            frameworkLog().debug() << "HTTP: Request (" << request->count << ") start: " << requestLine;
 
             if (!request->initiate(request)) {
-                frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                      << ") delivering failed: " << requestLine;
+                frameworkLog().warn() << "HTTP: Request (" << request->count << ") delivering failed: " << requestLine;
 
                 core::EventReceiver::atNextTick([masterRequest = std::weak_ptr(masterRequest)]() {
                     if (!masterRequest.expired()) {
@@ -178,9 +174,8 @@ namespace web::http::client {
                                 const std::shared_ptr<Request>& request = socketContext->pendingRequests.front();
 
                                 socketContext->frameworkLog().debug()
-                                    << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                    << ") dequeued: " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
-                                    << request->httpMinor;
+                                    << "HTTP: Request (" << request->count << ") dequeued: " << request->method << " " << request->url
+                                    << " HTTP/" << request->httpMajor << "." << request->httpMinor;
 
                                 socketContext->initiateRequest();
                             }
@@ -204,8 +199,8 @@ namespace web::http::client {
                                             .append(std::to_string(currentRequest->httpMinor));
 
         if (success) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << currentRequest->count
-                                   << ") delivered: " << requestLine << " " << pendingRequests.size();
+            frameworkLog().debug() << "HTTP: Request (" << currentRequest->count << ") delivered: " << requestLine << " "
+                                   << pendingRequests.size();
 
             deliveredRequests.push_back(currentRequest);
 
@@ -218,9 +213,8 @@ namespace web::http::client {
                             const std::shared_ptr<Request>& request = socketContext->pendingRequests.front();
 
                             socketContext->frameworkLog().debug()
-                                << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                                << ") dequeued: " << request->method << " " << request->url << " HTTP/" << request->httpMajor << "."
-                                << request->httpMinor;
+                                << "HTTP: Request (" << request->count << ") dequeued: " << request->method << " " << request->url
+                                << " HTTP/" << request->httpMajor << "." << request->httpMinor;
 
                             socketContext->initiateRequest();
                         }
@@ -228,8 +222,7 @@ namespace web::http::client {
                 });
             }
         } else {
-            frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << currentRequest->count
-                                  << ") deliver failed: " << requestLine;
+            frameworkLog().warn() << "HTTP: Request (" << currentRequest->count << ") deliver failed: " << requestLine;
 
             shutdownWrite();
         }
@@ -237,7 +230,7 @@ namespace web::http::client {
 
     void SocketContext::responseStarted() {
         if (deliveredRequests.empty()) {
-            frameworkLog().error() << getSocketConnection()->getConnectionName() << " HTTP: Response without delivered request";
+            frameworkLog().error() << "HTTP: Response without delivered request";
 
             close();
         }
@@ -255,16 +248,14 @@ namespace web::http::client {
                                             .append(".")
                                             .append(std::to_string(request->httpMinor));
 
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Response received for request (" << request->count
-                               << "): " << requestLine;
+        frameworkLog().debug() << "HTTP: Response received for request (" << request->count << "): " << requestLine;
 
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << "   HTTP/" << response->httpMajor << "."
-                               << response->httpMinor << " " << response->statusCode << " " << response->reason;
+        frameworkLog().debug() << "  HTTP/" << response->httpMajor << "." << response->httpMinor << " " << response->statusCode << " "
+                               << response->reason;
 
         request->deliverResponse(request, response);
 
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request (" << request->count
-                               << ") completed: " << requestLine;
+        frameworkLog().debug() << "HTTP: Request (" << request->count << ") completed: " << requestLine;
 
         requestCompleted(response);
     }
@@ -281,8 +272,8 @@ namespace web::http::client {
                                             .append(".")
                                             .append(std::to_string(request->httpMinor));
 
-        frameworkLog().warn() << getSocketConnection()->getConnectionName() << " HTTP: Response parse error: " << reason << " (" << status
-                              << ") for request (" << request->count << "): " << requestLine
+        frameworkLog().warn() << "HTTP: Response parse error: " << reason << " (" << status << ") for request (" << request->count
+                              << "): " << requestLine
                               << std::string(request->method)
                                      .append(" ")
                                      .append(request->url)
@@ -302,11 +293,11 @@ namespace web::http::client {
                      ((response->httpMajor == 0 && response->httpMinor == 0) || (response->httpMajor == 1 && response->httpMinor == 0)));
 
         if (httpClose) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Close";
+            frameworkLog().debug() << "HTTP: Connection = Close";
 
             shutdownWrite();
         } else {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Keep-Alive";
+            frameworkLog().debug() << "HTTP: Connection = Keep-Alive";
 
             if (!pipelinedRequests && !pendingRequests.empty()) {
                 core::EventReceiver::atNextTick([masterRequest = std::weak_ptr(masterRequest)]() {
@@ -317,9 +308,8 @@ namespace web::http::client {
                             const std::shared_ptr<Request>& request = socketContext->pendingRequests.front();
 
                             socketContext->frameworkLog().debug()
-                                << socketContext->getSocketConnection()->getConnectionName() << " HTTP: Initiating request ("
-                                << request->count << "): " << request->method << " " << request->url << " HTTP/" << request->httpMajor
-                                << "." << request->httpMinor;
+                                << "HTTP: Initiating request (" << request->count << "): " << request->method << " " << request->url
+                                << " HTTP/" << request->httpMajor << "." << request->httpMinor;
 
                             socketContext->initiateRequest();
                         }
@@ -336,7 +326,7 @@ namespace web::http::client {
     }
 
     void SocketContext::onConnected() {
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connected";
+        frameworkLog().debug() << "HTTP: Connected";
 
         onHttpConnected(masterRequest);
     }
@@ -370,11 +360,11 @@ namespace web::http::client {
         masterRequest->disconnect();
         onHttpDisconnected(masterRequest);
 
-        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received disconnect";
+        frameworkLog().info() << "HTTP: Received disconnect";
     }
 
     bool SocketContext::onSignal([[maybe_unused]] int signum) {
-        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received signal " << signum;
+        frameworkLog().info() << "HTTP: Received signal " << signum;
 
         return true;
     }

--- a/src/web/http/server/SocketContext.cpp
+++ b/src/web/http/server/SocketContext.cpp
@@ -67,11 +67,11 @@ namespace web::http::server {
         , parser(
               this,
               [this]() {
-                  frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request start";
+                  frameworkLog().debug() << "HTTP: Request start";
               },
               [this](web::http::server::Request&& request) {
-                  frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request parse success: " << request.method
-                                         << " " << request.url << " HTTP/" << request.httpMajor << "." << request.httpMinor;
+                  frameworkLog().debug() << "HTTP: Request parse success: " << request.method << " " << request.url << " HTTP/"
+                                         << request.httpMajor << "." << request.httpMinor;
 
                   pendingRequests.emplace_back(std::make_shared<Request>(std::move(request)));
 
@@ -80,8 +80,7 @@ namespace web::http::server {
                   }
               },
               [this](int status, const std::string& reason) {
-                  frameworkLog().error() << getSocketConnection()->getConnectionName() << " HTTP: Request parse error: " << reason << " ("
-                                         << status << ") ";
+                  frameworkLog().error() << "HTTP: Request parse error: " << reason << " (" << status << ") ";
                   shutdownRead();
 
                   pendingRequests.emplace_back(std::make_shared<Request>(Request(status, reason)));
@@ -109,9 +108,8 @@ namespace web::http::server {
             const std::shared_ptr<Request>& pendingRequest = pendingRequests.front();
 
             if (pendingRequest->status == 0) {
-                frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Request deliver: " << pendingRequest->method
-                                       << " " << pendingRequest->url << " HTTP/" << pendingRequest->httpMajor << "."
-                                       << pendingRequest->httpMinor;
+                frameworkLog().debug() << "HTTP: Request deliver: " << pendingRequest->method << " " << pendingRequest->url << " HTTP/"
+                                       << pendingRequest->httpMajor << "." << pendingRequest->httpMinor;
 
                 masterResponse->init();
                 masterResponse->requestMethod = pendingRequest->method;
@@ -135,7 +133,7 @@ namespace web::http::server {
                 masterResponse->status(pendingRequest->status).send(pendingRequest->reason);
             }
         } else {
-            frameworkLog().trace() << getSocketConnection()->getConnectionName() << " HTTP: No more pending request";
+            frameworkLog().trace() << "HTTP: No more pending request";
         }
     }
 
@@ -149,10 +147,9 @@ namespace web::http::server {
                 getSocketConnection()->setReadTimeout(0);
             }
 
-            frameworkLog().debug() << getSocketConnection()->getConnectionName()
-                                   << " HTTP: Response start for request: " << pendingRequest->method << " " << pendingRequest->url
+            frameworkLog().debug() << "HTTP: Response start for request: " << pendingRequest->method << " " << pendingRequest->url
                                    << " HTTP/" << pendingRequest->httpMajor << "." << pendingRequest->httpMinor;
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << "   "
+            frameworkLog().debug() << "  "
                                    << "HTTP/" + std::to_string(response.httpMajor)
                                                     .append(".")
                                                     .append(std::to_string(response.httpMinor))
@@ -167,8 +164,7 @@ namespace web::http::server {
         if (success) {
             requestCompleted(response);
         } else {
-            frameworkLog().warn() << getSocketConnection()->getConnectionName()
-                                  << " HTTP: Response completed with error: " << response.statusCode << " "
+            frameworkLog().warn() << "HTTP: Response completed with error: " << response.statusCode << " "
                                   << StatusCode::reason(response.statusCode);
 
             close();
@@ -179,9 +175,9 @@ namespace web::http::server {
         const std::shared_ptr<Request> request = std::move(pendingRequests.front());
         pendingRequests.pop_front();
 
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Response completed for request: " << request->method
-                               << " " << request->url << " HTTP/" << request->httpMajor << "." << request->httpMinor;
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << "   "
+        frameworkLog().debug() << "HTTP: Response completed for request: " << request->method << " " << request->url << " HTTP/"
+                               << request->httpMajor << "." << request->httpMinor;
+        frameworkLog().debug() << "  "
                                << "HTTP/" + std::to_string(response.httpMajor)
                                                 .append(".")
                                                 .append(std::to_string(response.httpMinor))
@@ -195,11 +191,11 @@ namespace web::http::server {
                      ((response.httpMajor == 0 && response.httpMinor == 9) || (response.httpMajor == 1 && response.httpMinor == 0)));
 
         if (httpClose) {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Close";
+            frameworkLog().debug() << "HTTP: Connection = Close";
 
             shutdownWrite();
         } else {
-            frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connection = Keep-Alive";
+            frameworkLog().debug() << "HTTP: Connection = Keep-Alive";
 
             if (!pendingRequests.empty()) {
                 core::EventReceiver::atNextTick([response = std::weak_ptr<Response>(masterResponse)]() {
@@ -216,7 +212,7 @@ namespace web::http::server {
     }
 
     void SocketContext::onConnected() {
-        frameworkLog().debug() << getSocketConnection()->getConnectionName() << " HTTP: Connected";
+        frameworkLog().debug() << "HTTP: Connected";
 
         for (const auto& onConnectEventReceiver : onConnectEventReceiverList) {
             onConnectEventReceiver();
@@ -236,7 +232,7 @@ namespace web::http::server {
     void SocketContext::onDisconnected() {
         masterResponse->disconnect();
 
-        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received disconnect";
+        frameworkLog().info() << "HTTP: Received disconnect";
 
         for (const auto& onDisconnectEventReceiver : onDisconnectEventReceiverList) {
             onDisconnectEventReceiver();
@@ -244,7 +240,7 @@ namespace web::http::server {
     }
 
     bool SocketContext::onSignal(int signum) {
-        frameworkLog().info() << getSocketConnection()->getConnectionName() << " HTTP: Received signal " << signum;
+        frameworkLog().info() << "HTTP: Received signal " << signum;
 
         return true;
     }


### PR DESCRIPTION
### Motivation
- Remove duplicated free-text connection-name prefixes from object-scoped `frameworkLog()` messages in HTTP SocketContext call sites flagged by the merged audit rows `CSI-P085`–`CSI-P121` so structured `conn=`/`inst=` identity carried by the scope is not redundantly repeated in the human-readable message.
- Preserve all logging surfaces, log levels, formatters, categories, and the substantive HTTP message content (method, URL, version, status, counters, error details) while removing only the duplicated connection-name expressions and their separator characters.

### Description
- Edited only the audited call sites in `src/web/http/client/SocketContext.cpp` and `src/web/http/server/SocketContext.cpp` to remove explicit `getSocketConnection()->getConnectionName()` insertions that duplicated the scoped structured identity; removed only the connection-name expressions and separators so messages now begin with the substantive text (for example `HTTP: Connected`).
- Preserved continuation/detail indentation (e.g. `"  HTTP/..."`) and preserved all control flow, conditions, log levels, and the `frameworkLog()` surface.
- Implementation note: `CSI-P085–CSI-P106` were applied to HTTP client `SocketContext`; `CSI-P107–CSI-P121` were applied to HTTP server `SocketContext`.
- Files changed: `src/web/http/client/SocketContext.cpp`, `src/web/http/server/SocketContext.cpp`; audited rows inspected: 37; message prefixes removed: 37.

### Testing
- Configured and generated build files with tests enabled: `cmake -S . -B build -DSNODEC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug` (succeeded).
- Formatted modified files with `clang-format -i` and ran `git diff --check` (no issues).
- Built affected targets: `cmake --build build --target http-client http-server` (succeeded).
- Ran focused unit/component tests and migrations used by the logging/http CI: `SemanticLoggerRound2Test`, `HttpClientMigration07aTest`, `HttpServerMigration07bTest`, plus HTTP unit tests (`HttpMessageParserTest`, `HttpRequestFormatterRawWireTest`, `HttpResponseFormatterRawWireTest`, `HttpMessageHeaderCasingTest`, `HttpMessageTargetQueryEdgeTest`); all executed tests passed (one harness-skipped test observed: `InetHttpServerClientGetRoundTripTest` was skipped by the test harness).
- Verified via source search that explicit `getConnectionName()` insertions into `frameworkLog()` messages were removed from the two modified files and no other production files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f585605c832cbf2a0216dd2c311e)