### PR TITLE
Harden WebSocket frame validation

### DIFF
--- a/src/web/websocket/Receiver.cpp
+++ b/src/web/websocket/Receiver.cpp
@@ -50,6 +50,7 @@
 
 #include <endian.h>
 #include <string>
+#include <limits>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -107,7 +108,7 @@ namespace web::websocket {
                     break;
             }
             consumed += ret;
-        } while (ret > 0 && parserState != ParserState::BEGIN && parserState != ParserState::ERROR);
+        } while (ret > 0 && parserState != ParserState::BEGIN);
 
         return consumed;
     }
@@ -120,33 +121,76 @@ namespace web::websocket {
         return readFrameChunk(chunk, chunkLen);
     }
 
+    namespace {
+        constexpr uint16_t ProtocolError = 1002;
+
+        bool isControlOpCode(uint8_t opCode) {
+            return opCode >= 0x08;
+        }
+
+        bool isKnownOpCode(uint8_t opCode) {
+            return opCode == 0x00 || opCode == 0x01 || opCode == 0x02 || opCode == 0x08 || opCode == 0x09 || opCode == 0x0A;
+        }
+
+        bool isValidCloseStatus(uint16_t status) {
+            return (status >= 1000 && status <= 1014 && status != 1004 && status != 1005 && status != 1006) ||
+                   (status >= 3000 && status <= 4999);
+        }
+    } // namespace
+
     std::size_t Receiver::readOpcode() {
         char byte = 0;
         const std::size_t ret = readFrameData(&byte, 1);
 
         if (ret > 0) {
             const uint8_t opCodeByte = static_cast<uint8_t>(byte);
+            const bool rsvSet = (opCodeByte & 0b01110000) != 0;
 
             fin = (opCodeByte & 0b10000000) != 0;
             opCode = opCodeByte & 0b00001111;
+            currentFrameIsControl = isControlOpCode(opCode);
 
-            if (!continuation) {
+            if (rsvSet) {
+                parserState = ParserState::ERROR;
+                errorState = ProtocolError;
+                frameLog().error() << "WebSocket: RSV bits are not supported without negotiated extensions";
+            } else if (!isKnownOpCode(opCode)) {
+                parserState = ParserState::ERROR;
+                errorState = ProtocolError;
+                frameLog().error() << "WebSocket: Reserved or unknown opcode";
+            } else if (currentFrameIsControl && !fin) {
+                parserState = ParserState::ERROR;
+                errorState = ProtocolError;
+                frameLog().error() << "WebSocket: Control frames must not be fragmented";
+            } else if (opCode == 0) {
+                if (!fragmentedMessageActive) {
+                    parserState = ParserState::ERROR;
+                    errorState = ProtocolError;
+                    frameLog().error() << "WebSocket: Continuation frame without active fragmented message";
+                } else {
+                    parserState = ParserState::LENGTH;
+                }
+            } else if (currentFrameIsControl) {
                 onMessageStart(opCode);
                 parserState = ParserState::LENGTH;
-            } else if (opCode == 0) {
-                parserState = ParserState::LENGTH;
-            } else {
+            } else if (fragmentedMessageActive) {
                 parserState = ParserState::ERROR;
-                errorState = 1002;
-                frameLog().error() << "WebSocket: Error opcode in continuation frame";
+                errorState = ProtocolError;
+                frameLog().error() << "WebSocket: New data frame before fragmented message completed";
+            } else {
+                onMessageStart(opCode);
+                if (!fin) {
+                    fragmentedMessageActive = true;
+                }
+                parserState = ParserState::LENGTH;
             }
-            continuation = !fin;
         }
 
         return ret;
     }
 
     std::size_t Receiver::readLength() {
+        controlPayload.clear();
         char byte = 0;
         const std::size_t ret = readFrameData(&byte, 1);
 
@@ -155,9 +199,14 @@ namespace web::websocket {
 
             masked = (lengthByte & 0b10000000) != 0;
             if (masked == maskingExpected) {
-                payloadNumBytes = payloadNumBytesLeft = lengthByte & 0b01111111;
+                payloadLengthCode = lengthByte & 0b01111111;
+                payloadNumBytes = payloadNumBytesLeft = payloadLengthCode;
 
-                if (payloadNumBytes > 125) {
+                if (currentFrameIsControl && payloadLengthCode > 125) {
+                    parserState = ParserState::ERROR;
+                    errorState = ProtocolError;
+                    frameLog().error() << "WebSocket: Control frame uses extended payload length";
+                } else if (payloadNumBytes > 125) {
                     switch (payloadNumBytes) {
                         case 126:
                             elengthNumBytes = elengthNumBytesLeft = 2;
@@ -182,6 +231,8 @@ namespace web::websocket {
                 }
             } else {
                 parserState = ParserState::ERROR;
+                errorState = ProtocolError;
+                frameLog().error() << "WebSocket: Frame masking does not match endpoint role";
             }
         }
 
@@ -237,9 +288,18 @@ namespace web::websocket {
         }
 
         if (elengthNumBytesLeft == 0) {
-            if ((payloadNumBytes & static_cast<uint64_t>(0x01) << 63) != 0) {
+            if ((payloadNumBytes & (static_cast<uint64_t>(0x01) << 63)) != 0) {
                 parserState = ParserState::ERROR;
-                errorState = 1004;
+                errorState = ProtocolError;
+                frameLog().error() << "WebSocket: 64-bit payload length has MSB set";
+            } else if ((payloadLengthCode == 126 && payloadNumBytes < 126) || (payloadLengthCode == 127 && payloadNumBytes < 65536)) {
+                parserState = ParserState::ERROR;
+                errorState = ProtocolError;
+                frameLog().error() << "WebSocket: Non-minimal payload length encoding";
+            } else if (payloadNumBytes > static_cast<uint64_t>(std::numeric_limits<std::size_t>::max())) {
+                parserState = ParserState::ERROR;
+                errorState = ProtocolError;
+                frameLog().error() << "WebSocket: Payload length exceeds platform size limits";
             } else if (masked) {
                 parserState = ParserState::MASKINGKEY;
             } else {
@@ -265,6 +325,9 @@ namespace web::websocket {
             if (payloadNumBytes > 0) {
                 parserState = ParserState::PAYLOAD;
             } else {
+                if (opCode == 0 && fin) {
+                    fragmentedMessageActive = false;
+                }
                 if (fin) {
                     onMessageEnd();
                 }
@@ -296,6 +359,10 @@ namespace web::websocket {
                 frameLog().trace("WebSocket receive: Frame data\n{}", utils::hexDump(payloadChunk, payloadChunkLen, 32, true));
             }
 
+            if (currentFrameIsControl) {
+                controlPayload.append(payloadChunk, payloadChunkLen);
+            }
+
             onMessageData(payloadChunk, payloadChunkLen);
 
             payloadNumBytesLeft -= payloadChunkLen;
@@ -303,10 +370,30 @@ namespace web::websocket {
         }
 
         if (payloadNumBytesLeft == 0) {
-            if (fin) {
-                onMessageEnd();
+            if (opCode == 0 && fin) {
+                fragmentedMessageActive = false;
             }
-            reset();
+            if (opCode == 8) {
+                if (controlPayload.size() == 1) {
+                    parserState = ParserState::ERROR;
+                    errorState = ProtocolError;
+                    frameLog().error() << "WebSocket: Close frame payload length 1 is invalid";
+                } else if (controlPayload.size() >= 2) {
+                    const uint16_t closeStatus = (static_cast<uint16_t>(static_cast<unsigned char>(controlPayload[0])) << 8) |
+                                                 static_cast<uint16_t>(static_cast<unsigned char>(controlPayload[1]));
+                    if (!isValidCloseStatus(closeStatus)) {
+                        parserState = ParserState::ERROR;
+                        errorState = ProtocolError;
+                        frameLog().error() << "WebSocket: Close frame status code is invalid";
+                    }
+                }
+            }
+            if (parserState != ParserState::ERROR) {
+                if (fin) {
+                    onMessageEnd();
+                }
+                reset();
+            }
         }
 
         return ret;
@@ -316,10 +403,11 @@ namespace web::websocket {
         parserState = ParserState::BEGIN;
 
         fin = false;
-        continuation = false;
         masked = false;
+        currentFrameIsControl = false;
 
         opCode = 0;
+        payloadLengthCode = 0;
 
         elengthNumBytes = 0;
         elengthNumBytesLeft = 0;
@@ -331,6 +419,7 @@ namespace web::websocket {
         maskingKeyNumBytesLeft = 4;
 
         errorState = 0;
+        controlPayload.clear();
     }
 
 } // namespace web::websocket

--- a/src/web/websocket/Receiver.h
+++ b/src/web/websocket/Receiver.h
@@ -49,6 +49,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <string>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -94,14 +95,17 @@ namespace web::websocket {
         enum struct ParserState { BEGIN, OPCODE, LENGTH, ELENGTH, MASKINGKEY, PAYLOAD, ERROR } parserState = ParserState::BEGIN;
 
         bool fin = false;
-        bool continuation = false;
         bool masked = false;
+        bool fragmentedMessageActive = false;
+        bool currentFrameIsControl = false;
 
         bool maskingExpected = false;
 
         uint8_t opCode = 0;
+        uint8_t payloadLengthCode = 0;
 
         char maskingKey[4]{};
+        std::string controlPayload;
 
         union ELength8 {
             uint64_t asValue;

--- a/src/web/websocket/SocketContextUpgrade.h
+++ b/src/web/websocket/SocketContextUpgrade.h
@@ -146,6 +146,7 @@ namespace web::websocket {
 
     private:
         int receivedOpCode = 0;
+        int fragmentedDataOpCode = 0;
 
         std::string pongCloseData;
     };

--- a/src/web/websocket/SocketContextUpgrade.hpp
+++ b/src/web/websocket/SocketContextUpgrade.hpp
@@ -155,6 +155,7 @@ namespace web::websocket {
             case SubProtocolContext::OpCode::PONG:
                 break;
             default:
+                fragmentedDataOpCode = opCode;
                 subProtocol->onMessageStart(opCode);
                 break;
         }
@@ -201,16 +202,25 @@ namespace web::websocket {
                     sendClose(pongCloseData.data(), pongCloseData.length());
                     pongCloseData.clear();
                 }
+                fragmentedDataOpCode = 0;
                 break;
             case SubProtocolContext::OpCode::PING:
                 sendPong(pongCloseData.data(), pongCloseData.length());
                 pongCloseData.clear();
+                if (fragmentedDataOpCode != 0) {
+                    receivedOpCode = fragmentedDataOpCode;
+                }
                 break;
             case SubProtocolContext::OpCode::PONG:
                 subProtocol->onPongReceived();
+                pongCloseData.clear();
+                if (fragmentedDataOpCode != 0) {
+                    receivedOpCode = fragmentedDataOpCode;
+                }
                 break;
             default:
                 subProtocol->onMessageEnd();
+                fragmentedDataOpCode = 0;
                 break;
         }
     }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -44,6 +44,8 @@ add_subdirectory(net)
 
 add_subdirectory(http)
 
+add_subdirectory(websocket)
+
 add_subdirectory(log)
 
 add_subdirectory(mqtt)

--- a/tests/unit/websocket/CMakeLists.txt
+++ b/tests/unit/websocket/CMakeLists.txt
@@ -1,0 +1,4 @@
+snodec_add_test(WebSocketReceiverValidationTest WebSocketReceiverValidationTest.cpp)
+target_link_libraries(WebSocketReceiverValidationTest PRIVATE snodec-test-support snodec::websocket)
+target_compile_features(WebSocketReceiverValidationTest PRIVATE cxx_std_20)
+set_tests_properties(WebSocketReceiverValidationTest PROPERTIES LABELS "unit;websocket;validation")

--- a/tests/unit/websocket/WebSocketReceiverValidationTest.cpp
+++ b/tests/unit/websocket/WebSocketReceiverValidationTest.cpp
@@ -1,0 +1,162 @@
+#include "support/TestResult.h"
+#include "web/websocket/Receiver.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+    class BufferReceiver : public web::websocket::Receiver {
+    public:
+        explicit BufferReceiver(bool maskingExpected)
+            : Receiver(maskingExpected) {
+        }
+
+        void feed(const std::vector<uint8_t>& bytes) {
+            input.insert(input.end(), bytes.begin(), bytes.end());
+            while (offset < input.size() && errors == 0) {
+                const std::size_t consumed = receive();
+                if (consumed == 0) {
+                    break;
+                }
+            }
+        }
+
+        int starts = 0;
+        int ends = 0;
+        int errors = 0;
+        uint16_t lastError = 0;
+        std::vector<int> opcodes;
+        std::string data;
+
+    private:
+        std::size_t readFrameChunk(char* chunk, std::size_t chunkLen) const override {
+            const std::size_t available = input.size() - offset;
+            const std::size_t toRead = std::min(chunkLen, available);
+            if (toRead > 0) {
+                std::memcpy(chunk, input.data() + offset, toRead);
+                offset += toRead;
+            }
+            return toRead;
+        }
+
+        void onMessageStart(int opCode) override {
+            starts++;
+            opcodes.push_back(opCode);
+        }
+
+        void onMessageData(const char* chunk, uint64_t chunkLen) override {
+            data.append(chunk, static_cast<std::size_t>(chunkLen));
+        }
+
+        void onMessageEnd() override {
+            ends++;
+        }
+
+        void onMessageError(uint16_t errnum) override {
+            errors++;
+            lastError = errnum;
+        }
+
+        mutable std::size_t offset = 0;
+        mutable std::vector<uint8_t> input;
+    };
+
+    std::vector<uint8_t> mask(std::initializer_list<uint8_t> header, const std::string& payload = {}) {
+        constexpr uint8_t maskingKey[] = {0x01, 0x02, 0x03, 0x04};
+        std::vector<uint8_t> frame(header);
+        frame.insert(frame.end(), std::begin(maskingKey), std::end(maskingKey));
+        for (std::size_t i = 0; i < payload.size(); ++i) {
+            frame.push_back(static_cast<uint8_t>(payload[i]) ^ maskingKey[i % 4]);
+        }
+        return frame;
+    }
+
+    std::vector<uint8_t> unmasked(std::initializer_list<uint8_t> header, const std::string& payload = {}) {
+        std::vector<uint8_t> frame(header);
+        frame.insert(frame.end(), payload.begin(), payload.end());
+        return frame;
+    }
+
+    void expectAccepted(tests::support::TestResult& result, const std::string& name, BufferReceiver& receiver, int ends = 1) {
+        result.expectEqual(0, receiver.errors, name + " has no protocol error");
+        result.expectEqual(ends, receiver.ends, name + " completes expected messages");
+    }
+
+    void expectProtocolError(tests::support::TestResult& result, const std::string& name, BufferReceiver& receiver) {
+        result.expectEqual(1, receiver.errors, name + " is rejected");
+        result.expectEqual(1002, receiver.lastError, name + " uses protocol error status");
+    }
+}
+
+int main() {
+    tests::support::TestResult result;
+
+    for (const auto& frame : {mask({0xC1, 0x82}, "hi"), mask({0xA1, 0x82}, "hi"), mask({0x91, 0x82}, "hi")}) {
+        BufferReceiver r(true);
+        r.feed(frame);
+        expectProtocolError(result, "RSV bit", r);
+    }
+    { BufferReceiver r(true); r.feed(mask({0x81, 0x82}, "hi")); expectAccepted(result, "normal masked text", r); }
+
+    for (uint8_t opcode : {0x03, 0x07, 0x0B, 0x0F}) {
+        BufferReceiver r(true);
+        r.feed(mask({static_cast<uint8_t>(0x80 | opcode), 0x80}));
+        expectProtocolError(result, "reserved opcode", r);
+    }
+    for (uint8_t opcode : {0x01, 0x02, 0x09, 0x0A, 0x08}) {
+        BufferReceiver r(true);
+        r.feed(mask({static_cast<uint8_t>(0x80 | opcode), 0x80}));
+        expectAccepted(result, "valid opcode baseline", r);
+    }
+
+    for (uint8_t opcode : {0x08, 0x09, 0x0A}) {
+        BufferReceiver r(true);
+        r.feed(mask({opcode, 0x80}));
+        expectProtocolError(result, "fragmented control", r);
+    }
+    { BufferReceiver r(true); r.feed(mask({0x89, 0xFD}, std::string(125, 'x'))); expectAccepted(result, "ping length 125", r); }
+    for (uint8_t opcode : {0x08, 0x09, 0x0A}) {
+        BufferReceiver r(true);
+        std::vector<uint8_t> frame = mask({static_cast<uint8_t>(0x80 | opcode), 0xFE, 0x00, 0x7E}, std::string(126, 'x'));
+        r.feed(frame);
+        expectProtocolError(result, "control extended length", r);
+    }
+
+    { BufferReceiver r(true); r.feed(mask({0x80, 0x80})); expectProtocolError(result, "continuation without start", r); }
+    { BufferReceiver r(true); auto a = mask({0x01, 0x81}, "a"); auto b = mask({0x81, 0x81}, "b"); a.insert(a.end(), b.begin(), b.end()); r.feed(a); expectProtocolError(result, "new text while fragmented", r); }
+    { BufferReceiver r(true); auto a = mask({0x01, 0x81}, "a"); auto b = mask({0x82, 0x81}, "b"); a.insert(a.end(), b.begin(), b.end()); r.feed(a); expectProtocolError(result, "new binary while fragmented", r); }
+    { BufferReceiver r(true); auto a = mask({0x01, 0x82}, "he"); auto b = mask({0x80, 0x83}, "llo"); a.insert(a.end(), b.begin(), b.end()); r.feed(a); expectAccepted(result, "fragmented text", r); result.expectTrue(r.data == "hello", "fragmented text is delivered once in order"); }
+    { BufferReceiver r(true); auto a = mask({0x02, 0x81}, "a"); auto b = mask({0x00, 0x81}, "b"); auto c = mask({0x80, 0x81}, "c"); a.insert(a.end(), b.begin(), b.end()); a.insert(a.end(), c.begin(), c.end()); r.feed(a); expectAccepted(result, "multi-continuation binary", r); result.expectTrue(r.data == "abc", "binary fragments are delivered once in order"); }
+    { BufferReceiver r(true); auto a = mask({0x01, 0x81}, "a"); auto p = mask({0x89, 0x80}); auto b = mask({0x80, 0x81}, "b"); a.insert(a.end(), p.begin(), p.end()); a.insert(a.end(), b.begin(), b.end()); r.feed(a); expectAccepted(result, "ping during fragmented message", r, 2); result.expectTrue(r.data == "ab", "fragmented message continues after ping"); }
+
+    { BufferReceiver r(true); r.feed(mask({0x81, 0x82}, "hi")); expectAccepted(result, "server accepts masked client text", r); }
+    { BufferReceiver r(true); r.feed(unmasked({0x81, 0x02}, "hi")); expectProtocolError(result, "server rejects unmasked client text", r); }
+    { BufferReceiver r(false); r.feed(unmasked({0x81, 0x02}, "hi")); expectAccepted(result, "client accepts unmasked server text", r); }
+    { BufferReceiver r(false); r.feed(mask({0x81, 0x82}, "hi")); expectProtocolError(result, "client rejects masked server text", r); }
+
+    { BufferReceiver r(false); r.feed(unmasked({0x81, 0x7D}, std::string(125, 'x'))); expectAccepted(result, "text length 125 direct", r); }
+    { BufferReceiver r(false); r.feed(unmasked({0x81, 0x7E, 0x00, 0x7D}, std::string(125, 'x'))); expectProtocolError(result, "text length 125 encoded as 126", r); }
+    { BufferReceiver r(false); r.feed(unmasked({0x81, 0x7E, 0x00, 0x7E}, std::string(126, 'x'))); expectAccepted(result, "text length 126 encoded as 126", r); }
+    { BufferReceiver r(false); r.feed(unmasked({0x81, 0x7F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7E}, std::string(126, 'x'))); expectProtocolError(result, "text length 126 encoded as 127", r); }
+    { BufferReceiver r(false); r.feed(unmasked({0x81, 0x7F, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})); expectProtocolError(result, "64-bit length MSB set", r); }
+
+    { BufferReceiver r(true); r.feed(mask({0x88, 0x80})); expectAccepted(result, "close length 0", r); }
+    { BufferReceiver r(true); r.feed(mask({0x88, 0x81}, "x")); expectProtocolError(result, "close length 1", r); }
+    for (uint16_t code : {uint16_t(1000), uint16_t(3000), uint16_t(4000)}) {
+        BufferReceiver r(true);
+        std::string payload{static_cast<char>(code >> 8), static_cast<char>(code & 0xff)};
+        r.feed(mask({0x88, 0x82}, payload));
+        expectAccepted(result, "valid close code", r);
+    }
+    for (uint16_t code : {uint16_t(999), uint16_t(1005), uint16_t(1006), uint16_t(1015), uint16_t(5000)}) {
+        BufferReceiver r(true);
+        std::string payload{static_cast<char>(code >> 8), static_cast<char>(code & 0xff)};
+        r.feed(mask({0x88, 0x82}, payload));
+        expectProtocolError(result, "invalid close code", r);
+    }
+
+    return result.processResult();
+}


### PR DESCRIPTION
### Motivation
- Ensure RFC 6455 frame parsing in the WebSocket receive path rejects malformed frames deterministically (RSV bits, reserved opcodes, control-frame/fragmentation/masking/length/close violations) while preserving valid-frame behavior.

### Description
- Add strict frame validation to `Receiver`: reject RSV1/2/3 when no extension negotiated, reject reserved/unknown opcodes, and enforce control-frame rules (must be final, payload <=125, no extended lengths).
- Implement fragmentation state tracking so continuation frames are only accepted after a fragmented text/binary start and new data frames are rejected while a fragmented message is active; control frames may be interleaved without corrupting fragmentation state.
- Enforce masking direction via existing role expectation (`maskingExpected`) and fail frames whose mask-bit does not match endpoint role; add payload-length encoding checks including 64-bit MSB rejection, non-minimal encoding detection, and platform-size overflow guard; reject control frames using extended-length forms.
- Validate close-frame payload semantics: reject payload length 1, parse two-byte close status when present and reject invalid status codes; accumulate control payloads to validate at frame end.
- Preserve existing public API and behavior: small internal parser state fields added (`fragmentedMessageActive`, `currentFrameIsControl`, `payloadLengthCode`, `controlPayload`), and `SocketContextUpgrade` adjusted to preserve/restore fragmented data opcode across interleaved control frames.
- Add focused unit test `WebSocketReceiverValidationTest` (raw frame byte feeds) and add it into tests CMake; test vectors cover RSV rejection, reserved-opcode rejection, control-frame rules, fragmentation sequences, masking direction (server/client), payload-length encodings, and close payload/status validation.

### Testing
- Built and executed tests locally using the repository test workflow: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` then `cmake --build build --parallel 2` and `ctest --test-dir build --output-on-failure` and all unit/component tests completed successfully (full test run reported 143 tests, all passed in this environment).
- Built and ran the focused test target: `cmake --build build --target WebSocketReceiverValidationTest --parallel 2` and `ctest --test-dir build -R WebSocketReceiverValidationTest --output-on-failure`; `WebSocketReceiverValidationTest` passed.

Known limitation: UTF-8 validation of completed text messages (RFC 6455 close code 1007) was intentionally left out of this focused change and remains a documented semantic gap for follow-up work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f6ce83c4832ca87042e5cd6f42c9)