### PR TITLE
Add graceful endpoint shutdown summaries

### DIFF
--- a/docs/logging/endpoint-lifetime-identity-counters-report.md
+++ b/docs/logging/endpoint-lifetime-identity-counters-report.md
@@ -11,7 +11,12 @@ records dispatched reconnect attempts. The counters intentionally live in the
 flow controllers and do not introduce logging dependencies there.
 
 Shared endpoint contexts own the instance-level semantic summary scope and emit
-one Info lifetime summary only when a normal runtime retry/reconnect
-continuation is rejected by SocketServer/SocketClient policy.
+one Info lifetime summary exactly once when either SocketServer/SocketClient
+policy rejects a normal runtime retry/reconnect continuation, or the EventLoop
+performs graceful shutdown. Graceful shutdown includes SIGINT, SIGTERM, SIGHUP,
+and `SNodeC::stop()`. The same Context-owned exactly-once guard covers both
+paths, so a policy-triggered summary is not repeated during `EventLoop::free()`.
+SIGKILL, crashes, aborts, and immediate process termination cannot guarantee a
+final endpoint summary.
 
 Constructor compatibility note: `SocketConnection`, `SocketConnectionT`, `SocketAcceptor`, `SocketConnector`, all legacy acceptor/connector/connection variants, and all TLS acceptor/connector/connection variants now carry the explicit connection-ID allocator or value. These installed public headers changed source and ABI compatibility, so dependent applications and libraries must be rebuilt.

--- a/docs/logging/semantic-logging-contract.md
+++ b/docs/logging/semantic-logging-contract.md
@@ -320,8 +320,16 @@ it. `reconnects` counts reconnect attempts that were actually dispatched after
 an established client connection disconnected; arming or cancelling a reconnect
 timer does not increment it.
 
-A server or client instance summary is emitted only when normal runtime
-continuation is rejected by policy: a terminal listen/connect failure that
-cannot continue by retry, or a client disconnect during `RUNNING` that cannot
-continue by reconnect. Framework shutdown, destructor paths, and explicit
-termination calls do not produce this lifetime summary.
+A server or client instance summary is emitted exactly once when either normal
+runtime continuation is rejected by policy or the EventLoop performs graceful
+shutdown. Rejected continuation covers terminal listen/connect failure that
+cannot continue by retry, and client disconnect during `RUNNING` that cannot
+continue by reconnect. Graceful shutdown covers the normal EventLoop shutdown
+path, including SIGINT, SIGTERM, SIGHUP, and `SNodeC::stop()`.
+
+The summary is emitted by the shared endpoint Context. The same Context-owned
+exactly-once guard covers both rejected-continuation and graceful-shutdown paths,
+so a summary emitted by policy rejection is not emitted again during
+`EventLoop::free()`. SIGKILL, crashes, aborts, and immediate process termination
+cannot guarantee a final endpoint summary. Destructor paths do not emit this
+lifetime summary.

--- a/src/core/EventLoop.cpp
+++ b/src/core/EventLoop.cpp
@@ -360,9 +360,14 @@ namespace core {
             timeout -= seconds.count();
         } while (timeout > 0 && (tickStatus == TickStatus::SUCCESS));
 
-        for (const PreShutdownCallback& callback : preShutdownCallbacks) {
-            callback();
+        auto callbacks = std::exchange(preShutdownCallbacks, std::vector<PreShutdownCallback>{});
+
+        for (PreShutdownCallback& callback : callbacks) {
+            if (callback) {
+                callback();
+            }
         }
+
         preShutdownCallbacks.clear();
 
         EventLoop::instance().log().trace("Core: Shutdown config system");

--- a/src/core/EventLoop.cpp
+++ b/src/core/EventLoop.cpp
@@ -53,6 +53,7 @@
 #include <cerrno>
 #include <chrono>
 #include <utility>
+#include <vector>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -63,6 +64,8 @@ namespace core {
     core::State EventLoop::eventLoopState = State::LOADED;
 
     namespace {
+        std::vector<EventLoop::PreShutdownCallback> preShutdownCallbacks;
+
         std::string signalName(int signum) {
             std::string signal = "SIG" + utils::system::sigabbrev_np(signum);
             if (signal == "SIGUNKNOWN") {
@@ -153,6 +156,10 @@ namespace core {
 
     State EventLoop::getEventLoopState() {
         return eventLoopState;
+    }
+
+    void EventLoop::addPreShutdownCallback(PreShutdownCallback callback) {
+        preShutdownCallbacks.push_back(std::move(callback));
     }
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, hicpp-avoid-c-arrays, modernize-avoid-c-arrays)
@@ -352,6 +359,11 @@ namespace core {
 
             timeout -= seconds.count();
         } while (timeout > 0 && (tickStatus == TickStatus::SUCCESS));
+
+        for (const PreShutdownCallback& callback : preShutdownCallbacks) {
+            callback();
+        }
+        preShutdownCallbacks.clear();
 
         EventLoop::instance().log().trace("Core: Shutdown config system");
 

--- a/src/core/EventLoop.h
+++ b/src/core/EventLoop.h
@@ -47,6 +47,8 @@
 #include "log/LogScopeOwner.h"
 #include "log/SemanticLogger.h"
 
+#include <functional>
+
 namespace core {
     class EventMultiplexer;
 } // namespace core
@@ -63,6 +65,8 @@ namespace core {
 
     class EventLoop {
     public:
+        using PreShutdownCallback = std::function<void()>;
+
         EventLoop(const EventLoop& eventLoop) = delete;
 
         EventLoop& operator=(const EventLoop& eventLoop) = delete;
@@ -83,6 +87,8 @@ namespace core {
                                    logger::BoundaryLogger::Clock clock = {}) const;
 
         static core::State getEventLoopState();
+
+        static void addPreShutdownCallback(PreShutdownCallback callback);
 
     private:
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, hicpp-avoid-c-arrays, modernize-avoid-c-arrays)

--- a/src/core/socket/stream/SocketClient.h
+++ b/src/core/socket/stream/SocketClient.h
@@ -42,6 +42,7 @@
 #ifndef CORE_SOCKET_STREAM_SOCKETCLIENT_H
 #define CORE_SOCKET_STREAM_SOCKETCLIENT_H
 
+#include "core/EventLoop.h"
 #include "core/EventReceiver.h"
 #include "core/SNodeC.h"
 #include "core/socket/Socket.h"                      // IWYU pragma: export
@@ -59,6 +60,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional> // IWYU pragma: export
+#include <memory>
 #include <optional>
 #include <type_traits> // IWYU pragma: export
 
@@ -121,6 +123,15 @@ namespace core::socket::stream {
                           flowController.getRetryCount(),
                           flowController.getReconnectCount());
             }
+
+            void emitTerminationSummaryOnce() {
+                if (!terminationSummaryEmitted) {
+                    terminationSummaryEmitted = true;
+                    emitTerminationSummary();
+                }
+            }
+
+            bool terminationSummaryEmitted{false};
 
             std::shared_ptr<SocketContextFactory> socketContextFactory;
 
@@ -186,6 +197,12 @@ namespace core::socket::stream {
                           onDisconnect(socketConnection);
                       }
                   })) {
+            const std::weak_ptr<Context> weakContext = sharedContext;
+            core::EventLoop::addPreShutdownCallback([weakContext] {
+                if (const auto context = weakContext.lock()) {
+                    context->emitTerminationSummaryOnce();
+                }
+            });
         }
 
         SocketClient(const std::function<void(SocketConnection*)>& onConnect,
@@ -240,7 +257,7 @@ namespace core::socket::stream {
                                             });
                                     } else if (core::eventLoopState() == core::State::RUNNING &&
                                                sharedContext->flowController.terminateFlow()) {
-                                        sharedContext->emitTerminationSummary();
+                                        sharedContext->emitTerminationSummaryOnce();
                                     }
                                 },
                                 [sharedContext](core::eventreceiver::ConnectEventReceiver* connectEventReceiver) {
@@ -290,7 +307,7 @@ namespace core::socket::stream {
                                     } else if (retryFlag &&
                                                (state == core::socket::State::ERROR || state == core::socket::State::FATAL) &&
                                                core::SNodeC::state() == core::State::RUNNING && sharedContext->flowController.terminateFlow()) {
-                                        sharedContext->emitTerminationSummary();
+                                        sharedContext->emitTerminationSummaryOnce();
                                     }
                                 },
                                 [sharedContext]() {

--- a/src/core/socket/stream/SocketServer.h
+++ b/src/core/socket/stream/SocketServer.h
@@ -42,6 +42,7 @@
 #ifndef CORE_SOCKET_STREAM_SOCKETSERVERNEW_H
 #define CORE_SOCKET_STREAM_SOCKETSERVERNEW_H
 
+#include "core/EventLoop.h"
 #include "core/EventReceiver.h"
 #include "core/SNodeC.h"
 #include "core/socket/Socket.h"                      // IWYU pragma: export
@@ -59,6 +60,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional> // IWYU pragma: export
+#include <memory>
 #include <optional>
 #include <type_traits> // IWYU pragma: export
 
@@ -113,6 +115,15 @@ namespace core::socket::stream {
                 logScope.logger(logger::Logger::semanticSink())
                     .info("Instance terminated: connections={} retries={}", connectionsCreated, flowController.getRetryCount());
             }
+
+            void emitTerminationSummaryOnce() {
+                if (!terminationSummaryEmitted) {
+                    terminationSummaryEmitted = true;
+                    emitTerminationSummary();
+                }
+            }
+
+            bool terminationSummaryEmitted{false};
 
             std::shared_ptr<SocketContextFactory> socketContextFactory;
 
@@ -178,6 +189,12 @@ namespace core::socket::stream {
                           onDisconnect(socketConnection);
                       }
                   })) {
+            const std::weak_ptr<Context> weakContext = sharedContext;
+            core::EventLoop::addPreShutdownCallback([weakContext] {
+                if (const auto context = weakContext.lock()) {
+                    context->emitTerminationSummaryOnce();
+                }
+            });
         }
 
         SocketServer(const std::function<void(SocketConnection*)>& onConnect,
@@ -252,7 +269,7 @@ namespace core::socket::stream {
                                     } else if (retryFlag &&
                                                (state == core::socket::State::ERROR || state == core::socket::State::FATAL) &&
                                                core::SNodeC::state() == core::State::RUNNING && sharedContext->flowController.terminateFlow()) {
-                                        sharedContext->emitTerminationSummary();
+                                        sharedContext->emitTerminationSummaryOnce();
                                     }
                                 },
                                 [sharedContext]() {

--- a/tests/unit/log/EndpointLifetimeCountersTest.cpp
+++ b/tests/unit/log/EndpointLifetimeCountersTest.cpp
@@ -33,7 +33,7 @@ namespace {
             logger::Logger::init();
             logger::LogManager::init();
             logger::Logger::setLogLevel(6);
-            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setVerboseLevel(6);
             logger::Logger::setQuiet(true);
             logger::Logger::setDisableColor(true);
             logger::Logger::setTickResolver([]() {
@@ -484,6 +484,13 @@ namespace {
     bool hasSummaryScope(const std::string& log, const std::string& role, const std::string& instance) {
         return log.find(" INF framework/instance core.socket.stream role=" + role + " inst=" + instance + " ") != std::string::npos;
     }
+
+    bool summaryAppearsBeforeShutdown(const std::string& log) {
+        const auto summary = log.find("Instance terminated:");
+        const auto config = log.find("Core: Shutdown config system");
+        const auto bye = log.find("SNode.C: Ended ... BYE");
+        return summary != std::string::npos && (config == std::string::npos || summary < config) && (bye == std::string::npos || summary < bye);
+    }
 } // namespace
 
 int main(int argc, char* argv[]) {
@@ -501,6 +508,9 @@ int main(int argc, char* argv[]) {
         "client-disconnect-stopping",
         "server-sequence",
         "client-sequence",
+        "expired-weak-context",
+        "callback-reset-first",
+        "callback-reset-second",
     };
 
     if (argc == 1) {
@@ -532,6 +542,7 @@ int main(int argc, char* argv[]) {
         result.expectTrue(hasSummaryScope(log, "server", "endpoint-server-terminal"),
                           "server summary is Info framework/instance core.socket.stream with server role and instance");
         result.expectTrue(log.find("conn=") == std::string::npos, "server instance summary has no connection field");
+        result.expectTrue(summaryAppearsBeforeShutdown(log), "server terminal summary remains before shutdown logs and is not repeated by free");
     }
 
     if (scenario == "server-retry") {
@@ -552,7 +563,7 @@ int main(int argc, char* argv[]) {
         result.expectEqual(1, static_cast<int>(server.getFlowController()->getRetryCount()),
                            "real server retry dispatch increments retryCount once");
         result.expectEqual(1, static_cast<int>(retrySeenByObserver), "server retry observer sees incremented retryCount");
-        result.expectTrue(log.find("Instance terminated:") == std::string::npos, "accepted server retry emits no summary");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=1")), "accepted server retry emits graceful shutdown summary with accumulated counter");
     }
 
     if (scenario == "server-no-retry") {
@@ -565,8 +576,9 @@ int main(int argc, char* argv[]) {
         server.listen([](const TestSocketAddress&, core::socket::State) {});
         runLoopOnce();
         logger::Logger::disableLogToFile();
-        result.expectTrue(readFile(logPath).find("Instance terminated:") == std::string::npos,
-                          "server NO_RETRY address fallback emits no summary");
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=0")),
+                           "server NO_RETRY address fallback emits graceful shutdown summary");
     }
 
     if (scenario == "server-shutdown") {
@@ -579,8 +591,10 @@ int main(int argc, char* argv[]) {
         server.listen([](const TestSocketAddress&, core::socket::State) {});
         runLoopOnce();
         logger::Logger::disableLogToFile();
-        result.expectTrue(readFile(logPath).find("Instance terminated:") == std::string::npos,
-                          "server framework shutdown emits no summary");
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=0")),
+                           "server graceful shutdown emits exactly one summary");
+        result.expectTrue(summaryAppearsBeforeShutdown(log), "server graceful summary appears before config shutdown and BYE");
     }
 
     if (scenario == "client-terminal") {
@@ -600,6 +614,7 @@ int main(int argc, char* argv[]) {
         result.expectTrue(hasSummaryScope(log, "client", "endpoint-client-terminal"),
                           "client connect summary is Info framework/instance core.socket.stream with client role and instance");
         result.expectTrue(log.find("conn=") == std::string::npos, "client connect instance summary has no connection field");
+        result.expectTrue(summaryAppearsBeforeShutdown(log), "client terminal summary remains before shutdown logs and is not repeated by free");
     }
 
     if (scenario == "client-retry") {
@@ -620,7 +635,7 @@ int main(int argc, char* argv[]) {
         result.expectEqual(1, static_cast<int>(client.getFlowController()->getRetryCount()),
                            "real client retry dispatch increments retryCount once");
         result.expectEqual(1, static_cast<int>(retrySeenByObserver), "client retry observer sees incremented retryCount");
-        result.expectTrue(log.find("Instance terminated:") == std::string::npos, "accepted client retry emits no summary");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=1 reconnects=0")), "accepted client retry emits graceful shutdown summary with accumulated counter");
     }
 
     if (scenario == "client-no-retry") {
@@ -633,8 +648,9 @@ int main(int argc, char* argv[]) {
         client.connect([](const TestSocketAddress&, core::socket::State) {});
         runLoopOnce();
         logger::Logger::disableLogToFile();
-        result.expectTrue(readFile(logPath).find("Instance terminated:") == std::string::npos,
-                          "client NO_RETRY address fallback emits no summary");
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=0 reconnects=0")),
+                           "client NO_RETRY address fallback emits graceful shutdown summary");
     }
 
     if (scenario == "client-shutdown") {
@@ -647,8 +663,10 @@ int main(int argc, char* argv[]) {
         client.connect([](const TestSocketAddress&, core::socket::State) {});
         runLoopOnce();
         logger::Logger::disableLogToFile();
-        result.expectTrue(readFile(logPath).find("Instance terminated:") == std::string::npos,
-                          "client framework shutdown during connect emits no summary");
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=0 reconnects=0")),
+                           "client graceful shutdown emits exactly one summary");
+        result.expectTrue(summaryAppearsBeforeShutdown(log), "client graceful summary appears before config shutdown and BYE");
     }
 
     if (scenario == "client-disconnect-terminal") {
@@ -694,7 +712,7 @@ int main(int argc, char* argv[]) {
         result.expectEqual(1, static_cast<int>(reconnectSeenByObserver), "reconnect observer sees incremented reconnectCount");
         result.expectTrue(connectionIds.size() == 2 && connectionIds[0] == 1 && connectionIds[1] == 2,
                           "reconnect-created client connections continue the same shared sequence");
-        result.expectTrue(log.find("Instance terminated:") == std::string::npos, "accepted client reconnect emits no summary");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=2 retries=0 reconnects=1")), "accepted client reconnect emits graceful shutdown summary with accumulated counters");
     }
 
     if (scenario == "client-disconnect-stopping") {
@@ -707,8 +725,9 @@ int main(int argc, char* argv[]) {
         client.connect([](const TestSocketAddress&, core::socket::State) {});
         runLoopOnce();
         logger::Logger::disableLogToFile();
-        result.expectTrue(readFile(logPath).find("Instance terminated:") == std::string::npos,
-                          "client disconnect while STOPPING emits no summary");
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=1 retries=0 reconnects=0")),
+                           "client disconnect while STOPPING emits graceful shutdown summary");
     }
 
     if (scenario == "server-sequence") {
@@ -737,6 +756,34 @@ int main(int argc, char* argv[]) {
         runLoopOnce();
         result.expectTrue(clientConnectionIds.size() == 1 && clientConnectionIds[0] == 1,
                           "real client connector allocator starts its independent sequence at conn=1");
+    }
+
+    if (scenario == "expired-weak-context") {
+        const auto logPath = tempLogPath("snodec-endpoint-expired-weak-context.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        {
+            TestSocketServer server("endpoint-expired-server");
+            TestSocketClient client("endpoint-expired-client");
+        }
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        result.expectTrue(readFile(logPath).find("Instance terminated:") == std::string::npos,
+                          "expired weak endpoint contexts are ignored safely");
+    }
+
+    if (scenario == "callback-reset-first" || scenario == "callback-reset-second") {
+        const auto logPath = tempLogPath("snodec-endpoint-" + scenario + ".log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestAcceptEventReceiver::reset({ServerAction::ErrorThenStopBeforePolicy});
+        TestSocketServer server("endpoint-" + scenario);
+        server.listen([](const TestSocketAddress&, core::socket::State) {});
+        runLoopOnce();
+        logger::Logger::disableLogToFile();
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated:")),
+                           scenario + " emits one summary without retained callbacks from earlier runs");
     }
 
     TestAcceptEventReceiver::cleanup();

--- a/tests/unit/log/EndpointLifetimeCountersTest.cpp
+++ b/tests/unit/log/EndpointLifetimeCountersTest.cpp
@@ -1,3 +1,4 @@
+#include "core/EventLoop.h"
 #include "core/SNodeC.h"
 #include "core/eventreceiver/AcceptEventReceiver.h"
 #include "core/eventreceiver/ConnectEventReceiver.h"
@@ -509,8 +510,7 @@ int main(int argc, char* argv[]) {
         "server-sequence",
         "client-sequence",
         "expired-weak-context",
-        "callback-reset-first",
-        "callback-reset-second",
+        "pre-shutdown-snapshot",
     };
 
     if (argc == 1) {
@@ -772,18 +772,22 @@ int main(int argc, char* argv[]) {
                           "expired weak endpoint contexts are ignored safely");
     }
 
-    if (scenario == "callback-reset-first" || scenario == "callback-reset-second") {
-        const auto logPath = tempLogPath("snodec-endpoint-" + scenario + ".log");
-        LoggerStateGuard loggerGuard(logPath.string());
-        SNodeCGuard snodeGuard;
-        TestAcceptEventReceiver::reset({ServerAction::ErrorThenStopBeforePolicy});
-        TestSocketServer server("endpoint-" + scenario);
-        server.listen([](const TestSocketAddress&, core::socket::State) {});
-        runLoopOnce();
-        logger::Logger::disableLogToFile();
-        const auto log = readFile(logPath);
-        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated:")),
-                           scenario + " emits one summary without retained callbacks from earlier runs");
+    if (scenario == "pre-shutdown-snapshot") {
+        int callbackInvocations = 0;
+        {
+            SNodeCGuard snodeGuard;
+            core::EventLoop::addPreShutdownCallback([&callbackInvocations] {
+                ++callbackInvocations;
+                core::EventLoop::addPreShutdownCallback([&callbackInvocations] {
+                    ++callbackInvocations;
+                });
+            });
+            runLoopOnce();
+            result.expectEqual(1, callbackInvocations,
+                               "callbacks registered during pre-shutdown dispatch are not invoked in the same shutdown");
+        }
+        result.expectEqual(1, callbackInvocations,
+                           "callbacks registered during pre-shutdown dispatch are cleared before a later free call");
     }
 
     TestAcceptEventReceiver::cleanup();


### PR DESCRIPTION
### Motivation
- Ensure endpoint lifetime summaries are emitted once during graceful EventLoop shutdown (SIGINT/SIGTERM/SIGHUP or `SNodeC::stop()`), without changing ownership or logging architecture. 
- Reuse the existing Context logging emitter and counter ownership so retry/reconnect counters are reflected if accumulated before shutdown.

### Description
- Add `using PreShutdownCallback = std::function<void()>;` and `static void addPreShutdownCallback(PreShutdownCallback)` to `core::EventLoop` and store callbacks in a simple `std::vector` to avoid synchronization overhead.  
- Invoke all pre-shutdown callbacks after descriptor termination/drain and before `utils::Config::terminate()` and the final BYE log, then `clear()` the container.  
- Register exactly one weak-pointer callback from each shared `SocketServer::Context` and `SocketClient::Context` immediately after the shared context is created using `std::weak_ptr<Context>` so the callback does not extend context lifetime.  
- Add `bool terminationSummaryEmitted{false};` and `void emitTerminationSummaryOnce()` to both server and client shared `Context` types and replace direct `emitTerminationSummary()` calls with `emitTerminationSummaryOnce()` so summaries are emitted exactly once (either on rejected retry/reconnect continuation or on EventLoop graceful shutdown).  
- Update the production-path endpoint tests (`tests/unit/log/EndpointLifetimeCountersTest.cpp`) to assert graceful-shutdown summaries are emitted once, appear before config shutdown and BYE, contain accumulated counters, ignore expired weak contexts safely, and that repeated init/start/free runs do not retain callbacks.

### Testing
- Built a Debug production build with `cmake -S . -B build-debug -DCMAKE_BUILD_TYPE=Debug && cmake --build build-debug -j2`; build succeeded (note: missing dev packages installed in this environment: `nlohmann-json3-dev`, `libmagic-dev`, `libbluetooth-dev`). — PASS
- Built tests and ran the focused test: `cmake -S . -B build-debug-tests -DCMAKE_BUILD_TYPE=Debug -DSNODEC_BUILD_TESTS=ON && cmake --build build-debug-tests -j2` and `ctest --test-dir build-debug-tests --output-on-failure -R EndpointLifetimeCountersTest`; focused `EndpointLifetimeCountersTest` passed. — PASS
- Ran the full CTest suite in the tests-enabled build with `ctest --test-dir build-debug-tests --output-on-failure`; all tests passed (150/150). — PASS
- Built an AddressSanitizer instrumented test build and ran the focused test with `-fsanitize=address` flags and `ctest --test-dir build-asan --output-on-failure -R EndpointLifetimeCountersTest`; ASan test run passed. — PASS
- Ran `git diff --check` to validate whitespace/patch hygiene; no issues found. — PASS

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a569e94e984832c8b3049970ff9d579)