### PR TITLE
Improve semantic text formatting and terminal colors

### DIFF
--- a/docs/logging/semantic-text-output-format.md
+++ b/docs/logging/semantic-text-output-format.md
@@ -1,0 +1,52 @@
+# Semantic text output format
+
+Semantic text output is the human-readable presentation for semantic `LogRecord` data. JSON schema v1 is unchanged, production call sites and semantic identity are unchanged, and legacy `LOG`/`PLOG`/`VLOG` output is unchanged.
+
+## Plain grammar
+
+```text
+<timestamp> <LVL> <origin>/<boundary> <component> [role=...] [inst=...] [conn=...] [event=...] [error=...] [src=...] — <message>
+```
+
+Field order is fixed: timestamp, level, origin/boundary, component, role, inst, conn, event, error, src, separator, message. The timestamp remains UTC `YYYY-MM-DDTHH:MM:SS.mmmZ`.
+
+Level labels are `TRC`, `DBG`, `INF`, `WRN`, `ERR`, `CRT`, and `OFF`. Origin and boundary always render both axes, including `application/application`.
+
+## Optional fields and escaping
+
+Optional keys are exactly `role=`, `inst=`, `conn=`, `event=`, `error=`, and `src=`. Present-empty optionals render as `key=""`. Errors render before the message as `error=<code>:<text>`. Event and source are visible in text; source renders as `src=<file>:<line>` or `src=<file>:<line>:<function>`.
+
+Unquoted values must match `[A-Za-z0-9._:/@#%+-]+`; all other values are quoted. Quoted values escape backslash, quote, newline, carriage return, tab, backspace, form feed, and all other controls through `\xNN` with uppercase hex. UTF-8 bytes pass through. User-controlled controls are escaped, so raw ANSI cannot be injected.
+
+## Messages and multiline records
+
+Messages are not quoted. CRLF is one logical newline, LF is a logical newline, and lone CR becomes `\r`. Other controls use the same deterministic escapes. Empty messages omit the em dash separator and leave no trailing whitespace.
+
+Subsequent logical lines start with `│ `, preserving blank and trailing continuation lines without alignment padding.
+
+## Examples
+
+```text
+2026-07-05T12:34:56.789Z INF application/application app
+2026-07-05T12:34:56.789Z INF framework/connection core.socket role=server inst=mqtt-broker conn="[7] mqtt" — Connected
+2026-07-05T12:34:56.789Z ERR framework/system core.runtime error="5:Input/output error" src=Runtime.cpp:42:tick — failed
+2026-07-05T12:34:56.789Z TRC framework/connection web.http — GET / HTTP/1.1
+│ Request:
+│   Method: GET
+2026-07-05T12:34:56.789Z INF application/application app inst="has spaces" conn="[7] mqtt client" — quoted
+```
+
+## Color and routing
+
+Colored output is semantic terminal text only. Files never contain ANSI. JSON never contains ANSI.
+
+Palette: `TRC` 35, `DBG` 92, `INF` 93, `WRN` 33, `ERR` 31, `CRT` 91, `OFF` 39. Timestamp, origin/boundary, field keys, component, and continuation markers may be styled; values and message text remain default.
+
+TTY detection only selects the initial default. Non-TTY stdout defaults to plain text, `Logger::setDisableColor(true)` forces plain, and `Logger::setDisableColor(false)` can force color on redirected stdout.
+
+| Format | stdout with color | stdout without color | file  |
+| ------ | ----------------- | -------------------- | ----- |
+| Text   | colored           | plain                | plain |
+| JSON   | plain             | plain                | plain |
+
+Quiet mode suppresses stdout but not configured file output. No CLI/configuration option is added and no async logging is introduced.

--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -102,6 +102,7 @@ install(
     FILES_MATCHING
     PATTERN "*.h"
     PATTERN "cmake" EXCLUDE
+    PATTERN "detail" EXCLUDE
 )
 
 install(

--- a/src/log/Logger.cpp
+++ b/src/log/Logger.cpp
@@ -108,7 +108,15 @@ namespace logger {
             return;
         }
 
-        backend.emitSemantic(record.level, LogManager::formatRecord(record));
+        if (LogManager::format() == LogManager::Format::Json) {
+            const std::string json = formatJsonV1(record);
+            backend.emitSemantic(record.level, json, json);
+            return;
+        }
+
+        const std::string plain = formatText(record);
+        const std::string colored = backend.semanticStdoutUsesColor() ? formatText(record, true) : plain;
+        backend.emitSemantic(record.level, plain, colored);
     }
 
     BoundaryLogger::Sink Logger::semanticSink() {

--- a/src/log/SemanticLogger.cpp
+++ b/src/log/SemanticLogger.cpp
@@ -46,6 +46,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
 namespace logger {
     namespace {
@@ -95,6 +96,141 @@ namespace logger {
         void appendInt(std::ostringstream& out, bool& first, std::string_view name, int value) {
             out << (first ? "" : ",") << "\"" << name << "\":" << value;
             first = false;
+        }
+
+        std::string textLevel(LogLevel level) {
+            switch (level) {
+                case LogLevel::Trace:
+                    return "TRC";
+                case LogLevel::Debug:
+                    return "DBG";
+                case LogLevel::Info:
+                    return "INF";
+                case LogLevel::Warn:
+                    return "WRN";
+                case LogLevel::Error:
+                    return "ERR";
+                case LogLevel::Critical:
+                    return "CRT";
+                case LogLevel::Off:
+                    return "OFF";
+            }
+            return "OFF";
+        }
+
+        const char* levelSgr(LogLevel level) {
+            switch (level) {
+                case LogLevel::Trace:
+                    return "\033[35m";
+                case LogLevel::Debug:
+                    return "\033[92m";
+                case LogLevel::Info:
+                    return "\033[93m";
+                case LogLevel::Warn:
+                    return "\033[33m";
+                case LogLevel::Error:
+                    return "\033[31m";
+                case LogLevel::Critical:
+                    return "\033[91m";
+                case LogLevel::Off:
+                    return "\033[39m";
+            }
+            return "\033[39m";
+        }
+
+        bool safeToken(const std::string& value) {
+            if (value.empty()) {
+                return false;
+            }
+            for (const unsigned char ch : value) {
+                const bool alphaNum = (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9');
+                switch (ch) {
+                    case '.':
+                    case '_':
+                    case ':':
+                    case '/':
+                    case '@':
+                    case '#':
+                    case '%':
+                    case '+':
+                    case '-':
+                        break;
+                    default:
+                        if (!alphaNum) {
+                            return false;
+                        }
+                }
+            }
+            return true;
+        }
+
+        void appendHexEscape(std::ostringstream& out, unsigned char ch) {
+            constexpr char digits[] = "0123456789ABCDEF";
+            out << "\\x" << digits[(ch >> 4) & 0x0F] << digits[ch & 0x0F];
+        }
+
+        void appendEscapedByte(std::ostringstream& out, unsigned char ch, bool field) {
+            switch (ch) {
+                case '\\':
+                    out << (field ? "\\\\" : "\\");
+                    break;
+                case '"':
+                    out << (field ? "\\\"" : "\"");
+                    break;
+                case '\n':
+                    out << "\\n";
+                    break;
+                case '\r':
+                    out << "\\r";
+                    break;
+                case '\t':
+                    out << "\\t";
+                    break;
+                case '\b':
+                    out << "\\b";
+                    break;
+                case '\f':
+                    out << "\\f";
+                    break;
+                default:
+                    if (ch < 0x20 || ch == 0x7F) {
+                        appendHexEscape(out, ch);
+                    } else {
+                        out << static_cast<char>(ch);
+                    }
+                    break;
+            }
+        }
+
+        std::string encodeFieldValue(const std::string& value) {
+            if (safeToken(value)) {
+                return value;
+            }
+            std::ostringstream out;
+            out << '"';
+            for (const unsigned char ch : value) {
+                appendEscapedByte(out, ch, true);
+            }
+            out << '"';
+            return out.str();
+        }
+
+        std::vector<std::string> sanitizeMessageLines(const std::string& message) {
+            std::vector<std::string> lines(1);
+            for (std::size_t i = 0; i < message.size(); ++i) {
+                const unsigned char ch = static_cast<unsigned char>(message[i]);
+                if (ch == '\r' && i + 1 < message.size() && message[i + 1] == '\n') {
+                    lines.emplace_back();
+                    ++i;
+                } else if (ch == '\n') {
+                    lines.emplace_back();
+                } else {
+                    std::ostringstream escaped;
+                    appendEscapedByte(escaped, ch, false);
+                    lines.back() += escaped.str();
+                }
+            }
+            return lines;
         }
 
         struct SemanticPolicy {
@@ -338,19 +474,55 @@ namespace logger {
     }
 
     std::string formatText(const LogRecord& record) {
+        return formatText(record, false);
+    }
+
+    std::string formatText(const LogRecord& record, bool colorEnabled) {
+        constexpr const char* reset = "\033[0m";
+        constexpr const char* dim = "\033[2m";
+        constexpr const char* cyan = "\033[36m";
+        auto styled = [&](const std::string& value, const char* sgr) {
+            return colorEnabled ? std::string(sgr) + value + reset : value;
+        };
+        auto appendOptional = [&](std::ostringstream& out, std::string_view key, const std::string& value) {
+            out << ' ' << styled(std::string(key) + "=", dim) << encodeFieldValue(value);
+        };
+
         std::ostringstream out;
-        out << formatTimestamp(record.ts) << ' ' << toString(record.level) << ' ' << toString(record.origin) << ' '
-            << toString(record.boundary) << ' ' << record.component;
-        if (record.instance)
-            out << " instance=" << *record.instance;
-        if (record.role)
-            if (auto role = toString(*record.role))
-                out << " role=" << *role;
-        if (record.connection)
-            out << " connection=" << *record.connection;
-        out << " - " << record.message;
-        if (record.error)
-            out << " error=" << record.error->code << ':' << record.error->text;
+        const std::string originBoundary = toString(record.origin) + "/" + toString(record.boundary);
+        out << styled(formatTimestamp(record.ts), dim) << ' ' << styled(textLevel(record.level), levelSgr(record.level)) << ' '
+            << styled(originBoundary, dim) << ' ' << styled(record.component, cyan);
+        if (record.role) {
+            if (auto role = toString(*record.role)) {
+                appendOptional(out, "role", std::string(*role));
+            }
+        }
+        if (record.instance) {
+            appendOptional(out, "inst", *record.instance);
+        }
+        if (record.connection) {
+            appendOptional(out, "conn", *record.connection);
+        }
+        if (record.event) {
+            appendOptional(out, "event", *record.event);
+        }
+        if (record.error) {
+            appendOptional(out, "error", std::to_string(record.error->code) + ":" + record.error->text);
+        }
+        if (record.source) {
+            std::string source = record.source->file + ":" + std::to_string(record.source->line);
+            if (!record.source->func.empty()) {
+                source += ":" + record.source->func;
+            }
+            appendOptional(out, "src", source);
+        }
+        if (!record.message.empty()) {
+            const auto lines = sanitizeMessageLines(record.message);
+            out << " — " << lines.front();
+            for (std::size_t i = 1; i < lines.size(); ++i) {
+                out << '\n' << styled("│ ", dim) << lines[i];
+            }
+        }
         return out.str();
     }
 

--- a/src/log/SemanticLogger.h
+++ b/src/log/SemanticLogger.h
@@ -111,6 +111,7 @@ namespace logger {
     std::string formatTimestamp(std::chrono::system_clock::time_point ts);
     std::string formatJsonV1(const LogRecord& record);
     std::string formatText(const LogRecord& record);
+    std::string formatText(const LogRecord& record, bool colorEnabled);
 
     class LogManager {
     public:

--- a/src/log/detail/SpdlogBackend.cpp
+++ b/src/log/detail/SpdlogBackend.cpp
@@ -247,16 +247,20 @@ namespace logger::detail {
             }
         }
 
-        void emitSemantic(const LogLevel level, const std::string& formattedRecord) {
+        bool semanticStdoutUsesColor() const {
+            return !quietMode && semanticStdoutLogger && !disableColor;
+        }
+
+        void emitSemantic(const LogLevel level, const std::string& plainRecord, const std::string& coloredRecord) {
             const auto spdlogLevel = mapSemanticLevel(level);
             if (!spdlogLevel) {
                 return;
             }
             if (!quietMode && semanticStdoutLogger) {
-                semanticStdoutLogger->log(*spdlogLevel, formattedRecord);
+                semanticStdoutLogger->log(*spdlogLevel, disableColor ? plainRecord : coloredRecord);
             }
             if (semanticFileLogger) {
-                semanticFileLogger->log(*spdlogLevel, formattedRecord);
+                semanticFileLogger->log(*spdlogLevel, plainRecord);
             }
         }
 
@@ -335,8 +339,12 @@ namespace logger::detail {
         impl_->emitLegacy(level, std::move(message), withErrno, errnoValue);
     }
 
-    void SpdlogBackend::emitSemantic(const LogLevel level, const std::string& formattedRecord) {
-        impl_->emitSemantic(level, formattedRecord);
+    void SpdlogBackend::emitSemantic(const LogLevel level, const std::string& plainRecord, const std::string& coloredRecord) {
+        impl_->emitSemantic(level, plainRecord, coloredRecord);
+    }
+
+    bool SpdlogBackend::semanticStdoutUsesColor() const {
+        return impl_->semanticStdoutUsesColor();
     }
 
     bool SpdlogBackend::shouldLog(const Level level) const {

--- a/src/log/detail/SpdlogBackend.h
+++ b/src/log/detail/SpdlogBackend.h
@@ -45,7 +45,8 @@ namespace logger::detail {
         void disableLogFile();
 
         void emitLegacy(Level level, std::string message, bool withErrno, int errnoValue);
-        void emitSemantic(LogLevel level, const std::string& formattedRecord);
+        void emitSemantic(LogLevel level, const std::string& plainRecord, const std::string& coloredRecord);
+        bool semanticStdoutUsesColor() const;
 
         bool shouldLog(Level level) const;
         bool shouldVerbose(int verboseLevel) const;

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -126,6 +126,12 @@ target_compile_features(SemanticEndToEndOutputTest PRIVATE cxx_std_20)
 target_link_libraries(SemanticEndToEndOutputTest PRIVATE snodec-test-support snodec::logger)
 set_tests_properties(SemanticEndToEndOutputTest PROPERTIES LABELS "unit;log;e2e")
 
+snodec_add_test(SemanticTerminalColorRoutingTest SemanticTerminalColorRoutingTest.cpp)
+target_include_directories(SemanticTerminalColorRoutingTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(SemanticTerminalColorRoutingTest PRIVATE cxx_std_20)
+target_link_libraries(SemanticTerminalColorRoutingTest PRIVATE snodec-test-support snodec::logger)
+set_tests_properties(SemanticTerminalColorRoutingTest PROPERTIES LABELS "unit;log;routing")
+
 function(snodec_set_source_policy_test_properties test_name labels)
     set_tests_properties(${test_name} PROPERTIES
         LABELS "${labels}"

--- a/tests/unit/log/ControlledMigrationRound8Test.cpp
+++ b/tests/unit/log/ControlledMigrationRound8Test.cpp
@@ -167,8 +167,8 @@ int main() {
     const auto connectionLog = readFile(connectionPath);
     result.expectTrue(connectionLog.find("SocketContext: switch") != std::string::npos,
                       "migrated SocketConnection call emits through semantic backend");
-    result.expectTrue(connectionLog.find(" framework connection core.socket.stream ") != std::string::npos,
-                      "migrated SocketConnection call carries framework connection scope");
+    result.expectTrue(connectionLog.find(" framework/connection core.socket.stream ") != std::string::npos,
+                      "migrated SocketConnection call carries framework/connection scope");
 
     const auto contextPath = tempLogPath("snodec-round8-context.log");
     {
@@ -182,7 +182,7 @@ int main() {
     const auto contextLog = readFile(contextPath);
     result.expectTrue(contextLog.find("SocketContext: EOF received") != std::string::npos,
                       "migrated SocketContext call emits through semantic backend");
-    result.expectTrue(contextLog.find(" framework context core.socket.context ") != std::string::npos,
+    result.expectTrue(contextLog.find(" framework/context core.socket.context ") != std::string::npos,
                       "migrated SocketContext framework-internal call emits with framework origin");
 
     const auto filterPath = tempLogPath("snodec-round8-filter.log");

--- a/tests/unit/log/CoreRuntimeMigration04Test.cpp
+++ b/tests/unit/log/CoreRuntimeMigration04Test.cpp
@@ -73,7 +73,7 @@ int main() {
     const auto enabledLog = readFile(enabledPath);
     result.expectTrue(enabledLog.find("core runtime semantic owner emitted") != std::string::npos,
                       "core runtime semantic owner emits when enabled");
-    result.expectTrue(enabledLog.find(" framework system core.event-loop ") != std::string::npos,
+    result.expectTrue(enabledLog.find(" framework/system core.event-loop ") != std::string::npos,
                       "emitted records carry framework core-runtime component scope");
 
     const auto managerFilterPath = tempLogPath("snodec-migration04-manager-filter.log");

--- a/tests/unit/log/FinalCleanupMigration09Test.cpp
+++ b/tests/unit/log/FinalCleanupMigration09Test.cpp
@@ -75,11 +75,11 @@ int main() {
                       "TLS config semantic logger emits when enabled");
     result.expectTrue(enabledLog.find("application request completed") != std::string::npos,
                       "app/example semantic logger emits when enabled");
-    result.expectTrue(enabledLog.find(" framework connection db.mariadb ") != std::string::npos,
+    result.expectTrue(enabledLog.find(" framework/connection db.mariadb ") != std::string::npos,
                       "DB records carry correct framework/connection/component scope");
-    result.expectTrue(enabledLog.find(" framework configuration net.config.tls ") != std::string::npos,
+    result.expectTrue(enabledLog.find(" framework/configuration net.config.tls ") != std::string::npos,
                       "TLS records carry correct framework/configuration/component scope");
-    result.expectTrue(enabledLog.find(" application application app ") != std::string::npos,
+    result.expectTrue(enabledLog.find(" application/application app ") != std::string::npos,
                       "application records carry correct application/application/component scope");
 
     const auto managerFilterPath = tempLogPath("snodec-migration09-manager-filter.log");

--- a/tests/unit/log/HttpClientMigration07aTest.cpp
+++ b/tests/unit/log/HttpClientMigration07aTest.cpp
@@ -71,7 +71,7 @@ int main() {
     const auto enabledLog = readFile(enabledPath);
     result.expectTrue(enabledLog.find("http client semantic logger emitted") != std::string::npos,
                       "HTTP client semantic logger emits when enabled");
-    result.expectTrue(enabledLog.find(" framework connection web.http.client ") != std::string::npos,
+    result.expectTrue(enabledLog.find(" framework/connection web.http.client ") != std::string::npos,
                       "records carry framework web.http.client component scope");
 
     const auto managerFilterPath = tempLogPath("snodec-migration07a-manager-filter.log");

--- a/tests/unit/log/HttpServerMigration07bTest.cpp
+++ b/tests/unit/log/HttpServerMigration07bTest.cpp
@@ -71,7 +71,7 @@ int main() {
     const auto enabledLog = readFile(enabledPath);
     result.expectTrue(enabledLog.find("http server semantic logger emitted") != std::string::npos,
                       "HTTP server semantic logger emits when enabled");
-    result.expectTrue(enabledLog.find(" framework connection web.http.server ") != std::string::npos,
+    result.expectTrue(enabledLog.find(" framework/connection web.http.server ") != std::string::npos,
                       "records carry framework web.http.server component scope");
 
     const auto managerFilterPath = tempLogPath("snodec-migration07b-manager-filter.log");

--- a/tests/unit/log/LogScopeOwnerRound3Test.cpp
+++ b/tests/unit/log/LogScopeOwnerRound3Test.cpp
@@ -8,7 +8,10 @@
 #include <vector>
 
 namespace {
-    void expectStringEqual(tests::support::TestResult& result, const std::string& expected, std::string_view actual, const std::string& message) {
+    void expectStringEqual(tests::support::TestResult& result,
+                           const std::string& expected,
+                           std::string_view actual,
+                           const std::string& message) {
         result.expectTrue(expected == actual, message + " expected='" + expected + "' actual='" + std::string(actual) + "'");
     }
 
@@ -21,10 +24,11 @@ namespace {
         std::string component = "core.socket.stream";
         std::string instance = "echo-server";
         std::string connection = "#7";
-        logger::LogScope borrowed{logger::LogOrigin::Framework, logger::LogBoundary::Connection, component, instance, logger::LogRole::Server, connection};
+        logger::LogScope borrowed{
+            logger::LogOrigin::Framework, logger::LogBoundary::Connection, component, instance, logger::LogRole::Server, connection};
         return logger::LogScopeOwner::fromScope(borrowed);
     }
-}
+} // namespace
 
 int main() {
     tests::support::TestResult result;
@@ -37,7 +41,8 @@ int main() {
     std::string component = "core.socket.stream";
     std::string instance = "echo-server";
     std::string connection = "#7";
-    logger::LogScope borrowed{logger::LogOrigin::Framework, logger::LogBoundary::Connection, component, instance, logger::LogRole::Server, connection};
+    logger::LogScope borrowed{
+        logger::LogOrigin::Framework, logger::LogBoundary::Connection, component, instance, logger::LogRole::Server, connection};
 
     auto owner = logger::LogScopeOwner::fromScope(borrowed);
 
@@ -61,7 +66,9 @@ int main() {
 
     std::vector<logger::LogRecord> records;
     auto log = owner.logger(
-        [&](logger::LogRecord record) { records.push_back(std::move(record)); },
+        [&](logger::LogRecord record) {
+            records.push_back(std::move(record));
+        },
         logger::LogLevel::Trace,
         fixedTimestamp);
     log.info("hello");
@@ -71,11 +78,14 @@ int main() {
     result.expectTrue(records[0].role && *records[0].role == logger::LogRole::Server, "logger from owner emits original known role");
     result.expectTrue(records[0].connection && *records[0].connection == "#7", "logger from owner emits original connection");
 
-    logger::LogScope unknownRole{logger::LogOrigin::Application, logger::LogBoundary::Context, "EchoServerContext", "", logger::LogRole::Unknown, ""};
+    logger::LogScope unknownRole{
+        logger::LogOrigin::Application, logger::LogBoundary::Context, "EchoServerContext", "", logger::LogRole::Unknown, ""};
     auto unknownOwner = logger::LogScopeOwner::fromScope(unknownRole);
     auto unknownScope = unknownOwner.scope();
-    result.expectTrue(unknownScope.role == logger::LogRole::Unknown, "unknown role remains absent in owner and appears as Unknown in borrowed view");
-    auto unknownRecord = logger::materialize(unknownScope, logger::LogLevel::Info, "hello", logger::LogRecordOptions{.ts = fixedTimestamp()});
+    result.expectTrue(unknownScope.role == logger::LogRole::Unknown,
+                      "unknown role remains absent in owner and appears as Unknown in borrowed view");
+    auto unknownRecord =
+        logger::materialize(unknownScope, logger::LogLevel::Info, "hello", logger::LogRecordOptions{.ts = fixedTimestamp()});
     const std::string unknownJson = logger::formatJsonV1(unknownRecord);
     result.expectTrue(unknownJson.find("role") == std::string::npos, "unknown role remains omitted from JSON");
     result.expectTrue(unknownJson.find("unknown") == std::string::npos, "unknown role string is not emitted in JSON");

--- a/tests/unit/log/MqttMigration08Test.cpp
+++ b/tests/unit/log/MqttMigration08Test.cpp
@@ -70,7 +70,7 @@ int main() {
     }
     const auto enabledLog = readFile(enabledPath);
     result.expectTrue(enabledLog.find("mqtt semantic logger emitted") != std::string::npos, "MQTT semantic logger emits when enabled");
-    result.expectTrue(enabledLog.find(" framework connection iot.mqtt ") != std::string::npos,
+    result.expectTrue(enabledLog.find(" framework/connection iot.mqtt ") != std::string::npos,
                       "records carry framework iot.mqtt component scope");
 
     const auto managerFilterPath = tempLogPath("snodec-migration08-manager-filter.log");

--- a/tests/unit/log/NetPhysicalSocketMigration05Test.cpp
+++ b/tests/unit/log/NetPhysicalSocketMigration05Test.cpp
@@ -74,7 +74,7 @@ int main() {
     const auto enabledLog = readFile(enabledPath);
     result.expectTrue(enabledLog.find("net physical socket semantic owner emitted") != std::string::npos,
                       "net physical-socket semantic owner emits when enabled");
-    result.expectTrue(enabledLog.find(" framework system net.un ") != std::string::npos,
+    result.expectTrue(enabledLog.find(" framework/system net.un ") != std::string::npos,
                       "emitted records carry framework net physical-socket component scope");
 
     const auto managerFilterPath = tempLogPath("snodec-migration05-manager-filter.log");

--- a/tests/unit/log/ProductionLogApiRound4Test.cpp
+++ b/tests/unit/log/ProductionLogApiRound4Test.cpp
@@ -20,52 +20,91 @@ namespace {
     class TestConfigInstance : public net::config::ConfigInstance {
     public:
         explicit TestConfigInstance(const std::string& instanceName)
-            : ConfigInstance(instanceName, Role::SERVER) {}
+            : ConfigInstance(instanceName, Role::SERVER) {
+        }
         ~TestConfigInstance() override = default;
     };
 
     class TestSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit TestSocketConnection(const std::string& instanceName)
-            : SocketConnection(7, instanceName, nullptr) {}
+            : SocketConnection(7, instanceName, nullptr) {
+        }
         ~TestSocketConnection() override = default;
 
-        int getFd() const override { return 7; }
-        void sendToPeer(const char*, std::size_t) override {}
-        bool streamToPeer(core::pipe::Source*) override { return false; }
-        void streamEof() override {}
-        std::size_t readFromPeer(char*, std::size_t) override { return 0; }
-        void shutdownRead() override {}
-        void shutdownWrite() override {}
-        const core::socket::SocketAddress& getBindAddress() const override { return unusableAddress(); }
-        const core::socket::SocketAddress& getLocalAddress() const override { return unusableAddress(); }
-        const core::socket::SocketAddress& getRemoteAddress() const override { return unusableAddress(); }
-        void close() override {}
-        void setTimeout(const utils::Timeval&) override {}
-        void setReadTimeout(const utils::Timeval&) override {}
-        void setWriteTimeout(const utils::Timeval&) override {}
-        std::size_t getTotalSent() const override { return 0; }
-        std::size_t getTotalQueued() const override { return 0; }
-        std::size_t getTotalRead() const override { return 0; }
-        std::size_t getTotalProcessed() const override { return 0; }
+        int getFd() const override {
+            return 7;
+        }
+        void sendToPeer(const char*, std::size_t) override {
+        }
+        bool streamToPeer(core::pipe::Source*) override {
+            return false;
+        }
+        void streamEof() override {
+        }
+        std::size_t readFromPeer(char*, std::size_t) override {
+            return 0;
+        }
+        void shutdownRead() override {
+        }
+        void shutdownWrite() override {
+        }
+        const core::socket::SocketAddress& getBindAddress() const override {
+            return unusableAddress();
+        }
+        const core::socket::SocketAddress& getLocalAddress() const override {
+            return unusableAddress();
+        }
+        const core::socket::SocketAddress& getRemoteAddress() const override {
+            return unusableAddress();
+        }
+        void close() override {
+        }
+        void setTimeout(const utils::Timeval&) override {
+        }
+        void setReadTimeout(const utils::Timeval&) override {
+        }
+        void setWriteTimeout(const utils::Timeval&) override {
+        }
+        std::size_t getTotalSent() const override {
+            return 0;
+        }
+        std::size_t getTotalQueued() const override {
+            return 0;
+        }
+        std::size_t getTotalRead() const override {
+            return 0;
+        }
+        std::size_t getTotalProcessed() const override {
+            return 0;
+        }
 
     private:
-        static const core::socket::SocketAddress& unusableAddress() { return *static_cast<const core::socket::SocketAddress*>(nullptr); }
+        static const core::socket::SocketAddress& unusableAddress() {
+            return *static_cast<const core::socket::SocketAddress*>(nullptr);
+        }
     };
 
     class TestSocketContext : public core::socket::stream::SocketContext {
     public:
         explicit TestSocketContext(core::socket::stream::SocketConnection* socketConnection)
-            : SocketContext(socketConnection) {}
+            : SocketContext(socketConnection) {
+        }
         ~TestSocketContext() override = default;
 
     private:
-        std::size_t onReceivedFromPeer() override { return 0; }
-        bool onSignal(int) override { return false; }
-        void onConnected() override {}
-        void onDisconnected() override {}
+        std::size_t onReceivedFromPeer() override {
+            return 0;
+        }
+        bool onSignal(int) override {
+            return false;
+        }
+        void onConnected() override {
+        }
+        void onDisconnected() override {
+        }
     };
-}
+} // namespace
 
 int main() {
     tests::support::TestResult result;
@@ -81,29 +120,60 @@ int main() {
 
     TestConfigInstance config("round4-instance");
     std::vector<logger::LogRecord> configRecords;
-    config.log([&](logger::LogRecord record) { configRecords.push_back(std::move(record)); }, logger::LogLevel::Trace, fixedTimestamp).info("config ready");
+    config
+        .log(
+            [&](logger::LogRecord record) {
+                configRecords.push_back(std::move(record));
+            },
+            logger::LogLevel::Trace,
+            fixedTimestamp)
+        .info("config ready");
     result.expectEqual(1, static_cast<int>(configRecords.size()), "ConfigInstance log emits one record");
     result.expectTrue(configRecords[0].origin == logger::LogOrigin::Framework, "ConfigInstance log uses framework origin");
     result.expectTrue(configRecords[0].boundary == logger::LogBoundary::Configuration, "ConfigInstance log uses configuration boundary");
     result.expectTrue(configRecords[0].component == "configuration", "ConfigInstance log uses configuration component");
-    result.expectTrue(configRecords[0].instance && *configRecords[0].instance == "round4-instance", "ConfigInstance log owns instance identity");
+    result.expectTrue(configRecords[0].instance && *configRecords[0].instance == "round4-instance",
+                      "ConfigInstance log owns instance identity");
     result.expectTrue(configRecords[0].role && *configRecords[0].role == logger::LogRole::Server, "ConfigInstance log maps server role");
     result.expectTrue(!configRecords[0].connection, "ConfigInstance log leaves connection absent");
 
     TestSocketConnection connection("round4-instance");
     std::vector<logger::LogRecord> connectionRecords;
-    connection.log([&](logger::LogRecord record) { connectionRecords.push_back(std::move(record)); }, logger::LogLevel::Trace, fixedTimestamp).info("connection ready");
+    connection
+        .log(
+            [&](logger::LogRecord record) {
+                connectionRecords.push_back(std::move(record));
+            },
+            logger::LogLevel::Trace,
+            fixedTimestamp)
+        .info("connection ready");
     result.expectEqual(1, static_cast<int>(connectionRecords.size()), "SocketConnection log emits one record");
     result.expectTrue(connectionRecords[0].origin == logger::LogOrigin::Framework, "SocketConnection log uses framework origin");
     result.expectTrue(connectionRecords[0].boundary == logger::LogBoundary::Connection, "SocketConnection log uses connection boundary");
     result.expectTrue(connectionRecords[0].component == "core.socket.stream", "SocketConnection log uses stream component");
-    result.expectTrue(connectionRecords[0].instance && *connectionRecords[0].instance == "round4-instance", "SocketConnection log owns instance identity");
-    result.expectTrue(connectionRecords[0].connection && *connectionRecords[0].connection == "[7] round4-instance", "SocketConnection log owns connection identity");
+    result.expectTrue(connectionRecords[0].instance && *connectionRecords[0].instance == "round4-instance",
+                      "SocketConnection log owns instance identity");
+    result.expectTrue(connectionRecords[0].connection && *connectionRecords[0].connection == "[7] round4-instance",
+                      "SocketConnection log owns connection identity");
 
     TestSocketContext context(&connection);
     std::vector<logger::LogRecord> contextRecords;
-    context.log([&](logger::LogRecord record) { contextRecords.push_back(std::move(record)); }, logger::LogLevel::Trace, fixedTimestamp).info("application context ready");
-    context.frameworkLog([&](logger::LogRecord record) { contextRecords.push_back(std::move(record)); }, logger::LogLevel::Trace, fixedTimestamp).info("framework context ready");
+    context
+        .log(
+            [&](logger::LogRecord record) {
+                contextRecords.push_back(std::move(record));
+            },
+            logger::LogLevel::Trace,
+            fixedTimestamp)
+        .info("application context ready");
+    context
+        .frameworkLog(
+            [&](logger::LogRecord record) {
+                contextRecords.push_back(std::move(record));
+            },
+            logger::LogLevel::Trace,
+            fixedTimestamp)
+        .info("framework context ready");
     result.expectEqual(2, static_cast<int>(contextRecords.size()), "SocketContext log APIs emit two records");
     result.expectTrue(contextRecords[0].origin == logger::LogOrigin::Application, "SocketContext log() uses application origin");
     result.expectTrue(contextRecords[1].origin == logger::LogOrigin::Framework, "SocketContext frameworkLog() uses framework origin");
@@ -111,8 +181,10 @@ int main() {
     result.expectTrue(contextRecords[1].boundary == logger::LogBoundary::Context, "SocketContext frameworkLog() uses context boundary");
     result.expectTrue(contextRecords[0].component == "core.socket.context" && contextRecords[1].component == "core.socket.context",
                       "SocketContext logs use context component");
-    result.expectTrue(contextRecords[0].instance && *contextRecords[0].instance == "round4-instance", "SocketContext log owns instance identity");
-    result.expectTrue(contextRecords[0].connection && *contextRecords[0].connection == "[7] round4-instance", "SocketContext log owns connection identity");
+    result.expectTrue(contextRecords[0].instance && *contextRecords[0].instance == "round4-instance",
+                      "SocketContext log owns instance identity");
+    result.expectTrue(contextRecords[0].connection && *contextRecords[0].connection == "[7] round4-instance",
+                      "SocketContext log owns connection identity");
 
     return result.processResult();
 }

--- a/tests/unit/log/SemanticEndToEndOutputTest.cpp
+++ b/tests/unit/log/SemanticEndToEndOutputTest.cpp
@@ -93,7 +93,7 @@ int main() {
     result.expectEqual(1, static_cast<int>(textLines.size()), "semantic text emits one logical output line");
     if (!textLines.empty()) {
         const auto& line = textLines.front();
-        result.expectTrue(contains(line, "2026-07-05T12:34:56.789Z info framework connection core.socket - semantic text output"),
+        result.expectTrue(contains(line, "2026-07-05T12:34:56.789Z INF framework/connection core.socket — semantic text output"),
                           "semantic text contains the formatter-selected text fields");
         result.expectTrue(!startsWith(line, "INFO") && !startsWith(line, "DEBUG") && !startsWith(line, "TRACE") &&
                               !startsWith(line, "WARNING") && !startsWith(line, "ERROR") && !startsWith(line, "FATAL"),

--- a/tests/unit/log/SemanticEndToEndOutputTest.cpp
+++ b/tests/unit/log/SemanticEndToEndOutputTest.cpp
@@ -67,6 +67,10 @@ namespace {
         return value.find(needle) != std::string::npos;
     }
 
+    bool containsAnsi(const std::string& value) {
+        return contains(value, "\033[");
+    }
+
     std::chrono::system_clock::time_point fixedTimestamp() {
         using namespace std::chrono;
         return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
@@ -93,8 +97,9 @@ int main() {
     result.expectEqual(1, static_cast<int>(textLines.size()), "semantic text emits one logical output line");
     if (!textLines.empty()) {
         const auto& line = textLines.front();
-        result.expectTrue(contains(line, "2026-07-05T12:34:56.789Z INF framework/connection core.socket — semantic text output"),
-                          "semantic text contains the formatter-selected text fields");
+        result.expectTrue(line == "2026-07-05T12:34:56.789Z INF framework/connection core.socket — semantic text output",
+                          "semantic text file output exactly matches the final plain formatter shape");
+        result.expectTrue(!containsAnsi(line), "semantic text file output contains no ANSI");
         result.expectTrue(!startsWith(line, "INFO") && !startsWith(line, "DEBUG") && !startsWith(line, "TRACE") &&
                               !startsWith(line, "WARNING") && !startsWith(line, "ERROR") && !startsWith(line, "FATAL"),
                           "semantic text is not wrapped with a legacy severity prefix");
@@ -112,18 +117,20 @@ int main() {
     }
     const auto jsonLines = readLines(jsonPath);
     result.expectEqual(2, static_cast<int>(jsonLines.size()), "semantic JSON emits one object per record line");
-    for (const auto& line : jsonLines) {
-        result.expectTrue(startsWith(line, "{"), "semantic JSON line starts with a JSON object");
-        result.expectTrue(!startsWith(line, "INFO ") && !startsWith(line, "WARNING") && !startsWith(line, "ERROR") &&
-                              !contains(line, " E2ETICK "),
-                          "semantic JSON line is not legacy-prefixed");
-        result.expectTrue(contains(line, "\"v\":1"), "semantic JSON line contains schema version");
-        result.expectTrue(contains(line, "\"component\":\"web.http\""), "semantic JSON line contains component");
-        result.expectTrue(contains(line, "\"message\":"), "semantic JSON line contains message");
-        result.expectTrue(line.back() == '}', "semantic JSON line ends as one object");
+    const std::vector<std::string> expectedJsonLines{
+        R"({"v":1,"ts":"2026-07-05T12:34:56.789Z","level":"info","origin":"framework","boundary":"connection","component":"web.http","message":"semantic json output"})",
+        R"({"v":1,"ts":"2026-07-05T12:34:56.789Z","level":"warn","origin":"framework","boundary":"connection","component":"web.http","message":"semantic json warning"})",
+    };
+    if (jsonLines.size() == expectedJsonLines.size()) {
+        for (std::size_t i = 0; i < jsonLines.size(); ++i) {
+            result.expectTrue(jsonLines[i] == expectedJsonLines[i], "semantic JSON file line exactly matches JSON baseline");
+            result.expectTrue(startsWith(jsonLines[i], "{") && jsonLines[i].back() == '}', "semantic JSON line is one complete object");
+            result.expectTrue(!containsAnsi(jsonLines[i]), "semantic JSON file line contains no ANSI");
+            result.expectTrue(!startsWith(jsonLines[i], "INFO ") && !startsWith(jsonLines[i], "WARNING") &&
+                                  !startsWith(jsonLines[i], "ERROR") && !contains(jsonLines[i], " E2ETICK "),
+                              "semantic JSON line is not legacy-prefixed");
+        }
     }
-    result.expectTrue(contains(jsonLines.empty() ? std::string() : jsonLines.front(), "\"level\":\"info\""),
-                      "semantic JSON info record contains expected level");
 
     const auto legacyPath = tempLogPath("snodec-semantic-e2e-legacy.log");
     {

--- a/tests/unit/log/SemanticLoggerRound2Test.cpp
+++ b/tests/unit/log/SemanticLoggerRound2Test.cpp
@@ -69,10 +69,47 @@ int main() {
                       "JSON does not emit raw control bytes below 0x20");
 
     const std::string text = logger::formatText(owned);
-    result.expectTrue(text.find("2026-07-05T12:34:56.789Z") != std::string::npos &&
-                          text.find("info framework connection mqtt.server") != std::string::npos &&
-                          text.find("ready") != std::string::npos,
-                      "text formatter includes timestamp level origin boundary component and message");
+    expectStringEqual(result,
+                      "2026-07-05T12:34:56.789Z INF framework/connection mqtt.server role=server inst=mqtt-broker conn=#7 — ready",
+                      text,
+                      "text formatter uses final semantic grammar");
+    result.expectTrue(logger::formatText(owned) == logger::formatText(owned, false), "plain overloads are byte-equivalent");
+    const std::string coloredText = logger::formatText(owned, true);
+    result.expectTrue(coloredText.find("\033[") != std::string::npos, "colored formatter emits ANSI SGR");
+
+    auto emptyMessage = logger::materialize(unknownRole, logger::LogLevel::Info, "", logger::LogRecordOptions{.ts = fixedTimestamp()});
+    expectStringEqual(result,
+                      "2026-07-05T12:34:56.789Z INF application/context EchoServerContext",
+                      logger::formatText(emptyMessage),
+                      "empty semantic messages omit separator and trailing whitespace");
+
+    logger::LogRecord rich = owned;
+    rich.event = std::string("http.response");
+    rich.error = logger::LogError{5, "Input/output error"};
+    rich.source = logger::LogSource{"SocketContext.cpp", 123, "onRead"};
+    rich.connection = std::string("[7] mqtt client");
+    expectStringEqual(
+        result,
+        R"(2026-07-05T12:34:56.789Z INF framework/connection mqtt.server role=server inst=mqtt-broker conn="[7] mqtt client" event=http.response error="5:Input/output error" src=SocketContext.cpp:123:onRead — ready)",
+        logger::formatText(rich),
+        "rich text formatter renders deterministic fields before the message");
+
+    logger::LogRecord escaped = emptyMessage;
+    escaped.instance = std::string("space = | , ; [ ] \" \\");
+    escaped.connection = std::string("line\ncr\rtab\tbs\bff\f") + static_cast<char>(0) + static_cast<char>(0x1B) + static_cast<char>(0x7F);
+    escaped.event = std::string("");
+    escaped.message = std::string("first\r\n\nthird\nraw") + static_cast<char>(0x1B) + " utf8=µ";
+    const std::string escapedText = logger::formatText(escaped);
+    result.expectTrue(escapedText.find("inst=\"") != std::string::npos && escapedText.find("\\\"") != std::string::npos &&
+                          escapedText.find("\\\\") != std::string::npos,
+                      "quoted fields escape quotes and backslashes");
+    result.expectTrue(escapedText.find("event=\"\"") != std::string::npos, "present-empty optionals render quoted empty strings");
+    result.expectTrue(escapedText.find("\\x00") != std::string::npos && escapedText.find("\\x1B") != std::string::npos &&
+                          escapedText.find("\\x7F") != std::string::npos,
+                      "control bytes are escaped as deterministic hex");
+    result.expectTrue(escapedText.find("— first\n│ \n│ third\n│ raw\\x1B utf8=µ") != std::string::npos,
+                      "CRLF, blank lines, trailing markers, ESC sanitization, and UTF-8 messages are preserved");
+    result.expectTrue(escapedText.find(static_cast<char>(0x1B)) == std::string::npos, "raw ESC never reaches plain semantic output");
 
     std::vector<logger::LogRecord> records;
     logger::LogScope scope{logger::LogOrigin::Framework,

--- a/tests/unit/log/SemanticLoggerRound2Test.cpp
+++ b/tests/unit/log/SemanticLoggerRound2Test.cpp
@@ -2,6 +2,7 @@
 #include "log/SemanticLogger.h"
 #include "tests/support/TestResult.h"
 
+#include <cctype>
 #include <cerrno>
 #include <chrono>
 #include <iostream>
@@ -20,6 +21,37 @@ namespace {
     std::chrono::system_clock::time_point fixedTimestamp() {
         using namespace std::chrono;
         return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
+    }
+
+    bool containsAnsi(const std::string& value) {
+        return value.find("\033[") != std::string::npos;
+    }
+
+    std::string stripAnsi(std::string_view value) {
+        std::string stripped;
+        for (std::size_t i = 0; i < value.size();) {
+            if (value[i] == '\033' && i + 2 < value.size() && value[i + 1] == '[') {
+                std::size_t j = i + 2;
+                while (j < value.size() && (std::isdigit(static_cast<unsigned char>(value[j])) || value[j] == ';')) {
+                    ++j;
+                }
+                if (j < value.size() && value[j] == 'm') {
+                    i = j + 1;
+                    continue;
+                }
+            }
+            stripped.push_back(value[i]);
+            ++i;
+        }
+        return stripped;
+    }
+
+    logger::LogRecord simpleRecord(logger::LogLevel level, std::string message = "connected") {
+        return logger::materialize(
+            logger::LogScope{logger::LogOrigin::Application, logger::LogBoundary::Application, "app", "", logger::LogRole::Unknown, ""},
+            level,
+            std::move(message),
+            logger::LogRecordOptions{.ts = fixedTimestamp()});
     }
 } // namespace
 
@@ -75,7 +107,42 @@ int main() {
                       "text formatter uses final semantic grammar");
     result.expectTrue(logger::formatText(owned) == logger::formatText(owned, false), "plain overloads are byte-equivalent");
     const std::string coloredText = logger::formatText(owned, true);
-    result.expectTrue(coloredText.find("\033[") != std::string::npos, "colored formatter emits ANSI SGR");
+    result.expectTrue(!containsAnsi(text), "plain formatter emits no ANSI SGR");
+    result.expectTrue(containsAnsi(coloredText), "colored formatter emits ANSI SGR");
+
+    expectStringEqual(result,
+                      "2026-07-05T12:34:56.789Z INF application/application app — connected",
+                      logger::formatText(simpleRecord(logger::LogLevel::Info)),
+                      "application/application remains explicit in semantic text");
+
+    const std::vector<std::pair<logger::LogLevel, std::string>> levelExpectations{
+        {logger::LogLevel::Trace, "TRC"},
+        {logger::LogLevel::Debug, "DBG"},
+        {logger::LogLevel::Info, "INF"},
+        {logger::LogLevel::Warn, "WRN"},
+        {logger::LogLevel::Error, "ERR"},
+        {logger::LogLevel::Critical, "CRT"},
+        {logger::LogLevel::Off, "OFF"},
+    };
+    for (const auto& [level, label] : levelExpectations) {
+        expectStringEqual(result,
+                          "2026-07-05T12:34:56.789Z " + label + " application/application app — connected",
+                          logger::formatText(simpleRecord(level)),
+                          "semantic text level label " + label + " is exact");
+    }
+
+    expectStringEqual(result,
+                      "2026-07-05T12:34:56.789Z INF application/application app — first\n│ ",
+                      logger::formatText(simpleRecord(logger::LogLevel::Info, "first\n")),
+                      "trailing newline preserves a blank continuation line");
+    expectStringEqual(result,
+                      "2026-07-05T12:34:56.789Z INF application/application app — \n│ second",
+                      logger::formatText(simpleRecord(logger::LogLevel::Info, "\nsecond")),
+                      "leading newline receives separator and continuation line");
+    expectStringEqual(result,
+                      "2026-07-05T12:34:56.789Z INF application/application app — first\\rsecond",
+                      logger::formatText(simpleRecord(logger::LogLevel::Info, "first\rsecond")),
+                      "lone carriage return is rendered as printable backslash-r");
 
     auto emptyMessage = logger::materialize(unknownRole, logger::LogLevel::Info, "", logger::LogRecordOptions{.ts = fixedTimestamp()});
     expectStringEqual(result,
@@ -93,6 +160,21 @@ int main() {
         R"(2026-07-05T12:34:56.789Z INF framework/connection mqtt.server role=server inst=mqtt-broker conn="[7] mqtt client" event=http.response error="5:Input/output error" src=SocketContext.cpp:123:onRead — ready)",
         logger::formatText(rich),
         "rich text formatter renders deterministic fields before the message");
+
+    logger::LogRecord richMultiline = rich;
+    richMultiline.instance = std::string("mqtt broker");
+    richMultiline.connection = std::string("[7] mqtt client");
+    richMultiline.message = "first\nsecond";
+    const std::string richPlain = logger::formatText(richMultiline, false);
+    const std::string richColored = logger::formatText(richMultiline, true);
+    expectStringEqual(result, richPlain, stripAnsi(richColored), "stripping ANSI from colored semantic text equals plain byte-for-byte");
+    result.expectTrue(!containsAnsi(richPlain), "rich plain semantic text contains no ANSI SGR");
+    result.expectTrue(containsAnsi(richColored), "rich colored semantic text contains ANSI SGR");
+
+    const std::string expectedRichJson =
+        R"({"v":1,"ts":"2026-07-05T12:34:56.789Z","level":"info","origin":"framework","boundary":"connection","component":"mqtt.server","instance":"mqtt-broker","role":"server","connection":"[7] mqtt client","event":"http.response","message":"ready","error":{"code":5,"text":"Input/output error"},"source":{"file":"SocketContext.cpp","line":123,"func":"onRead"}})";
+    expectStringEqual(result, expectedRichJson, logger::formatJsonV1(rich), "rich JSON baseline preserves exact schema, keys, and order");
+    result.expectTrue(!containsAnsi(logger::formatJsonV1(rich)), "formatJsonV1 emits no ANSI SGR");
 
     logger::LogRecord escaped = emptyMessage;
     escaped.instance = std::string("space = | , ; [ ] \" \\");

--- a/tests/unit/log/SemanticProductionThresholdRepairTest.cpp
+++ b/tests/unit/log/SemanticProductionThresholdRepairTest.cpp
@@ -185,8 +185,8 @@ int main() {
     const auto enabledConnectionLog = readFile(enabledConnectionPath);
     result.expectTrue(enabledConnectionLog.find("expensive") != std::string::npos,
                       "enabled SocketConnection::log writes formatted message");
-    result.expectTrue(enabledConnectionLog.find(" framework connection core.socket.stream ") != std::string::npos,
-                      "enabled SocketConnection::log preserves framework connection scope");
+    result.expectTrue(enabledConnectionLog.find(" framework/connection core.socket.stream ") != std::string::npos,
+                      "enabled SocketConnection::log preserves framework/connection scope");
 
     const auto suppressedContextPath = tempLogPath("snodec-semantic-repair-context-suppressed.log");
     {

--- a/tests/unit/log/SemanticTerminalColorRoutingTest.cpp
+++ b/tests/unit/log/SemanticTerminalColorRoutingTest.cpp
@@ -80,6 +80,21 @@ int main() {
     tests::support::TestResult result;
 
     {
+        const auto stdoutPath = tempPath("snodec-semantic-default-redirected-stdout.log");
+        StdoutCapture capture(stdoutPath);
+        logger::Logger::init();
+        logger::LogManager::init();
+        logger::Logger::setLogLevel(6);
+        logger::Logger::setQuiet(false);
+        logger::LogManager::setFormat(logger::LogManager::Format::Text);
+        auto log = snode::semantic::appLog(logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedClock());
+        log.info("default redirected stdout");
+        const std::string stdoutText = capture.read();
+        result.expectTrue(contains(stdoutText, "default redirected stdout"), "default redirected semantic stdout emits text");
+        result.expectTrue(!contains(stdoutText, "\033["), "non-TTY redirected semantic stdout defaults to plain output");
+    }
+
+    {
         const auto stdoutPath = tempPath("snodec-semantic-color-stdout.log");
         const auto filePath = tempPath("snodec-semantic-color-file.log");
         StdoutCapture capture(stdoutPath);
@@ -118,6 +133,21 @@ int main() {
         const std::string stdoutText = capture.read();
         result.expectTrue(contains(stdoutText, "\"level\":\"info\""), "semantic JSON still uses lowercase JSON level");
         result.expectTrue(!contains(stdoutText, "\033["), "semantic JSON stdout remains ANSI-free when color is enabled");
+    }
+
+    {
+        const auto filePath = tempPath("snodec-semantic-json-file.log");
+        resetLogger();
+        logger::Logger::setDisableColor(false);
+        logger::Logger::logToFile(filePath.string());
+        logger::Logger::setQuiet(true);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        auto log = snode::semantic::appLog(logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedClock());
+        log.info("json file");
+        logger::Logger::disableLogToFile();
+        const std::string fileText = readFile(filePath);
+        result.expectTrue(contains(fileText, "\"level\":\"info\""), "semantic JSON file contains lowercase JSON level");
+        result.expectTrue(!contains(fileText, "\033["), "semantic JSON file remains ANSI-free when color is enabled");
     }
 
     {

--- a/tests/unit/log/SemanticTerminalColorRoutingTest.cpp
+++ b/tests/unit/log/SemanticTerminalColorRoutingTest.cpp
@@ -1,0 +1,141 @@
+#include "SemanticLog.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "tests/support/TestResult.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+    bool contains(const std::string& value, const std::string& needle) {
+        return value.find(needle) != std::string::npos;
+    }
+
+    std::chrono::system_clock::time_point fixedTimestamp() {
+        using namespace std::chrono;
+        return system_clock::time_point{seconds{1783254896} + milliseconds{789}};
+    }
+
+    logger::BoundaryLogger::Clock fixedClock() {
+        return []() {
+            return fixedTimestamp();
+        };
+    }
+
+    std::filesystem::path tempPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path, std::ios::binary);
+        std::ostringstream out;
+        out << in.rdbuf();
+        return out.str();
+    }
+
+    class StdoutCapture {
+    public:
+        explicit StdoutCapture(std::filesystem::path path)
+            : path(std::move(path))
+            , saved(::dup(STDOUT_FILENO)) {
+            file = ::fopen(this->path.c_str(), "w+");
+            ::dup2(::fileno(file), STDOUT_FILENO);
+        }
+        ~StdoutCapture() {
+            ::fflush(stdout);
+            ::dup2(saved, STDOUT_FILENO);
+            ::close(saved);
+            ::fclose(file);
+        }
+        std::string read() const {
+            ::fflush(stdout);
+            return readFile(path);
+        }
+
+    private:
+        std::filesystem::path path;
+        int saved;
+        FILE* file;
+    };
+
+    void resetLogger() {
+        logger::Logger::disableLogToFile();
+        logger::Logger::init();
+        logger::LogManager::init();
+        logger::Logger::setLogLevel(6);
+        logger::Logger::setQuiet(false);
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    {
+        const auto stdoutPath = tempPath("snodec-semantic-color-stdout.log");
+        const auto filePath = tempPath("snodec-semantic-color-file.log");
+        StdoutCapture capture(stdoutPath);
+        resetLogger();
+        logger::Logger::setDisableColor(false);
+        logger::Logger::logToFile(filePath.string());
+        logger::LogManager::setFormat(logger::LogManager::Format::Text);
+        auto log = snode::semantic::appLog(logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedClock());
+        log.info("colored stdout");
+        const std::string stdoutText = capture.read();
+        logger::Logger::disableLogToFile();
+        const std::string fileText = readFile(filePath);
+        result.expectTrue(contains(stdoutText, "\033["), "explicit color enable colors redirected semantic stdout");
+        result.expectTrue(!contains(fileText, "\033["), "semantic text file remains ANSI-free while stdout is colored");
+    }
+
+    {
+        const auto stdoutPath = tempPath("snodec-semantic-plain-stdout.log");
+        StdoutCapture capture(stdoutPath);
+        resetLogger();
+        logger::Logger::setDisableColor(true);
+        logger::LogManager::setFormat(logger::LogManager::Format::Text);
+        auto log = snode::semantic::appLog(logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedClock());
+        log.info("plain stdout");
+        result.expectTrue(!contains(capture.read(), "\033["), "explicit color disable keeps redirected semantic stdout plain");
+    }
+
+    {
+        const auto stdoutPath = tempPath("snodec-semantic-json-stdout.log");
+        StdoutCapture capture(stdoutPath);
+        resetLogger();
+        logger::Logger::setDisableColor(false);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        auto log = snode::semantic::appLog(logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedClock());
+        log.info("json stdout");
+        const std::string stdoutText = capture.read();
+        result.expectTrue(contains(stdoutText, "\"level\":\"info\""), "semantic JSON still uses lowercase JSON level");
+        result.expectTrue(!contains(stdoutText, "\033["), "semantic JSON stdout remains ANSI-free when color is enabled");
+    }
+
+    {
+        const auto stdoutPath = tempPath("snodec-semantic-quiet-stdout.log");
+        const auto filePath = tempPath("snodec-semantic-quiet-file.log");
+        StdoutCapture capture(stdoutPath);
+        resetLogger();
+        logger::Logger::setDisableColor(false);
+        logger::Logger::setQuiet(true);
+        logger::Logger::logToFile(filePath.string());
+        logger::LogManager::setFormat(logger::LogManager::Format::Text);
+        auto log = snode::semantic::appLog(logger::Logger::semanticSink(), logger::LogLevel::Trace, fixedClock());
+        log.info("quiet file");
+        result.expectTrue(capture.read().empty(), "quiet mode suppresses semantic stdout");
+        logger::Logger::disableLogToFile();
+        result.expectTrue(contains(readFile(filePath), "quiet file"), "quiet mode still writes semantic file output");
+    }
+
+    resetLogger();
+    return result.processResult();
+}

--- a/tests/unit/log/SocketConnectionMigration01Test.cpp
+++ b/tests/unit/log/SocketConnectionMigration01Test.cpp
@@ -135,8 +135,8 @@ int main() {
     const auto enabledLog = readFile(enabledPath);
     result.expectTrue(enabledLog.find("SocketConnection: switch completed") != std::string::npos,
                       "migrated non-error SocketConnection.hpp call emits semantically when enabled");
-    result.expectTrue(enabledLog.find(" framework connection core.socket.stream ") != std::string::npos,
-                      "migrated call carries framework connection core.socket.stream scope");
+    result.expectTrue(enabledLog.find(" framework/connection core.socket.stream ") != std::string::npos,
+                      "migrated call carries framework/connection core.socket.stream scope");
 
     const auto managerFilterPath = tempLogPath("snodec-migration01-manager-filter.log");
     {

--- a/tests/unit/log/SocketConnectorAcceptorMigration02Test.cpp
+++ b/tests/unit/log/SocketConnectorAcceptorMigration02Test.cpp
@@ -134,12 +134,11 @@ int main() {
                       "migrated SocketConnector semantic owner emits when enabled");
     result.expectTrue(enabledLog.find("acceptor migrated semantic owner emitted") != std::string::npos,
                       "migrated SocketAcceptor semantic owner emits when enabled");
-    result.expectTrue(enabledLog.find(" framework instance core.socket.stream instance=migration02-connector role=client ") !=
+    result.expectTrue(enabledLog.find(" framework/instance core.socket.stream role=client inst=migration02-connector ") !=
                           std::string::npos,
-                      "connector emitted records carry framework instance client scope");
-    result.expectTrue(enabledLog.find(" framework instance core.socket.stream instance=migration02-acceptor role=server ") !=
-                          std::string::npos,
-                      "acceptor emitted records carry framework instance server scope");
+                      "connector emitted records carry framework/instance client scope");
+    result.expectTrue(enabledLog.find(" framework/instance core.socket.stream role=server inst=migration02-acceptor ") != std::string::npos,
+                      "acceptor emitted records carry framework/instance server scope");
 
     const auto managerFilterPath = tempLogPath("snodec-migration02-manager-filter.log");
     {

--- a/tests/unit/log/SocketEndpointLogApiRound5Test.cpp
+++ b/tests/unit/log/SocketEndpointLogApiRound5Test.cpp
@@ -4,8 +4,8 @@
 #include "core/socket/SocketAddress.h"
 #include "core/socket/stream/SocketAcceptor.h"
 #include "core/socket/stream/SocketClient.h"
-#include "core/socket/stream/SocketConnector.h"
 #include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketConnector.h"
 #include "core/socket/stream/SocketContextFactory.h"
 #include "core/socket/stream/SocketServer.h"
 #include "log/SemanticLogger.h"
@@ -27,42 +27,76 @@ namespace {
     class TestConfigInstance : public net::config::ConfigInstance {
     public:
         explicit TestConfigInstance(const std::string& instanceName)
-            : ConfigInstance(instanceName, Role::SERVER) {}
+            : ConfigInstance(instanceName, Role::SERVER) {
+        }
         ~TestConfigInstance() override = default;
     };
 
     class TestSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit TestSocketConnection(const std::string& instanceName)
-            : SocketConnection(7, instanceName, nullptr) {}
+            : SocketConnection(7, instanceName, nullptr) {
+        }
         ~TestSocketConnection() override = default;
 
-        int getFd() const override { return 7; }
-        void sendToPeer(const char*, std::size_t) override {}
-        bool streamToPeer(core::pipe::Source*) override { return false; }
-        void streamEof() override {}
-        std::size_t readFromPeer(char*, std::size_t) override { return 0; }
-        void shutdownRead() override {}
-        void shutdownWrite() override {}
-        const core::socket::SocketAddress& getBindAddress() const override { return unusableAddress(); }
-        const core::socket::SocketAddress& getLocalAddress() const override { return unusableAddress(); }
-        const core::socket::SocketAddress& getRemoteAddress() const override { return unusableAddress(); }
-        void close() override {}
-        void setTimeout(const utils::Timeval&) override {}
-        void setReadTimeout(const utils::Timeval&) override {}
-        void setWriteTimeout(const utils::Timeval&) override {}
-        std::size_t getTotalSent() const override { return 0; }
-        std::size_t getTotalQueued() const override { return 0; }
-        std::size_t getTotalRead() const override { return 0; }
-        std::size_t getTotalProcessed() const override { return 0; }
+        int getFd() const override {
+            return 7;
+        }
+        void sendToPeer(const char*, std::size_t) override {
+        }
+        bool streamToPeer(core::pipe::Source*) override {
+            return false;
+        }
+        void streamEof() override {
+        }
+        std::size_t readFromPeer(char*, std::size_t) override {
+            return 0;
+        }
+        void shutdownRead() override {
+        }
+        void shutdownWrite() override {
+        }
+        const core::socket::SocketAddress& getBindAddress() const override {
+            return unusableAddress();
+        }
+        const core::socket::SocketAddress& getLocalAddress() const override {
+            return unusableAddress();
+        }
+        const core::socket::SocketAddress& getRemoteAddress() const override {
+            return unusableAddress();
+        }
+        void close() override {
+        }
+        void setTimeout(const utils::Timeval&) override {
+        }
+        void setReadTimeout(const utils::Timeval&) override {
+        }
+        void setWriteTimeout(const utils::Timeval&) override {
+        }
+        std::size_t getTotalSent() const override {
+            return 0;
+        }
+        std::size_t getTotalQueued() const override {
+            return 0;
+        }
+        std::size_t getTotalRead() const override {
+            return 0;
+        }
+        std::size_t getTotalProcessed() const override {
+            return 0;
+        }
 
     private:
-        static const core::socket::SocketAddress& unusableAddress() { return *static_cast<const core::socket::SocketAddress*>(nullptr); }
+        static const core::socket::SocketAddress& unusableAddress() {
+            return *static_cast<const core::socket::SocketAddress*>(nullptr);
+        }
     };
 
     class TestSocketContextFactory : public core::socket::stream::SocketContextFactory {
     public:
-        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection*) override { return nullptr; }
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection*) override {
+            return nullptr;
+        }
     };
 
     class TestSocketAcceptor : public core::eventreceiver::AcceptEventReceiver {
@@ -81,7 +115,9 @@ namespace {
 
     class TestSocketAddress : public core::socket::SocketAddress {
     public:
-        std::string toString(bool = true) const override { return "test-address"; }
+        std::string toString(bool = true) const override {
+            return "test-address";
+        }
     };
 
     class TestPhysicalSocket {
@@ -98,7 +134,7 @@ namespace {
         core::socket::stream::SocketConnector<TestPhysicalSocket, TestConfigInstance, TestTemplatedSocketConnection>;
     using TestSocketServer = core::socket::stream::SocketServer<TestSocketAcceptor, TestSocketContextFactory>;
     using TestSocketClient = core::socket::stream::SocketClient<TestSocketConnector, TestSocketContextFactory>;
-}
+} // namespace
 
 int main() {
     tests::support::TestResult result;
@@ -114,25 +150,39 @@ int main() {
 
     TestSocketServer server("round5-server");
     std::vector<logger::LogRecord> serverRecords;
-    server.log([&](logger::LogRecord record) { serverRecords.push_back(std::move(record)); }, logger::LogLevel::Trace, fixedTimestamp)
+    server
+        .log(
+            [&](logger::LogRecord record) {
+                serverRecords.push_back(std::move(record));
+            },
+            logger::LogLevel::Trace,
+            fixedTimestamp)
         .info("server endpoint ready");
     result.expectEqual(1, static_cast<int>(serverRecords.size()), "SocketServer log emits one record");
     result.expectTrue(serverRecords[0].origin == logger::LogOrigin::Framework, "SocketServer log uses framework origin");
     result.expectTrue(serverRecords[0].boundary == logger::LogBoundary::Instance, "SocketServer log uses instance boundary");
     result.expectTrue(serverRecords[0].component == "core.socket.stream", "SocketServer log uses stream component");
-    result.expectTrue(serverRecords[0].instance && *serverRecords[0].instance == "round5-server", "SocketServer log owns instance identity");
+    result.expectTrue(serverRecords[0].instance && *serverRecords[0].instance == "round5-server",
+                      "SocketServer log owns instance identity");
     result.expectTrue(serverRecords[0].role && *serverRecords[0].role == logger::LogRole::Server, "SocketServer log uses server role");
     result.expectTrue(!serverRecords[0].connection, "SocketServer log leaves connection absent");
 
     TestSocketClient client("round5-client");
     std::vector<logger::LogRecord> clientRecords;
-    client.log([&](logger::LogRecord record) { clientRecords.push_back(std::move(record)); }, logger::LogLevel::Trace, fixedTimestamp)
+    client
+        .log(
+            [&](logger::LogRecord record) {
+                clientRecords.push_back(std::move(record));
+            },
+            logger::LogLevel::Trace,
+            fixedTimestamp)
         .info("client endpoint ready");
     result.expectEqual(1, static_cast<int>(clientRecords.size()), "SocketClient log emits one record");
     result.expectTrue(clientRecords[0].origin == logger::LogOrigin::Framework, "SocketClient log uses framework origin");
     result.expectTrue(clientRecords[0].boundary == logger::LogBoundary::Instance, "SocketClient log uses instance boundary");
     result.expectTrue(clientRecords[0].component == "core.socket.stream", "SocketClient log uses stream component");
-    result.expectTrue(clientRecords[0].instance && *clientRecords[0].instance == "round5-client", "SocketClient log owns instance identity");
+    result.expectTrue(clientRecords[0].instance && *clientRecords[0].instance == "round5-client",
+                      "SocketClient log owns instance identity");
     result.expectTrue(clientRecords[0].role && *clientRecords[0].role == logger::LogRole::Client, "SocketClient log uses client role");
     result.expectTrue(!clientRecords[0].connection, "SocketClient log leaves connection absent");
 

--- a/tests/unit/log/SocketServerClientMigration03Test.cpp
+++ b/tests/unit/log/SocketServerClientMigration03Test.cpp
@@ -165,12 +165,10 @@ int main() {
                       "SocketServer semantic owner emits when enabled");
     result.expectTrue(enabledLog.find("client semantic owner emitted") != std::string::npos,
                       "SocketClient semantic owner emits when enabled");
-    result.expectTrue(enabledLog.find(" framework instance core.socket.stream instance=migration03-server role=server ") !=
-                          std::string::npos,
-                      "server emitted records carry framework instance core.socket.stream scope and server role");
-    result.expectTrue(enabledLog.find(" framework instance core.socket.stream instance=migration03-client role=client ") !=
-                          std::string::npos,
-                      "client emitted records carry framework instance core.socket.stream scope and client role");
+    result.expectTrue(enabledLog.find(" framework/instance core.socket.stream role=server inst=migration03-server ") != std::string::npos,
+                      "server emitted records carry framework/instance core.socket.stream scope and server role");
+    result.expectTrue(enabledLog.find(" framework/instance core.socket.stream role=client inst=migration03-client ") != std::string::npos,
+                      "client emitted records carry framework/instance core.socket.stream scope and client role");
 
     const auto managerFilterPath = tempLogPath("snodec-migration03-manager-filter.log");
     {

--- a/tests/unit/log/TlsSocketStreamMigration06Test.cpp
+++ b/tests/unit/log/TlsSocketStreamMigration06Test.cpp
@@ -141,7 +141,7 @@ int main() {
                       "TLS reader semantic owner emits when enabled");
     result.expectTrue(enabledLog.find("tls writer semantic owner emitted") != std::string::npos,
                       "TLS writer semantic owner emits when enabled");
-    result.expectTrue(enabledLog.find(" framework connection core.socket.stream.tls ") != std::string::npos,
+    result.expectTrue(enabledLog.find(" framework/connection core.socket.stream.tls ") != std::string::npos,
                       "emitted records carry framework core.socket.stream.tls component scope");
 
     const auto managerFilterPath = tempLogPath("snodec-migration06-manager-filter.log");

--- a/tests/unit/log/WebSocketMigration07cTest.cpp
+++ b/tests/unit/log/WebSocketMigration07cTest.cpp
@@ -71,7 +71,7 @@ int main() {
     const auto enabledLog = readFile(enabledPath);
     result.expectTrue(enabledLog.find("websocket semantic logger emitted") != std::string::npos,
                       "WebSocket semantic logger emits when enabled");
-    result.expectTrue(enabledLog.find(" framework connection web.websocket ") != std::string::npos,
+    result.expectTrue(enabledLog.find(" framework/connection web.websocket ") != std::string::npos,
                       "records carry framework web.websocket component scope");
 
     const auto managerFilterPath = tempLogPath("snodec-migration07c-manager-filter.log");


### PR DESCRIPTION
### Motivation

Finalize the semantic logging presentation before integrating the logging surface into the SNode.C book.

This PR introduces the final human-readable semantic text format, restores terminal coloring for semantic stdout, and keeps JSON, files, filtering, legacy logging, CLI/configuration, and production log call sites unchanged.

### Final text format

```text
<timestamp> <LVL> <origin>/<boundary> <component> [fields...] — <message>
```

Example:

```text
2026-07-05T12:34:56.789Z INF framework/connection core.socket role=server inst=mqtt-broker conn="[7] mqtt" — Connected
```

Semantic text uses `TRC`, `DBG`, `INF`, `WRN`, `ERR`, `CRT`, and `OFF`. Both semantic axes are always visible, including `application/application`.

Optional fields are emitted in deterministic order:

```text
role= inst= conn= event= error= src=
```

Unsafe values are quoted and escaped. Control bytes such as ESC are rendered safely, so user-controlled ANSI sequences cannot reach the terminal.

Multiline messages keep the first line after the em dash; continuation lines begin with `│ `. Empty messages omit the separator entirely.

### Color and routing

| Format | stdout with color | stdout without color | file |
|---|---|---|---|
| Text | colored | plain | plain |
| JSON | plain | plain | plain |

Non-TTY stdout defaults to plain output. `Logger::setDisableColor(false)` can explicitly enable color on redirected stdout.

Files and JSON never contain ANSI. Quiet mode suppresses stdout but still writes to a configured file.

### Compatibility

- JSON schema v1 and JSON field order remain unchanged.
- Legacy `LOG`/`PLOG`/`VLOG` behavior remains unchanged.
- No production protocol/application log call site changed.
- No semantic identity, component, level, or message changed.
- No CLI/configuration option or async logging was added.
- Internal `detail` headers are no longer installed publicly.

### Validation

Tests cover exact text formatting, all level labels, quoting and escaping, UTF-8, empty and multiline messages, ANSI stripping, non-TTY defaults, explicit color override, ANSI-free JSON/file output, and exact JSON baselines.

A staged install confirms that public logger headers are installed while `log/detail/SpdlogBackend.h` is excluded.

GitHub Actions CI for head commit `aa537a04727e0291ff8de949d418d91c8e30450d` completed successfully.