### PR TITLE
Add scoped semantic logging for WebSocket, MQTT, and Express

### DIFF
--- a/docs/logging/semantic-identity-callsite-audit.md
+++ b/docs/logging/semantic-identity-callsite-audit.md
@@ -485,3 +485,15 @@ The primary raw evidence command produced 646 matches after excluding this repor
 1. Remove duplicated identity prefixes from proven object-scoped logger messages listed under REMOVE_LATER.
 2. Decide static-helper scope design only for surfaces where this audit recommends `FOLLOW_UP_SCOPED_HELPER_DESIGN`.
 3. Improve semantic text formatting and terminal coloring afterward.
+
+## Resolution status
+
+The following `FOLLOW_UP_SCOPED_HELPER_DESIGN` rows are resolved by the scoped semantic logging PR associated with this branch. The original classifications above are intentionally preserved as audit history.
+
+| Rows | Resolution approach | Rows resolved | Structured identity confirmation |
+|---|---|---:|---|
+| CSI-P075–CSI-P084 | WebSocket subprotocol logging now has a narrow connection-scoped helper overload that copies `inst=` and `conn=` from the active `SocketConnection`; the audited WebSocket call sites use that scoped helper before removing the duplicated connection-name prefix from message text. | 10 | `inst=`/`conn=` are populated from the active socket connection before free-text identity removal. |
+| CSI-P135–CSI-P142 | MQTT-over-WebSocket logging now has a narrow connection-scoped helper overload that copies `inst=` and `conn=` from the active `SocketConnection`; the audited MQTT-over-WebSocket call sites use that scoped helper before removing the duplicated connection-name prefix from message text. | 8 | `inst=`/`conn=` are populated from the active socket connection before free-text identity removal. |
+| CSI-P143–CSI-P150 | Express logging now has a narrow connection-scoped helper overload that copies `inst=` and `conn=` from the active request/response socket connection; the audited Express middleware and dispatcher call sites use that scoped helper before removing the duplicated connection-name prefix from message text. | 8 | `inst=`/`conn=` are populated from the active socket connection before free-text identity removal. |
+
+Total resolved in this branch: 26 audited logging call sites. CSI-P085–CSI-P121 were completed by PR #187, CSI-P122–CSI-P134 are KEEP rows and remain unchanged, and the socket/TLS rows completed by PR #189 remain outside this resolution update.

--- a/src/SemanticLog.h
+++ b/src/SemanticLog.h
@@ -1,6 +1,7 @@
 #ifndef SNODEC_SEMANTICLOG_H
 #define SNODEC_SEMANTICLOG_H
 
+#include "core/socket/stream/SocketConnection.h"
 #include "log/LogScopeOwner.h"
 #include "log/Logger.h"
 
@@ -16,6 +17,12 @@ namespace snode::semantic {
         std::optional<logger::LogRole> role;
         std::optional<std::string> connection;
     };
+
+    inline LogIdentity logIdentity(const core::socket::stream::SocketConnection& connection) {
+        return {connection.getInstanceName().empty() ? std::nullopt : std::optional<std::string>(connection.getInstanceName()),
+                std::nullopt,
+                connection.getConnectionName()};
+    }
 
     inline logger::BoundaryLogger scopedLog(const logger::LogOrigin origin,
                                             const logger::LogBoundary boundary,
@@ -294,6 +301,27 @@ namespace snode::semantic {
                          logger::LogBoundary::Connection,
                          "web.http",
                          std::move(identity),
+                         std::move(sink),
+                         threshold,
+                         std::move(clock));
+    }
+
+    inline logger::BoundaryLogger expressLog(const core::socket::stream::SocketConnection& connection) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Application,
+                         "express",
+                         logIdentity(connection),
+                         logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger expressLog(const core::socket::stream::SocketConnection& connection,
+                                             logger::BoundaryLogger::Sink sink,
+                                             const logger::LogLevel threshold = logger::LogLevel::Trace,
+                                             logger::BoundaryLogger::Clock clock = {}) {
+        return scopedLog(logger::LogOrigin::Framework,
+                         logger::LogBoundary::Application,
+                         "express",
+                         logIdentity(connection),
                          std::move(sink),
                          threshold,
                          std::move(clock));

--- a/src/express/dispatcher/ApplicationDispatcher.cpp
+++ b/src/express/dispatcher/ApplicationDispatcher.cpp
@@ -72,7 +72,7 @@ namespace express::dispatcher {
                                          bool caseInsensitiveRouting,
                                          bool mergeParams) {
         snode::semantic::expressLog().trace() << "======================= APPLICATION DISPATCH =======================";
-        snode::semantic::expressLog().trace() << controller.getResponse()->getSocketContext()->getSocketConnection()->getConnectionName();
+        snode::semantic::expressLog(*controller.getResponse()->getSocketContext()->getSocketConnection()).trace() << "Application dispatch";
         snode::semantic::expressLog().trace() << "          Request Method: " << controller.getRequest()->method;
         snode::semantic::expressLog().trace() << "             Request Url: " << controller.getRequest()->url;
         snode::semantic::expressLog().trace() << "            Request Path: " << controller.getRequest()->path;

--- a/src/express/dispatcher/MiddlewareDispatcher.cpp
+++ b/src/express/dispatcher/MiddlewareDispatcher.cpp
@@ -72,7 +72,7 @@ namespace express::dispatcher {
                                         bool caseInsensitiveRouting,
                                         bool mergeParams) {
         snode::semantic::expressLog().trace() << "======================= MIDDLEWARE  DISPATCH =======================";
-        snode::semantic::expressLog().trace() << controller.getResponse()->getSocketContext()->getSocketConnection()->getConnectionName();
+        snode::semantic::expressLog(*controller.getResponse()->getSocketContext()->getSocketConnection()).trace() << "Middleware dispatch";
         snode::semantic::expressLog().trace() << "          Request Method: " << controller.getRequest()->method;
         snode::semantic::expressLog().trace() << "             Request Url: " << controller.getRequest()->url;
         snode::semantic::expressLog().trace() << "            Request Path: " << controller.getRequest()->path;

--- a/src/express/dispatcher/RouterDispatcher.cpp
+++ b/src/express/dispatcher/RouterDispatcher.cpp
@@ -71,7 +71,7 @@ namespace express::dispatcher {
                                     [[maybe_unused]] bool caseInsensitiveRoutingUnused,
                                     [[maybe_unused]] bool mergeParamsUnused) {
         snode::semantic::expressLog().trace() << "======================= ROUTER      DISPATCH =======================";
-        snode::semantic::expressLog().trace() << controller.getResponse()->getSocketContext()->getSocketConnection()->getConnectionName();
+        snode::semantic::expressLog(*controller.getResponse()->getSocketContext()->getSocketConnection()).trace() << "Router dispatch";
         snode::semantic::expressLog().trace() << "          Request Method: " << controller.getRequest()->method;
         snode::semantic::expressLog().trace() << "             Request Url: " << controller.getRequest()->url;
         snode::semantic::expressLog().trace() << "            Request Path: " << controller.getRequest()->path;

--- a/src/express/middleware/StaticMiddleware.cpp
+++ b/src/express/middleware/StaticMiddleware.cpp
@@ -67,8 +67,7 @@ namespace express::middleware {
              &stdCookies = this->stdCookies,
              &connectionState = this->defaultConnectionState,
              &fallThrough = this->fallThrough] MIDDLEWARE(req, res, next) {
-                snode::semantic::expressLog().debug()
-                    << res->getSocketContext()->getSocketConnection()->getConnectionName() << " Express " << req->method;
+                snode::semantic::expressLog(*res->getSocketContext()->getSocketConnection()).debug() << "Express " << req->method;
 
                 if (req->method != "GET") {
                     if (fallThrough) {
@@ -96,9 +95,8 @@ namespace express::middleware {
                     if (index.empty()) {
                         res->status(404).send("Unsupported resource: " + req->url + "\n");
                     } else {
-                        snode::semantic::expressLog().info()
-                            << res->getSocketContext()->getSocketConnection()->getConnectionName()
-                            << " Express StaticMiddleware Redirecting: " << req->url << " -> "
+                        snode::semantic::expressLog(*res->getSocketContext()->getSocketConnection()).info()
+                            << "Express StaticMiddleware Redirecting: " << req->url << " -> "
                             << req->originalPath +
                                    (!req->originalPath.empty() && req->originalPath.back() != '/' && index.front() != '/' ? "/" : "") +
                                    index;
@@ -115,13 +113,12 @@ namespace express::middleware {
                 const std::string decodedPath = httputils::url_decode(req->path);
                 res->sendFile(root + decodedPath, [&root, decodedPath, req, res, &next, &fallThrough](int ret) {
                     if (ret == 0) {
-                        snode::semantic::expressLog().info()
-                            << res->getSocketContext()->getSocketConnection()->getConnectionName() << " Express StaticMiddleware: GET "
-                            << req->url + " -> " << root + decodedPath;
+                        snode::semantic::expressLog(*res->getSocketContext()->getSocketConnection()).info()
+                            << "Express StaticMiddleware: GET " << req->url + " -> " << root + decodedPath;
                     } else {
-                        snode::semantic::sysError(snode::semantic::expressLog(), logger::LogLevel::Error, ret)
-                            << res->getSocketContext()->getSocketConnection()->getConnectionName() << " Express StaticMiddleware "
-                            << req->url + " -> " << root + decodedPath;
+                        snode::semantic::sysError(
+                            snode::semantic::expressLog(*res->getSocketContext()->getSocketConnection()), logger::LogLevel::Error, ret)
+                            << "Express StaticMiddleware " << req->url + " -> " << root + decodedPath;
 
                         if (fallThrough) {
                             next();

--- a/src/express/middleware/VerboseRequest.cpp
+++ b/src/express/middleware/VerboseRequest.cpp
@@ -58,9 +58,8 @@ namespace express::middleware {
 
     VerboseRequest::VerboseRequest(Details details) {
         use("/", [details] MIDDLEWARE(req, res, next) {
-            snode::semantic::expressLog().debug()
-                << res->getSocketContext()->getSocketConnection()->getConnectionName() << " Express VerboseMiddleware: " << req->method
-                << " " << req->url << " " << req->httpVersion << "\n"
+            snode::semantic::expressLog(*res->getSocketContext()->getSocketConnection()).debug()
+                << "Express VerboseMiddleware: " << req->method << " " << req->url << " " << req->httpVersion << "\n"
                 << httputils::toString(
                        req->method,
                        req->url,

--- a/src/iot/mqtt/SemanticLog.h
+++ b/src/iot/mqtt/SemanticLog.h
@@ -1,9 +1,12 @@
 #ifndef IOT_MQTT_SEMANTICLOG_H
 #define IOT_MQTT_SEMANTICLOG_H
 
+#include "core/socket/stream/SocketConnection.h"
 #include "log/LogScopeOwner.h"
 #include "log/Logger.h"
 
+#include <optional>
+#include <string>
 #include <utility>
 
 namespace iot::mqtt::semantic {
@@ -48,6 +51,16 @@ namespace iot::mqtt::semantic {
         return scope;
     }
 
+    inline logger::LogScopeOwner mqttWebSocketLogScope(const core::socket::stream::SocketConnection& connection) {
+        return logger::LogScopeOwner(logger::LogOrigin::Framework,
+                                     logger::LogBoundary::Connection,
+                                     "iot.mqtt.websocket",
+                                     connection.getInstanceName().empty() ? std::nullopt
+                                                                          : std::optional<std::string>(connection.getInstanceName()),
+                                     std::nullopt,
+                                     connection.getConnectionName());
+    }
+
 #define IOT_MQTT_SEMANTIC_HELPER(name)                                                                                                     \
     inline logger::BoundaryLogger name() {                                                                                                 \
         return name##Scope().logger(logger::Logger::semanticSink());                                                                       \
@@ -66,6 +79,17 @@ namespace iot::mqtt::semantic {
     IOT_MQTT_SEMANTIC_HELPER(mqttPacketLog)
     IOT_MQTT_SEMANTIC_HELPER(mqttTopicLog)
     IOT_MQTT_SEMANTIC_HELPER(mqttWebSocketLog)
+
+    inline logger::BoundaryLogger mqttWebSocketLog(const core::socket::stream::SocketConnection& connection) {
+        return mqttWebSocketLogScope(connection).logger(logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger mqttWebSocketLog(const core::socket::stream::SocketConnection& connection,
+                                                   logger::BoundaryLogger::Sink sink,
+                                                   logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                   logger::BoundaryLogger::Clock clock = {}) {
+        return mqttWebSocketLogScope(connection).logger(std::move(sink), threshold, std::move(clock));
+    }
 
 #undef IOT_MQTT_SEMANTIC_HELPER
 

--- a/src/iot/mqtt/SubProtocol.hpp
+++ b/src/iot/mqtt/SubProtocol.hpp
@@ -105,19 +105,17 @@ namespace iot::mqtt {
 
     template <typename WSSubProtocolRole>
     void SubProtocol<WSSubProtocolRole>::onConnected() {
-        iot::mqtt::semantic::mqttWebSocketLog().info() << getSocketConnection()->getConnectionName() << " WsMqtt: connected:";
+        iot::mqtt::semantic::mqttWebSocketLog(*getSocketConnection()).info() << "WsMqtt: connected:";
         iot::mqtt::MqttContext::onConnected();
     }
 
     template <typename WSSubProtocolRole>
     void SubProtocol<WSSubProtocolRole>::onMessageStart(int opCode) {
         if (opCode == web::websocket::SubProtocolContext::OpCode::TEXT) {
-            iot::mqtt::semantic::mqttWebSocketLog().error()
-                << getSocketConnection()->getConnectionName() << " WsMqtt: Wrong Opcode: " << opCode << " (TEXT)";
+            iot::mqtt::semantic::mqttWebSocketLog(*getSocketConnection()).error() << "WsMqtt: Wrong Opcode: " << opCode << " (TEXT)";
             this->close();
         } else {
-            iot::mqtt::semantic::mqttWebSocketLog().debug()
-                << getSocketConnection()->getConnectionName() << " WsMqtt: Message START: " << opCode << " (BIN)";
+            iot::mqtt::semantic::mqttWebSocketLog(*getSocketConnection()).debug() << "WsMqtt: Message START: " << opCode << " (BIN)";
         }
     }
 
@@ -125,16 +123,16 @@ namespace iot::mqtt {
     void SubProtocol<WSSubProtocolRole>::onMessageData(const char* chunk, std::size_t chunkLen) {
         data.append(std::string(chunk, chunkLen));
 
-        auto log = iot::mqtt::semantic::mqttWebSocketLog();
+        auto log = iot::mqtt::semantic::mqttWebSocketLog(*getSocketConnection());
         if (log.enabled(logger::LogLevel::Debug)) {
-            log.debug() << getSocketConnection()->getConnectionName() << " WsMqtt: Frame Data:\n"
+            log.debug() << "WsMqtt: Frame Data:\n"
                         << std::string(32, ' ').append(utils::hexDump(std::vector<char>(chunk, chunk + chunkLen), 32));
         }
     }
 
     template <typename WSSubProtocolRole>
     void SubProtocol<WSSubProtocolRole>::onMessageEnd() {
-        iot::mqtt::semantic::mqttWebSocketLog().debug() << getSocketConnection()->getConnectionName() << " WsMqtt: Message END";
+        iot::mqtt::semantic::mqttWebSocketLog(*getSocketConnection()).debug() << "WsMqtt: Message END";
 
         buffer.insert(buffer.end(), data.begin(), data.end());
         size += data.size();
@@ -150,21 +148,20 @@ namespace iot::mqtt {
 
     template <typename WSSubProtocolRole>
     void SubProtocol<WSSubProtocolRole>::onMessageError(uint16_t errnum) {
-        iot::mqtt::semantic::mqttWebSocketLog().error()
-            << getSocketConnection()->getConnectionName() << " WsMqtt: Message error: " << errnum;
+        iot::mqtt::semantic::mqttWebSocketLog(*getSocketConnection()).error() << "WsMqtt: Message error: " << errnum;
     }
 
     template <typename WSSubProtocolRole>
     void SubProtocol<WSSubProtocolRole>::onDisconnected() {
         iot::mqtt::MqttContext::onDisconnected();
-        iot::mqtt::semantic::mqttWebSocketLog().debug() << getSocketConnection()->getConnectionName() << " WsMqtt: disconnected";
+        iot::mqtt::semantic::mqttWebSocketLog(*getSocketConnection()).debug() << "WsMqtt: disconnected";
     }
 
     template <typename WSSubProtocolRole>
     bool SubProtocol<WSSubProtocolRole>::onSignal(int sig) {
         bool ret = iot::mqtt::MqttContext::onSignal(sig);
-        iot::mqtt::semantic::mqttWebSocketLog().info() << getSocketConnection()->getConnectionName() << " WsMqtt: exit due to signal SIG"
-                                                       << utils::system::sigabbrev_np(sig) << " (" << sig << ")";
+        iot::mqtt::semantic::mqttWebSocketLog(*getSocketConnection()).info()
+            << "WsMqtt: exit due to signal SIG" << utils::system::sigabbrev_np(sig) << " (" << sig << ")";
 
         this->sendClose();
 

--- a/src/web/websocket/SemanticLog.h
+++ b/src/web/websocket/SemanticLog.h
@@ -1,9 +1,12 @@
 #ifndef WEB_WEBSOCKET_SEMANTICLOG_H
 #define WEB_WEBSOCKET_SEMANTICLOG_H
 
+#include "core/socket/stream/SocketConnection.h"
 #include "log/LogScopeOwner.h"
 #include "log/Logger.h"
 
+#include <optional>
+#include <string>
 #include <utility>
 
 namespace web::websocket::semantic {
@@ -22,6 +25,16 @@ namespace web::websocket::semantic {
         static const logger::LogScopeOwner scope(
             logger::LogOrigin::Framework, logger::LogBoundary::Connection, "web.websocket.subprotocol");
         return scope;
+    }
+
+    inline logger::LogScopeOwner webSocketSubProtocolLogScope(const core::socket::stream::SocketConnection& connection) {
+        return logger::LogScopeOwner(logger::LogOrigin::Framework,
+                                     logger::LogBoundary::Connection,
+                                     "web.websocket.subprotocol",
+                                     connection.getInstanceName().empty() ? std::nullopt
+                                                                          : std::optional<std::string>(connection.getInstanceName()),
+                                     std::nullopt,
+                                     connection.getConnectionName());
     }
 
     inline const logger::LogScopeOwner& webSocketFactoryLogScope() {
@@ -57,6 +70,17 @@ namespace web::websocket::semantic {
                                                           logger::LogLevel threshold = logger::LogLevel::Trace,
                                                           logger::BoundaryLogger::Clock clock = {}) {
         return webSocketSubProtocolLogScope().logger(std::move(sink), threshold, std::move(clock));
+    }
+
+    inline logger::BoundaryLogger webSocketSubProtocolLog(const core::socket::stream::SocketConnection& connection) {
+        return webSocketSubProtocolLogScope(connection).logger(logger::Logger::semanticSink());
+    }
+
+    inline logger::BoundaryLogger webSocketSubProtocolLog(const core::socket::stream::SocketConnection& connection,
+                                                          logger::BoundaryLogger::Sink sink,
+                                                          logger::LogLevel threshold = logger::LogLevel::Trace,
+                                                          logger::BoundaryLogger::Clock clock = {}) {
+        return webSocketSubProtocolLogScope(connection).logger(std::move(sink), threshold, std::move(clock));
     }
 
     inline logger::BoundaryLogger webSocketFactoryLog() {

--- a/src/web/websocket/SocketContextUpgrade.hpp
+++ b/src/web/websocket/SocketContextUpgrade.hpp
@@ -116,9 +116,8 @@ namespace web::websocket {
     template <typename SubProtocol, typename Request, typename Response>
     void SocketContextUpgrade<SubProtocol, Request, Response>::sendClose(const char* message, std::size_t messageLength) {
         if (!closeSent) {
-            semantic::webSocketSubProtocolLog().debug()
-                << this->getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
-                << "' sending close to peer";
+            semantic::webSocketSubProtocolLog(*this->getSocketConnection()).debug()
+                << "WebSocketContext: Subprotocol '" << subProtocol->name << "' sending close to peer";
 
             sendMessage(8, message, messageLength);
 
@@ -189,15 +188,13 @@ namespace web::websocket {
             case SubProtocolContext::OpCode::CLOSE:
                 if (closeSent) { // active close
                     closeSent = false;
-                    semantic::webSocketSubProtocolLog().debug()
-                        << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
-                        << "' close confirmed from peer";
+                    semantic::webSocketSubProtocolLog(*getSocketConnection()).debug()
+                        << "WebSocketContext: Subprotocol '" << subProtocol->name << "' close confirmed from peer";
 
                     shutdownWrite();
                 } else { // passive close
-                    semantic::webSocketSubProtocolLog().debug()
-                        << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name
-                        << "' close request received - replying with close";
+                    semantic::webSocketSubProtocolLog(*getSocketConnection()).debug()
+                        << "WebSocketContext: Subprotocol '" << subProtocol->name << "' close request received - replying with close";
 
                     sendClose(pongCloseData.data(), pongCloseData.length());
                     pongCloseData.clear();
@@ -233,16 +230,16 @@ namespace web::websocket {
 
     template <typename SubProtocol, typename Request, typename Response>
     void SocketContextUpgrade<SubProtocol, Request, Response>::onConnected() {
-        semantic::webSocketSubProtocolLog().info()
-            << getSocketConnection()->getConnectionName() << " WebSocketContext: Subprotocol '" << subProtocol->name << "' connect";
+        semantic::webSocketSubProtocolLog(*getSocketConnection()).info()
+            << "WebSocketContext: Subprotocol '" << subProtocol->name << "' connect";
         subProtocol->attach();
     }
 
     template <typename SubProtocol, typename Request, typename Response>
     void SocketContextUpgrade<SubProtocol, Request, Response>::onDisconnected() {
         subProtocol->detach();
-        semantic::webSocketSubProtocolLog().info()
-            << getSocketConnection()->getConnectionName() << " WebSocketContext:  Subprotocol '" << subProtocol->name << "' disconnected";
+        semantic::webSocketSubProtocolLog(*getSocketConnection()).info()
+            << "WebSocketContext:  Subprotocol '" << subProtocol->name << "' disconnected";
     }
 
     template <typename SubProtocol, typename Request, typename Response>

--- a/src/web/websocket/SubProtocol.hpp
+++ b/src/web/websocket/SubProtocol.hpp
@@ -70,9 +70,8 @@ namespace web::websocket {
                         sendPing();
                         flyingPings++;
                     } else {
-                        semantic::webSocketSubProtocolLog().warn()
-                            << this->subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << this->name
-                            << "': MaxFlyingPings exceeded - closing";
+                        semantic::webSocketSubProtocolLog(*this->subProtocolContext->getSocketConnection()).warn()
+                            << "Subprotocol '" << this->name << "': MaxFlyingPings exceeded - closing";
 
                         sendClose();
                         stop();
@@ -131,8 +130,7 @@ namespace web::websocket {
 
     template <typename SocketContextUpgrade>
     void SubProtocol<SocketContextUpgrade>::sendPing(const char* reason, std::size_t reasonLength) const {
-        semantic::webSocketSubProtocolLog().debug()
-            << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': Ping sent";
+        semantic::webSocketSubProtocolLog(*subProtocolContext->getSocketConnection()).debug() << "Subprotocol '" << name << "': Ping sent";
 
         subProtocolContext->sendPing(reason, reasonLength);
     }
@@ -144,8 +142,7 @@ namespace web::websocket {
 
     template <typename SocketContextUpgrade>
     void SubProtocol<SocketContextUpgrade>::attach() {
-        semantic::webSocketSubProtocolLog().debug()
-            << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': start";
+        semantic::webSocketSubProtocolLog(*subProtocolContext->getSocketConnection()).debug() << "Subprotocol '" << name << "': start";
 
         onConnected();
     }
@@ -154,8 +151,7 @@ namespace web::websocket {
     void SubProtocol<SocketContextUpgrade>::detach() {
         onDisconnected();
 
-        semantic::webSocketSubProtocolLog().debug()
-            << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': stopped";
+        semantic::webSocketSubProtocolLog(*subProtocolContext->getSocketConnection()).debug() << "Subprotocol '" << name << "': stopped";
 
         semantic::webSocketSubProtocolLog().debug() << "       Total Payload sent: " << getPayloadTotalSent();
         semantic::webSocketSubProtocolLog().debug() << "  Total Payload processed: " << getPayloadTotalRead();
@@ -163,8 +159,8 @@ namespace web::websocket {
 
     template <typename SocketContextUpgrade>
     void SubProtocol<SocketContextUpgrade>::onPongReceived() {
-        semantic::webSocketSubProtocolLog().debug()
-            << subProtocolContext->getSocketConnection()->getConnectionName() << " Subprotocol '" << name << "': Pong received";
+        semantic::webSocketSubProtocolLog(*subProtocolContext->getSocketConnection()).debug()
+            << "Subprotocol '" << name << "': Pong received";
 
         flyingPings = 0;
     }

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -175,3 +175,8 @@ target_include_directories(SemanticStructuralLoggerCacheTest PRIVATE ${PROJECT_S
 target_compile_features(SemanticStructuralLoggerCacheTest PRIVATE cxx_std_20)
 target_link_libraries(SemanticStructuralLoggerCacheTest PRIVATE snodec-test-support snodec::core snodec::logger)
 snodec_set_source_policy_test_properties(SemanticStructuralLoggerCacheTest "unit;log;structural-cache")
+
+snodec_add_test(ScopedSemanticLoggingMigrationTest ScopedSemanticLoggingMigrationTest.cpp)
+target_include_directories(ScopedSemanticLoggingMigrationTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(ScopedSemanticLoggingMigrationTest PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
+set_tests_properties(ScopedSemanticLoggingMigrationTest PROPERTIES LABELS "unit;log;scoped-semantic")

--- a/tests/unit/log/ScopedSemanticLoggingMigrationTest.cpp
+++ b/tests/unit/log/ScopedSemanticLoggingMigrationTest.cpp
@@ -1,0 +1,146 @@
+#include "SemanticLog.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "iot/mqtt/SemanticLog.h"
+#include "log/Logger.h"
+#include "tests/support/TestResult.h"
+#include "utils/Timeval.h"
+#include "web/websocket/SemanticLog.h"
+
+#include <cstdlib>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+    class FakeSocketConnection : public core::socket::stream::SocketConnection {
+    public:
+        explicit FakeSocketConnection(int fd, std::string instance)
+            : SocketConnection(fd, instance, nullptr) {
+        }
+
+        ~FakeSocketConnection() override = default;
+
+        int getFd() const override {
+            return 0;
+        }
+
+        void sendToPeer(const char*, std::size_t) override {
+        }
+
+        bool streamToPeer(core::pipe::Source*) override {
+            return false;
+        }
+
+        void streamEof() override {
+        }
+
+        std::size_t readFromPeer(char*, std::size_t) override {
+            return 0;
+        }
+
+        void shutdownRead() override {
+        }
+
+        void shutdownWrite() override {
+        }
+
+        const core::socket::SocketAddress& getBindAddress() const override {
+            std::abort();
+        }
+
+        const core::socket::SocketAddress& getLocalAddress() const override {
+            std::abort();
+        }
+
+        const core::socket::SocketAddress& getRemoteAddress() const override {
+            std::abort();
+        }
+
+        void close() override {
+        }
+
+        void setTimeout(const utils::Timeval&) override {
+        }
+
+        void setReadTimeout(const utils::Timeval&) override {
+        }
+
+        void setWriteTimeout(const utils::Timeval&) override {
+        }
+
+        std::size_t getTotalSent() const override {
+            return 0;
+        }
+
+        std::size_t getTotalQueued() const override {
+            return 0;
+        }
+
+        std::size_t getTotalRead() const override {
+            return 0;
+        }
+
+        std::size_t getTotalProcessed() const override {
+            return 0;
+        }
+    };
+
+    bool noAnsi(const std::string& message) {
+        return message.find("\033[") == std::string::npos;
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+    logger::Logger::init();
+    logger::LogManager::init();
+
+    FakeSocketConnection first(101, "inst-a");
+    FakeSocketConnection second(202, "inst-b");
+
+    std::vector<logger::LogRecord> records;
+    const auto collect = [&](logger::LogRecord record) {
+        records.push_back(std::move(record));
+    };
+
+    web::websocket::semantic::webSocketSubProtocolLog(first, collect).debug() << "Subprotocol 'chat': start";
+    web::websocket::semantic::webSocketSubProtocolLog(second, collect).debug()
+        << "WebSocketContext: Subprotocol 'mqtt' close confirmed from peer";
+    iot::mqtt::semantic::mqttWebSocketLog(first, collect).info() << "WsMqtt: connected:";
+    iot::mqtt::semantic::mqttWebSocketLog(first, collect).debug() << "WsMqtt: Frame Data:\n" << std::string(32, ' ').append("payload-hex");
+    snode::semantic::expressLog(second, collect).trace() << "Router dispatch";
+    snode::semantic::expressLog(second, collect).debug() << "Express VerboseMiddleware: GET / HTTP/1.1";
+    web::websocket::semantic::webSocketSubProtocolLog(collect).debug() << "unscoped compatibility";
+
+    result.expectEqual(static_cast<std::size_t>(7), records.size(), "all scoped and compatibility records emitted");
+
+    result.expectTrue(records[0].origin == logger::LogOrigin::Framework && records[0].boundary == logger::LogBoundary::Connection &&
+                          records[0].component == "web.websocket.subprotocol" && records[0].instance == "inst-a" &&
+                          records[0].connection == first.getConnectionName() && records[0].message == "Subprotocol 'chat': start" &&
+                          records[0].message.rfind(first.getConnectionName(), 0) != 0,
+                      "WebSocket scoped helper preserves category and adds active inst/conn before removing text identity");
+    result.expectTrue(records[1].instance == "inst-b" && records[1].connection == second.getConnectionName() &&
+                          records[1].message.find("close confirmed from peer") != std::string::npos,
+                      "independent WebSocket connections do not cross-contaminate scoped identity");
+    result.expectTrue(records[2].component == "iot.mqtt.websocket" && records[2].instance == "inst-a" &&
+                          records[2].connection == first.getConnectionName() && records[2].message == "WsMqtt: connected:",
+                      "MQTT-over-WebSocket scoped helper preserves message content without duplicated identity");
+    result.expectTrue(records[3].message == "WsMqtt: Frame Data:\n                                payload-hex",
+                      "MQTT-over-WebSocket multiline frame-data content is preserved after identity removal");
+    result.expectTrue(records[4].boundary == logger::LogBoundary::Application && records[4].component == "express" &&
+                          records[4].instance == "inst-b" && records[4].connection == second.getConnectionName() &&
+                          records[4].message == "Router dispatch",
+                      "Express scoped helper adds active inst/conn and replaces identity-only message with non-empty operation text");
+    result.expectTrue(!records[5].message.empty() && records[5].message.rfind(second.getConnectionName(), 0) != 0,
+                      "Express middleware messages are non-empty and do not duplicate connection identity");
+    result.expectTrue(!records[6].instance && !records[6].connection && records[6].message == "unscoped compatibility",
+                      "zero-argument static helpers remain unscoped and do not inherit stale identity");
+
+    const std::string json = logger::formatJsonV1(records[0]);
+    result.expectTrue(json.find("\"instance\":\"inst-a\"") != std::string::npos &&
+                          json.find("\"connection\":\"" + first.getConnectionName() + "\"") != std::string::npos,
+                      "existing JSON path contains structured scoped identity");
+    result.expectTrue(noAnsi(logger::formatText(records[0])) && noAnsi(json), "scoped semantic logging introduces no ANSI color text");
+
+    return result.processResult();
+}

--- a/tests/unit/log/ScopedSemanticLoggingMigrationTest.cpp
+++ b/tests/unit/log/ScopedSemanticLoggingMigrationTest.cpp
@@ -103,6 +103,18 @@ int main() {
         records.push_back(std::move(record));
     };
 
+    constexpr std::size_t webSocketScoped = 0;
+    constexpr std::size_t webSocketIndependentScoped = 1;
+    constexpr std::size_t mqttScoped = 2;
+    constexpr std::size_t mqttMultilineScoped = 3;
+    constexpr std::size_t expressDispatcherScoped = 4;
+    constexpr std::size_t expressMiddlewareScoped = 5;
+    constexpr std::size_t webSocketUnscoped = 6;
+    constexpr std::size_t mqttUnscoped = 7;
+    constexpr std::size_t expressUnscoped = 8;
+    constexpr std::size_t retainedExpressScoped = 9;
+    constexpr std::size_t retainedWebSocketScoped = 10;
+
     web::websocket::semantic::webSocketSubProtocolLog(first, collect).debug() << "Subprotocol 'chat': start";
     web::websocket::semantic::webSocketSubProtocolLog(second, collect).debug()
         << "WebSocketContext: Subprotocol 'mqtt' close confirmed from peer";
@@ -110,37 +122,110 @@ int main() {
     iot::mqtt::semantic::mqttWebSocketLog(first, collect).debug() << "WsMqtt: Frame Data:\n" << std::string(32, ' ').append("payload-hex");
     snode::semantic::expressLog(second, collect).trace() << "Router dispatch";
     snode::semantic::expressLog(second, collect).debug() << "Express VerboseMiddleware: GET / HTTP/1.1";
-    web::websocket::semantic::webSocketSubProtocolLog(collect).debug() << "unscoped compatibility";
+    web::websocket::semantic::webSocketSubProtocolLog(collect).debug() << "websocket unscoped compatibility";
+    iot::mqtt::semantic::mqttWebSocketLog(collect).debug() << "mqtt websocket unscoped compatibility";
+    snode::semantic::expressLog(collect).debug() << "express unscoped compatibility";
 
-    result.expectEqual(static_cast<std::size_t>(7), records.size(), "all scoped and compatibility records emitted");
+    std::string retainedExpressConnectionName;
+    auto retainedExpressLogger = [&collect, &retainedExpressConnectionName]() {
+        FakeSocketConnection temporary(303, "temporary-instance");
+        retainedExpressConnectionName = temporary.getConnectionName();
+        return snode::semantic::expressLog(temporary, collect);
+    }();
+    retainedExpressLogger.info() << "after connection destruction";
 
-    result.expectTrue(records[0].origin == logger::LogOrigin::Framework && records[0].boundary == logger::LogBoundary::Connection &&
-                          records[0].component == "web.websocket.subprotocol" && records[0].instance == "inst-a" &&
-                          records[0].connection == first.getConnectionName() && records[0].message == "Subprotocol 'chat': start" &&
-                          records[0].message.rfind(first.getConnectionName(), 0) != 0,
-                      "WebSocket scoped helper preserves category and adds active inst/conn before removing text identity");
-    result.expectTrue(records[1].instance == "inst-b" && records[1].connection == second.getConnectionName() &&
-                          records[1].message.find("close confirmed from peer") != std::string::npos,
+    std::string retainedWebSocketConnectionName;
+    auto retainedWebSocketLogger = [&collect, &retainedWebSocketConnectionName]() {
+        FakeSocketConnection temporary(404, "temporary-websocket-instance");
+        retainedWebSocketConnectionName = temporary.getConnectionName();
+        return web::websocket::semantic::webSocketSubProtocolLog(temporary, collect);
+    }();
+    retainedWebSocketLogger.info() << "websocket after connection destruction";
+
+    result.expectEqual(
+        static_cast<std::size_t>(11), records.size(), "all scoped, unscoped compatibility, and retained log records emitted");
+
+    result.expectTrue(records[webSocketScoped].origin == logger::LogOrigin::Framework &&
+                          records[webSocketScoped].boundary == logger::LogBoundary::Connection &&
+                          records[webSocketScoped].component == "web.websocket.subprotocol" &&
+                          records[webSocketScoped].instance == "inst-a" &&
+                          records[webSocketScoped].connection == first.getConnectionName() &&
+                          records[webSocketScoped].message == "Subprotocol 'chat': start" &&
+                          records[webSocketScoped].message.rfind(first.getConnectionName(), 0) != 0,
+                      "WebSocket scoped helper preserves full category and adds active inst/conn before removing text identity");
+    result.expectTrue(records[webSocketIndependentScoped].origin == logger::LogOrigin::Framework &&
+                          records[webSocketIndependentScoped].boundary == logger::LogBoundary::Connection &&
+                          records[webSocketIndependentScoped].component == "web.websocket.subprotocol" &&
+                          records[webSocketIndependentScoped].instance == "inst-b" &&
+                          records[webSocketIndependentScoped].connection == second.getConnectionName() &&
+                          records[webSocketIndependentScoped].message == "WebSocketContext: Subprotocol 'mqtt' close confirmed from peer",
                       "independent WebSocket connections do not cross-contaminate scoped identity");
-    result.expectTrue(records[2].component == "iot.mqtt.websocket" && records[2].instance == "inst-a" &&
-                          records[2].connection == first.getConnectionName() && records[2].message == "WsMqtt: connected:",
-                      "MQTT-over-WebSocket scoped helper preserves message content without duplicated identity");
-    result.expectTrue(records[3].message == "WsMqtt: Frame Data:\n                                payload-hex",
+    result.expectTrue(
+        records[mqttScoped].origin == logger::LogOrigin::Framework && records[mqttScoped].boundary == logger::LogBoundary::Connection &&
+            records[mqttScoped].component == "iot.mqtt.websocket" && records[mqttScoped].instance == "inst-a" &&
+            records[mqttScoped].connection == first.getConnectionName() && records[mqttScoped].message == "WsMqtt: connected:",
+        "MQTT-over-WebSocket scoped helper preserves full category and message content without duplicated identity");
+    result.expectTrue(records[mqttMultilineScoped].origin == logger::LogOrigin::Framework &&
+                          records[mqttMultilineScoped].boundary == logger::LogBoundary::Connection &&
+                          records[mqttMultilineScoped].component == "iot.mqtt.websocket" &&
+                          records[mqttMultilineScoped].instance == "inst-a" &&
+                          records[mqttMultilineScoped].connection == first.getConnectionName() &&
+                          records[mqttMultilineScoped].message == "WsMqtt: Frame Data:\n                                payload-hex",
                       "MQTT-over-WebSocket multiline frame-data content is preserved after identity removal");
-    result.expectTrue(records[4].boundary == logger::LogBoundary::Application && records[4].component == "express" &&
-                          records[4].instance == "inst-b" && records[4].connection == second.getConnectionName() &&
-                          records[4].message == "Router dispatch",
-                      "Express scoped helper adds active inst/conn and replaces identity-only message with non-empty operation text");
-    result.expectTrue(!records[5].message.empty() && records[5].message.rfind(second.getConnectionName(), 0) != 0,
-                      "Express middleware messages are non-empty and do not duplicate connection identity");
-    result.expectTrue(!records[6].instance && !records[6].connection && records[6].message == "unscoped compatibility",
-                      "zero-argument static helpers remain unscoped and do not inherit stale identity");
+    result.expectTrue(
+        records[expressDispatcherScoped].origin == logger::LogOrigin::Framework &&
+            records[expressDispatcherScoped].boundary == logger::LogBoundary::Application &&
+            records[expressDispatcherScoped].component == "express" && records[expressDispatcherScoped].instance == "inst-b" &&
+            records[expressDispatcherScoped].connection == second.getConnectionName() &&
+            records[expressDispatcherScoped].message == "Router dispatch",
+        "Express dispatcher scoped helper adds active inst/conn and replaces identity-only message with non-empty operation text");
+    result.expectTrue(records[expressMiddlewareScoped].origin == logger::LogOrigin::Framework &&
+                          records[expressMiddlewareScoped].boundary == logger::LogBoundary::Application &&
+                          records[expressMiddlewareScoped].component == "express" &&
+                          records[expressMiddlewareScoped].instance == "inst-b" &&
+                          records[expressMiddlewareScoped].connection == second.getConnectionName() &&
+                          records[expressMiddlewareScoped].message == "Express VerboseMiddleware: GET / HTTP/1.1" &&
+                          records[expressMiddlewareScoped].message.rfind(second.getConnectionName(), 0) != 0,
+                      "Express middleware scoped helper preserves full category and exact message without duplicated identity");
 
-    const std::string json = logger::formatJsonV1(records[0]);
+    result.expectTrue(records[webSocketUnscoped].origin == logger::LogOrigin::Framework &&
+                          records[webSocketUnscoped].boundary == logger::LogBoundary::Connection &&
+                          records[webSocketUnscoped].component == "web.websocket.subprotocol" && !records[webSocketUnscoped].instance &&
+                          !records[webSocketUnscoped].connection &&
+                          records[webSocketUnscoped].message == "websocket unscoped compatibility",
+                      "zero-argument WebSocket subprotocol helper remains identity-free and preserves message exactly");
+    result.expectTrue(records[mqttUnscoped].origin == logger::LogOrigin::Framework &&
+                          records[mqttUnscoped].boundary == logger::LogBoundary::Connection &&
+                          records[mqttUnscoped].component == "iot.mqtt.websocket" && !records[mqttUnscoped].instance &&
+                          !records[mqttUnscoped].connection && records[mqttUnscoped].message == "mqtt websocket unscoped compatibility",
+                      "zero-argument MQTT-over-WebSocket helper remains identity-free and preserves message exactly");
+    result.expectTrue(records[expressUnscoped].origin == logger::LogOrigin::Framework &&
+                          records[expressUnscoped].boundary == logger::LogBoundary::Application &&
+                          records[expressUnscoped].component == "express" && !records[expressUnscoped].instance &&
+                          !records[expressUnscoped].connection && records[expressUnscoped].message == "express unscoped compatibility",
+                      "zero-argument Express helper remains identity-free and preserves message exactly");
+
+    result.expectTrue(records[retainedExpressScoped].origin == logger::LogOrigin::Framework &&
+                          records[retainedExpressScoped].boundary == logger::LogBoundary::Application &&
+                          records[retainedExpressScoped].component == "express" &&
+                          records[retainedExpressScoped].instance == "temporary-instance" &&
+                          records[retainedExpressScoped].connection == retainedExpressConnectionName &&
+                          records[retainedExpressScoped].message == "after connection destruction",
+                      "Express scoped logger owns copied identity and remains valid after source connection destruction");
+    result.expectTrue(records[retainedWebSocketScoped].origin == logger::LogOrigin::Framework &&
+                          records[retainedWebSocketScoped].boundary == logger::LogBoundary::Connection &&
+                          records[retainedWebSocketScoped].component == "web.websocket.subprotocol" &&
+                          records[retainedWebSocketScoped].instance == "temporary-websocket-instance" &&
+                          records[retainedWebSocketScoped].connection == retainedWebSocketConnectionName &&
+                          records[retainedWebSocketScoped].message == "websocket after connection destruction",
+                      "WebSocket scoped logger owns copied identity and remains valid after source connection destruction");
+
+    const std::string json = logger::formatJsonV1(records[webSocketScoped]);
     result.expectTrue(json.find("\"instance\":\"inst-a\"") != std::string::npos &&
                           json.find("\"connection\":\"" + first.getConnectionName() + "\"") != std::string::npos,
                       "existing JSON path contains structured scoped identity");
-    result.expectTrue(noAnsi(logger::formatText(records[0])) && noAnsi(json), "scoped semantic logging introduces no ANSI color text");
+    result.expectTrue(noAnsi(logger::formatText(records[webSocketScoped])) && noAnsi(json),
+                      "scoped semantic logging introduces no ANSI color text");
 
     return result.processResult();
 }


### PR DESCRIPTION
### Motivation

- Resolve the remaining 26 `FOLLOW_UP_SCOPED_HELPER_DESIGN` audit rows (CSI-P075–CSI-P084, CSI-P135–CSI-P142, CSI-P143–CSI-P150) by adding the smallest safe connection-scoped semantic-logging helpers and migrating only the audited call sites. 
- Ensure structured identity (`inst=` and `conn=`) is copied from the active `SocketConnection` before removing duplicated connection-name prefixes from free-text messages.
- Preserve existing zero-argument helpers and the existing semantic logging abstractions (`LogScopeOwner`, `BoundaryLogger`) while avoiding global/thread-local identity or exposing spdlog types.

### Description

- Added narrow connection-scoped overloads that copy identity from `core::socket::stream::SocketConnection` and produce a `BoundaryLogger` via `LogScopeOwner` for each surface: `webSocketSubProtocolLog(const SocketConnection&)`, `mqttWebSocketLog(const SocketConnection&)`, and `expressLog(const SocketConnection&)`, reusing existing logging primitives and owning only copied strings. 
- Migrated the 26 audited call sites to the new scoped helpers (WebSocket SubProtocol and SocketContextUpgrade, MQTT SubProtocol, Express StaticMiddleware / VerboseRequest and Router/Application/Middleware dispatchers) and removed the duplicated connection-name prefix from free-text messages while preserving substantive content (and adding short non-empty messages where the old text was identity-only). 
- Added a focused runtime test `ScopedSemanticLoggingMigrationTest` that emits scoped and unscoped records and verifies origin/boundary/component preservation, `instance`/`connection` population, message-text changes, multiline MQTT frame-data preservation, and zero-argument helper compatibility. 
- Updated the audit document `docs/logging/semantic-identity-callsite-audit.md` with a concise `Resolution status` table documenting CSI-P075–CSI-P084, CSI-P135–CSI-P142, and CSI-P143–CSI-P150 as resolved by this branch; no unrelated KEEP/REMOVE_LATER rows were changed.

### Testing

- Configured and generated the build with tests enabled using `cmake -S . -B build -DSNODEC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug`; summary: `Configuring done`; `Generating done`; `Build files have been written to: /workspace/snode.c/build`. 
- Built focused targets including the semantic logging tests and subsystem targets with `cmake --build build --target websocket websocket-server websocket-client mqtt mqtt-client-websocket mqtt-server-websocket http-server-express ScopedSemanticLoggingMigrationTest WebSocketMigration07cTest MqttMigration08Test -j2`; build completed and produced the expected targets (for example `[100%] Built target MqttMigration08Test`).
- Ran the focused scoped test: `ctest --test-dir build -R ScopedSemanticLoggingMigrationTest --output-on-failure` which passed: `100% tests passed, 0 tests failed out of 1`.
- Ran a representative combined test selection: `ctest --test-dir build -R "ScopedSemanticLoggingMigrationTest|WebSocketMigration07cTest|MqttMigration08Test|Semantic(LoggerRound2|CompatibilityRound9|BackendRound6|FilterRound7)|InetExpress(...)|WebSocketReceiverValidationTest|InetWebSocketServerClient(...)|Mqtt311PacketValidationTest" --output-on-failure` and observed `100% tests passed, 0 tests failed out of 22` with several component tests reported as skipped by CTest in this container; the focused semantic tests and related migration tests passed.

(Changed files and the focused test are included in the branch; build and test outputs above are the exact final summary lines produced during verification.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5202f3bf18832cb9a6aa7878c0da5f)