### PR TITLE
Add per-instance connection IDs and endpoint lifetime counters

### DIFF
--- a/docs/logging/endpoint-lifetime-identity-counters-report.md
+++ b/docs/logging/endpoint-lifetime-identity-counters-report.md
@@ -1,0 +1,15 @@
+# Endpoint lifetime identity and counters report
+
+This update separates stream connection display names from semantic connection
+identity. Shared SocketServer and SocketClient contexts allocate monotonically
+increasing per-endpoint connection IDs, pass them through acceptor/connector and
+legacy/TLS construction paths, and use them as the semantic `conn` value while
+leaving `getConnectionName()` unchanged for display compatibility.
+
+FlowController now records dispatched retry attempts, and ClientFlowController
+records dispatched reconnect attempts. The counters intentionally live in the
+flow controllers and do not introduce logging dependencies there.
+
+Shared endpoint contexts own the instance-level semantic summary scope and emit
+one Info lifetime summary only when a normal runtime retry/reconnect
+continuation is rejected by SocketServer/SocketClient policy.

--- a/docs/logging/endpoint-lifetime-identity-counters-report.md
+++ b/docs/logging/endpoint-lifetime-identity-counters-report.md
@@ -4,7 +4,7 @@ This update separates stream connection display names from semantic connection
 identity. Shared SocketServer and SocketClient contexts allocate monotonically
 increasing per-endpoint connection IDs, pass them through acceptor/connector and
 legacy/TLS construction paths, and use them as the semantic `conn` value while
-leaving `getConnectionName()` unchanged for display compatibility.
+leaving `getConnectionName()` unchanged for display compatibility. Unnamed endpoints deliberately retain the framework `ConfigInstance` behavior and emit `inst=<anonymous> conn=<n>`.
 
 FlowController now records dispatched retry attempts, and ClientFlowController
 records dispatched reconnect attempts. The counters intentionally live in the
@@ -13,3 +13,5 @@ flow controllers and do not introduce logging dependencies there.
 Shared endpoint contexts own the instance-level semantic summary scope and emit
 one Info lifetime summary only when a normal runtime retry/reconnect
 continuation is rejected by SocketServer/SocketClient policy.
+
+Constructor compatibility note: `SocketConnection`, `SocketConnectionT`, `SocketAcceptor`, `SocketConnector`, all legacy acceptor/connector/connection variants, and all TLS acceptor/connector/connection variants now carry the explicit connection-ID allocator or value. These installed public headers changed source and ABI compatibility, so dependent applications and libraries must be rebuilt.

--- a/docs/logging/semantic-logging-contract.md
+++ b/docs/logging/semantic-logging-contract.md
@@ -293,3 +293,33 @@ For this round, the branch and draft PR are:
 ```text
 codex/implement-logging-roadmap-round-1
 ```
+
+## Endpoint lifetime connection identity and summaries
+
+For stream socket connection records, the semantic `conn` field is a decimal
+per-endpoint connection sequence. The sequence is scoped by the semantic
+`inst` value: two different named endpoint instances may each emit `conn=1`,
+and the complete stable connection identity is the pair `(inst, conn)`. The
+sequence starts at `1` for each newly constructed shared server or client
+endpoint context, increases monotonically, is not reused during that context's
+lifetime, and is not process-global. It is also not the operating-system file
+descriptor.
+
+`SocketConnection::getConnectionName()` remains a separate human-readable
+compatibility/display value, currently shaped like `[fd] instance`. It may
+continue to appear in legacy messages, reader/writer labels, OpenSSL diagnostic
+labels, and compatibility APIs, but semantic connection identity uses the
+numeric connection sequence.
+
+Endpoint lifetime summaries report dispatched continuation attempts. `retries`
+counts retry attempts that were actually dispatched after the initial
+listen/connect attempt; arming or cancelling a retry timer does not increment
+it. `reconnects` counts reconnect attempts that were actually dispatched after
+an established client connection disconnected; arming or cancelling a reconnect
+timer does not increment it.
+
+A server or client instance summary is emitted only when normal runtime
+continuation is rejected by policy: a terminal listen/connect failure that
+cannot continue by retry, or a client disconnect during `RUNNING` that cannot
+continue by reconnect. Framework shutdown, destructor paths, and explicit
+termination calls do not produce this lifetime summary.

--- a/docs/logging/semantic-logging-contract.md
+++ b/docs/logging/semantic-logging-contract.md
@@ -303,13 +303,15 @@ and the complete stable connection identity is the pair `(inst, conn)`. The
 sequence starts at `1` for each newly constructed shared server or client
 endpoint context, increases monotonically, is not reused during that context's
 lifetime, and is not process-global. It is also not the operating-system file
-descriptor.
+descriptor. Unnamed framework endpoints use the existing `ConfigInstance::getInstanceName()` behavior and therefore emit `inst=<anonymous>` together with the numeric connection ID (for example, `inst=<anonymous> conn=1`).
 
 `SocketConnection::getConnectionName()` remains a separate human-readable
 compatibility/display value, currently shaped like `[fd] instance`. It may
 continue to appear in legacy messages, reader/writer labels, OpenSSL diagnostic
 labels, and compatibility APIs, but semantic connection identity uses the
 numeric connection sequence.
+
+The connection-ID constructor change affects the installed `SocketConnection`, `SocketConnectionT`, `SocketAcceptor`, `SocketConnector`, legacy acceptor/connector/connection variants, and TLS acceptor/connector/connection variants. This is a source and ABI compatibility change for applications or libraries that construct or derive from these public headers; dependent binaries must be rebuilt.
 
 Endpoint lifetime summaries report dispatched continuation attempts. `retries`
 counts retry attempts that were actually dispatched after the initial

--- a/docs/logging/semantic-text-output-format.md
+++ b/docs/logging/semantic-text-output-format.md
@@ -28,12 +28,12 @@ Subsequent logical lines start with `│ `, preserving blank and trailing contin
 
 ```text
 2026-07-05T12:34:56.789Z INF application/application app
-2026-07-05T12:34:56.789Z INF framework/connection core.socket role=server inst=mqtt-broker conn="[7] mqtt" — Connected
+2026-07-05T12:34:56.789Z INF framework/connection core.socket role=server inst=mqtt-broker conn=7 — Connected
 2026-07-05T12:34:56.789Z ERR framework/system core.runtime error="5:Input/output error" src=Runtime.cpp:42:tick — failed
 2026-07-05T12:34:56.789Z TRC framework/connection web.http — GET / HTTP/1.1
 │ Request:
 │   Method: GET
-2026-07-05T12:34:56.789Z INF application/application app inst="has spaces" conn="[7] mqtt client" — quoted
+2026-07-05T12:34:56.789Z INF application/application app inst="has spaces" conn=7 — quoted
 ```
 
 ## Color and routing

--- a/src/SemanticLog.h
+++ b/src/SemanticLog.h
@@ -21,7 +21,7 @@ namespace snode::semantic {
     inline LogIdentity logIdentity(const core::socket::stream::SocketConnection& connection) {
         return {connection.getInstanceName().empty() ? std::nullopt : std::optional<std::string>(connection.getInstanceName()),
                 std::nullopt,
-                connection.getConnectionName()};
+                std::to_string(connection.getConnectionId())};
     }
 
     inline logger::BoundaryLogger scopedLog(const logger::LogOrigin origin,

--- a/src/core/socket/stream/ClientFlowController.cpp
+++ b/src/core/socket/stream/ClientFlowController.cpp
@@ -32,6 +32,10 @@ namespace core::socket::stream {
         return reconnectEnabled;
     }
 
+    std::uint64_t ClientFlowController::getReconnectCount() const noexcept {
+        return reconnectCount;
+    }
+
     ClientFlowController* ClientFlowController::setOnFlowReconnect(const std::function<void(ClientFlowController*)>& callback) {
         const std::function<void(ClientFlowController*)> oldCallback = onFlowReconnectCallback;
         onFlowReconnectCallback = [oldCallback, callback](ClientFlowController* flowController) {
@@ -43,6 +47,7 @@ namespace core::socket::stream {
     }
 
     void ClientFlowController::reportFlowReconnect() {
+        ++reconnectCount;
         onFlowReconnectCallback(this);
     }
 

--- a/src/core/socket/stream/ClientFlowController.h
+++ b/src/core/socket/stream/ClientFlowController.h
@@ -77,6 +77,7 @@ namespace core::socket::stream {
 
         void stopReconnect();
         bool isReconnectEnabled() const;
+        std::uint64_t getReconnectCount() const noexcept;
 
         ClientFlowController* setOnFlowReconnect(const std::function<void(ClientFlowController*)>& callback);
 
@@ -90,6 +91,8 @@ namespace core::socket::stream {
         void terminateAsyncSubFlow() override;
 
         void cancelReconnectTimer();
+
+        std::uint64_t reconnectCount{0};
 
         bool reconnectEnabled{true};
 

--- a/src/core/socket/stream/ClientFlowController.h
+++ b/src/core/socket/stream/ClientFlowController.h
@@ -81,8 +81,10 @@ namespace core::socket::stream {
 
         ClientFlowController* setOnFlowReconnect(const std::function<void(ClientFlowController*)>& callback);
 
-    private:
+    protected:
         void reportFlowReconnect();
+
+    private:
 
         void observeConnectEventReceiver(core::eventreceiver::ConnectEventReceiver* connectEventReceiver);
 

--- a/src/core/socket/stream/ClientFlowController.h
+++ b/src/core/socket/stream/ClientFlowController.h
@@ -81,10 +81,8 @@ namespace core::socket::stream {
 
         ClientFlowController* setOnFlowReconnect(const std::function<void(ClientFlowController*)>& callback);
 
-    protected:
-        void reportFlowReconnect();
-
     private:
+        void reportFlowReconnect();
 
         void observeConnectEventReceiver(core::eventreceiver::ConnectEventReceiver* connectEventReceiver);
 

--- a/src/core/socket/stream/FlowController.h
+++ b/src/core/socket/stream/FlowController.h
@@ -82,6 +82,7 @@ namespace core::socket::stream {
 
         void stopRetry();
         bool isRetryEnabled() const;
+        std::uint64_t getRetryCount() const noexcept;
 
         ConcreteFlowController* setOnFlowRetry(const std::function<void(ConcreteFlowController*)>& callback);
         ConcreteFlowController* setOnFlowCompleted(const std::function<void(uint64_t, const std::string&)>& callback);
@@ -101,6 +102,8 @@ namespace core::socket::stream {
         static uint64_t idCounter;
         void cancelRetryTimer();
         void notifyFlowTerminated();
+
+        std::uint64_t retryCount{0};
 
         bool retryEnabled{true};
         bool terminated{false};

--- a/src/core/socket/stream/FlowController.hpp
+++ b/src/core/socket/stream/FlowController.hpp
@@ -112,6 +112,11 @@ namespace core::socket::stream {
     }
 
     template <typename ConcreteFlowController>
+    std::uint64_t FlowController<ConcreteFlowController>::getRetryCount() const noexcept {
+        return retryCount;
+    }
+
+    template <typename ConcreteFlowController>
     ConcreteFlowController*
     FlowController<ConcreteFlowController>::setOnFlowRetry(const std::function<void(ConcreteFlowController*)>& callback) {
         const std::function<void(ConcreteFlowController*)> oldCallback = onFlowRetryCallback;
@@ -156,6 +161,7 @@ namespace core::socket::stream {
 
     template <typename ConcreteFlowController>
     void FlowController<ConcreteFlowController>::reportFlowRetry() {
+        ++retryCount;
         onFlowRetryCallback(dynamic_cast<ConcreteFlowController*>(this));
     }
 

--- a/src/core/socket/stream/SocketAcceptor.h
+++ b/src/core/socket/stream/SocketAcceptor.h
@@ -54,6 +54,7 @@ namespace core::socket::stream {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -86,6 +87,7 @@ namespace core::socket::stream {
                        const std::function<void(SocketConnection*)>& onDisconnect,
                        const std::function<void(core::eventreceiver::AcceptEventReceiver*)>& onInitState,
                        const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+                       const std::function<std::uint64_t()>& allocateConnectionId,
                        const std::shared_ptr<Config>& config);
 
         SocketAcceptor(const SocketAcceptor& socketAcceptor);
@@ -130,6 +132,7 @@ namespace core::socket::stream {
         std::function<void(core::eventreceiver::AcceptEventReceiver*)> onInitState;
 
         std::function<void(const SocketAddress&, core::socket::State)> onStatus = nullptr;
+        std::function<std::uint64_t()> allocateConnectionId;
 
         static logger::LogScopeOwner makeLogScope(const std::string& instanceName) {
             return logger::LogScopeOwner(logger::LogOrigin::Framework,

--- a/src/core/socket/stream/SocketAcceptor.hpp
+++ b/src/core/socket/stream/SocketAcceptor.hpp
@@ -48,6 +48,7 @@
 #include "log/Logger.h"
 #include "utils/PreserveErrno.h"
 
+#include <cstdint>
 #include <iomanip>
 #include <string>
 #include <utility>
@@ -65,6 +66,7 @@ namespace core::socket::stream {
         const std::function<void(SocketConnection*)>& onDisconnect,
         const std::function<void(core::eventreceiver::AcceptEventReceiver*)>& onInitState,
         const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+        const std::function<std::uint64_t()>& allocateConnectionId,
         const std::shared_ptr<Config>& config)
         : core::eventreceiver::AcceptEventReceiver(config->getInstanceName() + " SocketAcceptor", 0)
         , onConnect(onConnect)
@@ -72,6 +74,7 @@ namespace core::socket::stream {
         , onDisconnect(onDisconnect)
         , onInitState(onInitState)
         , onStatus(onStatus)
+        , allocateConnectionId(allocateConnectionId)
         , logScope(makeLogScope(config->getInstanceName()))
         , config(config) {
     }
@@ -86,6 +89,7 @@ namespace core::socket::stream {
         , onDisconnect(socketAcceptor.onDisconnect)
         , onInitState(socketAcceptor.onInitState)
         , onStatus(socketAcceptor.onStatus)
+        , allocateConnectionId(socketAcceptor.allocateConnectionId)
         , logScope(socketAcceptor.logScope)
         , config(socketAcceptor.config) {
     }
@@ -233,7 +237,9 @@ namespace core::socket::stream {
                 const int errnum = errno;
 
                 if (connectedPhysicalSocket.isValid()) {
-                    SocketConnection* socketConnection = new SocketConnection(std::move(connectedPhysicalSocket), onDisconnect, config);
+                    const std::uint64_t connectionId = allocateConnectionId();
+                    SocketConnection* socketConnection =
+                        new SocketConnection(std::move(connectedPhysicalSocket), onDisconnect, connectionId, config);
 
                     snode::semantic::coreSocketLog().debug()
                         << config->getInstanceName() << " accept " << physicalServerSocket.getBindAddress().toString() << ": success";

--- a/src/core/socket/stream/SocketClient.h
+++ b/src/core/socket/stream/SocketClient.h
@@ -57,6 +57,7 @@
 #include "utils/Random.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <functional> // IWYU pragma: export
 #include <optional>
 #include <type_traits> // IWYU pragma: export
@@ -98,6 +99,7 @@ namespace core::socket::stream {
                                          callback();
                                      });
                                  })
+                , logScope(makeLogScope(config->getInstanceName()))
                 , socketContextFactory(socketContextFactory)
                 , onConnect(onConnect)
                 , onConnected(onConnected)
@@ -105,6 +107,20 @@ namespace core::socket::stream {
             }
 
             ClientFlowController flowController;
+            logger::LogScopeOwner logScope;
+            std::uint64_t connectionsCreated{0};
+
+            std::uint64_t allocateConnectionId() noexcept {
+                return ++connectionsCreated;
+            }
+
+            void emitTerminationSummary() const {
+                logScope.logger(logger::Logger::semanticSink())
+                    .info("Instance terminated: connections={} retries={} reconnects={}",
+                          connectionsCreated,
+                          flowController.getRetryCount(),
+                          flowController.getReconnectCount());
+            }
 
             std::shared_ptr<SocketContextFactory> socketContextFactory;
 
@@ -222,6 +238,9 @@ namespace core::socket::stream {
                                                     log.info("Reconnect disabled during wait");
                                                 }
                                             });
+                                    } else if (core::eventLoopState() == core::State::RUNNING &&
+                                               sharedContext->flowController.terminateFlow()) {
+                                        sharedContext->emitTerminationSummary();
                                     }
                                 },
                                 [sharedContext](core::eventreceiver::ConnectEventReceiver* connectEventReceiver) {
@@ -268,7 +287,14 @@ namespace core::socket::stream {
                                                     log.info("Retry connect disabled during wait");
                                                 }
                                             });
+                                    } else if (retryFlag &&
+                                               (state == core::socket::State::ERROR || state == core::socket::State::FATAL) &&
+                                               core::SNodeC::state() == core::State::RUNNING && sharedContext->flowController.terminateFlow()) {
+                                        sharedContext->emitTerminationSummary();
                                     }
+                                },
+                                [sharedContext]() {
+                                    return sharedContext->allocateConnectionId();
                                 },
                                 config);
                         }

--- a/src/core/socket/stream/SocketConnection.cpp
+++ b/src/core/socket/stream/SocketConnection.cpp
@@ -60,15 +60,19 @@ struct tm;
 
 namespace core::socket::stream {
 
-    SocketConnection::SocketConnection(int fd, const std::string& instanceName, const net::config::ConfigInstance* config)
+    SocketConnection::SocketConnection(int fd,
+                                           std::uint64_t connectionId,
+                                           const std::string& instanceName,
+                                           const net::config::ConfigInstance* config)
         : instanceName(instanceName)
+        , connectionId(connectionId)
         , connectionName("[" + std::to_string(fd) + "]" + (!instanceName.empty() ? " " + instanceName : ""))
         , logScope(logger::LogOrigin::Framework,
                    logger::LogBoundary::Connection,
                    "core.socket.stream",
                    instanceName.empty() ? std::nullopt : std::optional<std::string>(instanceName),
                    std::nullopt,
-                   connectionName)
+                   std::to_string(connectionId))
         , onlineSinceTimePoint(std::chrono::system_clock::now())
         , config(config) {
     }
@@ -118,6 +122,10 @@ namespace core::socket::stream {
 
     const std::string& SocketConnection::getConnectionName() const {
         return connectionName;
+    }
+
+    std::uint64_t SocketConnection::getConnectionId() const noexcept {
+        return connectionId;
     }
 
     logger::BoundaryLogger SocketConnection::log() const {

--- a/src/core/socket/stream/SocketConnection.h
+++ b/src/core/socket/stream/SocketConnection.h
@@ -85,7 +85,7 @@ namespace core::socket::stream {
 
     class SocketConnection {
     public:
-        SocketConnection(int fd, const std::string& instanceName, const net::config::ConfigInstance* config);
+        SocketConnection(int fd, std::uint64_t connectionId, const std::string& instanceName, const net::config::ConfigInstance* config);
         SocketConnection(const SocketConnection&) = delete;
 
         virtual int getFd() const = 0;
@@ -113,6 +113,7 @@ namespace core::socket::stream {
 
         const std::string& getInstanceName() const;
         const std::string& getConnectionName() const;
+        std::uint64_t getConnectionId() const noexcept;
 
         logger::BoundaryLogger log() const;
         logger::BoundaryLogger log(logger::BoundaryLogger::Sink sink,
@@ -153,6 +154,7 @@ namespace core::socket::stream {
         core::socket::stream::SocketContext* newSocketContext = nullptr;
 
         std::string instanceName;
+        const std::uint64_t connectionId;
         std::string connectionName;
         logger::LogScopeOwner logScope;
         mutable std::optional<logger::BoundaryLogger> cachedLog_;
@@ -186,6 +188,7 @@ namespace core::socket::stream {
     protected:
         SocketConnectionT(PhysicalSocket&& physicalSocket,
                           const std::function<void()>& onDisconnect,
+                          std::uint64_t connectionId,
                           const std::shared_ptr<Config>& config);
 
         ~SocketConnectionT() override;

--- a/src/core/socket/stream/SocketConnection.hpp
+++ b/src/core/socket/stream/SocketConnection.hpp
@@ -109,8 +109,9 @@ namespace core::socket::stream {
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
     SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::SocketConnectionT(PhysicalSocket&& physicalSocket,
                                                                                              const std::function<void()>& onDisconnect,
+                                                                                             std::uint64_t connectionId,
                                                                                              const std::shared_ptr<Config>& config)
-        : SocketConnection(physicalSocket.getFd(), config->getInstanceName(), config.get())
+        : SocketConnection(physicalSocket.getFd(), connectionId, config->getInstanceName(), config.get())
         , SocketReader(
               Super::getConnectionName(),
               [this](int errnum) {

--- a/src/core/socket/stream/SocketConnector.h
+++ b/src/core/socket/stream/SocketConnector.h
@@ -54,6 +54,7 @@ namespace core::socket::stream {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -81,6 +82,7 @@ namespace core::socket::stream {
                         const std::function<void(SocketConnection*)>& onDisconnect,
                         const std::function<void(core::eventreceiver::ConnectEventReceiver*)>& onInitState,
                         const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+                        const std::function<std::uint64_t()>& allocateConnectionId,
                         const std::shared_ptr<Config>& config);
 
         SocketConnector(const SocketConnector& socketConnector);
@@ -126,6 +128,7 @@ namespace core::socket::stream {
         std::function<void(core::eventreceiver::ConnectEventReceiver*)> onInitState;
 
         std::function<void(const SocketAddress&, core::socket::State)> onStatus;
+        std::function<std::uint64_t()> allocateConnectionId;
 
         static logger::LogScopeOwner makeLogScope(const std::string& instanceName) {
             return logger::LogScopeOwner(logger::LogOrigin::Framework,

--- a/src/core/socket/stream/SocketConnector.hpp
+++ b/src/core/socket/stream/SocketConnector.hpp
@@ -48,6 +48,7 @@
 #include "log/Logger.h"
 #include "utils/PreserveErrno.h"
 
+#include <cstdint>
 #include <iomanip>
 #include <string>
 #include <utility>
@@ -65,6 +66,7 @@ namespace core::socket::stream {
         const std::function<void(SocketConnection*)>& onDisconnect,
         const std::function<void(core::eventreceiver::ConnectEventReceiver*)>& onInitState,
         const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+        const std::function<std::uint64_t()>& allocateConnectionId,
         const std::shared_ptr<Config>& config)
         : core::eventreceiver::ConnectEventReceiver(config->getInstanceName() + " SocketConnector", 0)
         , onConnect(onConnect)
@@ -72,6 +74,7 @@ namespace core::socket::stream {
         , onDisconnect(onDisconnect)
         , onInitState(onInitState)
         , onStatus(onStatus)
+        , allocateConnectionId(allocateConnectionId)
         , logScope(makeLogScope(config->getInstanceName()))
         , config(config) {
     }
@@ -86,6 +89,7 @@ namespace core::socket::stream {
         , onDisconnect(socketConnector.onDisconnect)
         , onInitState(socketConnector.onInitState)
         , onStatus(socketConnector.onStatus)
+        , allocateConnectionId(socketConnector.allocateConnectionId)
         , logScope(socketConnector.logScope)
         , config(socketConnector.config) {
     }
@@ -208,7 +212,7 @@ namespace core::socket::stream {
                                     }
                                 } else {
                                     SocketConnection* socketConnection =
-                                        new SocketConnection(std::move(physicalClientSocket), onDisconnect, config);
+                                        new SocketConnection(std::move(physicalClientSocket), onDisconnect, allocateConnectionId(), config);
 
                                     snode::semantic::coreSocketLog().debug()
                                         << config->getInstanceName() << " connect " << remoteAddress.toString() << ": success";
@@ -264,7 +268,7 @@ namespace core::socket::stream {
             const int errnum = cErrno;
 
             if (errnum == 0) {
-                SocketConnection* socketConnection = new SocketConnection(std::move(physicalClientSocket), onDisconnect, config);
+                SocketConnection* socketConnection = new SocketConnection(std::move(physicalClientSocket), onDisconnect, allocateConnectionId(), config);
 
                 snode::semantic::coreSocketLog().debug()
                     << config->getInstanceName() << " connect " << remoteAddress.toString() << ": success";

--- a/src/core/socket/stream/SocketContext.cpp
+++ b/src/core/socket/stream/SocketContext.cpp
@@ -67,14 +67,14 @@ namespace core::socket::stream {
                               socketConnection->getInstanceName().empty() ? std::nullopt
                                                                           : std::optional<std::string>(socketConnection->getInstanceName()),
                               std::nullopt,
-                              socketConnection->getConnectionName())
+                              std::to_string(socketConnection->getConnectionId()))
         , frameworkLogScope(logger::LogOrigin::Framework,
                             logger::LogBoundary::Context,
                             "core.socket.context",
                             socketConnection->getInstanceName().empty() ? std::nullopt
                                                                         : std::optional<std::string>(socketConnection->getInstanceName()),
                             std::nullopt,
-                            socketConnection->getConnectionName())
+                            std::to_string(socketConnection->getConnectionId()))
         , onlineSinceTimePoint(std::chrono::system_clock::now()) {
     }
 

--- a/src/core/socket/stream/SocketServer.h
+++ b/src/core/socket/stream/SocketServer.h
@@ -57,6 +57,7 @@
 #include "utils/Random.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <functional> // IWYU pragma: export
 #include <optional>
 #include <type_traits> // IWYU pragma: export
@@ -93,6 +94,7 @@ namespace core::socket::stream {
                                          callback();
                                      });
                                  })
+                , logScope(makeLogScope(config->getInstanceName()))
                 , socketContextFactory(socketContextFactory)
                 , onConnect(onConnect)
                 , onConnected(onConnected)
@@ -100,6 +102,18 @@ namespace core::socket::stream {
             }
 
             ServerFlowController flowController;
+            logger::LogScopeOwner logScope;
+            std::uint64_t connectionsCreated{0};
+
+            std::uint64_t allocateConnectionId() noexcept {
+                return ++connectionsCreated;
+            }
+
+            void emitTerminationSummary() const {
+                logScope.logger(logger::Logger::semanticSink())
+                    .info("Instance terminated: connections={} retries={}", connectionsCreated, flowController.getRetryCount());
+            }
+
             std::shared_ptr<SocketContextFactory> socketContextFactory;
 
             std::function<void(SocketConnection*)> onConnect;
@@ -235,7 +249,14 @@ namespace core::socket::stream {
                                                     log.info("Retry listen disabled during wait");
                                                 }
                                             });
+                                    } else if (retryFlag &&
+                                               (state == core::socket::State::ERROR || state == core::socket::State::FATAL) &&
+                                               core::SNodeC::state() == core::State::RUNNING && sharedContext->flowController.terminateFlow()) {
+                                        sharedContext->emitTerminationSummary();
                                     }
+                                },
+                                [sharedContext]() {
+                                    return sharedContext->allocateConnectionId();
                                 },
                                 config);
                         }

--- a/src/core/socket/stream/legacy/SocketAcceptor.h
+++ b/src/core/socket/stream/legacy/SocketAcceptor.h
@@ -51,6 +51,8 @@ namespace core::socket::stream::legacy {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include <cstdint>
+
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace core::socket::stream::legacy {
@@ -72,6 +74,7 @@ namespace core::socket::stream::legacy {
                        const std::function<void(SocketConnection*)>& onDisconnect,
                        const std::function<void(core::eventreceiver::AcceptEventReceiver*)>& onInitState,
                        const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+                       const std::function<std::uint64_t()>& allocateConnectionId,
                        const std::shared_ptr<Config>& config);
 
         SocketAcceptor(const SocketAcceptor& socketAcceptor);

--- a/src/core/socket/stream/legacy/SocketAcceptor.hpp
+++ b/src/core/socket/stream/legacy/SocketAcceptor.hpp
@@ -58,6 +58,7 @@ namespace core::socket::stream::legacy {
         const std::function<void(SocketConnection*)>& onDisconnect,
         const std::function<void(core::eventreceiver::AcceptEventReceiver*)>& onInitState,
         const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+        const std::function<std::uint64_t()>& allocateConnectionId,
         const std::shared_ptr<Config>& config)
         : Super(
               onConnect,
@@ -69,6 +70,7 @@ namespace core::socket::stream::legacy {
               onDisconnect,
               onInitState,
               onStatus,
+              allocateConnectionId,
               config) {
         if (core::eventLoopState() == core::State::RUNNING) {
             Super::init();

--- a/src/core/socket/stream/legacy/SocketConnection.h
+++ b/src/core/socket/stream/legacy/SocketConnection.h
@@ -76,6 +76,7 @@ namespace core::socket::stream::legacy {
 
         SocketConnection(PhysicalSocket&& physicalSocket,
                          const std::function<void(SocketConnection*)>& onDisconnect,
+                         std::uint64_t connectionId,
                          const std::shared_ptr<Config>& config);
 
         template <typename PhysicalSocket, typename Config>

--- a/src/core/socket/stream/legacy/SocketConnection.hpp
+++ b/src/core/socket/stream/legacy/SocketConnection.hpp
@@ -53,12 +53,14 @@ namespace core::socket::stream::legacy {
     template <typename PhysicalSocket, typename Config>
     SocketConnection<PhysicalSocket, Config>::SocketConnection(PhysicalSocket&& physicalSocket,
                                                                const std::function<void(SocketConnection*)>& onDisconnect,
+                                                               std::uint64_t connectionId,
                                                                const std::shared_ptr<Config>& config)
         : Super(
               std::move(physicalSocket),
               [onDisconnect, this]() {
                   onDisconnect(this);
               },
+              connectionId,
               config) {
     }
 

--- a/src/core/socket/stream/legacy/SocketConnector.h
+++ b/src/core/socket/stream/legacy/SocketConnector.h
@@ -51,6 +51,8 @@ namespace core::socket::stream::legacy {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include <cstdint>
+
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace core::socket::stream::legacy {
@@ -72,6 +74,7 @@ namespace core::socket::stream::legacy {
                         const std::function<void(SocketConnection*)>& onDisconnect,
                         const std::function<void(core::eventreceiver::ConnectEventReceiver*)>& onInitState,
                         const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+                        const std::function<std::uint64_t()>& allocateConnectionId,
                         const std::shared_ptr<Config>& config);
 
         SocketConnector(const SocketConnector& socketConnector);

--- a/src/core/socket/stream/legacy/SocketConnector.hpp
+++ b/src/core/socket/stream/legacy/SocketConnector.hpp
@@ -58,6 +58,7 @@ namespace core::socket::stream::legacy {
         const std::function<void(SocketConnection*)>& onDisconnect,
         const std::function<void(core::eventreceiver::ConnectEventReceiver*)>& onInitState,
         const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+        const std::function<std::uint64_t()>& allocateConnectionId,
         const std::shared_ptr<Config>& config)
         : Super(
               onConnect,
@@ -69,6 +70,7 @@ namespace core::socket::stream::legacy {
               onDisconnect,
               onInitState,
               onStatus,
+              allocateConnectionId,
               config) {
         if (core::eventLoopState() == core::State::RUNNING) {
             Super::init();

--- a/src/core/socket/stream/tls/SocketAcceptor.h
+++ b/src/core/socket/stream/tls/SocketAcceptor.h
@@ -54,6 +54,8 @@ namespace core::socket::stream::tls {
 using SSL_CTX = struct ssl_ctx_st;
 using SSL = struct ssl_st;
 
+#include <cstdint>
+
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace core::socket::stream::tls {
@@ -77,6 +79,7 @@ namespace core::socket::stream::tls {
                        const std::function<void(SocketConnection*)>& onDisconnect,
                        const std::function<void(core::eventreceiver::AcceptEventReceiver*)>& onInitState,
                        const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+                       const std::function<std::uint64_t()>& allocateConnectionId,
                        const std::shared_ptr<Config>& config);
 
         SocketAcceptor(const SocketAcceptor& socketAcceptor);

--- a/src/core/socket/stream/tls/SocketAcceptor.hpp
+++ b/src/core/socket/stream/tls/SocketAcceptor.hpp
@@ -63,6 +63,7 @@ namespace core::socket::stream::tls {
         const std::function<void(SocketConnection*)>& onDisconnect,
         const std::function<void(core::eventreceiver::AcceptEventReceiver*)>& onInitState,
         const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+        const std::function<std::uint64_t()>& allocateConnectionId,
         const std::shared_ptr<Config>& config)
         : Super(
               [onConnect, this](SocketConnection* socketConnection) { // onConnect
@@ -109,6 +110,7 @@ namespace core::socket::stream::tls {
               },
               onInitState,
               onStatus,
+              allocateConnectionId,
               config) {
         if (core::eventLoopState() == core::State::RUNNING) {
             init();

--- a/src/core/socket/stream/tls/SocketConnection.h
+++ b/src/core/socket/stream/tls/SocketConnection.h
@@ -81,6 +81,7 @@ namespace core::socket::stream::tls {
 
         SocketConnection(PhysicalSocket&& physicalSocket,
                          const std::function<void(SocketConnection*)>& onDisconnect,
+                         std::uint64_t connectionId,
                          const std::shared_ptr<Config>& config);
 
         SSL* getSSL() const;

--- a/src/core/socket/stream/tls/SocketConnection.hpp
+++ b/src/core/socket/stream/tls/SocketConnection.hpp
@@ -61,12 +61,14 @@ namespace core::socket::stream::tls {
     template <typename PhysicalSocket, typename Config>
     SocketConnection<PhysicalSocket, Config>::SocketConnection(PhysicalSocket&& physicalSocket,
                                                                const std::function<void(SocketConnection*)>& onDisconnect,
+                                                               std::uint64_t connectionId,
                                                                const std::shared_ptr<Config>& config)
         : Super(
               std::move(physicalSocket),
               [onDisconnect, this]() {
                   onDisconnect(this);
               },
+              connectionId,
               config)
         , sslInitTimeout(config->getInitTimeout())
         , sslShutdownTimeout(config->getShutdownTimeout())

--- a/src/core/socket/stream/tls/SocketConnector.h
+++ b/src/core/socket/stream/tls/SocketConnector.h
@@ -51,6 +51,8 @@ namespace core::socket::stream::tls {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include <cstdint>
+
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace core::socket::stream::tls {
@@ -74,6 +76,7 @@ namespace core::socket::stream::tls {
                         const std::function<void(SocketConnection*)>& onDisconnect,
                         const std::function<void(core::eventreceiver::ConnectEventReceiver*)>& onInitState,
                         const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+                        const std::function<std::uint64_t()>& allocateConnectionId,
                         const std::shared_ptr<Config>& config);
 
         SocketConnector(const SocketConnector& socketConnector);

--- a/src/core/socket/stream/tls/SocketConnector.hpp
+++ b/src/core/socket/stream/tls/SocketConnector.hpp
@@ -64,6 +64,7 @@ namespace core::socket::stream::tls {
         const std::function<void(SocketConnection*)>& onDisconnect,
         const std::function<void(core::eventreceiver::ConnectEventReceiver*)>& onInitState,
         const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+        const std::function<std::uint64_t()>& allocateConnectionId,
         const std::shared_ptr<Config>& config)
         : Super(
               [onConnect, this](SocketConnection* socketConnection) { // onConnect
@@ -112,6 +113,7 @@ namespace core::socket::stream::tls {
               },
               onInitState,
               onStatus,
+              allocateConnectionId,
               config) {
         if (core::eventLoopState() == core::State::RUNNING) {
             init();

--- a/src/iot/mqtt/SemanticLog.h
+++ b/src/iot/mqtt/SemanticLog.h
@@ -58,7 +58,7 @@ namespace iot::mqtt::semantic {
                                      connection.getInstanceName().empty() ? std::nullopt
                                                                           : std::optional<std::string>(connection.getInstanceName()),
                                      std::nullopt,
-                                     connection.getConnectionName());
+                                     std::to_string(connection.getConnectionId()));
     }
 
 #define IOT_MQTT_SEMANTIC_HELPER(name)                                                                                                     \

--- a/src/web/websocket/SemanticLog.h
+++ b/src/web/websocket/SemanticLog.h
@@ -34,7 +34,7 @@ namespace web::websocket::semantic {
                                      connection.getInstanceName().empty() ? std::nullopt
                                                                           : std::optional<std::string>(connection.getInstanceName()),
                                      std::nullopt,
-                                     connection.getConnectionName());
+                                     std::to_string(connection.getConnectionId()));
     }
 
     inline const logger::LogScopeOwner& webSocketFactoryLogScope() {

--- a/tests/unit/core/TLSLifecycleHelperOwnershipTest.cpp
+++ b/tests/unit/core/TLSLifecycleHelperOwnershipTest.cpp
@@ -480,7 +480,7 @@ namespace {
 
     TestConnection* makeConnection(PipeFd& pipeFd, SslContext& sslContext) {
         auto config = std::make_shared<TestConfig>();
-        auto* connection = new TestConnection(TestPhysicalSocket(pipeFd.fd()), [](TestConnection*) {}, config);
+        auto* connection = new TestConnection(TestPhysicalSocket(pipeFd.fd()), [](TestConnection*) {}, 1, config);
         TLSLifecycleTestAccess::startSSL(*connection, pipeFd.fd(), sslContext.ctx);
         return connection;
     }

--- a/tests/unit/http/HttpMessageParserTest.cpp
+++ b/tests/unit/http/HttpMessageParserTest.cpp
@@ -40,7 +40,7 @@ namespace {
     class BufferSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit BufferSocketConnection(std::string input)
-            : SocketConnection(-1, "HttpMessageParserTest", nullptr)
+            : SocketConnection(-1, 1, "HttpMessageParserTest", nullptr)
             , input(std::move(input)) {
         }
 

--- a/tests/unit/http/HttpMessageTargetQueryEdgeTest.cpp
+++ b/tests/unit/http/HttpMessageTargetQueryEdgeTest.cpp
@@ -33,7 +33,7 @@ namespace {
     class BufferSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit BufferSocketConnection(std::string input)
-            : SocketConnection(-1, "HttpMessageTargetQueryEdgeTest", nullptr)
+            : SocketConnection(-1, 1, "HttpMessageTargetQueryEdgeTest", nullptr)
             , input(std::move(input)) {
         }
 

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -72,6 +72,12 @@ target_compile_features(SocketServerClientMigration03Test PRIVATE cxx_std_20)
 target_link_libraries(SocketServerClientMigration03Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
 set_tests_properties(SocketServerClientMigration03Test PROPERTIES LABELS "unit;log;migration03")
 
+snodec_add_test(EndpointLifetimeCountersTest EndpointLifetimeCountersTest.cpp)
+target_include_directories(EndpointLifetimeCountersTest PRIVATE ${PROJECT_SOURCE_DIR})
+target_compile_features(EndpointLifetimeCountersTest PRIVATE cxx_std_20)
+target_link_libraries(EndpointLifetimeCountersTest PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
+set_tests_properties(EndpointLifetimeCountersTest PROPERTIES LABELS "unit;log;endpoint-counter")
+
 snodec_add_test(CoreRuntimeMigration04Test CoreRuntimeMigration04Test.cpp)
 target_include_directories(CoreRuntimeMigration04Test PRIVATE ${PROJECT_SOURCE_DIR})
 target_compile_features(CoreRuntimeMigration04Test PRIVATE cxx_std_20)

--- a/tests/unit/log/ControlledMigrationRound8Test.cpp
+++ b/tests/unit/log/ControlledMigrationRound8Test.cpp
@@ -54,7 +54,7 @@ namespace {
     class TestSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit TestSocketConnection(const std::string& instanceName)
-            : SocketConnection(8, instanceName, nullptr) {
+            : SocketConnection(8, 8, instanceName, nullptr) {
         }
         ~TestSocketConnection() override = default;
 

--- a/tests/unit/log/EndpointLifetimeCountersTest.cpp
+++ b/tests/unit/log/EndpointLifetimeCountersTest.cpp
@@ -1,203 +1,746 @@
-#include "core/socket/stream/ClientFlowController.h"
-#include "core/socket/stream/FlowController.hpp"
-#include "core/socket/stream/ServerFlowController.h"
-#include "log/LogScopeOwner.h"
+#include "core/SNodeC.h"
+#include "core/eventreceiver/AcceptEventReceiver.h"
+#include "core/eventreceiver/ConnectEventReceiver.h"
+#include "core/socket/Socket.hpp"
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketClient.h"
+#include "core/socket/stream/SocketConnection.h"
+#include "core/socket/stream/SocketContextFactory.h"
+#include "core/socket/stream/SocketServer.h"
 #include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "net/config/ConfigInstance.h"
 #include "tests/support/TestResult.h"
+#include "utils/Timeval.h"
 
+#include <cerrno>
+#include <cstdlib>
 #include <cstdint>
-#include <optional>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <memory>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
 namespace {
-    struct ExposedRetryFlowController : public core::socket::stream::FlowController<ExposedRetryFlowController> {
-        ExposedRetryFlowController()
-            : FlowController("retry-counter", {}) {
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::setTickResolver([]() {
+                return std::string("ENDPOINTLIFETIME");
+            });
+            logger::LogManager::setGlobalLevel(logger::LogLevel::Trace);
+            logger::Logger::logToFile(logFile);
         }
-        void dispatchRetry() {
-            reportFlowRetry();
-        }
-        void terminateAsyncSubFlow() override {
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::setTickResolver({});
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
         }
     };
 
-    struct ExposedClientFlowController : public core::socket::stream::ClientFlowController {
-        explicit ExposedClientFlowController(const std::string& instanceName = "reconnect-counter")
-            : ClientFlowController(instanceName, {}) {
+    class SNodeCGuard {
+    public:
+        SNodeCGuard() {
+            argv[0] = arg0;
+            argv[1] = nullptr;
+            core::SNodeC::init(1, argv);
         }
-        void dispatchReconnect() {
-            reportFlowReconnect();
+
+        ~SNodeCGuard() {
+            core::SNodeC::free();
         }
+
+    private:
+        char arg0[29] = "EndpointLifetimeCountersTest";
+        char* argv[2]{};
     };
 
-    struct ServerEndpointProbe {
-        explicit ServerEndpointProbe(std::string instanceName)
-            : flowController(instanceName, {})
-            , logScope(logger::LogOrigin::Framework,
-                       logger::LogBoundary::Instance,
-                       "core.socket.stream",
-                       instanceName.empty() ? std::nullopt : std::optional<std::string>(std::move(instanceName)),
-                       logger::LogRole::Server,
-                       std::nullopt) {
-        }
-        std::uint64_t allocateConnectionId() noexcept {
-            return ++connectionsCreated;
-        }
-        void emitTerminationSummary(logger::BoundaryLogger::Sink sink) const {
-            logScope.logger(std::move(sink)).info("Instance terminated: connections={} retries={}", connectionsCreated, flowController.getRetryCount());
-        }
-        core::socket::stream::ServerFlowController flowController;
-        logger::LogScopeOwner logScope;
-        std::uint64_t connectionsCreated{0};
-    };
+    std::filesystem::path tempLogPath(const std::string& name) {
+        auto path = std::filesystem::temp_directory_path() / name;
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
 
-    struct ClientEndpointProbe {
-        explicit ClientEndpointProbe(std::string instanceName)
-            : flowController(instanceName)
-            , logScope(logger::LogOrigin::Framework,
-                       logger::LogBoundary::Instance,
-                       "core.socket.stream",
-                       instanceName.empty() ? std::nullopt : std::optional<std::string>(std::move(instanceName)),
-                       logger::LogRole::Client,
-                       std::nullopt) {
-        }
-        std::uint64_t allocateConnectionId() noexcept {
-            return ++connectionsCreated;
-        }
-        void emitTerminationSummary(logger::BoundaryLogger::Sink sink) const {
-            logScope.logger(std::move(sink)).info("Instance terminated: connections={} retries={} reconnects={}",
-                                                  connectionsCreated,
-                                                  flowController.getRetryCount(),
-                                                  flowController.getReconnectCount());
-        }
-        ExposedClientFlowController flowController;
-        logger::LogScopeOwner logScope;
-        std::uint64_t connectionsCreated{0};
-    };
+    std::string readFile(const std::filesystem::path& path) {
+        std::ifstream in(path);
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
 
-    std::size_t countSummaries(const std::vector<logger::LogRecord>& records) {
+    std::size_t countOccurrences(const std::string& haystack, const std::string& needle) {
         std::size_t count = 0;
-        for (const logger::LogRecord& record : records) {
-            if (record.message.rfind("Instance terminated:", 0) == 0) {
-                ++count;
-            }
+        std::size_t pos = 0;
+        while ((pos = haystack.find(needle, pos)) != std::string::npos) {
+            ++count;
+            pos += needle.size();
         }
         return count;
     }
+
+    class TestSocketAddress : public core::socket::SocketAddress {
+    public:
+        std::string toString(bool = true) const override {
+            return "endpoint-lifetime-address";
+        }
+    };
+
+    class TestSocketConnection {
+    public:
+        TestSocketConnection(int fd, std::uint64_t connectionId, std::string instanceName)
+            : fd(fd)
+            , connectionId(connectionId)
+            , connectionName("[" + std::to_string(fd) + "] " + std::move(instanceName)) {
+        }
+
+        int getFd() const noexcept {
+            return fd;
+        }
+
+        std::uint64_t getConnectionId() const noexcept {
+            return connectionId;
+        }
+
+        const std::string& getConnectionName() const noexcept {
+            return connectionName;
+        }
+
+        const TestSocketAddress& getLocalAddress() const {
+            return address;
+        }
+
+        const TestSocketAddress& getRemoteAddress() const {
+            return address;
+        }
+
+        std::string getOnlineSince() const {
+            return "endpoint-lifetime-online-since";
+        }
+
+        double getOnlineDuration() const {
+            return 1.0;
+        }
+
+        std::size_t getTotalQueued() const {
+            return 0;
+        }
+
+        std::size_t getTotalSent() const {
+            return 0;
+        }
+
+        std::size_t getTotalRead() const {
+            return 0;
+        }
+
+        std::size_t getTotalProcessed() const {
+            return 0;
+        }
+
+    private:
+        int fd;
+        std::uint64_t connectionId;
+        std::string connectionName;
+        TestSocketAddress address;
+    };
+
+    class TestSocketContextFactory : public core::socket::stream::SocketContextFactory {
+    public:
+        core::socket::stream::SocketContext* create(core::socket::stream::SocketConnection*) override {
+            return nullptr;
+        }
+    };
+
+    class TestServerConfig : public net::config::ConfigInstance {
+    public:
+        explicit TestServerConfig(const std::string& instanceName)
+            : ConfigInstance(instanceName, Role::SERVER) {
+        }
+        ~TestServerConfig() override = default;
+
+        TestServerConfig* setRetry(bool enabled = true) {
+            retry = enabled;
+            return this;
+        }
+        bool getRetry() const {
+            return retry;
+        }
+        TestServerConfig* setRetryOnFatal(bool enabled = true) {
+            retryOnFatal = enabled;
+            return this;
+        }
+        bool getRetryOnFatal() const {
+            return retryOnFatal;
+        }
+        TestServerConfig* setRetryTimeout(double value) {
+            retryTimeout = value;
+            return this;
+        }
+        double getRetryTimeout() const {
+            return retryTimeout;
+        }
+        TestServerConfig* setRetryTries(unsigned int value = 0) {
+            retryTries = value;
+            return this;
+        }
+        unsigned int getRetryTries() const {
+            return retryTries;
+        }
+        TestServerConfig* setRetryBase(double value) {
+            retryBase = value;
+            return this;
+        }
+        double getRetryBase() const {
+            return retryBase;
+        }
+        TestServerConfig* setRetryLimit(unsigned int value) {
+            retryLimit = value;
+            return this;
+        }
+        double getRetryLimit() const {
+            return retryLimit;
+        }
+        TestServerConfig* setRetryJitter(double value) {
+            retryJitter = value;
+            return this;
+        }
+        double getRetryJitter() const {
+            return retryJitter;
+        }
+
+    private:
+        bool retry{false};
+        bool retryOnFatal{false};
+        double retryTimeout{1};
+        unsigned int retryTries{0};
+        double retryBase{1.8};
+        double retryLimit{0};
+        double retryJitter{0};
+    };
+
+    class TestClientConfig : public TestServerConfig {
+    public:
+        explicit TestClientConfig(const std::string& instanceName)
+            : TestServerConfig(instanceName) {
+            setInstanceName(instanceName);
+        }
+        ~TestClientConfig() override = default;
+
+        TestClientConfig* setReconnect(bool enabled = true) {
+            reconnect = enabled;
+            return this;
+        }
+        bool getReconnect() const {
+            return reconnect;
+        }
+        TestClientConfig* setReconnectTime(double value) {
+            reconnectTime = value;
+            return this;
+        }
+        double getReconnectTime() const {
+            return reconnectTime;
+        }
+
+    private:
+        bool reconnect{false};
+        double reconnectTime{1};
+    };
+
+    enum class ServerAction {
+        TerminalError,
+        ErrorThenStopBeforePolicy,
+        NoRetryError,
+        RetryableError,
+        OkStop,
+        TwoAcceptedConnectionsStop
+    };
+
+    enum class ClientAction {
+        TerminalError,
+        ErrorThenStopBeforePolicy,
+        NoRetryError,
+        RetryableError,
+        OkStop,
+        ConnectedThenDisconnect,
+        ConnectedThenDisconnectStopping,
+        ConnectedStop
+    };
+
+    class TestAcceptEventReceiver : public core::eventreceiver::AcceptEventReceiver {
+    public:
+        using Config = TestServerConfig;
+        using SocketAddress = TestSocketAddress;
+        using SocketConnection = TestSocketConnection;
+
+        TestAcceptEventReceiver(const std::shared_ptr<core::socket::stream::SocketContextFactory>&,
+                                const std::function<void(SocketConnection*)>& onConnect,
+                                const std::function<void(SocketConnection*)>& onConnected,
+                                const std::function<void(SocketConnection*)>&,
+                                const std::function<void(core::eventreceiver::AcceptEventReceiver*)>&,
+                                const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+                                const std::function<std::uint64_t()>& allocateConnectionId,
+                                const std::shared_ptr<Config>& config)
+            : core::eventreceiver::AcceptEventReceiver(config->getInstanceName() + " TestAcceptEventReceiver", 0) {
+            liveAcceptors.push_back(this);
+            const ServerAction action = nextAction();
+            if (action == ServerAction::TwoAcceptedConnectionsStop) {
+                acceptConnection(11, config->getInstanceName(), allocateConnectionId, onConnect, onConnected);
+                acceptConnection(11, config->getInstanceName(), allocateConnectionId, onConnect, onConnected);
+                core::SNodeC::stop();
+                return;
+            }
+
+            if (action == ServerAction::ErrorThenStopBeforePolicy) {
+                core::SNodeC::stop();
+            }
+
+            core::socket::State status = action == ServerAction::OkStop ? core::socket::State(core::socket::State::OK, __FILE__, __LINE__) : core::socket::State(core::socket::State::ERROR, __FILE__, __LINE__);
+            if (action == ServerAction::NoRetryError) {
+                status |= core::socket::State::NO_RETRY;
+            }
+            onStatus(address, status);
+
+            if (action == ServerAction::TerminalError || action == ServerAction::NoRetryError || action == ServerAction::OkStop) {
+                core::SNodeC::stop();
+            }
+        }
+
+        static void reset(std::vector<ServerAction> actions) {
+            queuedActions = std::move(actions);
+        }
+
+        static void cleanup() {
+            acceptedConnections.clear();
+            for (TestAcceptEventReceiver* acceptor : liveAcceptors) {
+                delete acceptor;
+            }
+            liveAcceptors.clear();
+        }
+
+    private:
+        void acceptEvent() override {
+        }
+
+        void unobservedEvent() override {
+        }
+
+        static ServerAction nextAction() {
+            if (queuedActions.empty()) {
+                return ServerAction::OkStop;
+            }
+            const ServerAction action = queuedActions.front();
+            queuedActions.erase(queuedActions.begin());
+            return action;
+        }
+
+        static void acceptConnection(int fd,
+                                     const std::string& instanceName,
+                                     const std::function<std::uint64_t()>& allocateConnectionId,
+                                     const std::function<void(SocketConnection*)>& onConnect,
+                                     const std::function<void(SocketConnection*)>& onConnected) {
+            acceptedConnections.push_back(std::make_unique<SocketConnection>(fd, allocateConnectionId(), instanceName));
+            SocketConnection* connection = acceptedConnections.back().get();
+            if (onConnect) {
+                onConnect(connection);
+            }
+            if (onConnected) {
+                onConnected(connection);
+            }
+        }
+
+        TestSocketAddress address;
+        static std::vector<ServerAction> queuedActions;
+        static std::vector<std::unique_ptr<SocketConnection>> acceptedConnections;
+        static std::vector<TestAcceptEventReceiver*> liveAcceptors;
+    };
+
+    std::vector<ServerAction> TestAcceptEventReceiver::queuedActions;
+    std::vector<std::unique_ptr<TestAcceptEventReceiver::SocketConnection>> TestAcceptEventReceiver::acceptedConnections;
+    std::vector<TestAcceptEventReceiver*> TestAcceptEventReceiver::liveAcceptors;
+
+    class TestConnectEventReceiver : public core::eventreceiver::ConnectEventReceiver {
+    public:
+        using Config = TestClientConfig;
+        using SocketAddress = TestSocketAddress;
+        using SocketConnection = TestSocketConnection;
+
+        TestConnectEventReceiver(const std::shared_ptr<core::socket::stream::SocketContextFactory>&,
+                                 const std::function<void(SocketConnection*)>& onConnect,
+                                 const std::function<void(SocketConnection*)>& onConnected,
+                                 const std::function<void(SocketConnection*)>& onDisconnect,
+                                 const std::function<void(core::eventreceiver::ConnectEventReceiver*)>&,
+                                 const std::function<void(const SocketAddress&, core::socket::State)>& onStatus,
+                                 const std::function<std::uint64_t()>& allocateConnectionId,
+                                 const std::shared_ptr<Config>& config)
+            : core::eventreceiver::ConnectEventReceiver(config->getInstanceName() + " TestConnectEventReceiver", 0) {
+            liveConnectors.push_back(this);
+            const ClientAction action = nextAction();
+            if (action == ClientAction::ConnectedThenDisconnect || action == ClientAction::ConnectedThenDisconnectStopping ||
+                action == ClientAction::ConnectedStop) {
+                connectConnection(11, config->getInstanceName(), allocateConnectionId, onConnect, onConnected, onDisconnect, action);
+                if (action == ClientAction::ConnectedStop) {
+                    core::SNodeC::stop();
+                }
+                return;
+            }
+
+            if (action == ClientAction::ErrorThenStopBeforePolicy) {
+                core::SNodeC::stop();
+            }
+
+            core::socket::State status = action == ClientAction::OkStop ? core::socket::State(core::socket::State::OK, __FILE__, __LINE__) : core::socket::State(core::socket::State::ERROR, __FILE__, __LINE__);
+            if (action == ClientAction::NoRetryError) {
+                status |= core::socket::State::NO_RETRY;
+            }
+            onStatus(address, status);
+
+            if (action == ClientAction::TerminalError || action == ClientAction::NoRetryError || action == ClientAction::OkStop) {
+                core::SNodeC::stop();
+            }
+        }
+
+        static void reset(std::vector<ClientAction> actions) {
+            queuedActions = std::move(actions);
+        }
+
+        static void cleanup() {
+            connectedConnections.clear();
+            for (TestConnectEventReceiver* connector : liveConnectors) {
+                delete connector;
+            }
+            liveConnectors.clear();
+        }
+
+    private:
+        void connectEvent() override {
+        }
+
+        void unobservedEvent() override {
+        }
+
+        static ClientAction nextAction() {
+            if (queuedActions.empty()) {
+                return ClientAction::OkStop;
+            }
+            const ClientAction action = queuedActions.front();
+            queuedActions.erase(queuedActions.begin());
+            return action;
+        }
+
+        static void connectConnection(int fd,
+                                      const std::string& instanceName,
+                                      const std::function<std::uint64_t()>& allocateConnectionId,
+                                      const std::function<void(SocketConnection*)>& onConnect,
+                                      const std::function<void(SocketConnection*)>& onConnected,
+                                      const std::function<void(SocketConnection*)>& onDisconnect,
+                                      ClientAction action) {
+            connectedConnections.push_back(std::make_unique<SocketConnection>(fd, allocateConnectionId(), instanceName));
+            SocketConnection* connection = connectedConnections.back().get();
+            if (onConnect) {
+                onConnect(connection);
+            }
+            if (onConnected) {
+                onConnected(connection);
+            }
+            if (action == ClientAction::ConnectedThenDisconnectStopping) {
+                core::SNodeC::stop();
+            }
+            if (action != ClientAction::ConnectedStop && onDisconnect) {
+                onDisconnect(connection);
+            }
+        }
+
+        TestSocketAddress address;
+        static std::vector<ClientAction> queuedActions;
+        static std::vector<std::unique_ptr<SocketConnection>> connectedConnections;
+        static std::vector<TestConnectEventReceiver*> liveConnectors;
+    };
+
+    std::vector<ClientAction> TestConnectEventReceiver::queuedActions;
+    std::vector<std::unique_ptr<TestConnectEventReceiver::SocketConnection>> TestConnectEventReceiver::connectedConnections;
+    std::vector<TestConnectEventReceiver*> TestConnectEventReceiver::liveConnectors;
+
+    using TestSocketServer = core::socket::stream::SocketServer<TestAcceptEventReceiver, TestSocketContextFactory>;
+    using TestSocketClient = core::socket::stream::SocketClient<TestConnectEventReceiver, TestSocketContextFactory>;
+
+    void runLoopOnce() {
+        core::SNodeC::start(utils::Timeval(0));
+    }
+
+    bool hasSummaryScope(const std::string& log, const std::string& role, const std::string& instance) {
+        return log.find(" INF framework/instance core.socket.stream role=" + role + " inst=" + instance + " ") != std::string::npos;
+    }
 } // namespace
 
-int main() {
+int main(int argc, char* argv[]) {
+    const std::vector<std::string> scenarios = {
+        "server-terminal",
+        "server-retry",
+        "server-no-retry",
+        "server-shutdown",
+        "client-terminal",
+        "client-retry",
+        "client-no-retry",
+        "client-shutdown",
+        "client-disconnect-terminal",
+        "client-reconnect-accepted",
+        "client-disconnect-stopping",
+        "server-sequence",
+        "client-sequence",
+    };
+
+    if (argc == 1) {
+        tests::support::TestResult parentResult;
+        for (const std::string& scenario : scenarios) {
+            const std::string command = std::string(argv[0]) + " " + scenario;
+            parentResult.expectEqual(0, std::system(command.c_str()), "endpoint lifetime scenario " + scenario + " passes");
+        }
+        return parentResult.processResult();
+    }
+
+    const std::string scenario = argv[1];
     tests::support::TestResult result;
 
-    ExposedRetryFlowController retryFlow;
-    std::uint64_t retrySeenByObserver = 0;
-    retryFlow.setOnFlowRetry([&](ExposedRetryFlowController* flow) {
-        retrySeenByObserver = flow->getRetryCount();
-    });
-    result.expectEqual(0, static_cast<int>(retryFlow.getRetryCount()), "retryCount starts at zero");
-    retryFlow.dispatchRetry();
-    result.expectEqual(1, static_cast<int>(retryFlow.getRetryCount()), "retryCount increments once per dispatched retry");
-    result.expectEqual(1, static_cast<int>(retrySeenByObserver), "retry observer sees incremented retryCount");
-
-    ExposedClientFlowController reconnectFlow;
-    std::uint64_t reconnectSeenByObserver = 0;
-    reconnectFlow.setOnFlowReconnect([&](core::socket::stream::ClientFlowController* flow) {
-        reconnectSeenByObserver = flow->getReconnectCount();
-    });
-    result.expectEqual(0, static_cast<int>(reconnectFlow.getReconnectCount()), "reconnectCount starts at zero");
-    reconnectFlow.dispatchReconnect();
-    result.expectEqual(1, static_cast<int>(reconnectFlow.getReconnectCount()), "reconnectCount increments once per dispatched reconnect");
-    result.expectEqual(1, static_cast<int>(reconnectSeenByObserver), "reconnect observer sees incremented reconnectCount");
-
-    ServerEndpointProbe server("endpoint-summary-server");
-    const std::uint64_t firstServerId = server.allocateConnectionId();
-    const std::uint64_t secondServerId = server.allocateConnectionId();
-    result.expectEqual(1, static_cast<int>(firstServerId), "first server connection receives conn=1");
-    result.expectEqual(2, static_cast<int>(secondServerId), "second server connection receives conn=2");
-    result.expectTrue(firstServerId != secondServerId, "descriptor reuse does not imply connection ID reuse");
-
-    std::vector<logger::LogRecord> serverRecords;
-    if (server.flowController.terminateFlow()) {
-        server.emitTerminationSummary([&](logger::LogRecord record) {
-            serverRecords.push_back(std::move(record));
-        });
+    if (scenario == "server-terminal") {
+        const auto logPath = tempLogPath("snodec-endpoint-server-terminal.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestAcceptEventReceiver::reset({ServerAction::TerminalError, ServerAction::TerminalError});
+        TestSocketServer server("endpoint-server-terminal");
+        server.getConfig()->setRetry(false);
+        server.listen([](const TestSocketAddress&, core::socket::State) {});
+        server.listen([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=0")),
+                           "real server terminal listen ERROR emits exactly one summary");
+        result.expectTrue(hasSummaryScope(log, "server", "endpoint-server-terminal"),
+                          "server summary is Info framework/instance core.socket.stream with server role and instance");
+        result.expectTrue(log.find("conn=") == std::string::npos, "server instance summary has no connection field");
     }
-    if (server.flowController.terminateFlow()) {
-        server.emitTerminationSummary([&](logger::LogRecord record) {
-            serverRecords.push_back(std::move(record));
-        });
-    }
-    result.expectEqual(1, static_cast<int>(countSummaries(serverRecords)), "server terminal retry rejection emits exactly one summary");
-    result.expectTrue(serverRecords.size() == 1 && serverRecords[0].level == logger::LogLevel::Info &&
-                          serverRecords[0].boundary == logger::LogBoundary::Instance && serverRecords[0].role == logger::LogRole::Server &&
-                          serverRecords[0].instance == "endpoint-summary-server" && !serverRecords[0].connection &&
-                          serverRecords[0].message == "Instance terminated: connections=2 retries=0",
-                      "server summary is Info, instance-scoped, server role, with no connection field");
 
-    std::vector<logger::LogRecord> acceptedRecords;
-    ServerEndpointProbe acceptedServer("endpoint-accepted-server");
-    acceptedServer.flowController.setOnFlowRetry([&](core::socket::stream::ServerFlowController*) {});
-    result.expectTrue(acceptedRecords.empty(), "accepted retry emits no summary when terminateFlow is not called");
-
-    ClientEndpointProbe connectClient("endpoint-connect-summary-client");
-    connectClient.allocateConnectionId();
-    std::vector<logger::LogRecord> connectClientRecords;
-    if (connectClient.flowController.terminateFlow()) {
-        connectClient.emitTerminationSummary([&](logger::LogRecord record) {
-            connectClientRecords.push_back(std::move(record));
+    if (scenario == "server-retry") {
+        const auto logPath = tempLogPath("snodec-endpoint-server-retry.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestAcceptEventReceiver::reset({ServerAction::RetryableError, ServerAction::OkStop});
+        TestSocketServer server("endpoint-server-retry");
+        server.getConfig()->setRetry(true)->setRetryTimeout(0)->setRetryTries(1);
+        std::uint64_t retrySeenByObserver = 0;
+        server.getFlowController()->setOnFlowRetry([&](core::socket::stream::ServerFlowController* flow) {
+            retrySeenByObserver = flow->getRetryCount();
         });
+        server.listen([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(server.getFlowController()->getRetryCount()),
+                           "real server retry dispatch increments retryCount once");
+        result.expectEqual(1, static_cast<int>(retrySeenByObserver), "server retry observer sees incremented retryCount");
+        result.expectTrue(log.find("Instance terminated:") == std::string::npos, "accepted server retry emits no summary");
     }
-    if (connectClient.flowController.terminateFlow()) {
-        connectClient.emitTerminationSummary([&](logger::LogRecord record) {
-            connectClientRecords.push_back(std::move(record));
-        });
-    }
-    result.expectEqual(1, static_cast<int>(countSummaries(connectClientRecords)), "client terminal connect-retry rejection emits exactly one summary");
-    result.expectTrue(connectClientRecords.size() == 1 && connectClientRecords[0].level == logger::LogLevel::Info &&
-                          connectClientRecords[0].boundary == logger::LogBoundary::Instance &&
-                          connectClientRecords[0].role == logger::LogRole::Client &&
-                          connectClientRecords[0].instance == "endpoint-connect-summary-client" && !connectClientRecords[0].connection &&
-                          connectClientRecords[0].message == "Instance terminated: connections=1 retries=0 reconnects=0",
-                      "client summary is Info, instance-scoped, client role, with no connection field");
 
-    ClientEndpointProbe reconnectClient("endpoint-reconnect-summary-client");
-    reconnectClient.allocateConnectionId();
-    reconnectClient.flowController.dispatchReconnect();
-    std::vector<logger::LogRecord> reconnectClientRecords;
-    if (reconnectClient.flowController.terminateFlow()) {
-        reconnectClient.emitTerminationSummary([&](logger::LogRecord record) {
-            reconnectClientRecords.push_back(std::move(record));
-        });
+    if (scenario == "server-no-retry") {
+        const auto logPath = tempLogPath("snodec-endpoint-server-no-retry.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestAcceptEventReceiver::reset({ServerAction::NoRetryError});
+        TestSocketServer server("endpoint-server-no-retry");
+        server.getConfig()->setRetry(false);
+        server.listen([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        result.expectTrue(readFile(logPath).find("Instance terminated:") == std::string::npos,
+                          "server NO_RETRY address fallback emits no summary");
     }
-    if (reconnectClient.flowController.terminateFlow()) {
-        reconnectClient.emitTerminationSummary([&](logger::LogRecord record) {
-            reconnectClientRecords.push_back(std::move(record));
-        });
+
+    if (scenario == "server-shutdown") {
+        const auto logPath = tempLogPath("snodec-endpoint-server-shutdown.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestAcceptEventReceiver::reset({ServerAction::ErrorThenStopBeforePolicy});
+        TestSocketServer server("endpoint-server-shutdown");
+        server.getConfig()->setRetry(false);
+        server.listen([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        result.expectTrue(readFile(logPath).find("Instance terminated:") == std::string::npos,
+                          "server framework shutdown emits no summary");
     }
-    result.expectEqual(1,
-                       static_cast<int>(countSummaries(reconnectClientRecords)),
-                       "client reconnect rejection during RUNNING emits exactly one summary");
-    result.expectTrue(reconnectClientRecords.size() == 1 && reconnectClientRecords[0].level == logger::LogLevel::Info &&
-                          reconnectClientRecords[0].boundary == logger::LogBoundary::Instance &&
-                          reconnectClientRecords[0].role == logger::LogRole::Client &&
-                          reconnectClientRecords[0].instance == "endpoint-reconnect-summary-client" && !reconnectClientRecords[0].connection &&
-                          reconnectClientRecords[0].message == "Instance terminated: connections=1 retries=0 reconnects=1",
-                      "client reconnect summary contains reconnect count and no connection field");
 
-    std::vector<logger::LogRecord> shutdownRecords;
-    ClientEndpointProbe shutdownClient("endpoint-shutdown-client");
-    shutdownClient.allocateConnectionId();
-    result.expectTrue(shutdownRecords.empty(), "framework shutdown emits no summary without the rejected-continuation terminateFlow path");
+    if (scenario == "client-terminal") {
+        const auto logPath = tempLogPath("snodec-endpoint-client-terminal.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestConnectEventReceiver::reset({ClientAction::TerminalError, ClientAction::TerminalError});
+        TestSocketClient client("endpoint-client-terminal");
+        client.getConfig()->setRetry(false);
+        client.connect([](const TestSocketAddress&, core::socket::State) {});
+        client.connect([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=0 reconnects=0")),
+                           "real client terminal connect ERROR emits exactly one summary");
+        result.expectTrue(hasSummaryScope(log, "client", "endpoint-client-terminal"),
+                          "client connect summary is Info framework/instance core.socket.stream with client role and instance");
+        result.expectTrue(log.find("conn=") == std::string::npos, "client connect instance summary has no connection field");
+    }
 
-    std::vector<logger::LogRecord> acceptedReconnectRecords;
-    ClientEndpointProbe acceptedClient("endpoint-accepted-client");
-    acceptedClient.allocateConnectionId();
-    acceptedClient.flowController.dispatchReconnect();
-    acceptedClient.allocateConnectionId();
-    result.expectEqual(2, static_cast<int>(acceptedClient.connectionsCreated), "accepted reconnect preserves one shared client sequence");
-    result.expectTrue(acceptedReconnectRecords.empty(), "accepted reconnect emits no summary when continuation is accepted");
+    if (scenario == "client-retry") {
+        const auto logPath = tempLogPath("snodec-endpoint-client-retry.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestConnectEventReceiver::reset({ClientAction::RetryableError, ClientAction::OkStop});
+        TestSocketClient client("endpoint-client-retry");
+        client.getConfig()->setRetry(true)->setRetryTimeout(0)->setRetryTries(1);
+        std::uint64_t retrySeenByObserver = 0;
+        client.getFlowController()->setOnFlowRetry([&](core::socket::stream::ClientFlowController* flow) {
+            retrySeenByObserver = flow->getRetryCount();
+        });
+        client.connect([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(client.getFlowController()->getRetryCount()),
+                           "real client retry dispatch increments retryCount once");
+        result.expectEqual(1, static_cast<int>(retrySeenByObserver), "client retry observer sees incremented retryCount");
+        result.expectTrue(log.find("Instance terminated:") == std::string::npos, "accepted client retry emits no summary");
+    }
+
+    if (scenario == "client-no-retry") {
+        const auto logPath = tempLogPath("snodec-endpoint-client-no-retry.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestConnectEventReceiver::reset({ClientAction::NoRetryError});
+        TestSocketClient client("endpoint-client-no-retry");
+        client.getConfig()->setRetry(false);
+        client.connect([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        result.expectTrue(readFile(logPath).find("Instance terminated:") == std::string::npos,
+                          "client NO_RETRY address fallback emits no summary");
+    }
+
+    if (scenario == "client-shutdown") {
+        const auto logPath = tempLogPath("snodec-endpoint-client-shutdown.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestConnectEventReceiver::reset({ClientAction::ErrorThenStopBeforePolicy});
+        TestSocketClient client("endpoint-client-shutdown");
+        client.getConfig()->setRetry(false);
+        client.connect([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        result.expectTrue(readFile(logPath).find("Instance terminated:") == std::string::npos,
+                          "client framework shutdown during connect emits no summary");
+    }
+
+    if (scenario == "client-disconnect-terminal") {
+        const auto logPath = tempLogPath("snodec-endpoint-client-disconnect-terminal.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestConnectEventReceiver::reset({ClientAction::ConnectedThenDisconnect, ClientAction::ConnectedThenDisconnect});
+        TestSocketClient client("endpoint-client-disconnect-terminal");
+        client.getConfig()->setReconnect(false);
+        client.connect([](const TestSocketAddress&, core::socket::State) {});
+        client.connect([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=1 retries=0 reconnects=0")),
+                           "real client reconnect rejection during RUNNING emits exactly one summary");
+        result.expectTrue(hasSummaryScope(log, "client", "endpoint-client-disconnect-terminal"),
+                          "client reconnect summary is Info framework/instance core.socket.stream with client role and instance");
+        result.expectTrue(log.find("conn=") == std::string::npos, "client reconnect instance summary has no connection field");
+    }
+
+    if (scenario == "client-reconnect-accepted") {
+        const auto logPath = tempLogPath("snodec-endpoint-client-reconnect-accepted.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestConnectEventReceiver::reset({ClientAction::ConnectedThenDisconnect, ClientAction::ConnectedStop});
+        TestSocketClient client("endpoint-client-reconnect-accepted");
+        client.getConfig()->setReconnect(true)->setReconnectTime(0);
+        std::uint64_t reconnectSeenByObserver = 0;
+        client.getFlowController()->setOnFlowReconnect([&](core::socket::stream::ClientFlowController* flow) {
+            reconnectSeenByObserver = flow->getReconnectCount();
+        });
+        std::vector<std::uint64_t> connectionIds;
+        client.setOnConnected([&](TestSocketConnection* connection) {
+            connectionIds.push_back(connection->getConnectionId());
+        });
+        client.connect([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(client.getFlowController()->getReconnectCount()),
+                           "real client reconnect dispatch increments reconnectCount once");
+        result.expectEqual(1, static_cast<int>(reconnectSeenByObserver), "reconnect observer sees incremented reconnectCount");
+        result.expectTrue(connectionIds.size() == 2 && connectionIds[0] == 1 && connectionIds[1] == 2,
+                          "reconnect-created client connections continue the same shared sequence");
+        result.expectTrue(log.find("Instance terminated:") == std::string::npos, "accepted client reconnect emits no summary");
+    }
+
+    if (scenario == "client-disconnect-stopping") {
+        const auto logPath = tempLogPath("snodec-endpoint-client-disconnect-stopping.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestConnectEventReceiver::reset({ClientAction::ConnectedThenDisconnectStopping});
+        TestSocketClient client("endpoint-client-disconnect-stopping");
+        client.getConfig()->setReconnect(false);
+        client.connect([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        result.expectTrue(readFile(logPath).find("Instance terminated:") == std::string::npos,
+                          "client disconnect while STOPPING emits no summary");
+    }
+
+    if (scenario == "server-sequence") {
+        SNodeCGuard snodeGuard;
+        TestAcceptEventReceiver::reset({ServerAction::TwoAcceptedConnectionsStop});
+        std::vector<std::uint64_t> serverConnectionIds;
+        TestSocketServer server("endpoint-server-sequence");
+        server.setOnConnected([&](TestSocketConnection* connection) {
+            serverConnectionIds.push_back(connection->getConnectionId());
+        });
+        server.listen([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        result.expectTrue(serverConnectionIds.size() == 2 && serverConnectionIds[0] == 1 && serverConnectionIds[1] == 2,
+                          "real server acceptor allocator gives conn=1 then conn=2 despite descriptor reuse");
+    }
+
+    if (scenario == "client-sequence") {
+        SNodeCGuard snodeGuard;
+        TestConnectEventReceiver::reset({ClientAction::ConnectedStop});
+        std::vector<std::uint64_t> clientConnectionIds;
+        TestSocketClient client("endpoint-client-sequence");
+        client.setOnConnected([&](TestSocketConnection* connection) {
+            clientConnectionIds.push_back(connection->getConnectionId());
+        });
+        client.connect([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        result.expectTrue(clientConnectionIds.size() == 1 && clientConnectionIds[0] == 1,
+                          "real client connector allocator starts its independent sequence at conn=1");
+    }
+
+    TestAcceptEventReceiver::cleanup();
+    TestConnectEventReceiver::cleanup();
 
     return result.processResult();
 }

--- a/tests/unit/log/EndpointLifetimeCountersTest.cpp
+++ b/tests/unit/log/EndpointLifetimeCountersTest.cpp
@@ -1,0 +1,203 @@
+#include "core/socket/stream/ClientFlowController.h"
+#include "core/socket/stream/FlowController.hpp"
+#include "core/socket/stream/ServerFlowController.h"
+#include "log/LogScopeOwner.h"
+#include "log/Logger.h"
+#include "tests/support/TestResult.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+    struct ExposedRetryFlowController : public core::socket::stream::FlowController<ExposedRetryFlowController> {
+        ExposedRetryFlowController()
+            : FlowController("retry-counter", {}) {
+        }
+        void dispatchRetry() {
+            reportFlowRetry();
+        }
+        void terminateAsyncSubFlow() override {
+        }
+    };
+
+    struct ExposedClientFlowController : public core::socket::stream::ClientFlowController {
+        explicit ExposedClientFlowController(const std::string& instanceName = "reconnect-counter")
+            : ClientFlowController(instanceName, {}) {
+        }
+        void dispatchReconnect() {
+            reportFlowReconnect();
+        }
+    };
+
+    struct ServerEndpointProbe {
+        explicit ServerEndpointProbe(std::string instanceName)
+            : flowController(instanceName, {})
+            , logScope(logger::LogOrigin::Framework,
+                       logger::LogBoundary::Instance,
+                       "core.socket.stream",
+                       instanceName.empty() ? std::nullopt : std::optional<std::string>(std::move(instanceName)),
+                       logger::LogRole::Server,
+                       std::nullopt) {
+        }
+        std::uint64_t allocateConnectionId() noexcept {
+            return ++connectionsCreated;
+        }
+        void emitTerminationSummary(logger::BoundaryLogger::Sink sink) const {
+            logScope.logger(std::move(sink)).info("Instance terminated: connections={} retries={}", connectionsCreated, flowController.getRetryCount());
+        }
+        core::socket::stream::ServerFlowController flowController;
+        logger::LogScopeOwner logScope;
+        std::uint64_t connectionsCreated{0};
+    };
+
+    struct ClientEndpointProbe {
+        explicit ClientEndpointProbe(std::string instanceName)
+            : flowController(instanceName)
+            , logScope(logger::LogOrigin::Framework,
+                       logger::LogBoundary::Instance,
+                       "core.socket.stream",
+                       instanceName.empty() ? std::nullopt : std::optional<std::string>(std::move(instanceName)),
+                       logger::LogRole::Client,
+                       std::nullopt) {
+        }
+        std::uint64_t allocateConnectionId() noexcept {
+            return ++connectionsCreated;
+        }
+        void emitTerminationSummary(logger::BoundaryLogger::Sink sink) const {
+            logScope.logger(std::move(sink)).info("Instance terminated: connections={} retries={} reconnects={}",
+                                                  connectionsCreated,
+                                                  flowController.getRetryCount(),
+                                                  flowController.getReconnectCount());
+        }
+        ExposedClientFlowController flowController;
+        logger::LogScopeOwner logScope;
+        std::uint64_t connectionsCreated{0};
+    };
+
+    std::size_t countSummaries(const std::vector<logger::LogRecord>& records) {
+        std::size_t count = 0;
+        for (const logger::LogRecord& record : records) {
+            if (record.message.rfind("Instance terminated:", 0) == 0) {
+                ++count;
+            }
+        }
+        return count;
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    ExposedRetryFlowController retryFlow;
+    std::uint64_t retrySeenByObserver = 0;
+    retryFlow.setOnFlowRetry([&](ExposedRetryFlowController* flow) {
+        retrySeenByObserver = flow->getRetryCount();
+    });
+    result.expectEqual(0, static_cast<int>(retryFlow.getRetryCount()), "retryCount starts at zero");
+    retryFlow.dispatchRetry();
+    result.expectEqual(1, static_cast<int>(retryFlow.getRetryCount()), "retryCount increments once per dispatched retry");
+    result.expectEqual(1, static_cast<int>(retrySeenByObserver), "retry observer sees incremented retryCount");
+
+    ExposedClientFlowController reconnectFlow;
+    std::uint64_t reconnectSeenByObserver = 0;
+    reconnectFlow.setOnFlowReconnect([&](core::socket::stream::ClientFlowController* flow) {
+        reconnectSeenByObserver = flow->getReconnectCount();
+    });
+    result.expectEqual(0, static_cast<int>(reconnectFlow.getReconnectCount()), "reconnectCount starts at zero");
+    reconnectFlow.dispatchReconnect();
+    result.expectEqual(1, static_cast<int>(reconnectFlow.getReconnectCount()), "reconnectCount increments once per dispatched reconnect");
+    result.expectEqual(1, static_cast<int>(reconnectSeenByObserver), "reconnect observer sees incremented reconnectCount");
+
+    ServerEndpointProbe server("endpoint-summary-server");
+    const std::uint64_t firstServerId = server.allocateConnectionId();
+    const std::uint64_t secondServerId = server.allocateConnectionId();
+    result.expectEqual(1, static_cast<int>(firstServerId), "first server connection receives conn=1");
+    result.expectEqual(2, static_cast<int>(secondServerId), "second server connection receives conn=2");
+    result.expectTrue(firstServerId != secondServerId, "descriptor reuse does not imply connection ID reuse");
+
+    std::vector<logger::LogRecord> serverRecords;
+    if (server.flowController.terminateFlow()) {
+        server.emitTerminationSummary([&](logger::LogRecord record) {
+            serverRecords.push_back(std::move(record));
+        });
+    }
+    if (server.flowController.terminateFlow()) {
+        server.emitTerminationSummary([&](logger::LogRecord record) {
+            serverRecords.push_back(std::move(record));
+        });
+    }
+    result.expectEqual(1, static_cast<int>(countSummaries(serverRecords)), "server terminal retry rejection emits exactly one summary");
+    result.expectTrue(serverRecords.size() == 1 && serverRecords[0].level == logger::LogLevel::Info &&
+                          serverRecords[0].boundary == logger::LogBoundary::Instance && serverRecords[0].role == logger::LogRole::Server &&
+                          serverRecords[0].instance == "endpoint-summary-server" && !serverRecords[0].connection &&
+                          serverRecords[0].message == "Instance terminated: connections=2 retries=0",
+                      "server summary is Info, instance-scoped, server role, with no connection field");
+
+    std::vector<logger::LogRecord> acceptedRecords;
+    ServerEndpointProbe acceptedServer("endpoint-accepted-server");
+    acceptedServer.flowController.setOnFlowRetry([&](core::socket::stream::ServerFlowController*) {});
+    result.expectTrue(acceptedRecords.empty(), "accepted retry emits no summary when terminateFlow is not called");
+
+    ClientEndpointProbe connectClient("endpoint-connect-summary-client");
+    connectClient.allocateConnectionId();
+    std::vector<logger::LogRecord> connectClientRecords;
+    if (connectClient.flowController.terminateFlow()) {
+        connectClient.emitTerminationSummary([&](logger::LogRecord record) {
+            connectClientRecords.push_back(std::move(record));
+        });
+    }
+    if (connectClient.flowController.terminateFlow()) {
+        connectClient.emitTerminationSummary([&](logger::LogRecord record) {
+            connectClientRecords.push_back(std::move(record));
+        });
+    }
+    result.expectEqual(1, static_cast<int>(countSummaries(connectClientRecords)), "client terminal connect-retry rejection emits exactly one summary");
+    result.expectTrue(connectClientRecords.size() == 1 && connectClientRecords[0].level == logger::LogLevel::Info &&
+                          connectClientRecords[0].boundary == logger::LogBoundary::Instance &&
+                          connectClientRecords[0].role == logger::LogRole::Client &&
+                          connectClientRecords[0].instance == "endpoint-connect-summary-client" && !connectClientRecords[0].connection &&
+                          connectClientRecords[0].message == "Instance terminated: connections=1 retries=0 reconnects=0",
+                      "client summary is Info, instance-scoped, client role, with no connection field");
+
+    ClientEndpointProbe reconnectClient("endpoint-reconnect-summary-client");
+    reconnectClient.allocateConnectionId();
+    reconnectClient.flowController.dispatchReconnect();
+    std::vector<logger::LogRecord> reconnectClientRecords;
+    if (reconnectClient.flowController.terminateFlow()) {
+        reconnectClient.emitTerminationSummary([&](logger::LogRecord record) {
+            reconnectClientRecords.push_back(std::move(record));
+        });
+    }
+    if (reconnectClient.flowController.terminateFlow()) {
+        reconnectClient.emitTerminationSummary([&](logger::LogRecord record) {
+            reconnectClientRecords.push_back(std::move(record));
+        });
+    }
+    result.expectEqual(1,
+                       static_cast<int>(countSummaries(reconnectClientRecords)),
+                       "client reconnect rejection during RUNNING emits exactly one summary");
+    result.expectTrue(reconnectClientRecords.size() == 1 && reconnectClientRecords[0].level == logger::LogLevel::Info &&
+                          reconnectClientRecords[0].boundary == logger::LogBoundary::Instance &&
+                          reconnectClientRecords[0].role == logger::LogRole::Client &&
+                          reconnectClientRecords[0].instance == "endpoint-reconnect-summary-client" && !reconnectClientRecords[0].connection &&
+                          reconnectClientRecords[0].message == "Instance terminated: connections=1 retries=0 reconnects=1",
+                      "client reconnect summary contains reconnect count and no connection field");
+
+    std::vector<logger::LogRecord> shutdownRecords;
+    ClientEndpointProbe shutdownClient("endpoint-shutdown-client");
+    shutdownClient.allocateConnectionId();
+    result.expectTrue(shutdownRecords.empty(), "framework shutdown emits no summary without the rejected-continuation terminateFlow path");
+
+    std::vector<logger::LogRecord> acceptedReconnectRecords;
+    ClientEndpointProbe acceptedClient("endpoint-accepted-client");
+    acceptedClient.allocateConnectionId();
+    acceptedClient.flowController.dispatchReconnect();
+    acceptedClient.allocateConnectionId();
+    result.expectEqual(2, static_cast<int>(acceptedClient.connectionsCreated), "accepted reconnect preserves one shared client sequence");
+    result.expectTrue(acceptedReconnectRecords.empty(), "accepted reconnect emits no summary when continuation is accepted");
+
+    return result.processResult();
+}

--- a/tests/unit/log/ProductionLogApiRound4Test.cpp
+++ b/tests/unit/log/ProductionLogApiRound4Test.cpp
@@ -28,7 +28,7 @@ namespace {
     class TestSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit TestSocketConnection(const std::string& instanceName)
-            : SocketConnection(7, instanceName, nullptr) {
+            : SocketConnection(7, 7, instanceName, nullptr) {
         }
         ~TestSocketConnection() override = default;
 
@@ -153,7 +153,7 @@ int main() {
     result.expectTrue(connectionRecords[0].component == "core.socket.stream", "SocketConnection log uses stream component");
     result.expectTrue(connectionRecords[0].instance && *connectionRecords[0].instance == "round4-instance",
                       "SocketConnection log owns instance identity");
-    result.expectTrue(connectionRecords[0].connection && *connectionRecords[0].connection == "[7] round4-instance",
+    result.expectTrue(connectionRecords[0].connection && *connectionRecords[0].connection == "7",
                       "SocketConnection log owns connection identity");
 
     TestSocketContext context(&connection);
@@ -183,7 +183,7 @@ int main() {
                       "SocketContext logs use context component");
     result.expectTrue(contextRecords[0].instance && *contextRecords[0].instance == "round4-instance",
                       "SocketContext log owns instance identity");
-    result.expectTrue(contextRecords[0].connection && *contextRecords[0].connection == "[7] round4-instance",
+    result.expectTrue(contextRecords[0].connection && *contextRecords[0].connection == "7",
                       "SocketContext log owns connection identity");
 
     return result.processResult();

--- a/tests/unit/log/ScopedSemanticLoggingMigrationTest.cpp
+++ b/tests/unit/log/ScopedSemanticLoggingMigrationTest.cpp
@@ -15,7 +15,7 @@ namespace {
     class FakeSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit FakeSocketConnection(int fd, std::string instance)
-            : SocketConnection(fd, instance, nullptr) {
+            : SocketConnection(fd, static_cast<std::uint64_t>(fd), instance, nullptr) {
         }
 
         ~FakeSocketConnection() override = default;
@@ -126,18 +126,18 @@ int main() {
     iot::mqtt::semantic::mqttWebSocketLog(collect).debug() << "mqtt websocket unscoped compatibility";
     snode::semantic::expressLog(collect).debug() << "express unscoped compatibility";
 
-    std::string retainedExpressConnectionName;
-    auto retainedExpressLogger = [&collect, &retainedExpressConnectionName]() {
+    std::string retainedExpressConnectionId;
+    auto retainedExpressLogger = [&collect, &retainedExpressConnectionId]() {
         FakeSocketConnection temporary(303, "temporary-instance");
-        retainedExpressConnectionName = temporary.getConnectionName();
+        retainedExpressConnectionId = std::to_string(temporary.getConnectionId());
         return snode::semantic::expressLog(temporary, collect);
     }();
     retainedExpressLogger.info() << "after connection destruction";
 
-    std::string retainedWebSocketConnectionName;
-    auto retainedWebSocketLogger = [&collect, &retainedWebSocketConnectionName]() {
+    std::string retainedWebSocketConnectionId;
+    auto retainedWebSocketLogger = [&collect, &retainedWebSocketConnectionId]() {
         FakeSocketConnection temporary(404, "temporary-websocket-instance");
-        retainedWebSocketConnectionName = temporary.getConnectionName();
+        retainedWebSocketConnectionId = std::to_string(temporary.getConnectionId());
         return web::websocket::semantic::webSocketSubProtocolLog(temporary, collect);
     }();
     retainedWebSocketLogger.info() << "websocket after connection destruction";
@@ -149,7 +149,7 @@ int main() {
                           records[webSocketScoped].boundary == logger::LogBoundary::Connection &&
                           records[webSocketScoped].component == "web.websocket.subprotocol" &&
                           records[webSocketScoped].instance == "inst-a" &&
-                          records[webSocketScoped].connection == first.getConnectionName() &&
+                          records[webSocketScoped].connection == std::to_string(first.getConnectionId()) &&
                           records[webSocketScoped].message == "Subprotocol 'chat': start" &&
                           records[webSocketScoped].message.rfind(first.getConnectionName(), 0) != 0,
                       "WebSocket scoped helper preserves full category and adds active inst/conn before removing text identity");
@@ -157,33 +157,33 @@ int main() {
                           records[webSocketIndependentScoped].boundary == logger::LogBoundary::Connection &&
                           records[webSocketIndependentScoped].component == "web.websocket.subprotocol" &&
                           records[webSocketIndependentScoped].instance == "inst-b" &&
-                          records[webSocketIndependentScoped].connection == second.getConnectionName() &&
+                          records[webSocketIndependentScoped].connection == std::to_string(second.getConnectionId()) &&
                           records[webSocketIndependentScoped].message == "WebSocketContext: Subprotocol 'mqtt' close confirmed from peer",
                       "independent WebSocket connections do not cross-contaminate scoped identity");
     result.expectTrue(
         records[mqttScoped].origin == logger::LogOrigin::Framework && records[mqttScoped].boundary == logger::LogBoundary::Connection &&
             records[mqttScoped].component == "iot.mqtt.websocket" && records[mqttScoped].instance == "inst-a" &&
-            records[mqttScoped].connection == first.getConnectionName() && records[mqttScoped].message == "WsMqtt: connected:",
+            records[mqttScoped].connection == std::to_string(first.getConnectionId()) && records[mqttScoped].message == "WsMqtt: connected:",
         "MQTT-over-WebSocket scoped helper preserves full category and message content without duplicated identity");
     result.expectTrue(records[mqttMultilineScoped].origin == logger::LogOrigin::Framework &&
                           records[mqttMultilineScoped].boundary == logger::LogBoundary::Connection &&
                           records[mqttMultilineScoped].component == "iot.mqtt.websocket" &&
                           records[mqttMultilineScoped].instance == "inst-a" &&
-                          records[mqttMultilineScoped].connection == first.getConnectionName() &&
+                          records[mqttMultilineScoped].connection == std::to_string(first.getConnectionId()) &&
                           records[mqttMultilineScoped].message == "WsMqtt: Frame Data:\n                                payload-hex",
                       "MQTT-over-WebSocket multiline frame-data content is preserved after identity removal");
     result.expectTrue(
         records[expressDispatcherScoped].origin == logger::LogOrigin::Framework &&
             records[expressDispatcherScoped].boundary == logger::LogBoundary::Application &&
             records[expressDispatcherScoped].component == "express" && records[expressDispatcherScoped].instance == "inst-b" &&
-            records[expressDispatcherScoped].connection == second.getConnectionName() &&
+            records[expressDispatcherScoped].connection == std::to_string(second.getConnectionId()) &&
             records[expressDispatcherScoped].message == "Router dispatch",
         "Express dispatcher scoped helper adds active inst/conn and replaces identity-only message with non-empty operation text");
     result.expectTrue(records[expressMiddlewareScoped].origin == logger::LogOrigin::Framework &&
                           records[expressMiddlewareScoped].boundary == logger::LogBoundary::Application &&
                           records[expressMiddlewareScoped].component == "express" &&
                           records[expressMiddlewareScoped].instance == "inst-b" &&
-                          records[expressMiddlewareScoped].connection == second.getConnectionName() &&
+                          records[expressMiddlewareScoped].connection == std::to_string(second.getConnectionId()) &&
                           records[expressMiddlewareScoped].message == "Express VerboseMiddleware: GET / HTTP/1.1" &&
                           records[expressMiddlewareScoped].message.rfind(second.getConnectionName(), 0) != 0,
                       "Express middleware scoped helper preserves full category and exact message without duplicated identity");
@@ -209,20 +209,20 @@ int main() {
                           records[retainedExpressScoped].boundary == logger::LogBoundary::Application &&
                           records[retainedExpressScoped].component == "express" &&
                           records[retainedExpressScoped].instance == "temporary-instance" &&
-                          records[retainedExpressScoped].connection == retainedExpressConnectionName &&
+                          records[retainedExpressScoped].connection == retainedExpressConnectionId &&
                           records[retainedExpressScoped].message == "after connection destruction",
                       "Express scoped logger owns copied identity and remains valid after source connection destruction");
     result.expectTrue(records[retainedWebSocketScoped].origin == logger::LogOrigin::Framework &&
                           records[retainedWebSocketScoped].boundary == logger::LogBoundary::Connection &&
                           records[retainedWebSocketScoped].component == "web.websocket.subprotocol" &&
                           records[retainedWebSocketScoped].instance == "temporary-websocket-instance" &&
-                          records[retainedWebSocketScoped].connection == retainedWebSocketConnectionName &&
+                          records[retainedWebSocketScoped].connection == retainedWebSocketConnectionId &&
                           records[retainedWebSocketScoped].message == "websocket after connection destruction",
                       "WebSocket scoped logger owns copied identity and remains valid after source connection destruction");
 
     const std::string json = logger::formatJsonV1(records[webSocketScoped]);
     result.expectTrue(json.find("\"instance\":\"inst-a\"") != std::string::npos &&
-                          json.find("\"connection\":\"" + first.getConnectionName() + "\"") != std::string::npos,
+                          json.find("\"connection\":\"" + std::to_string(first.getConnectionId()) + "\"") != std::string::npos,
                       "existing JSON path contains structured scoped identity");
     result.expectTrue(noAnsi(logger::formatText(records[webSocketScoped])) && noAnsi(json),
                       "scoped semantic logging introduces no ANSI color text");

--- a/tests/unit/log/SemanticBackendRound6Test.cpp
+++ b/tests/unit/log/SemanticBackendRound6Test.cpp
@@ -80,7 +80,7 @@ namespace {
     class TestSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit TestSocketConnection(const std::string& instanceName)
-            : SocketConnection(7, instanceName, nullptr) {
+            : SocketConnection(7, 7, instanceName, nullptr) {
         }
         ~TestSocketConnection() override = default;
 

--- a/tests/unit/log/SemanticCompatibilityRound9Test.cpp
+++ b/tests/unit/log/SemanticCompatibilityRound9Test.cpp
@@ -74,7 +74,7 @@ namespace {
     class TestSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit TestSocketConnection(const std::string& instanceName)
-            : SocketConnection(9, instanceName, nullptr) {
+            : SocketConnection(9, 9, instanceName, nullptr) {
         }
         ~TestSocketConnection() override = default;
         using core::socket::stream::SocketConnection::setSocketContext;

--- a/tests/unit/log/SemanticProductionThresholdRepairTest.cpp
+++ b/tests/unit/log/SemanticProductionThresholdRepairTest.cpp
@@ -78,7 +78,7 @@ namespace {
     class TestSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit TestSocketConnection(const std::string& instanceName)
-            : SocketConnection(9, instanceName, nullptr) {
+            : SocketConnection(9, 9, instanceName, nullptr) {
         }
         ~TestSocketConnection() override = default;
 

--- a/tests/unit/log/SocketConnectionMigration01Test.cpp
+++ b/tests/unit/log/SocketConnectionMigration01Test.cpp
@@ -63,7 +63,7 @@ namespace {
     class TestSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit TestSocketConnection(const std::string& instanceName)
-            : SocketConnection(11, instanceName, nullptr) {
+            : SocketConnection(11, 23, instanceName, nullptr) {
         }
         ~TestSocketConnection() override = default;
 

--- a/tests/unit/log/SocketConnectionMigration01Test.cpp
+++ b/tests/unit/log/SocketConnectionMigration01Test.cpp
@@ -137,6 +137,33 @@ int main() {
                       "migrated non-error SocketConnection.hpp call emits semantically when enabled");
     result.expectTrue(enabledLog.find(" framework/connection core.socket.stream ") != std::string::npos,
                       "migrated call carries framework/connection core.socket.stream scope");
+    result.expectTrue(enabledLog.find("inst=migration01-instance conn=23") != std::string::npos,
+                      "text output uses the numeric connection ID rather than fd/display identity");
+    result.expectTrue(enabledLog.find("conn=\"[11] migration01-instance\"") == std::string::npos,
+                      "text output never uses the display connectionName as semantic conn");
+
+    TestSocketConnection identityConnection("migration01-instance");
+    result.expectEqual(11, identityConnection.getFd(), "discriminating identity test uses fd 11");
+    result.expectEqual(static_cast<std::uint64_t>(23), identityConnection.getConnectionId(),
+                       "discriminating identity test uses connectionId 23");
+    result.expectTrue(identityConnection.getConnectionName() == "[11] migration01-instance",
+                      "connectionName remains the fd/instance display value");
+    std::vector<logger::LogRecord> identityRecords;
+    identityConnection.log([&](logger::LogRecord record) {
+        identityRecords.push_back(std::move(record));
+    }).info("identity record");
+    result.expectTrue(identityRecords.size() == 1 && identityRecords[0].instance == "migration01-instance" &&
+                          identityRecords[0].connection == "23",
+                      "semantic record carries instance and numeric connection ID");
+
+    TestSocketConnection anonymousConnection("<anonymous>");
+    std::vector<logger::LogRecord> anonymousRecords;
+    anonymousConnection.log([&](logger::LogRecord record) {
+        anonymousRecords.push_back(std::move(record));
+    }).info("anonymous identity");
+    result.expectTrue(anonymousRecords.size() == 1 && anonymousRecords[0].instance == "<anonymous>" &&
+                          anonymousRecords[0].connection == "23",
+                      "anonymous framework instance behavior emits inst=<anonymous> with numeric conn");
 
     const auto managerFilterPath = tempLogPath("snodec-migration01-manager-filter.log");
     {
@@ -174,6 +201,9 @@ int main() {
     result.expectTrue(jsonLog.find("{\"v\":1") != std::string::npos &&
                           jsonLog.find("\"message\":\"SocketConnection: switch completed\"") != std::string::npos,
                       "migrated call respects JSON format selection");
+    result.expectTrue(jsonLog.find("\"connection\":\"23\"") != std::string::npos &&
+                          jsonLog.find("\"connection\":\"[11] migration01-instance\"") == std::string::npos,
+                      "JSON output uses numeric connection ID and not connectionName");
 
     std::vector<logger::LogRecord> sysErrorRecords;
     TestSocketConnection sysErrorConnection("migration01-instance");

--- a/tests/unit/log/SocketEndpointLogApiRound5Test.cpp
+++ b/tests/unit/log/SocketEndpointLogApiRound5Test.cpp
@@ -35,7 +35,7 @@ namespace {
     class TestSocketConnection : public core::socket::stream::SocketConnection {
     public:
         explicit TestSocketConnection(const std::string& instanceName)
-            : SocketConnection(7, instanceName, nullptr) {
+            : SocketConnection(7, 7, instanceName, nullptr) {
         }
         ~TestSocketConnection() override = default;
 


### PR DESCRIPTION
### Motivation

- Replace ambiguous semantic connection identity `conn="[fd] instance"` with a stable numeric per-endpoint sequence scoped by `inst` to avoid descriptor-reuse ambiguity and provide compact lifetime statistics.
- Record actually dispatched retry and reconnect attempts so reported `retries` and `reconnects` reflect work that was started, not merely timers that were armed.
- Emit a single instance-level lifetime summary when normal runtime continuation is rejected by the endpoint policy (terminal listen/connect or terminal reconnect) to provide concise endpoint lifetime telemetry.

### Description

- Added a per-shared-context allocator `connectionsCreated` and `allocateConnectionId()` to `SocketServer::Context` and `SocketClient::Context`, and exposed instance-level `emitTerminationSummary()` with a `core.socket.stream` instance-level `LogScopeOwner`.
- Propagated a narrow allocator callback `std::function<std::uint64_t()>` through `SocketAcceptor`/`SocketConnector` (and legacy/TLS wrappers) and invoked it exactly once immediately before constructing each `SocketConnection` instance.
- Extended `SocketConnection` to store an immutable `const std::uint64_t connectionId` and added `std::uint64_t getConnectionId() noexcept`; preserved `getConnectionName()` unchanged for human-display compatibility.
- Switched the semantic identity helper `snode::semantic::logIdentity(...)` and all connection-scoped semantic `LogScopeOwner` constructions to use `std::to_string(connection.getConnectionId())` while leaving display labels (e.g. `connectionName`) intact.
- Added `retryCount` to `FlowController` and `reconnectCount` to `ClientFlowController`, incremented in `reportFlowRetry()` and `reportFlowReconnect()` respectively (increment occurs before calling observer callbacks), and kept flow controllers logging-agnostic.
- Updated `SocketServer` and `SocketClient` policy branches to call `terminateFlow()` on terminal runtime conditions and to call `sharedContext->emitTerminationSummary()` only when `terminateFlow()` returns true so the summary is emitted exactly once and only for the requested triggers.
- Adjusted legacy/TLS `SocketConnection` constructors and all affected tests to accept the new `connectionId` parameter; documented the constructor signature impact in compatibility notes and updated normative logging docs.

### Testing

- Configured and built a Debug build with tests via `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON -DSNODEC_BUILD_APPS=ON` and `cmake --build build --parallel 2`, which completed successfully.
- Ran the full test suite with `ctest --test-dir build --output-on-failure` and observed the test run complete with all registered tests passing (no failures in this run); component-level skips were observed in this environment as normal.
- Ran focused migration/log tests via CTest and they passed: the focused set (`SocketConnectionMigration01Test`, `SocketServerClientMigration03Test`, `ScopedSemanticLoggingMigrationTest`, `SemanticEndToEndOutputTest`, `SemanticCompatibilityRound9Test`, HTTP/WebSocket/MQTT migration tests) reported success (9/9 passed for the focused suite shown).
- Performed an ASan-focused build/test using `-DSNODEC_ENABLE_ASAN=ON` and an ASan-preloaded `ctest` invocation for the focused set, which completed with the focused tests passing (9/9 passed) in the environment used here.
- Ran static/audit searches for `getConnectionName`, `getConnectionId`, `LogIdentity`, `reportFlowRetry`, `reportFlowReconnect`, and `connectionsCreated` to verify semantic identity sites and that `FlowController`/`ClientFlowController` remain logging-agnostic (no `log` includes or `logger::` usage introduced into flow-controller headers/source).
- Performed a staged install with `DESTDIR=/tmp/snodec-stage cmake --install build` and inspected the staged tree to ensure no new private/test-only headers were installed by this change.

Notes: the change intentionally updates the `SocketConnection` construction API to accept an explicit `std::uint64_t connectionId` (source-compatibility impact), and all affected construction sites and tests were updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5664c97bf8832cb4bf59a2a4760ed7)