### PR TITLE
Remove duplicated socket and TLS log identity prefixes

### DIFF
--- a/src/core/socket/stream/SocketClient.h
+++ b/src/core/socket/stream/SocketClient.h
@@ -273,7 +273,7 @@ namespace core::socket::stream {
                                 config);
                         }
                     } else {
-                        log.critical("{} required", config->getInstanceName());
+                        log.critical("required");
                     }
                 });
 

--- a/src/core/socket/stream/SocketServer.h
+++ b/src/core/socket/stream/SocketServer.h
@@ -240,7 +240,7 @@ namespace core::socket::stream {
                                 config);
                         }
                     } else {
-                        log.critical("{} required", config->getInstanceName());
+                        log.critical("required");
                     }
                 });
 

--- a/src/core/socket/stream/tls/SocketAcceptor.hpp
+++ b/src/core/socket/stream/tls/SocketAcceptor.hpp
@@ -75,25 +75,21 @@ namespace core::socket::stream::tls {
                   }
               },
               [socketContextFactory, onConnected](SocketConnection* socketConnection) { // on Connected
-                  static_cast<core::socket::stream::SocketConnection*>(socketConnection)
-                      ->log()
-                      .trace("{} SSL/TLS: Start handshake", socketConnection->getConnectionName());
+                  static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log().trace("SSL/TLS: Start handshake");
                   if (!socketConnection->doSSLHandshake(
                           [socketContextFactory,
                            onConnected,
                            socketConnection,
-                           log = static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log(),
-                           connectionName = socketConnection->getConnectionName()]() { // onSuccess
-                              log.debug("{} SSL/TLS: Handshake success", connectionName);
+                           log = static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log()]() { // onSuccess
+                              log.debug("SSL/TLS: Handshake success");
 
                               onConnected(socketConnection);
 
                               socketConnection->setSocketContext(socketContextFactory);
                           },
                           [socketConnection,
-                           log = static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log(),
-                           connectionName = socketConnection->getConnectionName()]() { // onTimeout
-                              log.error("{}SSL/TLS: Handshake timed out", connectionName);
+                           log = static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log()]() { // onTimeout
+                              log.error("SSL/TLS: Handshake timed out");
 
                               socketConnection->close();
                           },
@@ -102,9 +98,7 @@ namespace core::socket::stream::tls {
 
                               socketConnection->close();
                           })) {
-                      static_cast<core::socket::stream::SocketConnection*>(socketConnection)
-                          ->log()
-                          .error("{} SSL/TLS: Handshake failed", socketConnection->getConnectionName());
+                      static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log().error("SSL/TLS: Handshake failed");
 
                       socketConnection->close();
                   }
@@ -141,17 +135,17 @@ namespace core::socket::stream::tls {
     template <typename PhysicalSocketServer, typename Config>
     void SocketAcceptor<PhysicalSocketServer, Config>::init() {
         if (core::eventLoopState() == core::State::RUNNING && !config->getDisabled()) {
-            this->log().trace("{} SSL/TLS: SSL_CTX creating ...", config->getInstanceName());
+            this->log().trace("SSL/TLS: SSL_CTX creating ...");
             SSL_CTX* sslCtx = config->getSslCtx();
 
             if (sslCtx != nullptr) {
-                this->log().debug("{} SSL/TLS: SSL_CTX created", config->getInstanceName());
+                this->log().debug("SSL/TLS: SSL_CTX created");
 
                 SSL_CTX_set_client_hello_cb(sslCtx, clientHelloCallback, nullptr);
 
                 Super::init();
             } else {
-                this->log().error("{} SSL/TLS: SSL/TLS creation failed", config->getInstanceName());
+                this->log().error("SSL/TLS: SSL/TLS creation failed");
 
                 Super::onStatus(Super::config->Local::getSocketAddress(), core::socket::STATE_ERROR);
                 Super::destruct();

--- a/src/core/socket/stream/tls/SocketConnection.hpp
+++ b/src/core/socket/stream/tls/SocketConnection.hpp
@@ -166,10 +166,9 @@ namespace core::socket::stream::tls {
                     SocketWriter::resume();
                 }
                 if (SSL_get_shutdown(ssl) == (SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN)) {
-                    core::socket::stream::SocketConnection::log().debug("{} SSL/TLS: Passive close_notify received and sent",
-                                                                        Super::getConnectionName());
+                    core::socket::stream::SocketConnection::log().debug("SSL/TLS: Passive close_notify received and sent");
                 } else {
-                    core::socket::stream::SocketConnection::log().debug("{} SSL/TLS: Active close_notify sent", Super::getConnectionName());
+                    core::socket::stream::SocketConnection::log().debug("SSL/TLS: Active close_notify sent");
                 }
             },
             [this, resumeSocketReader, resumeSocketWriter]() { // onTimeout
@@ -179,7 +178,7 @@ namespace core::socket::stream::tls {
                 if (resumeSocketWriter) {
                     SocketWriter::resume();
                 }
-                core::socket::stream::SocketConnection::log().error("{} SSL/TLS: Shutdown handshake timed out", Super::getConnectionName());
+                core::socket::stream::SocketConnection::log().error("SSL/TLS: Shutdown handshake timed out");
                 Super::doWriteShutdown([this]() {
                     SocketConnection::close();
                 });
@@ -203,21 +202,19 @@ namespace core::socket::stream::tls {
     void SocketConnection<PhysicalSocket, Config>::onReadShutdown() {
         if ((SSL_get_shutdown(ssl) & SSL_RECEIVED_SHUTDOWN) != 0) {
             if ((SSL_get_shutdown(ssl) & SSL_SENT_SHUTDOWN) != 0) {
-                core::socket::stream::SocketConnection::log().debug("{} SSL/TLS: Active close_notify sent and received",
-                                                                    Super::getConnectionName());
+                core::socket::stream::SocketConnection::log().debug("SSL/TLS: Active close_notify sent and received");
                 SocketWriter::shutdownInProgress = false;
 
                 if (closeNotifyIsEOF) {
                     this->onReadError(0);
                 }
             } else {
-                core::socket::stream::SocketConnection::log().debug(
-                    "{} SSL/TLS: Passive close_notify received, answering with close_notify", Super::getConnectionName());
+                core::socket::stream::SocketConnection::log().debug("SSL/TLS: Passive close_notify received, answering with close_notify");
 
                 doSSLShutdown();
             }
         } else {
-            core::socket::stream::SocketConnection::log().error("{} SSL/TLS: Unexpected EOF error", Super::getConnectionName());
+            core::socket::stream::SocketConnection::log().error("SSL/TLS: Unexpected EOF error");
 
             SocketWriter::shutdownInProgress = false;
             SSL_set_shutdown(ssl, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
@@ -227,7 +224,7 @@ namespace core::socket::stream::tls {
     template <typename PhysicalSocket, typename Config>
     void SocketConnection<PhysicalSocket, Config>::doWriteShutdown(const std::function<void()>& onShutdown) {
         if ((SSL_get_shutdown(ssl) & SSL_SENT_SHUTDOWN) == 0) {
-            core::socket::stream::SocketConnection::log().debug("{} SSL/TLS: Active send close_notify", Super::getConnectionName());
+            core::socket::stream::SocketConnection::log().debug("SSL/TLS: Active send close_notify");
 
             doSSLShutdown();
         } else {

--- a/src/core/socket/stream/tls/SocketConnector.hpp
+++ b/src/core/socket/stream/tls/SocketConnector.hpp
@@ -78,25 +78,21 @@ namespace core::socket::stream::tls {
                   }
               },
               [socketContextFactory, onConnected](SocketConnection* socketConnection) { // onConnected
-                  static_cast<core::socket::stream::SocketConnection*>(socketConnection)
-                      ->log()
-                      .trace("{} SSL/TLS: Start handshake", socketConnection->getConnectionName());
+                  static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log().trace("SSL/TLS: Start handshake");
                   if (!socketConnection->doSSLHandshake(
                           [socketContextFactory,
                            onConnected,
                            socketConnection,
-                           log = static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log(),
-                           connectionName = socketConnection->getConnectionName()]() { // onSuccess
-                              log.debug("{} SSL/TLS: Handshake success", connectionName);
+                           log = static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log()]() { // onSuccess
+                              log.debug("SSL/TLS: Handshake success");
 
                               onConnected(socketConnection);
 
                               socketConnection->setSocketContext(socketContextFactory);
                           },
                           [socketConnection,
-                           log = static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log(),
-                           connectionName = socketConnection->getConnectionName()]() { // onTimeout
-                              log.error("{} SSL/TLS: Handshake timed out", connectionName);
+                           log = static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log()]() { // onTimeout
+                              log.error("SSL/TLS: Handshake timed out");
 
                               socketConnection->close();
                           },
@@ -105,9 +101,7 @@ namespace core::socket::stream::tls {
 
                               socketConnection->close();
                           })) {
-                      static_cast<core::socket::stream::SocketConnection*>(socketConnection)
-                          ->log()
-                          .error("{} SSL/TLS: Handshake failed", socketConnection->getConnectionName());
+                      static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log().error("SSL/TLS: Handshake failed");
 
                       socketConnection->close();
                   }
@@ -144,14 +138,14 @@ namespace core::socket::stream::tls {
     template <typename PhysicalSocketClient, typename Config>
     void SocketConnector<PhysicalSocketClient, Config>::init() {
         if (core::eventLoopState() == core::State::RUNNING && !config->getDisabled()) {
-            this->log().trace("{} SSL/TLS: SSL_CTX creating ...", config->getInstanceName());
+            this->log().trace("SSL/TLS: SSL_CTX creating ...");
 
             if (config->getSslCtx() != nullptr) {
-                this->log().debug("{} SSL/TLS: SSL_CTX created", config->getInstanceName());
+                this->log().debug("SSL/TLS: SSL_CTX created");
 
                 Super::init();
             } else {
-                this->log().error("{} SSL/TLS: SSL_CTX creation failed", config->getInstanceName());
+                this->log().error("SSL/TLS: SSL_CTX creation failed");
 
                 Super::onStatus(config->Remote::getSocketAddress(), core::socket::STATE_FATAL);
                 Super::destruct();


### PR DESCRIPTION
### Motivation
- Remove duplicated connection-name or instance-name free-text prefixes from proven object-scoped socket/TLS logger messages identified by the authoritative audit to avoid redundant human-readable output while preserving structured metadata.
- Preserve logger surface, log levels, control flow, TLS/error behavior and do not change `ssl_log()` or other static/helper logging patterns.

### Description
- Edited 5 files to remove duplicated formatting placeholders and arguments from 23 audited call sites and to drop 4 lambda captures that became unused as a direct mechanical consequence of those removals: `src/core/socket/stream/SocketClient.h`, `src/core/socket/stream/SocketServer.h`, `src/core/socket/stream/tls/SocketConnection.hpp`, `src/core/socket/stream/tls/SocketAcceptor.hpp`, and `src/core/socket/stream/tls/SocketConnector.hpp`.
- Audit group mapping implemented: CSI-P044, CSI-P048: SocketClient/SocketServer instance prefixes; CSI-P049–CSI-P055: TLS SocketConnection prefixes; CSI-P056, CSI-P058, CSI-P060, CSI-P061: TLS accept-side handshake callback prefixes; CSI-P066, CSI-P068, CSI-P070, CSI-P071: TLS connect-side handshake callback prefixes; CSI-P062–CSI-P064, CSI-P072–CSI-P074: TLS endpoint configuration instance prefixes.
- Removed only the duplicated `getInstanceName()` / `getConnectionName()` placeholders and their function arguments/stream prefixes, preserved `ssl_log()` calls and SNI/config callback logging, and ensured resulting free-text messages start cleanly (e.g. with `SSL/TLS:` where applicable).
- Per the audit rules, no logger surface, formatting, backend, category, level, helper, or architectural logging changes were made.

### Testing
- Built a debug test configuration and compiled the smallest set of targets that exercise the modified files; built targets included `core-socket-stream`, `core-socket-stream-legacy`, `core-socket-stream-tls`, `net-in-stream-legacy`, `net-in-stream-tls`, `net-in6-stream-legacy`, `net-in6-stream-tls`, `net-un-stream-legacy`, and `net-un-stream-tls`, and the relevant semantic migration and socket/TLS test executables; builds completed successfully.
- Enabled tests and ran selected unit/migration tests (`SemanticLoggerRound2Test`, `SocketEndpointLogApiRound5Test`, `SocketConnectionMigration01Test`, `SocketConnectorAcceptorMigration02Test`, `SocketServerClientMigration03Test`, `TlsSocketStreamMigration06Test` and related composition tests); the selected tests passed and composition tests were skipped by existing runtime conditions.
- Ran repository checks and formatting: `git diff --check` showed no whitespace problems and `clang-format -i` was applied to all modified C++ files.
- Performed search/manual verification with `rg` over the five scoped files for `getConnectionName|getInstanceName|connectionName` and for the SSL/TLS logging patterns and inspected remaining results to ensure only expected identity use remains (e.g., `ssl_log()`, OpenSSL ex-data, SNI/config callbacks, another-object logging and scope construction).

Notes: 23 audited logging call sites inspected, 23 message prefixes removed, 4 lambda captures removed because they became unused; structured `inst=` and `conn=` metadata remain unchanged; `ssl_log()` and KEEP/other excluded rows were left intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51fc7e8364832c918f083f0ff20b22)