### PR TITLE
Complete Codex backend client and canonicalize user messages

### DIFF
--- a/docs/ai/openai/codex/backend-core.md
+++ b/docs/ai/openai/codex/backend-core.md
@@ -152,9 +152,13 @@ backend events:
 - `ControllerChanged` and `SessionChanged`; and
 - `CodexExtensionReceived`.
 
-Unknown typed items with a stable ID remain items. Unknown events, or malformed
-future item events that cannot identify an owning entity, remain observable as
-bounded `CodexExtensionReceived` records with their original method or
+User messages and unknown typed items with a stable ID and envelope location
+remain canonical items. Unknown items retain their common ID, thread, and turn
+metadata along with raw JSON and any item-local decoding error. An item with a
+valid location but no stable ID remains observable through the bounded
+`codex/item-without-id` extension fallback. Unknown events, or malformed future
+item events that cannot identify an owning thread and turn, remain observable
+as bounded `CodexExtensionReceived` records with their original method or
 deliberate extension name, payload, and optional decoding error. They do not
 fail the backend and are not silently discarded.
 

--- a/docs/ai/openai/codex/backend-core.md
+++ b/docs/ai/openai/codex/backend-core.md
@@ -137,6 +137,17 @@ bounded suffix for complete output. These bounds are configurable through
 `ReducerOptions`; ordinary 1,000-delta test bursts remain below the defaults
 and reconstruct exactly.
 
+The typed `UserMessageItem` separately retains its complete opaque content
+array. Its normalized snapshot/event `data` object has a dedicated 65,536-byte
+compact-serialization bound: `content` remains an array containing an ordered
+prefix of complete, unmodified entries, and the adjacent
+`contentTruncated`, `originalContentBytes`, `retainedContentBytes`,
+`originalContentItems`, and `retainedContentItems` fields describe that
+projection. The byte counts are compact serialized array sizes, so an empty
+retained array counts as two bytes. This payload-specific truncation does not
+alter the top-level `contentTruncated` or `droppedContentBytes`; those fields
+retain their accumulated-visible-content meaning for every item type.
+
 ## Reducer semantics
 
 All ordinary domain transitions pass through `Reducer::apply()`. Typed Codex

--- a/docs/ai/openai/codex/codex-backend-reference-app.md
+++ b/docs/ai/openai/codex/codex-backend-reference-app.md
@@ -98,13 +98,106 @@ stdio client. Authentication and quota are properties of that local Codex
 installation, not of the frontend protocol.
 
 Start the server and client in separate terminals. The client sends `hello`
-automatically and provides typed `snapshot`, `acquire`, `threads`, and `read`
-commands as well as the other commands documented in its README:
+automatically and provides typed synchronization, controller, thread, and turn
+commands as documented in its README:
 
 ```sh
 codex-backend
 codex-backend-client
 ```
+
+## Reference client thread lifecycle
+
+The reference client exposes the existing Frontend Protocol v1 operations with
+the following thread-management syntax:
+
+```text
+start [--cwd <path>] [--model <model>]
+      [--model-provider <provider>]
+      [--approval-policy <policy>]
+      [--sandbox-mode <mode>]
+      [--ephemeral]
+
+resume <thread-id>
+       [--cwd <path>] [--model <model>]
+       [--model-provider <provider>]
+       [--approval-policy <policy>]
+       [--sandbox-mode <mode>]
+
+new [thread-start-options] -- <prompt>
+new <prompt>
+
+turn <thread-id> <prompt>
+read <thread-id>
+threads
+acquire
+release
+```
+
+Frontend sessions begin as observers, and the client does not acquire
+controller ownership automatically. `start`, `resume`, `new`, and `turn`
+therefore require a prior successful `acquire`; an observer receives the
+backend's ordinary `permission_denied` response.
+
+An interactive explicit workflow creates a thread, reports its ID, and then
+uses that ID for the first turn:
+
+```text
+acquire
+start --cwd /home/voc/projects/snode.c
+turn <returned-thread-id> Review the repository.
+```
+
+An existing persisted thread must be resumed before it can accept a turn in
+the running App Server:
+
+```text
+acquire
+threads
+resume <thread-id>
+turn <thread-id> Continue the previous task.
+```
+
+`threads` may include threads marked `notLoaded`. In particular:
+
+> `read` retrieves thread data but does not resume or load the thread into the
+> running Codex App Server. Use `resume <thread-id>` before starting a turn on a
+> persisted `notLoaded` thread.
+
+The convenience workflow is:
+
+```text
+acquire
+new --cwd /home/voc/projects/snode.c -- Review the repository.
+```
+
+`new` is solely a `codex-backend-client` compound command. It submits a typed
+`ThreadStart`, waits for the matching successful response, validates the
+returned `result.thread.id`, and submits a typed `TurnStart` with that ID and
+one text input containing the complete prompt. The backend and Frontend
+Protocol v1 gain no `new` operation, and the client does not send both requests
+before the start response arrives.
+
+Human mode reports concise started/resumed IDs and `new` stage results. In
+`--json` mode, stdout remains complete Frontend Protocol JSONL: `new` emits the
+real `thread.start` and `turn.start` responses and events, never a synthetic
+message. Local diagnostics remain on stderr.
+
+For example, a piped JSON workflow is:
+
+```sh
+printf '%s\n' \
+  'acquire' \
+  'new --cwd /home/voc/projects/snode.c -- Review the repository.' \
+  | codex-backend-client --json
+```
+
+EOF draining waits for both stages of `new`. If thread creation succeeds but
+the initial turn cannot be submitted or returns a failure, the client exits
+unsuccessfully, reports that the thread was created, and preserves its ID in
+the diagnostic. Disconnects and send failures during either stage likewise
+produce a deterministic failure rather than silently completing the compound
+command.
 
 ## Socket path
 

--- a/docs/ai/openai/codex/frontend-protocol-v1.md
+++ b/docs/ai/openai/codex/frontend-protocol-v1.md
@@ -269,7 +269,7 @@ Its deterministic `state` contains:
 - each item's lifecycle plus complete currently retained `agentText`,
   `reasoningText`, `reasoningSummary`, and `commandOutput`;
 - `contentTruncated` and `droppedContentBytes` when the backend's configurable
-  accumulated-content bound discarded an old prefix;
+  accumulated-visible-content bound discarded an old prefix;
 - pending request summaries, controller ownership, and connected sessions;
 - thread-list completeness, loaded-page count, and available cursors; and
 - frontend journal `oldestReplayableAfter`, `currentSequence`, and optional
@@ -282,8 +282,25 @@ stable Codex status string with independent `active` and `terminal` Booleans.
 Known item `type` strings are `user_message`, `agent_message`, `reasoning`,
 `command_execution`, `file_change`, `tool_call`, and `web_search`; a future
 unknown item retains its provided Codex type or uses `unknown`. A user-message
-item's normalized `data` retains its nullable `clientId` and bounded complete
-`content` array.
+item's normalized `data` is an object with a nullable string `clientId` and a
+`content` array. The typed layer retains the complete opaque App Server content
+array, while a snapshot or `item.updated` event retains an ordered prefix of
+complete entries whose complete normalized `data` serialization is at most
+65,536 bytes. Retained entries remain exact JSON values, including unknown
+future content-entry variants; no partial JSON serialization is exposed as an
+entry.
+
+User-message `data` also contains `contentTruncated`,
+`originalContentBytes`, `retainedContentBytes`, `originalContentItems`, and
+`retainedContentItems`. The byte counts are the compact serialized sizes of
+the original and retained content arrays, including their array delimiters;
+an empty retained array is therefore two bytes. The item counts report the
+corresponding array lengths. If even the first entry cannot fit with the
+client ID and metadata, `content` is empty and `contentTruncated` is true.
+These user-message fields describe normalized payload truncation. They do not
+change the top-level item `contentTruncated` and `droppedContentBytes`, which
+continue to describe old prefixes discarded from accumulated visible text and
+command-output channels.
 
 Snapshots do not contain callbacks, pointers, internal request-occurrence
 tokens, App Server client request IDs, authentication access tokens, or secret

--- a/docs/ai/openai/codex/frontend-protocol-v1.md
+++ b/docs/ai/openai/codex/frontend-protocol-v1.md
@@ -279,9 +279,11 @@ Lifecycle strings are `stopped`, `starting`, `initializing`, `ready`,
 `stopping`, and `failed`. Session roles are `observer` and `controller`. Item
 status is `unknown`, `started`, `completed`, or `failed`; turn status remains a
 stable Codex status string with independent `active` and `terminal` Booleans.
-Known item `type` strings are `agent_message`, `reasoning`,
+Known item `type` strings are `user_message`, `agent_message`, `reasoning`,
 `command_execution`, `file_change`, `tool_call`, and `web_search`; a future
-unknown item retains its provided Codex type or uses `unknown`.
+unknown item retains its provided Codex type or uses `unknown`. A user-message
+item's normalized `data` retains its nullable `clientId` and bounded complete
+`content` array.
 
 Snapshots do not contain callbacks, pointers, internal request-occurrence
 tokens, App Server client request IDs, authentication access tokens, or secret

--- a/docs/ai/openai/codex/frontend-protocol-v1.schema.json
+++ b/docs/ai/openai/codex/frontend-protocol-v1.schema.json
@@ -549,7 +549,7 @@
         "id": { "$ref": "#/$defs/NonEmptyString" },
         "type": {
           "$ref": "#/$defs/NonEmptyString",
-          "description": "Known values are agent_message, reasoning, command_execution, file_change, tool_call, and web_search. Future Codex item types remain explicit strings."
+          "description": "Known values are user_message, agent_message, reasoning, command_execution, file_change, tool_call, and web_search. Future Codex item types remain explicit strings."
         },
         "status": { "enum": ["unknown", "started", "completed", "failed"] },
         "agentText": { "type": "string" },

--- a/docs/ai/openai/codex/frontend-protocol-v1.schema.json
+++ b/docs/ai/openai/codex/frontend-protocol-v1.schema.json
@@ -530,6 +530,33 @@
       },
       "additionalProperties": true
     },
+    "UserMessageData": {
+      "type": "object",
+      "description": "Normalized user-message data. Content is an ordered prefix of complete entries; byte counts measure compact serialization of the corresponding arrays.",
+      "required": [
+        "clientId",
+        "content",
+        "contentTruncated",
+        "originalContentBytes",
+        "retainedContentBytes",
+        "originalContentItems",
+        "retainedContentItems"
+      ],
+      "properties": {
+        "clientId": { "type": ["string", "null"] },
+        "content": {
+          "type": "array",
+          "items": true,
+          "description": "A bounded prefix of complete opaque Codex content entries in original order."
+        },
+        "contentTruncated": { "type": "boolean" },
+        "originalContentBytes": { "$ref": "#/$defs/UInt64" },
+        "retainedContentBytes": { "$ref": "#/$defs/UInt64" },
+        "originalContentItems": { "$ref": "#/$defs/UInt64" },
+        "retainedContentItems": { "$ref": "#/$defs/UInt64" }
+      },
+      "additionalProperties": true
+    },
     "ItemState": {
       "type": "object",
       "required": [
@@ -563,6 +590,21 @@
         "data": { "type": "object" },
         "extensions": { "type": "object" }
       },
+      "allOf": [
+        {
+          "if": {
+            "required": ["type"],
+            "properties": {
+              "type": { "const": "user_message" }
+            }
+          },
+          "then": {
+            "properties": {
+              "data": { "$ref": "#/$defs/UserMessageData" }
+            }
+          }
+        }
+      ],
       "additionalProperties": true
     },
     "TurnState": {

--- a/docs/ai/openai/codex/typed-api.md
+++ b/docs/ai/openai/codex/typed-api.md
@@ -87,17 +87,23 @@ currently include:
 A failed `turn/completed` payload becomes `TurnFailed`; there is no separate
 `turn/failed` wire method in the current schema.
 
-Principal item variants are agent message, reasoning, command execution, file
-change, MCP/dynamic tool call, and web search. Item metadata carries item,
-thread, and turn identity when the notification or parent turn supplies it.
-Every item retains its raw item JSON. `Turn::itemsView` preserves the current
-`notLoaded`, `summary`, or `full` completeness marker and any future
-string; an omitted marker has the schema-defined `full` default.
+Principal item variants are user message, agent message, reasoning, command
+execution, file change, MCP/dynamic tool call, and web search. A user message
+retains its nullable client ID and complete content array as JSON; content
+entries are not flattened or restricted to currently known input variants.
+Item metadata carries item, thread, and turn identity when the notification or
+parent turn supplies it. Every item retains its raw item JSON.
+`Turn::itemsView` preserves the current `notLoaded`, `summary`, or `full`
+completeness marker and any future string; an omitted marker has the
+schema-defined `full` default.
 
 Unknown notification methods become `UnknownEvent`. Unknown item
-discriminators become `UnknownItem`. A known notification with a malformed
-known payload also becomes `UnknownEvent` with `decodingError`. These values
-retain the raw method, params, and envelope and do not fail the connection.
+discriminators become `UnknownItem`. Unknown items retain any valid common item
+ID plus the thread and turn IDs supplied by their notification or parent turn.
+A malformed item-local field also degrades to `UnknownItem` with a
+`decodingError` when its object can still be retained; a malformed notification
+envelope becomes `UnknownEvent`. These values retain their original raw JSON
+and do not fail the connection.
 
 ## Server requests
 
@@ -169,3 +175,11 @@ Typed public headers are installed. Decoder headers under `detail/` remain
 private. Raw JSON on results, threads, turns, items, events, and server requests
 is the forward-compatibility escape hatch, and `client.raw()` remains
 available for protocol additions not yet represented by the typed layer.
+
+Adding `UserMessageItem` extends the public `Item` variant, and adding partial
+common metadata enlarges the public `UnknownItem` structure. Existing variant
+indices are retained and the new `UnknownItem` member is appended, preserving
+ordinary field access and existing three-field aggregate initializers at source
+level. The layouts are not binary-compatible, however, and exhaustive item
+visitors must handle the new alternative; already-built C++ consumers must be
+rebuilt.

--- a/docs/ai/openai/codex/typed-api.md
+++ b/docs/ai/openai/codex/typed-api.md
@@ -93,6 +93,12 @@ retains its nullable client ID and complete content array as JSON; content
 entries are not flattened or restricted to currently known input variants.
 Item metadata carries item, thread, and turn identity when the notification or
 parent turn supplies it. Every item retains its raw item JSON.
+When canonical state is projected into Frontend Protocol snapshots or events,
+user-message content is represented as an ordered, bounded prefix of complete
+entries. The normalized `data.content` value remains an array, every retained
+entry remains an exact JSON value, and explicit byte and item counts report
+whether entries were omitted. This frontend projection does not modify the
+complete `UserMessageItem::content` value held by the typed layer.
 `Turn::itemsView` preserves the current `notLoaded`, `summary`, or `full`
 completeness marker and any future string; an omitted marker has the
 schema-defined `full` default.

--- a/src/ai/openai/codex/backend/BackendState.cpp
+++ b/src/ai/openai/codex/backend/BackendState.cpp
@@ -40,6 +40,9 @@ namespace ai::openai::codex::backend {
             [](const auto& value) -> std::optional<typed::ItemId> {
                 using Value = std::decay_t<decltype(value)>;
                 if constexpr (std::is_same_v<Value, typed::UnknownItem>) {
+                    if (value.metadata.id && !value.metadata.id->value.empty()) {
+                        return value.metadata.id;
+                    }
                     try {
                         if (value.raw.is_object()) {
                             const auto iterator = value.raw.find("id");
@@ -52,7 +55,7 @@ namespace ai::openai::codex::backend {
                     }
                     return std::nullopt;
                 } else {
-                    return value.metadata.id;
+                    return value.metadata.id.value.empty() ? std::nullopt : std::optional<typed::ItemId>{value.metadata.id};
                 }
             },
             item);
@@ -64,6 +67,8 @@ namespace ai::openai::codex::backend {
                 using Value = std::decay_t<decltype(value)>;
                 if constexpr (std::is_same_v<Value, typed::AgentMessageItem>) {
                     return "agent_message";
+                } else if constexpr (std::is_same_v<Value, typed::UserMessageItem>) {
+                    return "user_message";
                 } else if constexpr (std::is_same_v<Value, typed::ReasoningItem>) {
                     return "reasoning";
                 } else if constexpr (std::is_same_v<Value, typed::CommandExecutionItem>) {
@@ -75,7 +80,7 @@ namespace ai::openai::codex::backend {
                 } else if constexpr (std::is_same_v<Value, typed::WebSearchItem>) {
                     return "web_search";
                 } else {
-                    return value.type.value_or("unknown");
+                    return value.type && !value.type->empty() ? *value.type : "unknown";
                 }
             },
             item);

--- a/src/ai/openai/codex/backend/Reducer.cpp
+++ b/src/ai/openai/codex/backend/Reducer.cpp
@@ -139,13 +139,17 @@ namespace ai::openai::codex::backend {
                 [](const auto& value) -> std::optional<std::pair<typed::ThreadId, typed::TurnId>> {
                     using Value = std::decay_t<decltype(value)>;
                     if constexpr (std::is_same_v<Value, typed::UnknownItem>) {
-                        return std::nullopt;
-                    } else {
-                        if (value.metadata.threadId && value.metadata.turnId) {
+                        if (value.metadata.threadId && !value.metadata.threadId->value.empty() && value.metadata.turnId &&
+                            !value.metadata.turnId->value.empty()) {
                             return std::pair{*value.metadata.threadId, *value.metadata.turnId};
                         }
-                        return std::nullopt;
+                    } else {
+                        if (value.metadata.threadId && !value.metadata.threadId->value.empty() && value.metadata.turnId &&
+                            !value.metadata.turnId->value.empty()) {
+                            return std::pair{*value.metadata.threadId, *value.metadata.turnId};
+                        }
                     }
+                    return std::nullopt;
                 },
                 item);
         }
@@ -179,10 +183,12 @@ namespace ai::openai::codex::backend {
             } else {
                 ItemState& itemState = iterator->second;
                 itemState.item = item;
-                itemState.lifecycle = lifecycle;
-                if (lifecycle == ItemLifecycle::Started) {
+                if (lifecycle != ItemLifecycle::Unknown || itemState.lifecycle == ItemLifecycle::Unknown) {
+                    itemState.lifecycle = lifecycle;
+                }
+                if (lifecycle == ItemLifecycle::Started && occurredAtMs) {
                     itemState.startedAtMs = occurredAtMs;
-                } else if (lifecycle == ItemLifecycle::Completed) {
+                } else if (lifecycle == ItemLifecycle::Completed && occurredAtMs) {
                     itemState.completedAtMs = occurredAtMs;
                 }
                 initializeVisibleContent(itemState, lifecycle == ItemLifecycle::Completed, contentLimit);
@@ -400,6 +406,7 @@ namespace ai::openai::codex::backend {
                         typed::UnknownItem placeholder;
                         placeholder.type = "backend.delta-placeholder";
                         placeholder.raw = Json::object({{"id", value.itemId.value}, {"backendPlaceholder", true}});
+                        placeholder.metadata = {value.itemId, value.threadId, value.turnId};
                         upsertItem(state,
                                    value.threadId,
                                    value.turnId,
@@ -432,6 +439,7 @@ namespace ai::openai::codex::backend {
                         typed::UnknownItem placeholder;
                         placeholder.type = "fileChange";
                         placeholder.raw = Json::object({{"id", value.itemId.value}, {"changes", value.changes}});
+                        placeholder.metadata = {value.itemId, value.threadId, value.turnId};
                         upsertItem(state,
                                    value.threadId,
                                    value.turnId,

--- a/src/ai/openai/codex/backend/Snapshot.cpp
+++ b/src/ai/openai/codex/backend/Snapshot.cpp
@@ -44,6 +44,50 @@ namespace ai::openai::codex::backend {
             }
         }
 
+        Json userMessageData(const typed::UserMessageItem& item) {
+            const std::size_t originalContentBytes = item.content.dump().size();
+            const std::size_t originalContentItems = item.content.size();
+            const Json clientId = item.clientId ? Json(*item.clientId) : Json(nullptr);
+            Json retainedContent = Json::array();
+            std::size_t retainedContentBytes = retainedContent.dump().size();
+            std::size_t retainedContentItems = 0;
+
+            const auto makeData = [&](const Json& content, bool contentTruncated, std::size_t contentBytes, std::size_t contentItems) {
+                return Json::object({{"clientId", clientId},
+                                     {"content", content},
+                                     {"contentTruncated", contentTruncated},
+                                     {"originalContentBytes", static_cast<std::uint64_t>(originalContentBytes)},
+                                     {"retainedContentBytes", static_cast<std::uint64_t>(contentBytes)},
+                                     {"originalContentItems", static_cast<std::uint64_t>(originalContentItems)},
+                                     {"retainedContentItems", static_cast<std::uint64_t>(contentItems)}});
+            };
+
+            for (const Json& contentEntry : item.content) {
+                const std::size_t separatorBytes = retainedContentItems == 0 ? 0 : 1;
+                const std::size_t contentEntryBytes = contentEntry.dump().size();
+                if (retainedContentBytes > MaxSerializedUserMessageDataBytes - separatorBytes ||
+                    contentEntryBytes > MaxSerializedUserMessageDataBytes - separatorBytes - retainedContentBytes) {
+                    break;
+                }
+
+                const std::size_t candidateContentBytes = retainedContentBytes + separatorBytes + contentEntryBytes;
+                const std::size_t candidateContentItems = retainedContentItems + 1;
+                const bool candidateTruncated = candidateContentItems < originalContentItems;
+                const Json candidateSkeleton = makeData(Json::array(), candidateTruncated, candidateContentBytes, candidateContentItems);
+                const std::size_t candidateDataBytes =
+                    candidateSkeleton.dump().size() - Json::array().dump().size() + candidateContentBytes;
+                if (candidateDataBytes > MaxSerializedUserMessageDataBytes) {
+                    break;
+                }
+
+                retainedContent.push_back(contentEntry);
+                retainedContentBytes = candidateContentBytes;
+                retainedContentItems = candidateContentItems;
+            }
+
+            return makeData(retainedContent, retainedContentItems < originalContentItems, retainedContentBytes, retainedContentItems);
+        }
+
         std::string safeUtf8Prefix(std::string_view value, std::size_t byteLimit) {
             std::size_t offset = 0;
             while (offset < value.size() && offset < byteLimit) {
@@ -208,8 +252,7 @@ namespace ai::openai::codex::backend {
                                       }
                                   },
                                   [&snapshot](const typed::UserMessageItem& value) {
-                                      snapshot.data = Json::object({{"clientId", value.clientId ? Json(*value.clientId) : Json(nullptr)},
-                                                                    {"content", boundedJson(value.content)}});
+                                      snapshot.data = userMessageData(value);
                                   },
                                   [&snapshot](const typed::ReasoningItem&) {
                                       snapshot.data["hasSummary"] = !snapshot.reasoningSummary.empty();

--- a/src/ai/openai/codex/backend/Snapshot.cpp
+++ b/src/ai/openai/codex/backend/Snapshot.cpp
@@ -207,6 +207,10 @@ namespace ai::openai::codex::backend {
                                           snapshot.data["phase"] = *value.phase;
                                       }
                                   },
+                                  [&snapshot](const typed::UserMessageItem& value) {
+                                      snapshot.data = Json::object({{"clientId", value.clientId ? Json(*value.clientId) : Json(nullptr)},
+                                                                    {"content", boundedJson(value.content)}});
+                                  },
                                   [&snapshot](const typed::ReasoningItem&) {
                                       snapshot.data["hasSummary"] = !snapshot.reasoningSummary.empty();
                                   },

--- a/src/ai/openai/codex/backend/Snapshot.h
+++ b/src/ai/openai/codex/backend/Snapshot.h
@@ -28,6 +28,7 @@ namespace ai::openai::codex::backend {
     inline constexpr std::size_t MaxSnapshotExtensionDecodingErrorBytes = 2U * 1024U;
     inline constexpr std::size_t MaxSerializedCodexExtensionEventBytes = 64U * 1024U;
     inline constexpr std::size_t MaxSerializedCodexExtensionEnvelopeOverheadBytes = 4U * 1024U;
+    inline constexpr std::size_t MaxSerializedUserMessageDataBytes = 64U * 1024U;
     static_assert(MaxSnapshotExtensionMethodBytes * 6U + MaxSnapshotExtensionPayloadBytes + MaxSnapshotExtensionDecodingErrorBytes * 6U +
                           MaxSerializedCodexExtensionEnvelopeOverheadBytes <=
                       MaxSerializedCodexExtensionEventBytes,

--- a/src/ai/openai/codex/detail/ItemDecoder.cpp
+++ b/src/ai/openai/codex/detail/ItemDecoder.cpp
@@ -163,9 +163,45 @@ namespace ai::openai::codex::detail {
             if (!requireString(value, "id", id, error)) {
                 return false;
             }
+            if (id.empty()) {
+                error = "item 'id' field must be a non-empty string";
+                return false;
+            }
 
             metadata = typed::ItemMetadata{typed::ItemId{std::move(id)}, threadId, turnId, value};
             return true;
+        }
+
+        typed::UnknownItem makeUnknownItem(const Json& value,
+                                           std::optional<std::string> type,
+                                           const std::optional<typed::ThreadId>& threadId,
+                                           const std::optional<typed::TurnId>& turnId,
+                                           std::optional<std::string> decodingError = std::nullopt) {
+            typed::UnknownItem item{std::move(type), value, std::move(decodingError), {}};
+            item.metadata.threadId = threadId;
+            item.metadata.turnId = turnId;
+
+            const Json* id = findMember(value, "id");
+            if (id == nullptr) {
+                if (!item.decodingError) {
+                    item.decodingError = "item is missing required 'id' field";
+                }
+            } else if (!id->is_string()) {
+                if (!item.decodingError) {
+                    item.decodingError = "item 'id' field must be a string";
+                }
+            } else {
+                const std::string idValue = id->get<std::string>();
+                if (idValue.empty()) {
+                    if (!item.decodingError) {
+                        item.decodingError = "item 'id' field must be a non-empty string";
+                    }
+                } else {
+                    item.metadata.id = typed::ItemId{idValue};
+                }
+            }
+
+            return item;
         }
 
         std::optional<typed::Item> decodeAgentMessage(const Json& value,
@@ -175,6 +211,18 @@ namespace ai::openai::codex::detail {
             typed::AgentMessageItem item;
             if (!makeMetadata(value, threadId, turnId, item.metadata, error) || !requireString(value, "text", item.text, error) ||
                 !readOptionalString(value, "phase", item.phase, error)) {
+                return std::nullopt;
+            }
+            return typed::Item{std::move(item)};
+        }
+
+        std::optional<typed::Item> decodeUserMessage(const Json& value,
+                                                     const std::optional<typed::ThreadId>& threadId,
+                                                     const std::optional<typed::TurnId>& turnId,
+                                                     std::string& error) {
+            typed::UserMessageItem item;
+            if (!makeMetadata(value, threadId, turnId, item.metadata, error) ||
+                !readOptionalString(value, "clientId", item.clientId, error) || !requireArray(value, "content", item.content, error)) {
                 return std::nullopt;
             }
             return typed::Item{std::move(item)};
@@ -325,38 +373,49 @@ namespace ai::openai::codex::detail {
 
             const Json* discriminator = findMember(value, "type");
             if (discriminator == nullptr) {
-                error = "item is missing required 'type' field";
-                return std::nullopt;
+                typed::UnknownItem item = makeUnknownItem(value, std::nullopt, threadId, turnId, "item is missing required 'type' field");
+                return typed::Item{std::move(item)};
             }
             if (!discriminator->is_string()) {
-                error = "item 'type' field must be a string";
-                return std::nullopt;
+                typed::UnknownItem item = makeUnknownItem(value, std::nullopt, threadId, turnId, "item 'type' field must be a string");
+                return typed::Item{std::move(item)};
             }
 
             const std::string type = discriminator->get<std::string>();
-            if (type == "agentMessage") {
-                return decodeAgentMessage(value, threadId, turnId, error);
-            }
-            if (type == "reasoning") {
-                return decodeReasoning(value, threadId, turnId, error);
-            }
-            if (type == "commandExecution") {
-                return decodeCommandExecution(value, threadId, turnId, error);
-            }
-            if (type == "fileChange") {
-                return decodeFileChange(value, threadId, turnId, error);
-            }
-            if (type == "mcpToolCall") {
-                return decodeMcpToolCall(value, threadId, turnId, error);
-            }
-            if (type == "dynamicToolCall") {
-                return decodeDynamicToolCall(value, threadId, turnId, error);
-            }
-            if (type == "webSearch") {
-                return decodeWebSearch(value, threadId, turnId, error);
+            if (type.empty()) {
+                typed::UnknownItem item =
+                    makeUnknownItem(value, std::nullopt, threadId, turnId, "item 'type' field must be a non-empty string");
+                return typed::Item{std::move(item)};
             }
 
-            return typed::Item{typed::UnknownItem{type, value, std::nullopt}};
+            std::optional<typed::Item> decoded;
+            if (type == "agentMessage") {
+                decoded = decodeAgentMessage(value, threadId, turnId, error);
+            } else if (type == "userMessage") {
+                decoded = decodeUserMessage(value, threadId, turnId, error);
+            } else if (type == "reasoning") {
+                decoded = decodeReasoning(value, threadId, turnId, error);
+            } else if (type == "commandExecution") {
+                decoded = decodeCommandExecution(value, threadId, turnId, error);
+            } else if (type == "fileChange") {
+                decoded = decodeFileChange(value, threadId, turnId, error);
+            } else if (type == "mcpToolCall") {
+                decoded = decodeMcpToolCall(value, threadId, turnId, error);
+            } else if (type == "dynamicToolCall") {
+                decoded = decodeDynamicToolCall(value, threadId, turnId, error);
+            } else if (type == "webSearch") {
+                decoded = decodeWebSearch(value, threadId, turnId, error);
+            } else {
+                return typed::Item{makeUnknownItem(value, type, threadId, turnId)};
+            }
+
+            if (decoded) {
+                return decoded;
+            }
+
+            typed::UnknownItem item = makeUnknownItem(value, type, threadId, turnId, error);
+            error.clear();
+            return typed::Item{std::move(item)};
         } catch (const std::exception& exception) {
             error = std::string("item decoding failed: ") + exception.what();
         } catch (...) {

--- a/src/ai/openai/codex/typed/Items.h
+++ b/src/ai/openai/codex/typed/Items.h
@@ -31,6 +31,12 @@ namespace ai::openai::codex::typed {
         std::optional<std::string> phase;
     };
 
+    struct UserMessageItem {
+        ItemMetadata metadata;
+        std::optional<std::string> clientId;
+        Json content = Json::array();
+    };
+
     struct ReasoningItem {
         ItemMetadata metadata;
         std::vector<std::string> summary;
@@ -73,14 +79,27 @@ namespace ai::openai::codex::typed {
         Json action = nullptr;
     };
 
+    struct UnknownItemMetadata {
+        std::optional<ItemId> id;
+        std::optional<ThreadId> threadId;
+        std::optional<TurnId> turnId;
+    };
+
     struct UnknownItem {
         std::optional<std::string> type;
         Json raw;
         std::optional<std::string> decodingError;
+        UnknownItemMetadata metadata = {};
     };
 
-    using Item =
-        std::variant<AgentMessageItem, ReasoningItem, CommandExecutionItem, FileChangeItem, ToolCallItem, WebSearchItem, UnknownItem>;
+    using Item = std::variant<AgentMessageItem,
+                              ReasoningItem,
+                              CommandExecutionItem,
+                              FileChangeItem,
+                              ToolCallItem,
+                              WebSearchItem,
+                              UnknownItem,
+                              UserMessageItem>;
 
 } // namespace ai::openai::codex::typed
 

--- a/src/apps/codex-backend-client/CommandDrainController.cpp
+++ b/src/apps/codex-backend-client/CommandDrainController.cpp
@@ -7,10 +7,17 @@
 
 #include "apps/codex-backend-client/CommandDrainController.h"
 
+#include "apps/codex-backend-client/CommandParser.h"
+
 #include <algorithm>
 #include <exception>
+#include <map>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string_view>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace apps::codex_backend_client {
 
@@ -20,6 +27,65 @@ namespace apps::codex_backend_client {
         bool waitsForSync(const frontend::Command& command) noexcept {
             return std::holds_alternative<frontend::SnapshotGet>(command.parameters) ||
                    std::holds_alternative<frontend::ReplayAfter>(command.parameters);
+        }
+
+        ResponsePresentation presentationFor(const frontend::Command& command) {
+            ResponsePresentation presentation;
+            if (std::holds_alternative<frontend::ThreadStart>(command.parameters)) {
+                presentation.kind = ResponsePresentation::Kind::ThreadStart;
+            } else if (const auto* resume = std::get_if<frontend::ThreadResume>(&command.parameters)) {
+                presentation.kind = ResponsePresentation::Kind::ThreadResume;
+                presentation.threadId = resume->threadId;
+            } else if (const auto* turn = std::get_if<frontend::TurnStart>(&command.parameters)) {
+                presentation.kind = ResponsePresentation::Kind::TurnStart;
+                presentation.threadId = turn->threadId;
+            }
+            return presentation;
+        }
+
+        std::optional<std::string> threadIdFromResult(const std::optional<frontend::Json>& result) {
+            if (!result.has_value() || !result->is_object()) {
+                return std::nullopt;
+            }
+
+            const auto thread = result->find("thread");
+            if (thread != result->end() && thread->is_object()) {
+                const auto id = thread->find("id");
+                if (id != thread->end() && id->is_string()) {
+                    std::string value = id->get<std::string>();
+                    if (!value.empty()) {
+                        return value;
+                    }
+                }
+            }
+
+            // BackendAdapter normally returns the normalized thread snapshot
+            // above. It deliberately falls back to threadId when the just-
+            // completed thread is not present in its current snapshot.
+            const auto id = result->find("threadId");
+            if (id != result->end() && id->is_string()) {
+                std::string value = id->get<std::string>();
+                if (!value.empty()) {
+                    return value;
+                }
+            }
+            return std::nullopt;
+        }
+
+        std::string responseFailure(std::string_view operation, const frontend::Response& response) {
+            std::string failure(operation);
+            failure += " failed";
+            if (response.error.has_value()) {
+                failure += ": ";
+                failure += frontend::toString(response.error->code);
+                if (!response.error->message.empty()) {
+                    failure += ": ";
+                    failure += response.error->message;
+                }
+            } else {
+                failure += " without error details";
+            }
+            return failure;
         }
     } // namespace
 
@@ -32,9 +98,9 @@ namespace apps::codex_backend_client {
             return false;
         }
 
-        if (currentSessionState != SessionState::Ready || !queuedMessages.empty()) {
+        if (currentSessionState != SessionState::Ready || activeNewCommand.has_value() || !queuedMessages.empty()) {
             queuedMessages.push_back(std::move(message));
-            if (currentSessionState == SessionState::Ready) {
+            if (currentSessionState == SessionState::Ready && !activeNewCommand.has_value()) {
                 flushQueued();
             }
             return currentOutcome == Outcome::Running;
@@ -50,6 +116,22 @@ namespace apps::codex_backend_client {
         return sent;
     }
 
+    bool CommandDrainController::enqueue(NewCommand command) {
+        if (currentOutcome != Outcome::Running || currentInputState != InputState::Reading) {
+            return false;
+        }
+
+        queuedMessages.emplace_back(QueuedNewCommand{std::move(command.threadStartRequestId),
+                                                     std::move(command.turnStartRequestId),
+                                                     std::move(command.options),
+                                                     std::move(command.prompt)});
+        if (currentSessionState == SessionState::Ready && !activeNewCommand.has_value()) {
+            flushQueued();
+        }
+        maybeCompleteDrain();
+        return currentOutcome == Outcome::Running;
+    }
+
     void CommandDrainController::connected() {
         if (currentOutcome != Outcome::Running || currentSessionState != SessionState::Connecting) {
             return;
@@ -57,37 +139,42 @@ namespace apps::codex_backend_client {
         currentSessionState = SessionState::Synchronizing;
     }
 
-    void CommandDrainController::receive(const frontend::ServerMessage& message) {
+    std::optional<ResponsePresentation> CommandDrainController::receive(const frontend::ServerMessage& message) {
         if (currentOutcome != Outcome::Running) {
-            return;
+            return std::nullopt;
         }
 
         if (const auto* protocolError = std::get_if<frontend::ProtocolErrorMessage>(&message)) {
-            if (currentInputState == InputState::DrainOnEof || protocolError->closeConnection) {
-                fail("frontend protocol error: " + protocolError->message);
+            const bool matchesActiveNew = activeNewCommand.has_value() && protocolError->requestId.has_value() &&
+                                          ((activeNewCommand->stage == NewStage::AwaitingThreadStartResponse &&
+                                            *protocolError->requestId == activeNewCommand->command.threadStartRequestId) ||
+                                           (activeNewCommand->stage == NewStage::AwaitingTurnStartResponse &&
+                                            *protocolError->requestId == activeNewCommand->command.turnStartRequestId));
+            if (currentInputState == InputState::DrainOnEof || protocolError->closeConnection || matchesActiveNew) {
+                failForActiveNew("frontend protocol error: " + protocolError->message);
             }
-            return;
+            return std::nullopt;
         }
 
         if (const auto* response = std::get_if<frontend::Response>(&message)) {
-            completeResponse(*response);
-            return;
+            return completeResponse(*response);
         }
 
         if (!std::holds_alternative<frontend::SyncComplete>(message)) {
-            return;
+            return std::nullopt;
         }
 
         if (currentSessionState == SessionState::Synchronizing) {
             currentSessionState = SessionState::Ready;
             flushQueued();
             maybeCompleteDrain();
-            return;
+            return std::nullopt;
         }
 
         if (currentSessionState == SessionState::Ready) {
             completeSync();
         }
+        return std::nullopt;
     }
 
     void CommandDrainController::inputEof() {
@@ -99,15 +186,15 @@ namespace apps::codex_backend_client {
     }
 
     void CommandDrainController::inputFailed(std::string message) {
-        fail(std::move(message));
+        failForActiveNew(std::move(message));
     }
 
     void CommandDrainController::connectionFailed(std::string message) {
-        fail(std::move(message));
+        failForActiveNew(std::move(message));
     }
 
     void CommandDrainController::protocolFailed(std::string message) {
-        fail(std::move(message));
+        failForActiveNew(std::move(message));
     }
 
     void CommandDrainController::disconnected() {
@@ -115,8 +202,8 @@ namespace apps::codex_backend_client {
             return;
         }
         if (currentOutcome == Outcome::Running) {
-            fail(currentInputState == InputState::DrainOnEof ? "frontend connection closed before command draining completed"
-                                                             : "frontend connection closed unexpectedly");
+            failForActiveNew(currentInputState == InputState::DrainOnEof ? "frontend connection closed before command draining completed"
+                                                                         : "frontend connection closed unexpectedly");
         }
         currentSessionState = SessionState::Closed;
     }
@@ -165,11 +252,28 @@ namespace apps::codex_backend_client {
         }));
     }
 
-    bool CommandDrainController::sendNow(const frontend::ClientMessage& message) {
+    CommandDrainController::NewStage CommandDrainController::newStage() const noexcept {
+        if (activeNewCommand.has_value()) {
+            return activeNewCommand->stage;
+        }
+        const bool queued = std::any_of(queuedMessages.begin(), queuedMessages.end(), [](const QueuedEntry& entry) {
+            return std::holds_alternative<QueuedNewCommand>(entry);
+        });
+        return queued ? NewStage::Queued : NewStage::None;
+    }
+
+    bool CommandDrainController::sendNow(const frontend::ClientMessage& message, PendingKind kind) {
         std::list<PendingCommand>::iterator tracked = pendingCommands.end();
         if (const auto* command = std::get_if<frontend::Command>(&message)) {
-            tracked =
-                pendingCommands.insert(pendingCommands.end(), PendingCommand{command->requestId, true, waitsForSync(*command), false});
+            ResponsePresentation presentation = presentationFor(*command);
+            if (kind == PendingKind::NewThreadStart) {
+                presentation.kind = ResponsePresentation::Kind::NewThreadStart;
+            } else if (kind == PendingKind::NewTurnStart) {
+                presentation.kind = ResponsePresentation::Kind::NewTurnStart;
+            }
+            tracked = pendingCommands.insert(
+                pendingCommands.end(),
+                PendingCommand{command->requestId, true, waitsForSync(*command), false, kind, std::move(presentation)});
         }
 
         bool sent = false;
@@ -179,13 +283,22 @@ namespace apps::codex_backend_client {
             if (tracked != pendingCommands.end()) {
                 pendingCommands.erase(tracked);
             }
-            fail("failed to send frontend message: " + std::string(exception.what()));
+            const std::string failure = "failed to send frontend message: " + std::string(exception.what());
+            if (kind == PendingKind::Ordinary) {
+                fail(failure);
+            } else {
+                failForActiveNew(failure);
+            }
             return false;
         } catch (...) {
             if (tracked != pendingCommands.end()) {
                 pendingCommands.erase(tracked);
             }
-            fail("failed to send frontend message");
+            if (kind == PendingKind::Ordinary) {
+                fail("failed to send frontend message");
+            } else {
+                failForActiveNew("failed to send frontend message");
+            }
             return false;
         }
 
@@ -193,7 +306,11 @@ namespace apps::codex_backend_client {
             if (tracked != pendingCommands.end()) {
                 pendingCommands.erase(tracked);
             }
-            fail("failed to send frontend message");
+            if (kind == PendingKind::Ordinary) {
+                fail("failed to send frontend message");
+            } else {
+                failForActiveNew("failed to send frontend message");
+            }
             return false;
         }
         return true;
@@ -206,38 +323,114 @@ namespace apps::codex_backend_client {
     }
 
     void CommandDrainController::flushQueued() {
-        while (currentOutcome == Outcome::Running && currentSessionState == SessionState::Ready && !queuedMessages.empty()) {
-            const auto* command = std::get_if<frontend::Command>(&queuedMessages.front());
-            if (command != nullptr && requestIdIsPending(command->requestId)) {
-                // Raw commands may deliberately reuse an ID. Serialize that
-                // reuse so response correlation stays deterministic.
+        while (currentOutcome == Outcome::Running && currentSessionState == SessionState::Ready && !activeNewCommand.has_value() &&
+               !queuedMessages.empty()) {
+            if (auto* message = std::get_if<frontend::ClientMessage>(&queuedMessages.front())) {
+                const auto* command = std::get_if<frontend::Command>(message);
+                if (command != nullptr && requestIdIsPending(command->requestId)) {
+                    // Raw commands may deliberately reuse an ID. Serialize that
+                    // reuse so response correlation stays deterministic.
+                    return;
+                }
+
+                frontend::ClientMessage next = std::move(*message);
+                queuedMessages.pop_front();
+                if (!sendNow(next)) {
+                    return;
+                }
+                continue;
+            }
+
+            auto* queuedNew = std::get_if<QueuedNewCommand>(&queuedMessages.front());
+            if (queuedNew == nullptr || requestIdIsPending(queuedNew->threadStartRequestId)) {
                 return;
             }
 
-            frontend::ClientMessage message = std::move(queuedMessages.front());
+            QueuedNewCommand command = std::move(*queuedNew);
             queuedMessages.pop_front();
-            if (!sendNow(message)) {
-                return;
-            }
+            activeNewCommand.emplace(ActiveNewCommand{std::move(command), NewStage::AwaitingThreadStartResponse, std::nullopt});
+
+            frontend::Command start{activeNewCommand->command.threadStartRequestId,
+                                    activeNewCommand->command.options,
+                                    frontend::Json::object(),
+                                    frontend::Json::object()};
+            static_cast<void>(sendNow(frontend::ClientMessage{std::move(start)}, PendingKind::NewThreadStart));
+            // A compound command remains the active queue head until both
+            // protocol operations complete. Later input cannot bypass it.
+            return;
         }
     }
 
-    void CommandDrainController::completeResponse(const frontend::Response& response) {
+    std::optional<ResponsePresentation> CommandDrainController::completeResponse(const frontend::Response& response) {
         const auto found = std::find_if(pendingCommands.begin(), pendingCommands.end(), [&response](const PendingCommand& pending) {
             return pending.responsePending && pending.requestId == response.requestId;
         });
         if (found == pendingCommands.end()) {
             if (currentInputState == InputState::DrainOnEof) {
-                fail("received an uncorrelated frontend response while draining: " + response.requestId);
+                failForActiveNew("received an uncorrelated frontend response while draining: " + response.requestId);
             }
-            return;
+            return std::nullopt;
         }
 
+        const PendingKind kind = found->kind;
+        ResponsePresentation presentation = found->presentation;
         found->responsePending = false;
         found->syncPending = response.ok && found->waitForSyncOnSuccess;
         removeCompletedCommands();
+
+        if (kind == PendingKind::NewThreadStart) {
+            if (!activeNewCommand.has_value() || activeNewCommand->stage != NewStage::AwaitingThreadStartResponse) {
+                fail("received a thread.start response without its active new command");
+                return presentation;
+            }
+            if (!response.ok) {
+                failForActiveNew(responseFailure("thread.start", response));
+                return presentation;
+            }
+
+            const std::optional<std::string> threadId = threadIdFromResult(response.result);
+            if (!threadId.has_value()) {
+                presentation.kind = ResponsePresentation::Kind::Generic;
+                failForActiveNew("successful thread.start response did not contain a non-empty thread ID");
+                return presentation;
+            }
+
+            activeNewCommand->threadId = *threadId;
+            activeNewCommand->stage = NewStage::WaitingToSubmitTurn;
+            presentation.threadId = *threadId;
+            static_cast<void>(submitActiveNewTurn());
+            maybeCompleteDrain();
+            return presentation;
+        }
+
+        if (kind == PendingKind::NewTurnStart) {
+            if (!activeNewCommand.has_value() || activeNewCommand->stage != NewStage::AwaitingTurnStartResponse ||
+                !activeNewCommand->threadId.has_value()) {
+                fail("received a turn.start response without its active new command");
+                return presentation;
+            }
+            presentation.threadId = activeNewCommand->threadId;
+            if (!response.ok) {
+                failForActiveNew(responseFailure("turn.start", response));
+                return presentation;
+            }
+
+            activeNewCommand.reset();
+            flushQueued();
+            maybeCompleteDrain();
+            return presentation;
+        }
+
+        if (response.ok && (presentation.kind == ResponsePresentation::Kind::ThreadStart ||
+                            presentation.kind == ResponsePresentation::Kind::ThreadResume)) {
+            if (const std::optional<std::string> threadId = threadIdFromResult(response.result); threadId.has_value()) {
+                presentation.threadId = *threadId;
+            }
+        }
+        static_cast<void>(submitActiveNewTurn());
         flushQueued();
         maybeCompleteDrain();
+        return presentation;
     }
 
     void CommandDrainController::completeSync() {
@@ -247,9 +440,31 @@ namespace apps::codex_backend_client {
         if (found != pendingCommands.end()) {
             found->syncPending = false;
             removeCompletedCommands();
+            static_cast<void>(submitActiveNewTurn());
             flushQueued();
         }
         maybeCompleteDrain();
+    }
+
+    bool CommandDrainController::submitActiveNewTurn() {
+        if (!activeNewCommand.has_value() || activeNewCommand->stage != NewStage::WaitingToSubmitTurn) {
+            return true;
+        }
+        if (!activeNewCommand->threadId.has_value()) {
+            failForActiveNew("cannot submit the initial turn without a created thread ID");
+            return false;
+        }
+        if (requestIdIsPending(activeNewCommand->command.turnStartRequestId)) {
+            return true;
+        }
+
+        frontend::TurnStart turn;
+        turn.threadId = *activeNewCommand->threadId;
+        turn.input.emplace_back(frontend::TextInput{activeNewCommand->command.prompt, frontend::Json::object()});
+        frontend::Command command{
+            activeNewCommand->command.turnStartRequestId, std::move(turn), frontend::Json::object(), frontend::Json::object()};
+        activeNewCommand->stage = NewStage::AwaitingTurnStartResponse;
+        return sendNow(frontend::ClientMessage{std::move(command)}, PendingKind::NewTurnStart);
     }
 
     void CommandDrainController::removeCompletedCommands() {
@@ -260,7 +475,8 @@ namespace apps::codex_backend_client {
 
     void CommandDrainController::maybeCompleteDrain() {
         if (currentOutcome == Outcome::Running && currentInputState == InputState::DrainOnEof &&
-            currentSessionState == SessionState::Ready && queuedMessages.empty() && pendingCommands.empty()) {
+            currentSessionState == SessionState::Ready && queuedMessages.empty() && pendingCommands.empty() &&
+            !activeNewCommand.has_value()) {
             finish(Outcome::Success);
         }
     }
@@ -298,6 +514,18 @@ namespace apps::codex_backend_client {
             }
         } catch (...) {
         }
+    }
+
+    void CommandDrainController::failForActiveNew(std::string message) {
+        if (activeNewCommand.has_value()) {
+            if (activeNewCommand->threadId.has_value()) {
+                fail("thread created id=" + *activeNewCommand->threadId + ", but initial turn failed: " + message);
+            } else {
+                fail("new thread creation failed: " + message);
+            }
+            return;
+        }
+        fail(std::move(message));
     }
 
 } // namespace apps::codex_backend_client

--- a/src/apps/codex-backend-client/CommandDrainController.h
+++ b/src/apps/codex-backend-client/CommandDrainController.h
@@ -14,9 +14,22 @@
 #include <deque>
 #include <functional>
 #include <list>
+#include <optional>
 #include <string>
+#include <variant>
 
 namespace apps::codex_backend_client {
+
+    struct NewCommand;
+
+    struct ResponsePresentation {
+        enum class Kind { Generic, ThreadStart, ThreadResume, TurnStart, NewThreadStart, NewTurnStart };
+
+        Kind kind = Kind::Generic;
+        std::optional<std::string> threadId;
+
+        bool operator==(const ResponsePresentation&) const = default;
+    };
 
     struct CommandDrainCallbacks {
         std::function<bool(const ai::openai::codex::frontend::ClientMessage&)> send;
@@ -29,13 +42,15 @@ namespace apps::codex_backend_client {
         enum class SessionState { Connecting, Synchronizing, Ready, Closing, Closed };
         enum class InputState { Reading, DrainOnEof, ImmediateQuit };
         enum class Outcome { Running, Success, Failure };
+        enum class NewStage { None, Queued, AwaitingThreadStartResponse, WaitingToSubmitTurn, AwaitingTurnStartResponse };
 
         explicit CommandDrainController(CommandDrainCallbacks callbacks = {});
 
         [[nodiscard]] bool enqueue(ai::openai::codex::frontend::ClientMessage message);
+        [[nodiscard]] bool enqueue(NewCommand command);
 
         void connected();
-        void receive(const ai::openai::codex::frontend::ServerMessage& message);
+        std::optional<ResponsePresentation> receive(const ai::openai::codex::frontend::ServerMessage& message);
         void inputEof();
         void inputFailed(std::string message);
         void connectionFailed(std::string message);
@@ -51,31 +66,54 @@ namespace apps::codex_backend_client {
         [[nodiscard]] std::size_t queuedCount() const noexcept;
         [[nodiscard]] std::size_t pendingResponseCount() const noexcept;
         [[nodiscard]] std::size_t pendingSyncCount() const noexcept;
+        [[nodiscard]] NewStage newStage() const noexcept;
 
     private:
+        enum class PendingKind { Ordinary, NewThreadStart, NewTurnStart };
+
+        struct QueuedNewCommand {
+            std::string threadStartRequestId;
+            std::string turnStartRequestId;
+            ai::openai::codex::frontend::ThreadStart options;
+            std::string prompt;
+        };
+
+        using QueuedEntry = std::variant<ai::openai::codex::frontend::ClientMessage, QueuedNewCommand>;
+
+        struct ActiveNewCommand {
+            QueuedNewCommand command;
+            NewStage stage = NewStage::AwaitingThreadStartResponse;
+            std::optional<std::string> threadId;
+        };
+
         struct PendingCommand {
             std::string requestId;
             bool responsePending = true;
             bool waitForSyncOnSuccess = false;
             bool syncPending = false;
+            PendingKind kind = PendingKind::Ordinary;
+            ResponsePresentation presentation;
         };
 
-        [[nodiscard]] bool sendNow(const ai::openai::codex::frontend::ClientMessage& message);
+        [[nodiscard]] bool sendNow(const ai::openai::codex::frontend::ClientMessage& message, PendingKind kind = PendingKind::Ordinary);
         [[nodiscard]] bool requestIdIsPending(const std::string& requestId) const noexcept;
         void flushQueued();
-        void completeResponse(const ai::openai::codex::frontend::Response& response);
+        [[nodiscard]] std::optional<ResponsePresentation> completeResponse(const ai::openai::codex::frontend::Response& response);
         void completeSync();
+        [[nodiscard]] bool submitActiveNewTurn();
         void removeCompletedCommands();
         void maybeCompleteDrain();
         void finish(Outcome outcome);
         void fail(std::string message);
+        void failForActiveNew(std::string message);
 
         CommandDrainCallbacks callbacks;
         SessionState currentSessionState = SessionState::Connecting;
         InputState currentInputState = InputState::Reading;
         Outcome currentOutcome = Outcome::Running;
-        std::deque<ai::openai::codex::frontend::ClientMessage> queuedMessages;
+        std::deque<QueuedEntry> queuedMessages;
         std::list<PendingCommand> pendingCommands;
+        std::optional<ActiveNewCommand> activeNewCommand;
         std::string currentFailureReason;
     };
 

--- a/src/apps/codex-backend-client/CommandParser.cpp
+++ b/src/apps/codex-backend-client/CommandParser.cpp
@@ -9,6 +9,7 @@
 
 #include "ai/openai/codex/frontend/Codec.h"
 
+#include <algorithm>
 #include <charconv>
 #include <cstddef>
 #include <limits>
@@ -71,6 +72,85 @@ namespace apps::codex_backend_client {
             return CommandParseError{std::move(message)};
         }
 
+        bool parseThreadOption(std::string_view option,
+                               std::string_view& remainder,
+                               frontend::ThreadStart& parsed,
+                               bool allowEphemeral,
+                               std::vector<std::string_view>& seen,
+                               std::string& error) {
+            const bool known = option == "--cwd" || option == "--model" || option == "--model-provider" || option == "--approval-policy" ||
+                               option == "--sandbox-mode" || option == "--ephemeral";
+            if (!known) {
+                error = "unknown option '" + std::string(option) + "'";
+                return false;
+            }
+            if (option == "--ephemeral" && !allowEphemeral) {
+                error = "option '--ephemeral' is not supported by resume";
+                return false;
+            }
+            if (std::find(seen.begin(), seen.end(), option) != seen.end()) {
+                error = "option '" + std::string(option) + "' may only be specified once";
+                return false;
+            }
+            seen.push_back(option);
+
+            if (option == "--ephemeral") {
+                parsed.ephemeral = true;
+                return true;
+            }
+
+            const std::string_view value = takeWord(remainder);
+            if (value.empty() || value.starts_with("--")) {
+                error = "option '" + std::string(option) + "' requires a value";
+                return false;
+            }
+
+            if (option == "--cwd") {
+                parsed.cwd = std::string(value);
+            } else if (option == "--model") {
+                parsed.model = std::string(value);
+            } else if (option == "--model-provider") {
+                parsed.modelProvider = std::string(value);
+            } else if (option == "--approval-policy") {
+                parsed.approvalPolicy = std::string(value);
+            } else {
+                parsed.sandboxMode = std::string(value);
+            }
+            return true;
+        }
+
+        bool parseThreadOptions(std::string_view& remainder,
+                                frontend::ThreadStart& parsed,
+                                bool allowEphemeral,
+                                bool stopAtSeparator,
+                                bool& separatorSeen,
+                                std::string& error) {
+            std::vector<std::string_view> seen;
+            while (!remainder.empty()) {
+                const std::string_view option = takeWord(remainder);
+                if (option == "--") {
+                    if (stopAtSeparator) {
+                        separatorSeen = true;
+                        return true;
+                    }
+                    error = "unexpected '--' separator";
+                    return false;
+                }
+                if (!option.starts_with("--")) {
+                    error = "unexpected positional argument '" + std::string(option) + "'";
+                    return false;
+                }
+                if (!parseThreadOption(option, remainder, parsed, allowEphemeral, seen, error)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        std::string commandUsage(std::string_view command, std::string detail) {
+            return std::string(command) + ": " + std::move(detail) + "; enter 'help' for command syntax";
+        }
+
     } // namespace
 
     CommandParser::CommandParser(std::string requestIdPrefix)
@@ -121,6 +201,70 @@ namespace apps::codex_backend_client {
         if (name == "threads") {
             return remainder.empty() ? send(frontend::ThreadList{}) : ParsedCommand{usageError("usage: threads")};
         }
+        if (name == "start") {
+            frontend::ThreadStart start;
+            bool separatorSeen = false;
+            std::string error;
+            if (!parseThreadOptions(remainder, start, true, false, separatorSeen, error)) {
+                return usageError(commandUsage(name, std::move(error)));
+            }
+            return send(std::move(start));
+        }
+        if (name == "resume") {
+            const std::string_view threadId = takeWord(remainder);
+            if (threadId.empty() || threadId.starts_with("--")) {
+                return usageError("usage: resume <thread-id> [thread-resume-options]");
+            }
+
+            frontend::ThreadStart options;
+            bool separatorSeen = false;
+            std::string error;
+            if (!parseThreadOptions(remainder, options, false, false, separatorSeen, error)) {
+                return usageError(commandUsage(name, std::move(error)));
+            }
+
+            frontend::ThreadResume resume;
+            resume.threadId = std::string(threadId);
+            resume.cwd = std::move(options.cwd);
+            resume.model = std::move(options.model);
+            resume.modelProvider = std::move(options.modelProvider);
+            resume.approvalPolicy = std::move(options.approvalPolicy);
+            resume.sandboxMode = std::move(options.sandboxMode);
+            return send(std::move(resume));
+        }
+        if (name == "new") {
+            if (remainder.empty()) {
+                return usageError("usage: new [thread-start-options] -- <prompt> | new <prompt>");
+            }
+
+            frontend::ThreadStart options;
+            std::string prompt;
+            std::string_view probe = remainder;
+            const std::string_view first = takeWord(probe);
+            if (!first.starts_with("--")) {
+                prompt = std::string(remainder);
+            } else {
+                bool separatorSeen = false;
+                std::string error;
+                if (!parseThreadOptions(remainder, options, true, true, separatorSeen, error)) {
+                    return usageError(commandUsage(name, std::move(error)));
+                }
+                if (!separatorSeen) {
+                    return usageError("new: thread-start options must be followed by '-- <prompt>'; enter 'help' for command syntax");
+                }
+                const std::string_view text = trim(remainder);
+                if (text.empty()) {
+                    return usageError("new: prompt must not be empty; enter 'help' for command syntax");
+                }
+                prompt = std::string(text);
+            }
+
+            const auto requestIds = allocateRequestIdPair();
+            if (!requestIds.has_value()) {
+                return usageError("frontend request ID space cannot allocate two IDs for new");
+            }
+            return NewCommand{requestIds->first, requestIds->second, std::move(options), std::move(prompt)};
+        }
         if (name == "replay") {
             const std::string_view value = takeWord(remainder);
             const std::optional<std::uint64_t> sequence = parseSequence(value);
@@ -140,7 +284,7 @@ namespace apps::codex_backend_client {
             const std::string_view threadId = takeWord(remainder);
             const std::string_view text = trim(remainder);
             if (threadId.empty() || text.empty()) {
-                return usageError("usage: turn <thread-id> <text>");
+                return usageError("usage: turn <thread-id> <prompt>");
             }
 
             frontend::TurnStart turn;
@@ -184,8 +328,20 @@ namespace apps::codex_backend_client {
                "  acquire\n"
                "  release\n"
                "  threads\n"
+               "  start [--cwd <path>] [--model <model>]\n"
+               "        [--model-provider <provider>]\n"
+               "        [--approval-policy <policy>]\n"
+               "        [--sandbox-mode <mode>]\n"
+               "        [--ephemeral]\n"
+               "  resume <thread-id>\n"
+               "         [--cwd <path>] [--model <model>]\n"
+               "         [--model-provider <provider>]\n"
+               "         [--approval-policy <policy>]\n"
+               "         [--sandbox-mode <mode>]\n"
+               "  new [thread-start-options] -- <prompt>\n"
+               "  new <prompt>\n"
                "  read <thread-id>\n"
-               "  turn <thread-id> <text>\n"
+               "  turn <thread-id> <prompt>\n"
                "  interrupt <thread-id> <turn-id>\n"
                "  raw <json>\n"
                "  watch on\n"
@@ -204,6 +360,23 @@ namespace apps::codex_backend_client {
             ++nextRequestId;
         }
         return requestId;
+    }
+
+    std::optional<std::pair<std::string, std::string>> CommandParser::allocateRequestIdPair() {
+        if (requestIdsExhausted || nextRequestId == std::numeric_limits<std::uint64_t>::max()) {
+            return std::nullopt;
+        }
+
+        const std::uint64_t firstSequence = nextRequestId;
+        const std::uint64_t secondSequence = firstSequence + 1;
+        std::pair<std::string, std::string> requestIds{requestIdPrefix + "-" + std::to_string(firstSequence),
+                                                       requestIdPrefix + "-" + std::to_string(secondSequence)};
+        if (secondSequence == std::numeric_limits<std::uint64_t>::max()) {
+            requestIdsExhausted = true;
+        } else {
+            nextRequestId = secondSequence + 1;
+        }
+        return requestIds;
     }
 
 } // namespace apps::codex_backend_client

--- a/src/apps/codex-backend-client/CommandParser.h
+++ b/src/apps/codex-backend-client/CommandParser.h
@@ -11,8 +11,11 @@
 #include "ai/openai/codex/frontend/Messages.h"
 
 #include <cstdint>
+#include <iterator>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <variant>
 
 namespace apps::codex_backend_client {
@@ -41,13 +44,22 @@ namespace apps::codex_backend_client {
         bool operator==(const SendCommand&) const = default;
     };
 
+    struct NewCommand {
+        std::string threadStartRequestId;
+        std::string turnStartRequestId;
+        ai::openai::codex::frontend::ThreadStart options;
+        std::string prompt;
+
+        bool operator==(const NewCommand&) const = default;
+    };
+
     struct CommandParseError {
         std::string message;
 
         bool operator==(const CommandParseError&) const = default;
     };
 
-    using ParsedCommand = std::variant<NoopCommand, HelpCommand, QuitCommand, WatchCommand, SendCommand, CommandParseError>;
+    using ParsedCommand = std::variant<NoopCommand, HelpCommand, QuitCommand, WatchCommand, SendCommand, NewCommand, CommandParseError>;
 
     class CommandParser {
     public:
@@ -58,6 +70,7 @@ namespace apps::codex_backend_client {
 
     private:
         [[nodiscard]] std::string allocateRequestId();
+        [[nodiscard]] std::optional<std::pair<std::string, std::string>> allocateRequestIdPair();
 
         std::string requestIdPrefix;
         std::uint64_t nextRequestId = 1;

--- a/src/apps/codex-backend-client/Presenter.cpp
+++ b/src/apps/codex-backend-client/Presenter.cpp
@@ -8,6 +8,7 @@
 #include "apps/codex-backend-client/Presenter.h"
 
 #include "ai/openai/codex/frontend/Codec.h"
+#include "apps/codex-backend-client/CommandDrainController.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -17,6 +18,7 @@
 #include <map>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -33,6 +35,7 @@ namespace apps::codex_backend_client {
         constexpr std::size_t maximumInlineJsonBytes = 4096;
         constexpr std::size_t maximumSummaryIdentifiers = 20;
         constexpr std::size_t maximumSummaryIdentifierBytes = 80;
+        constexpr std::size_t maximumSummaryMessageBytes = 512;
 
         void writeLine(std::ostream& stream, std::string_view value) {
             stream << value;
@@ -68,6 +71,14 @@ namespace apps::codex_backend_client {
         std::string boundedIdentifier(std::string value) {
             if (value.size() > maximumSummaryIdentifierBytes) {
                 value.resize(maximumSummaryIdentifierBytes);
+                value += "...";
+            }
+            return value;
+        }
+
+        std::string boundedMessage(std::string value) {
+            if (value.size() > maximumSummaryMessageBytes) {
+                value.resize(maximumSummaryMessageBytes);
                 value += "...";
             }
             return value;
@@ -151,6 +162,81 @@ namespace apps::codex_backend_client {
             return "<json omitted; bytes=" + std::to_string(encoded.size()) + "; use --json for complete protocol data>";
         }
 
+        std::string responseError(const frontend::Response& response) {
+            if (!response.error.has_value()) {
+                return "request failed without an error payload";
+            }
+
+            std::string error = std::string(frontend::toString(response.error->code));
+            if (!response.error->message.empty()) {
+                error += ": " + boundedMessage(response.error->message);
+            }
+            return error;
+        }
+
+        std::string turnId(const frontend::Response& response) {
+            if (!response.result.has_value() || !response.result->is_object()) {
+                return {};
+            }
+            const auto turn = response.result->find("turn");
+            if (turn != response.result->end() && turn->is_object()) {
+                const auto id = turn->find("id");
+                if (id != turn->end() && id->is_string()) {
+                    return id->get<std::string>();
+                }
+            }
+            const auto id = response.result->find("turnId");
+            return id != response.result->end() && id->is_string() ? id->get<std::string>() : std::string{};
+        }
+
+        bool presentCommandResponse(std::ostream& output, const frontend::Response& response, const ResponsePresentation& presentation) {
+            const std::string threadId = presentation.threadId.has_value() ? boundedIdentifier(*presentation.threadId) : "unknown";
+            const auto failure = [&output, &response](std::string_view action) {
+                output << action << " failed: " << responseError(response) << '\n';
+            };
+
+            switch (presentation.kind) {
+                case ResponsePresentation::Kind::Generic:
+                    return false;
+                case ResponsePresentation::Kind::ThreadStart:
+                    if (response.ok) {
+                        output << "thread started id=" << threadId << '\n';
+                    } else {
+                        failure("thread start");
+                    }
+                    return true;
+                case ResponsePresentation::Kind::ThreadResume:
+                    if (response.ok) {
+                        output << "thread resumed id=" << threadId << '\n';
+                    } else {
+                        output << "thread resume failed id=" << threadId << ": " << responseError(response) << '\n';
+                    }
+                    return true;
+                case ResponsePresentation::Kind::TurnStart:
+                    return false;
+                case ResponsePresentation::Kind::NewThreadStart:
+                    if (response.ok) {
+                        output << "thread created id=" << threadId << '\n';
+                    } else {
+                        failure("new thread creation");
+                    }
+                    return true;
+                case ResponsePresentation::Kind::NewTurnStart:
+                    if (response.ok) {
+                        output << "initial turn submitted thread=" << threadId;
+                        const std::string id = boundedIdentifier(turnId(response));
+                        if (!id.empty()) {
+                            output << " turn=" << id;
+                        }
+                        output << '\n';
+                    } else {
+                        output << "thread created id=" << threadId << ", but initial turn failed: " << responseError(response) << '\n';
+                    }
+                    return true;
+            }
+            return false;
+        }
+
     } // namespace
 
     Presenter::Presenter(OutputMode mode)
@@ -171,7 +257,19 @@ namespace apps::codex_backend_client {
         if (mode == OutputMode::Json) {
             presentJson(message);
         } else {
-            presentHuman(message);
+            presentHuman(message, nullptr);
+        }
+    }
+
+    void Presenter::present(const frontend::ServerMessage& message, const ResponsePresentation& presentation) {
+        if (!watching && std::holds_alternative<frontend::EventBatch>(message)) {
+            return;
+        }
+
+        if (mode == OutputMode::Json) {
+            presentJson(message);
+        } else {
+            presentHuman(message, &presentation);
         }
     }
 
@@ -209,10 +307,10 @@ namespace apps::codex_backend_client {
         writeLine(*diagnostics, "codex-backend-client: " + std::string(message));
     }
 
-    void Presenter::presentHuman(const frontend::ServerMessage& message) {
+    void Presenter::presentHuman(const frontend::ServerMessage& message, const ResponsePresentation* presentation) {
         try {
             std::visit(
-                [this]<typename Message>(const Message& value) {
+                [this, presentation]<typename Message>(const Message& value) {
                     using T = std::remove_cvref_t<Message>;
                     if constexpr (std::is_same_v<T, frontend::Welcome>) {
                         *output << "welcome session=" << value.sessionId << " role=" << frontend::toString(value.role)
@@ -229,6 +327,9 @@ namespace apps::codex_backend_client {
                             *output << "  [" << event.sequence.value() << "] " << event.type << ' ' << humanJson(event.data) << '\n';
                         }
                     } else if constexpr (std::is_same_v<T, frontend::Response>) {
+                        if (presentation != nullptr && presentCommandResponse(*output, value, *presentation)) {
+                            return;
+                        }
                         *output << "response request-id=" << value.requestId << " ok=" << (value.ok ? "true" : "false");
                         if (value.ok) {
                             if (value.result.has_value()) {

--- a/src/apps/codex-backend-client/Presenter.h
+++ b/src/apps/codex-backend-client/Presenter.h
@@ -15,6 +15,8 @@
 
 namespace apps::codex_backend_client {
 
+    struct ResponsePresentation;
+
     enum class OutputMode { Human, Json };
 
     class Presenter {
@@ -23,6 +25,7 @@ namespace apps::codex_backend_client {
         Presenter(OutputMode mode, std::ostream& output, std::ostream& diagnostics);
 
         void present(const ai::openai::codex::frontend::ServerMessage& message);
+        void present(const ai::openai::codex::frontend::ServerMessage& message, const ResponsePresentation& presentation);
 
         void setWatchEnabled(bool enabled) noexcept;
         [[nodiscard]] bool watchEnabled() const noexcept;
@@ -34,7 +37,7 @@ namespace apps::codex_backend_client {
         void error(std::string_view message);
 
     private:
-        void presentHuman(const ai::openai::codex::frontend::ServerMessage& message);
+        void presentHuman(const ai::openai::codex::frontend::ServerMessage& message, const ResponsePresentation* presentation);
         void presentJson(const ai::openai::codex::frontend::ServerMessage& message);
 
         OutputMode mode;

--- a/src/apps/codex-backend-client/README.md
+++ b/src/apps/codex-backend-client/README.md
@@ -35,8 +35,20 @@ replay <sequence>
 acquire
 release
 threads
+start [--cwd <path>] [--model <model>]
+      [--model-provider <provider>]
+      [--approval-policy <policy>]
+      [--sandbox-mode <mode>]
+      [--ephemeral]
+resume <thread-id>
+       [--cwd <path>] [--model <model>]
+       [--model-provider <provider>]
+       [--approval-policy <policy>]
+       [--sandbox-mode <mode>]
+new [thread-start-options] -- <prompt>
+new <prompt>
 read <thread-id>
-turn <thread-id> <text>
+turn <thread-id> <prompt>
 interrupt <thread-id> <turn-id>
 raw <json>
 watch on
@@ -48,15 +60,86 @@ Normal commands are encoded from the public typed frontend message classes.
 message. `watch` is local: disabling it suppresses event-batch presentation but
 does not change backend state or synchronization.
 
+## Thread lifecycle
+
+Every connection begins as an observer. The client never acquires controller
+ownership automatically. Run `acquire` before `start`, `resume`, `new`, or
+`turn`; otherwise the backend reports its normal `permission_denied` response.
+`release` gives up that ownership.
+
+To create a thread and submit its first turn explicitly, use the thread ID
+reported by `start`:
+
+```text
+acquire
+start --cwd /home/voc/projects/snode.c
+turn <returned-thread-id> Review the repository.
+```
+
+`start` maps directly to Frontend Protocol v1 `thread.start`. Its options are
+optional and remain unset when omitted, allowing Codex defaults to apply. A
+successful human-readable response identifies the returned thread ID.
+
+To continue an existing persisted thread:
+
+```text
+acquire
+threads
+resume <thread-id>
+turn <thread-id> Continue the previous task.
+```
+
+`threads` can report a persisted thread whose completeness is `notLoaded`.
+`resume` maps directly to `thread.resume` and loads that thread into the running
+Codex App Server before a later `turn` command. It accepts the same overrides as
+`start` except `--ephemeral`, which is not part of `thread.resume`.
+
+> `read` retrieves thread data but does not resume or load the thread into the
+> running Codex App Server. Use `resume <thread-id>` before starting a turn on a
+> persisted `notLoaded` thread.
+
+For the common create-and-prompt workflow, `new` performs both client-side
+steps:
+
+```text
+acquire
+new --cwd /home/voc/projects/snode.c -- Review the repository.
+```
+
+With no thread-start options, the separator may be omitted:
+
+```text
+acquire
+new Explain the current repository architecture.
+```
+
+When options are present, `--` ends option parsing and everything after it is
+the prompt, including words that begin with `--`. `new` is implemented only by
+`codex-backend-client`: it sends `thread.start`, waits for that request's
+successful response, extracts and validates `result.thread.id`, and then sends
+`turn.start` with one text input containing the complete prompt. It does not add
+a backend command or Frontend Protocol method, and it does not establish
+implicit current-thread state.
+
+If thread creation succeeds but the initial turn cannot be submitted or later
+fails, the diagnostic preserves the created thread ID and reports the compound
+operation as failed. The successful thread creation is not rolled back.
+
 Human mode reports when the connection is waiting for its initial
 synchronization and when commands are ready. Commands entered during that
 handshake are acknowledged as queued and remain behind the `sync.complete`
 barrier.
 
-Human-readable output is the default. `--json` writes each decoded server
-message as one compact protocol JSON object on stdout; connection notices,
-local command errors, and other diagnostics remain on stderr so stdout can be
-consumed by scripts.
+Human-readable output is the default. It gives concise stage summaries for
+started and resumed threads and for both stages of `new`, rather than dumping
+complete snapshots.
+
+`--json` writes each decoded server message as one compact protocol JSON object
+on stdout; connection notices, local command errors, and other diagnostics
+remain on stderr so stdout can be consumed by scripts. For `new`, stdout
+contains the complete real responses and events for its underlying
+`thread.start` and `turn.start` requests. There is no synthetic `new` protocol
+message and the original protocol messages are not hidden or rewritten.
 
 Stdin and the Unix socket are both integrated with the SNode.C event loop.
 Terminal and pipe input is nonblocking and line-buffered; regular-file stdin is
@@ -67,14 +150,25 @@ several records in one read.
 Piped commands are retained until the connection's initial `sync.complete`,
 then sent once in input order. EOF enters a deterministic drain: the client
 waits for every command's correlated response and, for `snapshot` and
-`replay`, the resulting `sync.complete` before disconnecting and exiting.
-Connection, protocol, or premature-disconnect failures during that drain
-produce a nonzero exit status. An explicit interactive `quit` remains an
-immediate shutdown.
+`replay`, the resulting `sync.complete` before disconnecting and exiting. A
+pending `new` keeps the client alive through both its start and turn stages.
+Connection, protocol, send, compound-operation, or premature-disconnect
+failures during that drain produce a nonzero exit status. An explicit
+interactive `quit` remains an immediate shutdown.
 
 For example, this waits for the handshake and both command responses before
 returning:
 
 ```sh
 printf 'acquire\nthreads\n' | codex-backend-client --json
+```
+
+This piped convenience workflow likewise waits for the generated thread ID to
+be handed from `thread.start` to `turn.start` before returning:
+
+```sh
+printf '%s\n' \
+  'acquire' \
+  'new --cwd /home/voc/projects/snode.c -- Review the repository.' \
+  | codex-backend-client --json
 ```

--- a/src/apps/codex-backend-client/main.cpp
+++ b/src/apps/codex-backend-client/main.cpp
@@ -24,6 +24,7 @@
 
 #include <exception>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -107,8 +108,12 @@ int main(int argc, char* argv[]) {
                     // Advance protocol state before presentation. A controlled
                     // EOF exit is posted for the next event-loop tick, so the
                     // current message is still rendered before disconnecting.
-                    lifecycle.receive(message);
-                    presenter.present(message);
+                    const std::optional<client::ResponsePresentation> presentation = lifecycle.receive(message);
+                    if (presentation.has_value()) {
+                        presenter.present(message, *presentation);
+                    } else {
+                        presenter.present(message);
+                    }
                     if (awaitingInitialSynchronization && lifecycle.sessionState() == client::CommandDrainController::SessionState::Ready &&
                         presenter.outputMode() == client::OutputMode::Human) {
                         presenter.localMessage("synchronized; commands are ready");
@@ -153,6 +158,18 @@ int main(int argc, char* argv[]) {
                                 lifecycle.sessionState() == client::CommandDrainController::SessionState::Connecting ||
                                 lifecycle.sessionState() == client::CommandDrainController::SessionState::Synchronizing;
                             const bool accepted = lifecycle.enqueue(std::move(command.message));
+                            if (!accepted) {
+                                if (!lifecycle.failed()) {
+                                    presenter.error("command input is closed; command was not queued");
+                                }
+                            } else if (waitingForInitialSynchronization && presenter.outputMode() == client::OutputMode::Human) {
+                                presenter.localMessage("command queued; waiting for initial synchronization");
+                            }
+                        } else if constexpr (std::is_same_v<T, client::NewCommand>) {
+                            const bool waitingForInitialSynchronization =
+                                lifecycle.sessionState() == client::CommandDrainController::SessionState::Connecting ||
+                                lifecycle.sessionState() == client::CommandDrainController::SessionState::Synchronizing;
+                            const bool accepted = lifecycle.enqueue(std::move(command));
                             if (!accepted) {
                                 if (!lifecycle.failed()) {
                                     presenter.error("command input is closed; command was not queued");

--- a/tests/component/codex/CMakeLists.txt
+++ b/tests/component/codex/CMakeLists.txt
@@ -262,10 +262,28 @@ if(TARGET codex-backend-client-support)
             PROPERTIES
                 LABELS
                 "component;ai;openai;codex;frontend;backend;client;unix;acceptance;interactive"
+                ENVIRONMENT
+                "SNODEC_CODEX_CLIENT_ACCEPTANCE_SCENARIO=interactive"
                 SKIP_RETURN_CODE
                 77
                 TIMEOUT
-                15
+                20
+        )
+        add_test(
+            NAME CodexBackendClientThreadWorkflowAcceptanceTest
+            COMMAND CodexBackendClientRealBackendAcceptanceTest
+        )
+        set_tests_properties(
+            CodexBackendClientThreadWorkflowAcceptanceTest
+            PROPERTIES
+                LABELS
+                "component;ai;openai;codex;frontend;backend;client;unix;acceptance;thread-workflow"
+                ENVIRONMENT
+                "SNODEC_CODEX_CLIENT_ACCEPTANCE_SCENARIO=thread-workflow"
+                SKIP_RETURN_CODE
+                77
+                TIMEOUT
+                20
         )
     endif()
 endif()

--- a/tests/component/codex/CMakeLists.txt
+++ b/tests/component/codex/CMakeLists.txt
@@ -175,6 +175,21 @@ if(TARGET codex-backend-client-support)
     )
 
     snodec_add_test(
+        CodexBackendClientPresenterTest CodexBackendClientPresenterTest.cpp
+    )
+    target_link_libraries(
+        CodexBackendClientPresenterTest PRIVATE snodec-test-support
+                                                codex-backend-client-support
+    )
+    target_compile_features(CodexBackendClientPresenterTest PRIVATE cxx_std_20)
+    set_tests_properties(
+        CodexBackendClientPresenterTest
+        PROPERTIES LABELS
+                   "component;ai;openai;codex;frontend;client;presentation"
+                   SKIP_RETURN_CODE 77 TIMEOUT 5
+    )
+
+    snodec_add_test(
         CodexBackendClientJsonLineFramerTest
         CodexBackendClientJsonLineFramerTest.cpp
     )

--- a/tests/component/codex/CodexBackendClientCommandDrainTest.cpp
+++ b/tests/component/codex/CodexBackendClientCommandDrainTest.cpp
@@ -7,6 +7,7 @@
 
 #include "ai/openai/codex/frontend/Messages.h"
 #include "apps/codex-backend-client/CommandDrainController.h"
+#include "apps/codex-backend-client/CommandParser.h"
 #include "support/TestResult.h"
 
 #include <cstddef>
@@ -36,8 +37,23 @@ namespace {
                         frontend::CommandError{frontend::ErrorCode::InvalidCommand, "rejected", std::nullopt, frontend::Json::object()})};
     }
 
+    frontend::ServerMessage successfulResponse(std::string requestId, frontend::Json result) {
+        return frontend::Response::success(std::move(requestId), std::move(result));
+    }
+
+    client::NewCommand
+    newCommand(std::string startRequestId, std::string turnRequestId, std::string prompt, frontend::ThreadStart options = {}) {
+        return client::NewCommand{std::move(startRequestId), std::move(turnRequestId), std::move(options), std::move(prompt)};
+    }
+
     const frontend::Command* sentCommand(const frontend::ClientMessage& message) {
         return std::get_if<frontend::Command>(&message);
+    }
+
+    template <typename Parameters>
+    const Parameters* sentParameters(const std::vector<frontend::ClientMessage>& sent, std::size_t index) {
+        const frontend::Command* command = index < sent.size() ? sentCommand(sent[index]) : nullptr;
+        return command == nullptr ? nullptr : std::get_if<Parameters>(&command->parameters);
     }
 
     struct Harness {
@@ -45,7 +61,9 @@ namespace {
             : controller(client::CommandDrainCallbacks{.send =
                                                            [this](const frontend::ClientMessage& message) {
                                                                sent.push_back(message);
-                                                               return sendSucceeds;
+                                                               ++sendAttempts;
+                                                               return sendSucceeds && (!failedSendAttempt.has_value() ||
+                                                                                       sendAttempts != *failedSendAttempt);
                                                            },
                                                        .requestExit =
                                                            [this]() {
@@ -63,6 +81,8 @@ namespace {
         }
 
         bool sendSucceeds = true;
+        std::optional<std::size_t> failedSendAttempt;
+        std::size_t sendAttempts = 0;
         std::vector<frontend::ClientMessage> sent;
         std::vector<std::string> failures;
         std::size_t exitRequests = 0;
@@ -291,6 +311,277 @@ namespace {
                               empty.controller.outcome() == client::CommandDrainController::Outcome::Success,
                           "an empty pipe exits cleanly immediately after initial synchronization");
     }
+
+    void testNewSynchronizationAndSuccessfulHandoff(tests::support::TestResult& result) {
+        Harness beforeConnection;
+        frontend::ThreadStart options;
+        options.cwd = "/tmp/new project";
+        options.model = "model-new";
+        options.ephemeral = true;
+        result.expectTrue(beforeConnection.controller.enqueue(newCommand("new-start", "new-turn", "preserve  spaces and --words", options)),
+                          "new entered before connection is accepted as one compound command");
+        result.expectTrue(beforeConnection.sent.empty() && beforeConnection.controller.queuedCount() == 1 &&
+                              beforeConnection.controller.newStage() == client::CommandDrainController::NewStage::Queued,
+                          "new remains queued before connection with an explicit queued stage");
+
+        beforeConnection.controller.connected();
+        result.expectTrue(beforeConnection.sent.empty() &&
+                              beforeConnection.controller.sessionState() == client::CommandDrainController::SessionState::Synchronizing,
+                          "connecting does not release new before initial synchronization");
+        beforeConnection.controller.receive(sync());
+        const frontend::Command* startCommand = beforeConnection.sent.empty() ? nullptr : sentCommand(beforeConnection.sent.front());
+        const frontend::ThreadStart* start = sentParameters<frontend::ThreadStart>(beforeConnection.sent, 0);
+        result.expectTrue(beforeConnection.sent.size() == 1 && startCommand != nullptr && startCommand->requestId == "new-start" &&
+                              start != nullptr && *start == options &&
+                              beforeConnection.controller.newStage() ==
+                                  client::CommandDrainController::NewStage::AwaitingThreadStartResponse,
+                          "sync.complete sends exactly the typed ThreadStart stage with every parsed option");
+
+        beforeConnection.controller.receive(response("unrelated"));
+        result.expectTrue(beforeConnection.sent.size() == 1 && beforeConnection.controller.newStage() ==
+                                                                   client::CommandDrainController::NewStage::AwaitingThreadStartResponse,
+                          "an unrelated response does not advance the compound command");
+
+        const auto startPresentation = beforeConnection.controller.receive(
+            successfulResponse("new-start", frontend::Json{{"thread", {{"id", "thread-created"}, {"status", "idle"}}}}));
+        startCommand = beforeConnection.sent.empty() ? nullptr : sentCommand(beforeConnection.sent.front());
+        const frontend::Command* turnCommand = beforeConnection.sent.size() > 1 ? sentCommand(beforeConnection.sent[1]) : nullptr;
+        const frontend::TurnStart* turn = sentParameters<frontend::TurnStart>(beforeConnection.sent, 1);
+        const frontend::TextInput* text =
+            turn != nullptr && turn->input.size() == 1 ? std::get_if<frontend::TextInput>(&turn->input.front()) : nullptr;
+        result.expectTrue(startPresentation.has_value() && startPresentation->kind == client::ResponsePresentation::Kind::NewThreadStart &&
+                              startPresentation->threadId == std::optional<std::string>{"thread-created"},
+                          "the matching start response exposes bounded presentation metadata for the created thread");
+        result.expectTrue(beforeConnection.sent.size() == 2 && turnCommand != nullptr && turnCommand->requestId == "new-turn" &&
+                              turn != nullptr && turn->threadId == "thread-created" && text != nullptr &&
+                              text->text == "preserve  spaces and --words" &&
+                              beforeConnection.controller.newStage() == client::CommandDrainController::NewStage::AwaitingTurnStartResponse,
+                          "the matching start result submits exactly one TurnStart with its returned ID and original TextInput");
+        result.expectTrue(startCommand != nullptr && turnCommand != nullptr && startCommand->requestId != turnCommand->requestId,
+                          "the compound stages use distinct generated request IDs");
+        result.expectTrue(std::holds_alternative<frontend::ThreadStart>(startCommand->parameters) &&
+                              std::holds_alternative<frontend::TurnStart>(turnCommand->parameters),
+                          "new emits only the real ThreadStart and TurnStart protocol operations");
+
+        beforeConnection.controller.receive(
+            successfulResponse("new-start", frontend::Json{{"thread", {{"id", "thread-created"}, {"status", "idle"}}}}));
+        result.expectTrue(beforeConnection.sent.size() == 2, "a duplicate or late start response never submits a second initial turn");
+
+        const auto turnPresentation = beforeConnection.controller.receive(response("new-turn"));
+        result.expectTrue(turnPresentation.has_value() && turnPresentation->kind == client::ResponsePresentation::Kind::NewTurnStart &&
+                              turnPresentation->threadId == std::optional<std::string>{"thread-created"} &&
+                              beforeConnection.controller.newStage() == client::CommandDrainController::NewStage::None &&
+                              beforeConnection.controller.outcome() == client::CommandDrainController::Outcome::Running,
+                          "a matching successful turn response completes new while interactive input stays open");
+
+        Harness duringSynchronization;
+        duringSynchronization.controller.connected();
+        result.expectTrue(duringSynchronization.controller.enqueue(newCommand("sync-start", "sync-turn", "during sync")),
+                          "new entered during initial synchronization is accepted");
+        result.expectTrue(duringSynchronization.sent.empty() && duringSynchronization.controller.queuedCount() == 1,
+                          "new entered during synchronization remains behind the barrier");
+        duringSynchronization.controller.receive(sync());
+        result.expectTrue(duringSynchronization.sent.size() == 1 &&
+                              sentParameters<frontend::ThreadStart>(duringSynchronization.sent, 0) != nullptr,
+                          "the synchronization barrier releases the queued new ThreadStart exactly once");
+    }
+
+    void testNewEofDrainAndQueueOrdering(tests::support::TestResult& result) {
+        Harness harness;
+        result.expectTrue(harness.controller.enqueue(newCommand("pipe-new-start", "pipe-new-turn", "first prompt")),
+                          "piped new is accepted before connection");
+        result.expectTrue(harness.controller.enqueue(command("after-new", frontend::ThreadList{})),
+                          "a later ordinary command queues behind new");
+        harness.controller.inputEof();
+        harness.establishAndSynchronize();
+        result.expectTrue(harness.sent.size() == 1 && sentParameters<frontend::ThreadStart>(harness.sent, 0) != nullptr &&
+                              harness.exitRequests == 0,
+                          "EOF sends ThreadStart but neither exits nor lets later input bypass active new");
+
+        harness.controller.receive(successfulResponse("pipe-new-start", frontend::Json{{"threadId", "thread-fallback"}}));
+        const frontend::TurnStart* turn = sentParameters<frontend::TurnStart>(harness.sent, 1);
+        result.expectTrue(harness.sent.size() == 2 && turn != nullptr && turn->threadId == "thread-fallback" && harness.exitRequests == 0 &&
+                              harness.controller.pendingResponseCount() == 1,
+                          "BackendAdapter's threadId fallback is handed to TurnStart and EOF waits for its response");
+
+        harness.controller.receive(response("pipe-new-turn"));
+        result.expectTrue(harness.sent.size() == 3 && sentParameters<frontend::ThreadList>(harness.sent, 2) != nullptr &&
+                              harness.exitRequests == 0,
+                          "only successful completion of both new stages releases the next queued command");
+        harness.controller.receive(response("after-new"));
+        result.expectTrue(harness.exitRequests == 1 && harness.controller.outcome() == client::CommandDrainController::Outcome::Success,
+                          "EOF exits successfully after both new stages and all later queued work complete");
+
+        Harness multiple;
+        multiple.establishAndSynchronize();
+        result.expectTrue(multiple.controller.enqueue(newCommand("first-start", "first-turn", "one")) &&
+                              multiple.controller.enqueue(newCommand("second-start", "second-turn", "two")),
+                          "multiple new operations are accepted in input order");
+        result.expectTrue(multiple.sent.size() == 1 && sentCommand(multiple.sent[0])->requestId == "first-start",
+                          "the second new cannot start while the first compound command is active");
+        multiple.controller.receive(successfulResponse("first-start", frontend::Json{{"thread", {{"id", "thread-one"}}}}));
+        multiple.controller.receive(response("first-turn"));
+        result.expectTrue(multiple.sent.size() == 3 && sentCommand(multiple.sent[2])->requestId == "second-start" &&
+                              sentParameters<frontend::ThreadStart>(multiple.sent, 2) != nullptr,
+                          "multiple new operations serialize at compound-command boundaries");
+    }
+
+    void testNewFailures(tests::support::TestResult& result) {
+        Harness startSendFailure;
+        startSendFailure.failedSendAttempt = 1;
+        startSendFailure.establishAndSynchronize();
+        result.expectTrue(!startSendFailure.controller.enqueue(newCommand("unsent-start", "unsent-turn", "prompt")) &&
+                              startSendFailure.controller.failed() && startSendFailure.sent.size() == 1 &&
+                              startSendFailure.exitRequests == 1 &&
+                              startSendFailure.controller.failureReason().find("new thread creation failed") != std::string::npos &&
+                              startSendFailure.controller.failureReason().find("failed to send frontend message") != std::string::npos &&
+                              startSendFailure.controller.failureReason().find("thread created id=") == std::string::npos,
+                          "ThreadStart send failure terminates new once without claiming that a thread was created");
+
+        Harness rejectedStart;
+        rejectedStart.establishAndSynchronize();
+        result.expectTrue(rejectedStart.controller.enqueue(newCommand("reject-start", "never-turn", "prompt")),
+                          "new is submitted for start-failure coverage");
+        const auto rejectedPresentation = rejectedStart.controller.receive(response("reject-start", false));
+        result.expectTrue(rejectedStart.controller.failed() && rejectedStart.sent.size() == 1 && rejectedStart.exitRequests == 1 &&
+                              rejectedPresentation.has_value() &&
+                              rejectedPresentation->kind == client::ResponsePresentation::Kind::NewThreadStart &&
+                              rejectedStart.controller.failureReason().find("thread.start failed") != std::string::npos,
+                          "a failed ThreadStart prevents TurnStart and makes the compound operation fail");
+
+        Harness missingId;
+        missingId.establishAndSynchronize();
+        result.expectTrue(missingId.controller.enqueue(newCommand("missing-id", "missing-id-turn", "prompt")),
+                          "new is submitted for malformed-success coverage");
+        missingId.controller.receive(successfulResponse("missing-id", frontend::Json{{"thread", {{"id", ""}}}}));
+        result.expectTrue(missingId.controller.failed() && missingId.sent.size() == 1 && missingId.exitRequests == 1 &&
+                              missingId.controller.failureReason().find("non-empty thread ID") != std::string::npos,
+                          "a successful ThreadStart without a valid ID fails locally and never submits TurnStart");
+
+        Harness turnSendFailure;
+        turnSendFailure.failedSendAttempt = 2;
+        turnSendFailure.establishAndSynchronize();
+        result.expectTrue(turnSendFailure.controller.enqueue(newCommand("send-start", "send-turn", "prompt")),
+                          "new is submitted for second-stage send-failure coverage");
+        turnSendFailure.controller.receive(successfulResponse("send-start", frontend::Json{{"thread", {{"id", "thread-send-failed"}}}}));
+        result.expectTrue(turnSendFailure.controller.failed() && turnSendFailure.sent.size() == 2 && turnSendFailure.exitRequests == 1 &&
+                              turnSendFailure.controller.failureReason().find("thread created id=thread-send-failed") !=
+                                  std::string::npos &&
+                              turnSendFailure.controller.failureReason().find("failed to send frontend message") != std::string::npos,
+                          "TurnStart send failure reports the successfully created thread ID and returns failure");
+
+        Harness turnResponseFailure;
+        turnResponseFailure.establishAndSynchronize();
+        result.expectTrue(turnResponseFailure.controller.enqueue(newCommand("response-start", "response-turn", "prompt")),
+                          "new is submitted for second-stage response-failure coverage");
+        turnResponseFailure.controller.receive(
+            successfulResponse("response-start", frontend::Json{{"thread", {{"id", "thread-turn-rejected"}}}}));
+        const auto partialPresentation = turnResponseFailure.controller.receive(response("response-turn", false));
+        result.expectTrue(
+            turnResponseFailure.controller.failed() && turnResponseFailure.exitRequests == 1 && partialPresentation.has_value() &&
+                partialPresentation->kind == client::ResponsePresentation::Kind::NewTurnStart &&
+                partialPresentation->threadId == std::optional<std::string>{"thread-turn-rejected"} &&
+                turnResponseFailure.controller.failureReason().find("thread created id=thread-turn-rejected") != std::string::npos &&
+                turnResponseFailure.controller.failureReason().find("turn.start failed") != std::string::npos,
+            "a failed TurnStart response reports partial failure with the preserved thread ID");
+    }
+
+    void testNewDisconnectsAndDuplicateTurnId(tests::support::TestResult& result) {
+        Harness duringStart;
+        duringStart.establishAndSynchronize();
+        result.expectTrue(duringStart.controller.enqueue(newCommand("disconnect-start", "disconnect-turn", "prompt")),
+                          "new is submitted for start-stage disconnect coverage");
+        duringStart.controller.disconnected();
+        result.expectTrue(duringStart.controller.failed() && duringStart.exitRequests == 1 &&
+                              duringStart.controller.failureReason().find("new thread creation failed") != std::string::npos,
+                          "disconnect during ThreadStart fails cleanly before any thread ID is claimed");
+
+        Harness duringTurn;
+        duringTurn.establishAndSynchronize();
+        result.expectTrue(duringTurn.controller.enqueue(newCommand("disconnect-start-ok", "disconnect-turn-pending", "prompt")),
+                          "new is submitted for turn-stage disconnect coverage");
+        duringTurn.controller.receive(
+            successfulResponse("disconnect-start-ok", frontend::Json{{"thread", {{"id", "thread-disconnected"}}}}));
+        duringTurn.controller.disconnected();
+        result.expectTrue(duringTurn.controller.failed() && duringTurn.exitRequests == 1 &&
+                              duringTurn.controller.failureReason().find("thread created id=thread-disconnected") != std::string::npos,
+                          "disconnect during TurnStart reports partial failure with the created thread ID");
+
+        Harness duplicateTurnId;
+        result.expectTrue(duplicateTurnId.controller.enqueue(command("shared-turn-id", frontend::ControllerAcquire{})),
+                          "a raw command can reserve the future generated turn ID");
+        result.expectTrue(duplicateTurnId.controller.enqueue(newCommand("distinct-start-id", "shared-turn-id", "prompt")),
+                          "new with a colliding internal turn ID remains accepted for serialized delivery");
+        duplicateTurnId.establishAndSynchronize();
+        result.expectTrue(duplicateTurnId.sent.size() == 2,
+                          "the earlier raw command and distinct ThreadStart are both sent in input order");
+        duplicateTurnId.controller.receive(
+            successfulResponse("distinct-start-id", frontend::Json{{"thread", {{"id", "thread-collision"}}}}));
+        result.expectTrue(duplicateTurnId.sent.size() == 2 &&
+                              duplicateTurnId.controller.newStage() == client::CommandDrainController::NewStage::WaitingToSubmitTurn,
+                          "a pending duplicate request ID blocks the internal TurnStart without bypassing protection");
+        duplicateTurnId.controller.receive(response("shared-turn-id"));
+        const frontend::Command* delayedTurn = duplicateTurnId.sent.size() > 2 ? sentCommand(duplicateTurnId.sent[2]) : nullptr;
+        result.expectTrue(duplicateTurnId.sent.size() == 3 && delayedTurn != nullptr && delayedTurn->requestId == "shared-turn-id" &&
+                              std::holds_alternative<frontend::TurnStart>(delayedTurn->parameters),
+                          "the internal TurnStart is submitted exactly once when its duplicate request ID becomes free");
+    }
+
+    void testNewCorrelatedProtocolErrors(tests::support::TestResult& result) {
+        Harness duringStart;
+        duringStart.establishAndSynchronize();
+        result.expectTrue(duringStart.controller.enqueue(newCommand("protocol-start", "protocol-turn", "prompt")),
+                          "new is submitted for correlated start-stage protocol-error coverage");
+        duringStart.controller.receive(frontend::ServerMessage{frontend::ProtocolErrorMessage{frontend::ErrorCode::InvalidCommand,
+                                                                                              "start protocol rejection",
+                                                                                              {},
+                                                                                              false,
+                                                                                              std::string{"protocol-start"},
+                                                                                              std::nullopt,
+                                                                                              frontend::Json::object()}});
+        result.expectTrue(duringStart.controller.failed() && duringStart.sent.size() == 1 && duringStart.exitRequests == 1 &&
+                              duringStart.controller.failureReason().find("new thread creation failed") != std::string::npos,
+                          "a matching non-closing protocol error terminates the interactive ThreadStart stage deterministically");
+
+        Harness duringTurn;
+        duringTurn.establishAndSynchronize();
+        result.expectTrue(duringTurn.controller.enqueue(newCommand("protocol-start-ok", "protocol-turn-failed", "prompt")),
+                          "new is submitted for correlated turn-stage protocol-error coverage");
+        duringTurn.controller.receive(
+            successfulResponse("protocol-start-ok", frontend::Json{{"thread", {{"id", "thread-protocol-error"}}}}));
+        duringTurn.controller.receive(frontend::ServerMessage{frontend::ProtocolErrorMessage{frontend::ErrorCode::InvalidCommand,
+                                                                                             "turn protocol rejection",
+                                                                                             {},
+                                                                                             false,
+                                                                                             std::string{"protocol-turn-failed"},
+                                                                                             std::nullopt,
+                                                                                             frontend::Json::object()}});
+        result.expectTrue(duringTurn.controller.failed() && duringTurn.sent.size() == 2 && duringTurn.exitRequests == 1 &&
+                              duringTurn.controller.failureReason().find("thread created id=thread-protocol-error") != std::string::npos,
+                          "a matching non-closing protocol error reports partial failure for the interactive TurnStart stage");
+    }
+
+    void testResponsePresentationCorrelation(tests::support::TestResult& result) {
+        Harness harness;
+        harness.establishAndSynchronize();
+        result.expectTrue(harness.controller.enqueue(command("friendly-start", frontend::ThreadStart{})) &&
+                              harness.controller.enqueue(command("friendly-resume", frontend::ThreadResume{"thread-resumed"})) &&
+                              harness.controller.enqueue(command("friendly-turn", frontend::TurnStart{"thread-turned"})),
+                          "friendly typed commands are accepted for presentation correlation");
+
+        const auto resumed =
+            harness.controller.receive(successfulResponse("friendly-resume", frontend::Json{{"thread", {{"id", "thread-resumed"}}}}));
+        const auto started =
+            harness.controller.receive(successfulResponse("friendly-start", frontend::Json{{"thread", {{"id", "thread-started"}}}}));
+        const auto turned = harness.controller.receive(response("friendly-turn", false));
+        result.expectTrue(resumed == std::optional<client::ResponsePresentation>{client::ResponsePresentation{
+                                         client::ResponsePresentation::Kind::ThreadResume, std::string{"thread-resumed"}}} &&
+                              started == std::optional<client::ResponsePresentation>{client::ResponsePresentation{
+                                             client::ResponsePresentation::Kind::ThreadStart, std::string{"thread-started"}}} &&
+                              turned == std::optional<client::ResponsePresentation>{client::ResponsePresentation{
+                                            client::ResponsePresentation::Kind::TurnStart, std::string{"thread-turned"}}},
+                          "out-of-order responses retain their correlated start, resume, and turn presentation context");
+    }
 } // namespace
 
 int main() {
@@ -301,6 +592,12 @@ int main() {
     testSnapshotAndReplaySynchronization(result);
     testRawMessagesAndDuplicateIds(result);
     testFailurePathsAndEmptyPipe(result);
+    testNewSynchronizationAndSuccessfulHandoff(result);
+    testNewEofDrainAndQueueOrdering(result);
+    testNewFailures(result);
+    testNewDisconnectsAndDuplicateTurnId(result);
+    testNewCorrelatedProtocolErrors(result);
+    testResponsePresentationCorrelation(result);
 
     return result.processResult();
 }

--- a/tests/component/codex/CodexBackendClientCommandTest.cpp
+++ b/tests/component/codex/CodexBackendClientCommandTest.cpp
@@ -17,6 +17,7 @@
 #include <string_view>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace {
     namespace client = apps::codex_backend_client;
@@ -24,6 +25,10 @@ namespace {
 
     const client::SendCommand* sendCommand(const client::ParsedCommand& parsed) {
         return std::get_if<client::SendCommand>(&parsed);
+    }
+
+    const client::NewCommand* newCommand(const client::ParsedCommand& parsed) {
+        return std::get_if<client::NewCommand>(&parsed);
     }
 
     const frontend::Command* protocolCommand(const client::ParsedCommand& parsed) {
@@ -63,6 +68,36 @@ namespace {
                                       {"params", std::move(params)}};
         result.expectTrue(!command->requestId.empty() && encoded.value() == expected,
                           description + " uses the exact Frontend Protocol v1 envelope and parameters");
+    }
+
+    void expectWireCommand(tests::support::TestResult& result,
+                           const frontend::Command& command,
+                           std::string_view method,
+                           frontend::Json params,
+                           const std::string& description) {
+        const auto encoded = frontend::Codec::encodeClient(frontend::ClientMessage{command});
+        result.expectTrue(encoded.hasValue(), description + " encodes through the shared frontend codec");
+        if (!encoded) {
+            return;
+        }
+
+        const frontend::Json expected{{"protocol", frontend::ProtocolIdentity},
+                                      {"version", frontend::ProtocolVersion},
+                                      {"kind", frontend::kind::Command},
+                                      {"requestId", command.requestId},
+                                      {"method", method},
+                                      {"params", std::move(params)}};
+        result.expectTrue(!command.requestId.empty() && encoded.value() == expected,
+                          description + " uses the exact Frontend Protocol v1 envelope and parameters");
+    }
+
+    bool hasNoStartOptions(const frontend::ThreadStart& start) {
+        return !start.cwd.has_value() && !start.model.has_value() && !start.modelProvider.has_value() &&
+               !start.approvalPolicy.has_value() && !start.sandboxMode.has_value() && !start.ephemeral.has_value();
+    }
+
+    const client::CommandParseError* parseError(const client::ParsedCommand& parsed) {
+        return std::get_if<client::CommandParseError>(&parsed);
     }
 } // namespace
 
@@ -115,6 +150,109 @@ int main() {
     result.expectTrue(parameters<ThreadList>(threads) != nullptr, "threads maps to a typed thread.list command");
     expectWireCommand(result, threads, method::ThreadList, Json::object(), "threads");
 
+    CommandParser threadParser("thread-command");
+
+    const ParsedCommand bareStart = threadParser.parse("start");
+    const ThreadStart* bareStartParameters = parameters<ThreadStart>(bareStart);
+    result.expectTrue(bareStartParameters != nullptr && hasNoStartOptions(*bareStartParameters),
+                      "bare start leaves every optional Codex thread.start setting unset");
+    expectWireCommand(result, bareStart, method::ThreadStart, Json::object(), "bare start");
+
+    const ParsedCommand configuredStart =
+        threadParser.parse("start --cwd /tmp/project --model gpt-5 --model-provider openai --approval-policy on-request "
+                           "--sandbox-mode workspace-write --ephemeral");
+    const ThreadStart* configuredStartParameters = parameters<ThreadStart>(configuredStart);
+    result.expectTrue(configuredStartParameters != nullptr && configuredStartParameters->cwd == "/tmp/project" &&
+                          configuredStartParameters->model == "gpt-5" && configuredStartParameters->modelProvider == "openai" &&
+                          configuredStartParameters->approvalPolicy == "on-request" &&
+                          configuredStartParameters->sandboxMode == "workspace-write" && configuredStartParameters->ephemeral == true,
+                      "start maps every supported option to the corresponding typed optional field");
+    expectWireCommand(result,
+                      configuredStart,
+                      method::ThreadStart,
+                      Json{{"cwd", "/tmp/project"},
+                           {"model", "gpt-5"},
+                           {"modelProvider", "openai"},
+                           {"approvalPolicy", "on-request"},
+                           {"sandboxMode", "workspace-write"},
+                           {"ephemeral", true}},
+                      "configured start");
+
+    const ParsedCommand bareResume = threadParser.parse("resume thread-existing");
+    const ThreadResume* bareResumeParameters = parameters<ThreadResume>(bareResume);
+    result.expectTrue(bareResumeParameters != nullptr && bareResumeParameters->threadId == "thread-existing" &&
+                          !bareResumeParameters->cwd.has_value() && !bareResumeParameters->model.has_value() &&
+                          !bareResumeParameters->modelProvider.has_value() && !bareResumeParameters->approvalPolicy.has_value() &&
+                          !bareResumeParameters->sandboxMode.has_value(),
+                      "bare resume preserves its thread ID and leaves all optional resume settings unset");
+    expectWireCommand(result, bareResume, method::ThreadResume, Json{{"threadId", "thread-existing"}}, "bare resume");
+
+    const ParsedCommand configuredResume =
+        threadParser.parse("resume thread-existing --cwd /tmp/resumed --model gpt-5-codex --model-provider azure "
+                           "--approval-policy never --sandbox-mode read-only");
+    const ThreadResume* configuredResumeParameters = parameters<ThreadResume>(configuredResume);
+    result.expectTrue(configuredResumeParameters != nullptr && configuredResumeParameters->threadId == "thread-existing" &&
+                          configuredResumeParameters->cwd == "/tmp/resumed" && configuredResumeParameters->model == "gpt-5-codex" &&
+                          configuredResumeParameters->modelProvider == "azure" && configuredResumeParameters->approvalPolicy == "never" &&
+                          configuredResumeParameters->sandboxMode == "read-only",
+                      "resume maps every supported option while retaining the explicit persisted thread ID");
+    expectWireCommand(result,
+                      configuredResume,
+                      method::ThreadResume,
+                      Json{{"threadId", "thread-existing"},
+                           {"cwd", "/tmp/resumed"},
+                           {"model", "gpt-5-codex"},
+                           {"modelProvider", "azure"},
+                           {"approvalPolicy", "never"},
+                           {"sandboxMode", "read-only"}},
+                      "configured resume");
+
+    const ParsedCommand simpleNew = threadParser.parse("new Explain the  current repository architecture.");
+    const NewCommand* simpleNewCommand = newCommand(simpleNew);
+    result.expectTrue(
+        simpleNewCommand != nullptr && !simpleNewCommand->threadStartRequestId.empty() && !simpleNewCommand->turnStartRequestId.empty() &&
+            simpleNewCommand->threadStartRequestId != simpleNewCommand->turnStartRequestId &&
+            hasNoStartOptions(simpleNewCommand->options) && simpleNewCommand->prompt == "Explain the  current repository architecture.",
+        "simple new carries two distinct generated IDs, unset start options, and the exact line-oriented prompt");
+    if (simpleNewCommand != nullptr) {
+        expectWireCommand(result,
+                          Command{simpleNewCommand->threadStartRequestId, simpleNewCommand->options, Json::object(), Json::object()},
+                          method::ThreadStart,
+                          Json::object(),
+                          "simple new internal start");
+    }
+
+    const ParsedCommand configuredNew =
+        threadParser.parse("new --cwd /tmp/new --model gpt-5 --model-provider openai --approval-policy on-request "
+                           "--sandbox-mode workspace-write --ephemeral -- Review the current implementation. --include-tests");
+    const NewCommand* configuredNewCommand = newCommand(configuredNew);
+    result.expectTrue(
+        configuredNewCommand != nullptr && configuredNewCommand->threadStartRequestId != configuredNewCommand->turnStartRequestId &&
+            configuredNewCommand->options.cwd == "/tmp/new" && configuredNewCommand->options.model == "gpt-5" &&
+            configuredNewCommand->options.modelProvider == "openai" && configuredNewCommand->options.approvalPolicy == "on-request" &&
+            configuredNewCommand->options.sandboxMode == "workspace-write" && configuredNewCommand->options.ephemeral == true &&
+            configuredNewCommand->prompt == "Review the current implementation. --include-tests",
+        "configured new keeps every start option and preserves words beginning with '--' after the separator");
+    if (configuredNewCommand != nullptr) {
+        expectWireCommand(
+            result,
+            Command{configuredNewCommand->threadStartRequestId, configuredNewCommand->options, Json::object(), Json::object()},
+            method::ThreadStart,
+            Json{{"cwd", "/tmp/new"},
+                 {"model", "gpt-5"},
+                 {"modelProvider", "openai"},
+                 {"approvalPolicy", "on-request"},
+                 {"sandboxMode", "workspace-write"},
+                 {"ephemeral", true}},
+            "configured new internal start");
+    }
+
+    const ParsedCommand separatedNew = threadParser.parse("new -- Prompt beginning with --literal and containing spaces");
+    const NewCommand* separatedNewCommand = newCommand(separatedNew);
+    result.expectTrue(separatedNewCommand != nullptr && hasNoStartOptions(separatedNewCommand->options) &&
+                          separatedNewCommand->prompt == "Prompt beginning with --literal and containing spaces",
+                      "new accepts an explicit separator without options and retains the complete prompt after it");
+
     const ParsedCommand read = parser.parse("read thread-7");
     const ThreadRead* readParameters = parameters<ThreadRead>(read);
     result.expectTrue(readParameters != nullptr && readParameters->threadId == "thread-7" && readParameters->includeTurns == std::nullopt,
@@ -153,6 +291,43 @@ int main() {
     result.expectTrue(rawRoundTrips,
                       "raw accepts only a valid frontend message and reuses the shared codec without changing its wire fields");
 
+    CommandParser validationParser("validation");
+    const std::vector<std::pair<std::string_view, std::string_view>> invalidThreadCommands{
+        {"start unexpected", "unexpected positional argument"},
+        {"start --cwd", "requires a value"},
+        {"start --cwd --model gpt-5", "requires a value"},
+        {"start --unknown value", "unknown option"},
+        {"start --model first --model second", "may only be specified once"},
+        {"start --ephemeral --ephemeral", "may only be specified once"},
+        {"resume", "usage: resume"},
+        {"resume --cwd /tmp/project", "usage: resume"},
+        {"resume thread-1 unexpected", "unexpected positional argument"},
+        {"resume thread-1 --cwd", "requires a value"},
+        {"resume thread-1 --unknown value", "unknown option"},
+        {"resume thread-1 --model first --model second", "may only be specified once"},
+        {"resume thread-1 --ephemeral", "not supported by resume"},
+        {"new", "usage: new"},
+        {"new --cwd", "requires a value"},
+        {"new --", "prompt must not be empty"},
+        {"new --cwd /tmp/project --", "prompt must not be empty"},
+        {"new --cwd /tmp/project missing-separator", "unexpected positional argument"},
+        {"new --cwd /tmp/project", "must be followed by '-- <prompt>'"},
+        {"new --unknown value -- prompt", "unknown option"},
+        {"new --model first --model second -- prompt", "may only be specified once"},
+        {"new --ephemeral --ephemeral -- prompt", "may only be specified once"},
+    };
+    for (const auto& [line, expectedDiagnostic] : invalidThreadCommands) {
+        const ParsedCommand invalid = validationParser.parse(line);
+        const CommandParseError* error = parseError(invalid);
+        result.expectTrue(error != nullptr && error->message.find(expectedDiagnostic) != std::string::npos,
+                          "invalid thread command reports a clear local error: " + std::string(line));
+    }
+
+    const ParsedCommand firstAfterValidationErrors = validationParser.parse("start");
+    result.expectTrue(protocolCommand(firstAfterValidationErrors) != nullptr &&
+                          protocolCommand(firstAfterValidationErrors)->requestId == "validation-1",
+                      "invalid start, resume, and new inputs do not consume generated frontend request IDs");
+
     for (const std::string_view invalid :
          {"replay nope", "read", "turn thread-7", "interrupt thread-7", "watch maybe", "raw {not-json", "unknown-command"}) {
         result.expectTrue(std::holds_alternative<CommandParseError>(parser.parse(invalid)),
@@ -160,9 +335,25 @@ int main() {
     }
 
     const std::string help = CommandParser::helpText();
-    for (const std::string_view command :
-         {"snapshot", "replay", "acquire", "release", "threads", "read", "turn", "interrupt", "raw", "watch", "quit"}) {
+    for (const std::string_view command : {"snapshot",
+                                           "replay",
+                                           "acquire",
+                                           "release",
+                                           "threads",
+                                           "start",
+                                           "resume",
+                                           "new",
+                                           "read",
+                                           "turn",
+                                           "interrupt",
+                                           "raw",
+                                           "watch",
+                                           "quit"}) {
         result.expectTrue(help.find(command) != std::string::npos, "help documents command: " + std::string(command));
+    }
+    for (const std::string_view option :
+         {"--cwd", "--model", "--model-provider", "--approval-policy", "--sandbox-mode", "--ephemeral", "-- <prompt>"}) {
+        result.expectTrue(help.find(option) != std::string::npos, "help documents thread option syntax: " + std::string(option));
     }
 
     return result.processResult();

--- a/tests/component/codex/CodexBackendClientPresenterTest.cpp
+++ b/tests/component/codex/CodexBackendClientPresenterTest.cpp
@@ -1,0 +1,111 @@
+/*
+ * SNode.C - A Slim Toolkit for Network Communication
+ * Copyright (C) Volker Christian <me@vchrist.at>
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later OR MIT
+ */
+
+#include "ai/openai/codex/frontend/Codec.h"
+#include "ai/openai/codex/frontend/Messages.h"
+#include "apps/codex-backend-client/CommandDrainController.h"
+#include "apps/codex-backend-client/Presenter.h"
+#include "support/TestResult.h"
+
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace {
+    namespace client = apps::codex_backend_client;
+    namespace frontend = ai::openai::codex::frontend;
+
+    frontend::ServerMessage success(std::string requestId, frontend::Json result) {
+        return frontend::ServerMessage{frontend::Response::success(std::move(requestId), std::move(result))};
+    }
+
+    frontend::ServerMessage failure(std::string requestId, std::string message) {
+        return frontend::ServerMessage{frontend::Response::failure(
+            std::move(requestId),
+            frontend::CommandError{frontend::ErrorCode::InvalidCommand, std::move(message), std::nullopt, frontend::Json::object()})};
+    }
+
+    bool contains(const std::string& value, const std::string& expected) {
+        return value.find(expected) != std::string::npos;
+    }
+
+    void testThreadSummaries(tests::support::TestResult& result) {
+        std::ostringstream output;
+        std::ostringstream diagnostics;
+        client::Presenter presenter(client::OutputMode::Human, output, diagnostics);
+
+        presenter.present(success("start-1", frontend::Json{{"thread", {{"id", "thread-created"}, {"turns", frontend::Json::array()}}}}),
+                          client::ResponsePresentation{client::ResponsePresentation::Kind::ThreadStart, "thread-created"});
+        presenter.present(success("resume-1", frontend::Json{{"threadId", "thread-persisted"}}),
+                          client::ResponsePresentation{client::ResponsePresentation::Kind::ThreadResume, "thread-persisted"});
+
+        result.expectTrue(output.str() == "thread started id=thread-created\nthread resumed id=thread-persisted\n",
+                          "human presentation identifies started and resumed threads without dumping their snapshots");
+        result.expectTrue(diagnostics.str().empty(), "successful human thread summaries produce no diagnostics");
+    }
+
+    void testNewSummaries(tests::support::TestResult& result) {
+        std::ostringstream output;
+        std::ostringstream diagnostics;
+        client::Presenter presenter(client::OutputMode::Human, output, diagnostics);
+
+        presenter.present(success("new-start", frontend::Json{{"thread", {{"id", "thread-new"}}}}),
+                          client::ResponsePresentation{client::ResponsePresentation::Kind::NewThreadStart, "thread-new"});
+        presenter.present(success("new-turn", frontend::Json{{"turn", {{"id", "turn-first"}, {"items", frontend::Json::array()}}}}),
+                          client::ResponsePresentation{client::ResponsePresentation::Kind::NewTurnStart, "thread-new"});
+
+        result.expectTrue(output.str() == "thread created id=thread-new\ninitial turn submitted thread=thread-new turn=turn-first\n",
+                          "human presentation reports both successful stages of the client-side new operation");
+        result.expectTrue(diagnostics.str().empty(), "successful new summaries produce no diagnostics");
+    }
+
+    void testFailureSummariesAreBounded(tests::support::TestResult& result) {
+        std::ostringstream output;
+        std::ostringstream diagnostics;
+        client::Presenter presenter(client::OutputMode::Human, output, diagnostics);
+
+        presenter.present(failure("start-failed", "controller ownership is required"),
+                          client::ResponsePresentation{client::ResponsePresentation::Kind::ThreadStart, std::nullopt});
+        presenter.present(failure("new-turn-failed", std::string(2048, 'x')),
+                          client::ResponsePresentation{client::ResponsePresentation::Kind::NewTurnStart, "thread-survives"});
+
+        const std::string rendered = output.str();
+        result.expectTrue(contains(rendered, "thread start failed: invalid_command: controller ownership is required"),
+                          "human presentation gives a useful thread-start failure summary");
+        result.expectTrue(contains(rendered, "thread created id=thread-survives, but initial turn failed: invalid_command:"),
+                          "partial new failure preserves the successfully created thread ID");
+        result.expectTrue(rendered.size() < 800, "human failure summaries stay bounded even when the backend error message is very large");
+        result.expectTrue(diagnostics.str().empty(), "protocol response failures remain protocol output rather than local diagnostics");
+    }
+
+    void testJsonPreservesOriginalMessages(tests::support::TestResult& result) {
+        std::ostringstream output;
+        std::ostringstream diagnostics;
+        client::Presenter presenter(client::OutputMode::Json, output, diagnostics);
+        const frontend::ServerMessage message =
+            success("json-new-start", frontend::Json{{"thread", {{"id", "thread-json"}, {"preview", std::string(5000, 'p')}}}});
+
+        presenter.present(message, client::ResponsePresentation{client::ResponsePresentation::Kind::NewThreadStart, "thread-json"});
+        const auto encoded = frontend::Codec::serializeServer(message);
+
+        result.expectTrue(encoded.hasValue() && output.str() == encoded.value() + "\n",
+                          "JSON mode emits the complete original Frontend Protocol response despite local new correlation");
+        result.expectTrue(diagnostics.str().empty(), "JSON response presentation adds no synthetic new diagnostic or protocol message");
+    }
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+
+    testThreadSummaries(result);
+    testNewSummaries(result);
+    testFailureSummariesAreBounded(result);
+    testJsonPreservesOriginalMessages(result);
+
+    return result.processResult();
+}

--- a/tests/component/codex/CodexBackendClientRealBackendAcceptanceTest.cpp
+++ b/tests/component/codex/CodexBackendClientRealBackendAcceptanceTest.cpp
@@ -41,7 +41,6 @@
 #include <streambuf>
 #include <string>
 #include <string_view>
-#include <sys/wait.h>
 #include <type_traits>
 #include <unistd.h>
 #include <utility>
@@ -708,19 +707,24 @@ namespace {
 } // namespace
 
 int main(int argc, char* argv[]) {
-    if (const char* scenario = std::getenv("SNODEC_CODEX_CLIENT_ACCEPTANCE_SCENARIO");
-        scenario != nullptr && std::string_view(scenario) == "thread-workflow") {
-        tests::support::TestResult workflowResult;
-        runThreadWorkflowAcceptance(workflowResult, argc, argv);
-        return workflowResult.processResult();
-    }
-
     tests::support::TestResult result;
     int returnCode = tests::support::cTestSkipReturnCode;
     const std::string path = socketPath();
+    const char* configuredScenario = std::getenv("SNODEC_CODEX_CLIENT_ACCEPTANCE_SCENARIO");
+    const std::string_view scenario = configuredScenario == nullptr ? "interactive" : configuredScenario;
+    const std::string testName =
+        scenario == "thread-workflow" ? "CodexBackendClientThreadWorkflowAcceptanceTest" : "CodexBackendClientRealBackendAcceptanceTest";
 
-    if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
-        tests::support::printRootWithoutSNodeCGroupSkipMessage("CodexBackendClientRealBackendAcceptanceTest");
+    if (scenario != "interactive" && scenario != "thread-workflow") {
+        result.expectTrue(false,
+                          "unknown SNODEC_CODEX_CLIENT_ACCEPTANCE_SCENARIO '" + std::string(scenario) +
+                              "'; expected 'interactive' or 'thread-workflow'");
+        returnCode = result.processResult();
+    } else if (tests::support::shouldSkipRootWithoutSNodeCGroup()) {
+        tests::support::printRootWithoutSNodeCGroupSkipMessage(testName);
+    } else if (scenario == "thread-workflow") {
+        runThreadWorkflowAcceptance(result, argc, argv);
+        returnCode = result.processResult();
     } else {
         std::remove(path.c_str());
         result.expectTrue(!pathExists(path), "the unique real-backend client socket path is absent before listen");
@@ -1238,24 +1242,6 @@ int main(int argc, char* argv[]) {
         result.expectTrue(pathCleanedByServer, "real frontend Unix server removes its owned socket path");
 
         core::SNodeC::free();
-        const pid_t workflowProcess = ::fork();
-        if (workflowProcess == 0) {
-            if (::setenv("SNODEC_CODEX_CLIENT_ACCEPTANCE_SCENARIO", "thread-workflow", 1) != 0) {
-                _exit(126);
-            }
-            ::execvp(argv[0], argv);
-            _exit(127);
-        }
-
-        int workflowStatus = 0;
-        pid_t waited = -1;
-        if (workflowProcess > 0) {
-            do {
-                waited = ::waitpid(workflowProcess, &workflowStatus, 0);
-            } while (waited < 0 && errno == EINTR);
-        }
-        result.expectTrue(workflowProcess > 0 && waited == workflowProcess && WIFEXITED(workflowStatus) && WEXITSTATUS(workflowStatus) == 0,
-                          "the isolated EOF-driven thread-workflow acceptance subprocess passes");
         returnCode = result.processResult();
     }
 

--- a/tests/component/codex/CodexBackendClientRealBackendAcceptanceTest.cpp
+++ b/tests/component/codex/CodexBackendClientRealBackendAcceptanceTest.cpp
@@ -31,6 +31,7 @@
 #include <cerrno>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <functional>
 #include <limits>
 #include <memory>
@@ -40,6 +41,7 @@
 #include <streambuf>
 #include <string>
 #include <string_view>
+#include <sys/wait.h>
 #include <type_traits>
 #include <unistd.h>
 #include <utility>
@@ -200,6 +202,14 @@ namespace {
             return true;
         }
 
+        [[nodiscard]] bool closeWriter() noexcept {
+            if (writeFd < 0) {
+                return true;
+            }
+            const int descriptor = std::exchange(writeFd, -1);
+            return ::close(descriptor) == 0;
+        }
+
         int readFd = -1;
 
     private:
@@ -218,9 +228,493 @@ namespace {
         return haystack.find(needle) != std::string_view::npos;
     }
 
+    std::string threadWorkflowSocketPath() {
+        return "/tmp/snodec-codex-client-thread-workflow-" + std::to_string(::getpid()) + ".sock";
+    }
+
+    void runThreadWorkflowAcceptance(tests::support::TestResult& result, int argc, char* argv[]) {
+        const std::string path = threadWorkflowSocketPath();
+        std::remove(path.c_str());
+        result.expectTrue(!pathExists(path), "the thread-workflow Unix socket path is absent before listen");
+        core::SNodeC::init(argc, argv);
+
+        constexpr std::string_view PersistedThreadId = "thread-persisted-acceptance";
+        constexpr std::string_view ExplicitThreadId = "thread-started-acceptance";
+        constexpr std::string_view NewThreadId = "thread-new-acceptance";
+        constexpr std::string_view ExplicitPrompt = "Continue the previous task.";
+        constexpr std::string_view NewPrompt = "Review  the current implementation. --literal";
+
+        bool timedOut = false;
+        bool serverListening = false;
+        bool backendHydratedBeforeInput = false;
+        bool inputClosedBeforeConnection = false;
+        bool eofEnteredDrain = false;
+        bool newStartObservedDuringEofDrain = false;
+        bool newTurnSentFromMatchingStart = false;
+        bool exitWaitedForNewTurnResponse = false;
+        bool lifecycleClosedCleanly = false;
+        bool eventLoopRunning = false;
+        bool exitScheduled = false;
+        bool completed = false;
+        int eventLoopResult = 1;
+        std::size_t listenSuccessCount = 0;
+        std::size_t connectSuccessCount = 0;
+        std::size_t connectionCallbackCount = 0;
+        std::size_t disconnectCallbackCount = 0;
+        std::size_t stdinLineCount = 0;
+        std::size_t stdinEofCount = 0;
+        std::size_t syncCompleteCount = 0;
+        std::size_t exitRequestCount = 0;
+        std::size_t appServerThreadListCount = 0;
+        std::size_t acquireResponseCount = 0;
+        std::size_t protocolErrorCount = 0;
+        std::size_t queuedCountAtEof = 0;
+        std::string explicitStartRequestId;
+        std::string resumeRequestId;
+        std::string explicitTurnRequestId;
+        std::string newStartRequestId;
+        std::string newTurnRequestId;
+        std::vector<std::string> acquireRequestIds;
+        std::vector<std::string> sentCommandIds;
+        std::vector<std::string> sentCommandMethods;
+        std::vector<std::size_t> sentCommandSyncCounts;
+        std::vector<std::string> responseIds;
+        std::vector<std::pair<std::string, Json>> appServerOperations;
+        std::optional<frontend::Response> explicitStartResponse;
+        std::optional<frontend::Response> resumeResponse;
+        std::optional<frontend::Response> explicitTurnResponse;
+        std::optional<frontend::Response> newStartResponse;
+        std::optional<frontend::Response> newTurnResponse;
+        std::vector<std::string> lifecycleFailures;
+        std::ostringstream humanOutput;
+        std::ostringstream diagnostics;
+
+        {
+            const auto transport = std::make_shared<tests::codex::FakeTransportState>();
+            tests::codex::installInitializingFake(transport, [&](const Json& message, const TransportCallbacks& callbacks) {
+                const auto method = message.find("method");
+                const auto id = message.find("id");
+                if (method == message.end() || !method->is_string() || id == message.end()) {
+                    return;
+                }
+
+                const std::string methodName = method->get<std::string>();
+                const Json params = message.value("params", Json::object());
+                if (methodName == "thread/list") {
+                    ++appServerThreadListCount;
+                    tests::codex::inject(callbacks,
+                                         Json{{"id", *id},
+                                              {"result",
+                                               {{"data", Json::array({tests::codex::threadValue(std::string(PersistedThreadId))})},
+                                                {"nextCursor", nullptr},
+                                                {"backwardsCursor", nullptr}}}});
+                    return;
+                }
+
+                appServerOperations.emplace_back(methodName, params);
+                if (methodName == "thread/start") {
+                    const std::string threadId = params.value("cwd", std::string{}) == "/tmp/acceptance-new"
+                                                     ? std::string(NewThreadId)
+                                                     : std::string(ExplicitThreadId);
+                    tests::codex::inject(callbacks, Json{{"id", *id}, {"result", tests::codex::threadOperationResult(threadId)}});
+                } else if (methodName == "thread/resume") {
+                    tests::codex::inject(
+                        callbacks, Json{{"id", *id}, {"result", tests::codex::threadOperationResult(std::string(PersistedThreadId))}});
+                } else if (methodName == "turn/start") {
+                    const std::string threadId = params.value("threadId", std::string{});
+                    const std::string turnId = threadId == NewThreadId ? "turn-new-acceptance" : "turn-resumed-acceptance";
+                    tests::codex::inject(callbacks, Json{{"id", *id}, {"result", tests::codex::turnOperationResult(threadId, turnId)}});
+                }
+            });
+
+            backend::BackendCoreOptions backendOptions;
+            backendOptions.initialThreadListLimit = 1;
+            FakeBackendCore backendCore(backendOptions, transport);
+
+            apps::codex_backend::SocketFrontendOptions frontendOptions;
+            using Server = net::un::stream::legacy::SocketServer<apps::codex_backend::CodexFrontendSocketContextFactory,
+                                                                 FakeBackendCore&,
+                                                                 apps::codex_backend::SocketFrontendOptions>;
+            Server server("codex-client-thread-workflow-server", backendCore, std::move(frontendOptions));
+            server.getConfig()->Instance::forceUnrequired();
+            backendCore.start();
+
+            Pipe inputPipe;
+            const std::string input = "acquire\n"
+                                      "start --cwd /tmp/acceptance-start --model start-model --model-provider start-provider "
+                                      "--approval-policy on-request --sandbox-mode workspace-write --ephemeral\n"
+                                      "acquire\n"
+                                      "resume thread-persisted-acceptance --cwd /tmp/acceptance-resume --model resume-model "
+                                      "--model-provider resume-provider --approval-policy never --sandbox-mode read-only\n"
+                                      "turn thread-persisted-acceptance Continue the previous task.\n"
+                                      "acquire\n"
+                                      "new --cwd /tmp/acceptance-new --model new-model --model-provider new-provider "
+                                      "--approval-policy on-request --sandbox-mode workspace-write --ephemeral -- "
+                                      "Review  the current implementation. --literal\n";
+            result.expectTrue(inputPipe.valid() && inputPipe.writeAll(input) && inputPipe.closeWriter(),
+                              "the deterministic thread-workflow pipe contains every command and closes before connection");
+
+            client::Presenter presenter(client::OutputMode::Human, humanOutput, diagnostics);
+            client::CommandParser parser("thread-workflow");
+            client::ClientConnection* connectionHandle = nullptr;
+            client::StdinReader* stdinReaderHandle = nullptr;
+            client::CommandDrainController* lifecycleHandle = nullptr;
+
+            client::CommandDrainController lifecycle(client::CommandDrainCallbacks{
+                .send =
+                    [&](const frontend::ClientMessage& message) {
+                        if (const auto* command = std::get_if<frontend::Command>(&message)) {
+                            sentCommandIds.push_back(command->requestId);
+                            sentCommandMethods.emplace_back(frontend::toString(frontend::commandMethod(command->parameters)));
+                            sentCommandSyncCounts.push_back(syncCompleteCount);
+                        }
+                        return connectionHandle != nullptr && connectionHandle->send(message);
+                    },
+                .requestExit =
+                    [&]() {
+                        ++exitRequestCount;
+                        exitWaitedForNewTurnResponse = newTurnResponse.has_value() && responseIds.size() == 8;
+                        if (stdinReaderHandle != nullptr) {
+                            stdinReaderHandle->stop();
+                        }
+                        if (!eventLoopRunning || exitScheduled) {
+                            return;
+                        }
+                        exitScheduled = true;
+                        core::EventReceiver::atNextTick([&]() {
+                            if (!eventLoopRunning) {
+                                return;
+                            }
+                            if (connectionHandle != nullptr && connectionHandle->connected()) {
+                                connectionHandle->disconnect();
+                            } else {
+                                core::SNodeC::stop();
+                            }
+                        });
+                    },
+                .reportFailure =
+                    [&](std::string message) {
+                        lifecycleFailures.push_back(message);
+                        presenter.error(std::move(message));
+                    }});
+            lifecycleHandle = &lifecycle;
+
+            client::ClientConnection connection(client::ClientConnectionCallbacks{
+                .onConnected =
+                    [&]() {
+                        ++connectionCallbackCount;
+                        lifecycle.connected();
+                        presenter.connected(path);
+                    },
+                .onMessage =
+                    [&](const frontend::ServerMessage& message) {
+                        const bool initialSync = std::holds_alternative<frontend::SyncComplete>(message) && syncCompleteCount == 0;
+                        const auto* response = std::get_if<frontend::Response>(&message);
+                        if (initialSync) {
+                            ++syncCompleteCount;
+                        } else if (response != nullptr) {
+                            responseIds.push_back(response->requestId);
+                            if (std::find(acquireRequestIds.begin(), acquireRequestIds.end(), response->requestId) !=
+                                acquireRequestIds.end()) {
+                                ++acquireResponseCount;
+                            } else if (response->requestId == explicitStartRequestId) {
+                                explicitStartResponse = *response;
+                            } else if (response->requestId == resumeRequestId) {
+                                resumeResponse = *response;
+                            } else if (response->requestId == explicitTurnRequestId) {
+                                explicitTurnResponse = *response;
+                            } else if (response->requestId == newStartRequestId) {
+                                newStartResponse = *response;
+                                newStartObservedDuringEofDrain =
+                                    lifecycle.inputState() == client::CommandDrainController::InputState::DrainOnEof &&
+                                    lifecycle.outcome() == client::CommandDrainController::Outcome::Running;
+                            } else if (response->requestId == newTurnRequestId) {
+                                newTurnResponse = *response;
+                            }
+                        } else if (std::holds_alternative<frontend::ProtocolErrorMessage>(message)) {
+                            ++protocolErrorCount;
+                        }
+
+                        const std::size_t sentBefore = sentCommandIds.size();
+                        const std::optional<client::ResponsePresentation> presentation = lifecycle.receive(message);
+                        if (presentation.has_value()) {
+                            presenter.present(message, *presentation);
+                        } else {
+                            presenter.present(message);
+                        }
+                        if (response != nullptr && response->requestId == newStartRequestId) {
+                            newTurnSentFromMatchingStart = sentCommandIds.size() == sentBefore + 1 &&
+                                                           sentCommandIds.back() == newTurnRequestId &&
+                                                           sentCommandMethods.back() == frontend::method::TurnStart;
+                        }
+                    },
+                .onProtocolError =
+                    [&](const frontend::CodecError& error) {
+                        ++protocolErrorCount;
+                        lifecycle.protocolFailed(std::string(frontend::toString(error.code)) + ": " + error.message);
+                    },
+                .onDisconnected =
+                    [&]() {
+                        ++disconnectCallbackCount;
+                        presenter.disconnected();
+                        lifecycle.disconnected();
+                        lifecycleClosedCleanly = lifecycle.sessionState() == client::CommandDrainController::SessionState::Closed &&
+                                                 lifecycle.outcome() == client::CommandDrainController::Outcome::Success &&
+                                                 lifecycle.queuedCount() == 0 && lifecycle.pendingResponseCount() == 0 &&
+                                                 lifecycle.pendingSyncCount() == 0;
+                        completed = true;
+                        if (eventLoopRunning) {
+                            core::SNodeC::stop();
+                        }
+                    }});
+            connectionHandle = &connection;
+
+            using Client = net::un::stream::legacy::SocketClient<client::CodexBackendClientSocketContextFactory, client::ClientConnection&>;
+            Client socketClient("codex-client-thread-workflow-client", connection);
+            socketClient.getConfig()->Instance::forceUnrequired();
+
+            std::unique_ptr<client::StdinReader> stdinReader;
+            const auto handleInput = [&](std::string line) {
+                ++stdinLineCount;
+                client::ParsedCommand parsed = parser.parse(line);
+                std::visit(
+                    [&]<typename Parsed>(Parsed&& command) {
+                        using T = std::remove_cvref_t<Parsed>;
+                        if constexpr (std::is_same_v<T, client::SendCommand>) {
+                            const auto* wireCommand = std::get_if<frontend::Command>(&command.message);
+                            if (wireCommand == nullptr) {
+                                result.expectTrue(false, "thread-workflow parser produces a typed frontend command");
+                                lifecycle.inputFailed("thread-workflow parser produced a non-command message");
+                                return;
+                            }
+                            if (std::holds_alternative<frontend::ControllerAcquire>(wireCommand->parameters)) {
+                                acquireRequestIds.push_back(wireCommand->requestId);
+                            } else if (std::holds_alternative<frontend::ThreadStart>(wireCommand->parameters)) {
+                                explicitStartRequestId = wireCommand->requestId;
+                            } else if (std::holds_alternative<frontend::ThreadResume>(wireCommand->parameters)) {
+                                resumeRequestId = wireCommand->requestId;
+                            } else if (std::holds_alternative<frontend::TurnStart>(wireCommand->parameters)) {
+                                explicitTurnRequestId = wireCommand->requestId;
+                            } else {
+                                result.expectTrue(false, "thread-workflow input contains only acquire, start, resume, turn, and new");
+                            }
+                            result.expectTrue(lifecycle.enqueue(std::move(command.message)),
+                                              "the lifecycle queues each ordinary thread-workflow command before connection");
+                        } else if constexpr (std::is_same_v<T, client::NewCommand>) {
+                            newStartRequestId = command.threadStartRequestId;
+                            newTurnRequestId = command.turnStartRequestId;
+                            result.expectTrue(lifecycle.enqueue(std::move(command)),
+                                              "the lifecycle queues the client-side new operation before connection");
+                        } else {
+                            result.expectTrue(false, "thread-workflow pipe parses without local or usage commands");
+                            lifecycle.inputFailed("thread-workflow pipe contained an unexpected parsed command");
+                        }
+                    },
+                    std::move(parsed));
+            };
+
+            const auto startInputWhenReady = [&]() {
+                const backend::Snapshot snapshot = backendCore.snapshot();
+                const bool persistedThreadHydrated = snapshot.threads.size() == 1 && snapshot.threads.front().id == PersistedThreadId;
+                if (!serverListening || stdinReader != nullptr || snapshot.lifecycle != backend::BackendLifecycle::Ready ||
+                    !persistedThreadHydrated) {
+                    return;
+                }
+                backendHydratedBeforeInput = sentCommandIds.empty();
+                try {
+                    stdinReader = std::make_unique<client::StdinReader>(
+                        handleInput,
+                        [&]() {
+                            ++stdinEofCount;
+                            queuedCountAtEof = lifecycle.queuedCount();
+                            inputClosedBeforeConnection = !connection.connected() && sentCommandIds.empty();
+                            lifecycle.inputEof();
+                            eofEnteredDrain = lifecycle.inputState() == client::CommandDrainController::InputState::DrainOnEof &&
+                                              lifecycle.outcome() == client::CommandDrainController::Outcome::Running;
+                            socketClient.connect(path, [&](const net::un::SocketAddress&, core::socket::State state) {
+                                if (state == core::socket::State::OK) {
+                                    ++connectSuccessCount;
+                                } else {
+                                    lifecycle.connectionFailed("thread-workflow production client failed to connect");
+                                }
+                            });
+                        },
+                        [&](std::string message) {
+                            lifecycle.inputFailed(std::move(message));
+                        },
+                        inputPipe.readFd);
+                    stdinReaderHandle = stdinReader.get();
+                } catch (const std::exception& exception) {
+                    lifecycle.inputFailed("failed to construct thread-workflow stdin reader: " + std::string(exception.what()));
+                }
+            };
+
+            backend::BackendObserverSubscription hydrationObserver =
+                backendCore.subscribe(backend::BackendObserverCallbacks{.onEvents =
+                                                                            [&](const std::vector<backend::SequencedBackendEvent>&) {
+                                                                                startInputWhenReady();
+                                                                            },
+                                                                        .onResynchronize =
+                                                                            [&](const backend::Snapshot&) {
+                                                                                startInputWhenReady();
+                                                                            }});
+            result.expectTrue(hydrationObserver.isOpen(), "the thread-workflow scenario observes deterministic backend hydration");
+
+            server.listen(path, [&](const net::un::SocketAddress&, core::socket::State state) {
+                if (state != core::socket::State::OK) {
+                    lifecycle.connectionFailed("thread-workflow real BackendAdapter Unix server failed to listen");
+                    return;
+                }
+                ++listenSuccessCount;
+                serverListening = true;
+                startInputWhenReady();
+            });
+
+            [[maybe_unused]] core::timer::Timer watchdog = core::timer::Timer::singleshotTimer(
+                [&]() {
+                    timedOut = true;
+                    core::SNodeC::stop();
+                },
+                utils::Timeval({10, 0}));
+            eventLoopRunning = true;
+            eventLoopResult = core::SNodeC::start(utils::Timeval({12, 0}));
+            eventLoopRunning = false;
+            if (stdinReader != nullptr) {
+                stdinReader->stop();
+            }
+            connection.disconnect();
+            backendCore.stop();
+        }
+
+        const std::vector<std::string> expectedCommandIds{acquireRequestIds.size() > 0 ? acquireRequestIds[0] : std::string{},
+                                                          explicitStartRequestId,
+                                                          acquireRequestIds.size() > 1 ? acquireRequestIds[1] : std::string{},
+                                                          resumeRequestId,
+                                                          explicitTurnRequestId,
+                                                          acquireRequestIds.size() > 2 ? acquireRequestIds[2] : std::string{},
+                                                          newStartRequestId,
+                                                          newTurnRequestId};
+        const std::vector<std::string> expectedCommandMethods{std::string(frontend::method::ControllerAcquire),
+                                                              std::string(frontend::method::ThreadStart),
+                                                              std::string(frontend::method::ControllerAcquire),
+                                                              std::string(frontend::method::ThreadResume),
+                                                              std::string(frontend::method::TurnStart),
+                                                              std::string(frontend::method::ControllerAcquire),
+                                                              std::string(frontend::method::ThreadStart),
+                                                              std::string(frontend::method::TurnStart)};
+        const std::vector<std::pair<std::string, Json>> expectedAppServerOperations{
+            {"thread/start",
+             Json{{"cwd", "/tmp/acceptance-start"},
+                  {"model", "start-model"},
+                  {"modelProvider", "start-provider"},
+                  {"approvalPolicy", "on-request"},
+                  {"sandbox", "workspace-write"},
+                  {"ephemeral", true}}},
+            {"thread/resume",
+             Json{{"threadId", PersistedThreadId},
+                  {"cwd", "/tmp/acceptance-resume"},
+                  {"model", "resume-model"},
+                  {"modelProvider", "resume-provider"},
+                  {"approvalPolicy", "never"},
+                  {"sandbox", "read-only"}}},
+            {"turn/start",
+             Json{{"threadId", PersistedThreadId},
+                  {"input", Json::array({Json{{"type", "text"}, {"text", ExplicitPrompt}, {"text_elements", Json::array()}}})}}},
+            {"thread/start",
+             Json{{"cwd", "/tmp/acceptance-new"},
+                  {"model", "new-model"},
+                  {"modelProvider", "new-provider"},
+                  {"approvalPolicy", "on-request"},
+                  {"sandbox", "workspace-write"},
+                  {"ephemeral", true}}},
+            {"turn/start",
+             Json{{"threadId", NewThreadId},
+                  {"input", Json::array({Json{{"type", "text"}, {"text", NewPrompt}, {"text_elements", Json::array()}}})}}}};
+
+        const auto responseHasThread = [](const std::optional<frontend::Response>& response, std::string_view threadId) {
+            if (!response.has_value() || !response->ok || !response->result.has_value()) {
+                return false;
+            }
+            const auto thread = response->result->find("thread");
+            return thread != response->result->end() && thread->is_object() && thread->value("id", std::string{}) == threadId;
+        };
+        const auto responseHasTurn = [](const std::optional<frontend::Response>& response, std::string_view threadId) {
+            if (!response.has_value() || !response->ok || !response->result.has_value()) {
+                return false;
+            }
+            const auto turn = response->result->find("turn");
+            return turn != response->result->end() && turn->is_object() && turn->value("threadId", std::string{}) == threadId;
+        };
+
+        std::vector<std::string> uniqueRequestIds = sentCommandIds;
+        std::sort(uniqueRequestIds.begin(), uniqueRequestIds.end());
+        const bool requestIdsAreUnique = std::adjacent_find(uniqueRequestIds.begin(), uniqueRequestIds.end()) == uniqueRequestIds.end();
+        result.expectTrue(!timedOut && completed, "the EOF-driven thread-workflow acceptance completes before its watchdog");
+        result.expectEqual(0, eventLoopResult, "the EOF-driven thread-workflow event loop stops cleanly");
+        result.expectEqual(1, static_cast<int>(listenSuccessCount), "the thread-workflow real frontend server listens exactly once");
+        result.expectEqual(1, static_cast<int>(connectSuccessCount), "the thread-workflow production client connects exactly once");
+        result.expectEqual(
+            1, static_cast<int>(connectionCallbackCount), "the thread-workflow production connection callback runs exactly once");
+        result.expectTrue(backendHydratedBeforeInput && appServerThreadListCount == 1,
+                          "the persisted thread is list-hydrated before the workflow pipe is consumed");
+        result.expectTrue(stdinLineCount == 7 && stdinEofCount == 1 && queuedCountAtEof == 7 && inputClosedBeforeConnection &&
+                              eofEnteredDrain,
+                          "all seven commands and EOF are queued deterministically before the Unix connection");
+        result.expectTrue(sentCommandIds == expectedCommandIds && sentCommandMethods == expectedCommandMethods,
+                          "acquire/start, acquire/resume/turn, and acquire/new cross the frontend in exact request order");
+        result.expectTrue(requestIdsAreUnique && newStartRequestId != newTurnRequestId,
+                          "every workflow request ID is unique and new allocates distinct IDs for its two stages");
+        result.expectTrue(sentCommandSyncCounts == std::vector<std::size_t>(8, 1),
+                          "every workflow command, including new's turn, is sent only after initial synchronization");
+        result.expectTrue(appServerOperations == expectedAppServerOperations,
+                          "the real BackendAdapter maps every start/resume option and both exact TextInput prompts in order");
+        result.expectTrue(newStartObservedDuringEofDrain && newTurnSentFromMatchingStart && exitWaitedForNewTurnResponse,
+                          "EOF remains draining while new waits for its matching start response and subsequent turn response");
+        result.expectTrue(responseHasThread(explicitStartResponse, ExplicitThreadId) &&
+                              responseHasThread(resumeResponse, PersistedThreadId) &&
+                              responseHasTurn(explicitTurnResponse, PersistedThreadId) &&
+                              responseHasThread(newStartResponse, NewThreadId) && responseHasTurn(newTurnResponse, NewThreadId),
+                          "real BackendAdapter responses preserve explicit, resumed, and generated thread IDs through both workflows");
+        result.expectTrue(acquireRequestIds.size() == 3 && acquireResponseCount == 3 && responseIds.size() == 8,
+                          "controller ownership is explicitly acquired for each workflow and all real responses are correlated");
+        result.expectEqual(0, static_cast<int>(protocolErrorCount), "the thread-workflow scenario reports no frontend protocol error");
+        result.expectEqual(1, static_cast<int>(exitRequestCount), "EOF completion requests exactly one controlled exit");
+        result.expectEqual(1, static_cast<int>(disconnectCallbackCount), "the thread-workflow client disconnects exactly once");
+        result.expectTrue(lifecycleFailures.empty() && lifecycleClosedCleanly,
+                          "the compound new workflow closes with no queued or pending lifecycle work");
+        result.expectTrue(std::none_of(sentCommandMethods.begin(),
+                                       sentCommandMethods.end(),
+                                       [](const std::string& method) {
+                                           return method.find("new") != std::string::npos;
+                                       }) &&
+                              std::none_of(appServerOperations.begin(),
+                                           appServerOperations.end(),
+                                           [](const auto& operation) {
+                                               return operation.first.find("new") != std::string::npos;
+                                           }),
+                          "new emits only real thread.start and turn.start operations with no synthetic protocol method");
+        result.expectTrue(contains(humanOutput.str(), "thread started id=" + std::string(ExplicitThreadId)) &&
+                              contains(humanOutput.str(), "thread resumed id=" + std::string(PersistedThreadId)) &&
+                              contains(humanOutput.str(), "thread created id=" + std::string(NewThreadId)) &&
+                              contains(humanOutput.str(), "initial turn submitted thread=" + std::string(NewThreadId)) &&
+                              diagnostics.str().empty(),
+                          "the production presenter emits bounded lifecycle summaries without diagnostics on the successful workflow");
+        result.expectTrue(!pathExists(path), "the thread-workflow Unix server removes its owned socket path");
+
+        core::SNodeC::free();
+        std::remove(path.c_str());
+    }
+
 } // namespace
 
 int main(int argc, char* argv[]) {
+    if (const char* scenario = std::getenv("SNODEC_CODEX_CLIENT_ACCEPTANCE_SCENARIO");
+        scenario != nullptr && std::string_view(scenario) == "thread-workflow") {
+        tests::support::TestResult workflowResult;
+        runThreadWorkflowAcceptance(workflowResult, argc, argv);
+        return workflowResult.processResult();
+    }
+
     tests::support::TestResult result;
     int returnCode = tests::support::cTestSkipReturnCode;
     const std::string path = socketPath();
@@ -744,6 +1238,24 @@ int main(int argc, char* argv[]) {
         result.expectTrue(pathCleanedByServer, "real frontend Unix server removes its owned socket path");
 
         core::SNodeC::free();
+        const pid_t workflowProcess = ::fork();
+        if (workflowProcess == 0) {
+            if (::setenv("SNODEC_CODEX_CLIENT_ACCEPTANCE_SCENARIO", "thread-workflow", 1) != 0) {
+                _exit(126);
+            }
+            ::execvp(argv[0], argv);
+            _exit(127);
+        }
+
+        int workflowStatus = 0;
+        pid_t waited = -1;
+        if (workflowProcess > 0) {
+            do {
+                waited = ::waitpid(workflowProcess, &workflowStatus, 0);
+            } while (waited < 0 && errno == EINTR);
+        }
+        result.expectTrue(workflowProcess > 0 && waited == workflowProcess && WIFEXITED(workflowStatus) && WEXITSTATUS(workflowStatus) == 0,
+                          "the isolated EOF-driven thread-workflow acceptance subprocess passes");
         returnCode = result.processResult();
     }
 

--- a/tests/component/codex/CodexBackendReducerTest.cpp
+++ b/tests/component/codex/CodexBackendReducerTest.cpp
@@ -42,6 +42,15 @@ namespace {
         return item;
     }
 
+    typed::UserMessageItem
+    userMessageItem(const std::string& threadId, const std::string& turnId, const std::string& itemId, Json content, Json raw) {
+        typed::UserMessageItem item;
+        item.metadata = metadata(threadId, turnId, itemId);
+        item.metadata.raw = std::move(raw);
+        item.content = std::move(content);
+        return item;
+    }
+
     typed::Item reasoningItem(const std::string& threadId,
                               const std::string& turnId,
                               const std::string& itemId,
@@ -360,6 +369,165 @@ namespace {
                           "file-change updates remain associated with the correct item");
     }
 
+    void testUserMessageLifecycle(tests::support::TestResult& result) {
+        backend::BackendState state;
+        backend::Reducer reducer;
+
+        const Json startedContent = Json::array({Json{{"type", "text"}, {"text", "Answer just with OK!"}}});
+        const Json startedRaw = {
+            {"type", "userMessage"}, {"id", "user-item"}, {"clientId", nullptr}, {"content", startedContent}, {"future", 1}};
+        const typed::UserMessageItem startedItem = userMessageItem("thread-user", "turn-user", "user-item", startedContent, startedRaw);
+        const Json startedEnvelope =
+            Json{{"method", "item/started"},
+                 {"params", {{"threadId", "thread-user"}, {"turnId", "turn-user"}, {"item", startedRaw}, {"startedAtMs", 101}}}};
+        const std::vector<backend::BackendEvent> startedEvents =
+            reducer.translate(typed::Event{typed::ItemStarted{typed::Item{startedItem}, 101, startedEnvelope}});
+        const auto* startedUpsert = startedEvents.size() == 1 ? std::get_if<backend::ItemUpserted>(&startedEvents.front()) : nullptr;
+        result.expectTrue(startedUpsert && startedUpsert->threadId.value == "thread-user" && startedUpsert->turnId.value == "turn-user" &&
+                              startedUpsert->lifecycle == backend::ItemLifecycle::Started && startedUpsert->occurredAtMs == 101,
+                          "userMessage start translates to a canonical item upsert at its envelope location");
+        if (startedUpsert) {
+            reducer.apply(state, *startedUpsert);
+        }
+
+        const backend::ItemState* startedState = findItem(state, "thread-user", "turn-user", "user-item");
+        const auto* canonicalStarted = startedState ? std::get_if<typed::UserMessageItem>(&startedState->item) : nullptr;
+        result.expectTrue(canonicalStarted && canonicalStarted->content == startedContent && !canonicalStarted->clientId &&
+                              canonicalStarted->metadata.raw == startedRaw && startedState->lifecycle == backend::ItemLifecycle::Started &&
+                              startedState->startedAtMs == 101 && !startedState->completedAtMs && state.recentExtensions.empty(),
+                          "userMessage start retains complete content, nullable client ID, raw item, timestamp, and no extension fallback");
+
+        const Json completedContent = Json::array({Json{{"type", "text"}, {"text", "Answer just with OK!"}},
+                                                   Json{{"type", "futureContent"}, {"payload", Json::array({1, 2, 3})}}});
+        const Json completedRaw = {
+            {"type", "userMessage"}, {"id", "user-item"}, {"clientId", nullptr}, {"content", completedContent}, {"future", 2}};
+        const typed::UserMessageItem completedItem =
+            userMessageItem("thread-user", "turn-user", "user-item", completedContent, completedRaw);
+        const Json completedEnvelope =
+            Json{{"method", "item/completed"},
+                 {"params", {{"threadId", "thread-user"}, {"turnId", "turn-user"}, {"item", completedRaw}, {"completedAtMs", 202}}}};
+        const std::vector<backend::BackendEvent> completedEvents =
+            reducer.translate(typed::Event{typed::ItemCompleted{typed::Item{completedItem}, 202, completedEnvelope}});
+        const auto* completedUpsert = completedEvents.size() == 1 ? std::get_if<backend::ItemUpserted>(&completedEvents.front()) : nullptr;
+        result.expectTrue(completedUpsert && completedUpsert->threadId.value == "thread-user" &&
+                              completedUpsert->turnId.value == "turn-user" &&
+                              completedUpsert->lifecycle == backend::ItemLifecycle::Completed && completedUpsert->occurredAtMs == 202,
+                          "userMessage completion translates to a canonical terminal item upsert");
+        if (completedUpsert) {
+            reducer.apply(state, *completedUpsert);
+        }
+
+        const backend::TurnState* userTurn = findTurn(state, "thread-user", "turn-user");
+        const backend::ItemState* completedState = findItem(state, "thread-user", "turn-user", "user-item");
+        const auto* canonicalCompleted = completedState ? std::get_if<typed::UserMessageItem>(&completedState->item) : nullptr;
+        result.expectTrue(
+            userTurn && userTurn->items.size() == 1 && userTurn->itemOrder.size() == 1 &&
+                userTurn->itemOrder.front().value == "user-item" && canonicalCompleted && canonicalCompleted->content == completedContent &&
+                canonicalCompleted->metadata.raw == completedRaw && completedState->lifecycle == backend::ItemLifecycle::Completed &&
+                completedState->startedAtMs == 101 && completedState->completedAtMs == 202 && state.recentExtensions.empty(),
+            "userMessage completion updates the same canonical item and retains both lifecycle timestamps without extensions");
+
+        const backend::Snapshot itemSnapshot = backend::makeSnapshot(state);
+        result.expectTrue(itemSnapshot.threads.size() == 1 && itemSnapshot.threads[0].turns.size() == 1 &&
+                              itemSnapshot.threads[0].turns[0].items.size() == 1 &&
+                              itemSnapshot.threads[0].turns[0].items[0].type == "user_message" &&
+                              itemSnapshot.threads[0].turns[0].items[0].data.at("content") == completedContent &&
+                              itemSnapshot.threads[0].turns[0].items[0].data.at("clientId").is_null(),
+                          "userMessage canonical snapshots retain structured content instead of flattening it");
+
+        typed::Turn terminalTurn =
+            turn("thread-user", "turn-user", typed::TurnStatus::completed(), std::vector<typed::Item>{typed::Item{completedItem}});
+        reducer.apply(state, backend::TurnCompleted{std::move(terminalTurn)});
+        completedState = findItem(state, "thread-user", "turn-user", "user-item");
+        result.expectTrue(completedState && completedState->lifecycle == backend::ItemLifecycle::Completed &&
+                              completedState->startedAtMs == 101 && completedState->completedAtMs == 202,
+                          "a later terminal turn snapshot does not erase item lifecycle timestamps");
+    }
+
+    void testUnknownItemCommonMetadataFallbacks(tests::support::TestResult& result) {
+        backend::Reducer reducer;
+        backend::BackendState state;
+
+        typed::UnknownItem located;
+        located.type = "futureItem";
+        located.raw = Json{{"type", "futureItem"}, {"id", "unknown-located"}, {"future", Json::array({1, 2, 3})}};
+        located.decodingError = "future detailed field is unsupported";
+        located.metadata.id = typed::ItemId{"unknown-located"};
+        located.metadata.threadId = typed::ThreadId{"thread-unknown"};
+        located.metadata.turnId = typed::TurnId{"turn-unknown"};
+        const Json locatedEnvelope =
+            Json{{"method", "item/started"},
+                 {"params", {{"threadId", "thread-unknown"}, {"turnId", "turn-unknown"}, {"item", located.raw}, {"startedAtMs", 303}}}};
+        const std::vector<backend::BackendEvent> locatedEvents =
+            reducer.translate(typed::Event{typed::ItemStarted{typed::Item{located}, 303, locatedEnvelope}});
+        const auto* locatedUpsert = locatedEvents.size() == 1 ? std::get_if<backend::ItemUpserted>(&locatedEvents.front()) : nullptr;
+        result.expectTrue(locatedUpsert && locatedUpsert->threadId.value == "thread-unknown" &&
+                              locatedUpsert->turnId.value == "turn-unknown",
+                          "an unknown item with valid common metadata translates canonically instead of reporting a false location error");
+        if (locatedUpsert) {
+            reducer.apply(state, *locatedUpsert);
+        }
+        const backend::ItemState* locatedState = findItem(state, "thread-unknown", "turn-unknown", "unknown-located");
+        const auto* canonicalUnknown = locatedState ? std::get_if<typed::UnknownItem>(&locatedState->item) : nullptr;
+        result.expectTrue(canonicalUnknown && canonicalUnknown->metadata.id && canonicalUnknown->metadata.id->value == "unknown-located" &&
+                              canonicalUnknown->metadata.threadId && canonicalUnknown->metadata.threadId->value == "thread-unknown" &&
+                              canonicalUnknown->metadata.turnId && canonicalUnknown->metadata.turnId->value == "turn-unknown" &&
+                              canonicalUnknown->raw == located.raw && canonicalUnknown->decodingError == located.decodingError &&
+                              state.recentExtensions.empty(),
+                          "canonical unknown items retain their ID, envelope location, raw JSON, and decoding error");
+
+        backend::ReducerOptions boundedOptions;
+        boundedOptions.retainedExtensions = 1;
+        boundedOptions.maxExtensionBytes = 64;
+        backend::Reducer boundedReducer(boundedOptions);
+        backend::BackendState noIdState;
+        typed::UnknownItem noId;
+        noId.type = "futureWithoutId";
+        noId.raw = Json{{"type", "futureWithoutId"}, {"payload", std::string(256, 'x')}};
+        noId.metadata.threadId = typed::ThreadId{"thread-no-id"};
+        noId.metadata.turnId = typed::TurnId{"turn-no-id"};
+        const Json noIdEnvelope =
+            Json{{"method", "item/started"},
+                 {"params", {{"threadId", "thread-no-id"}, {"turnId", "turn-no-id"}, {"item", noId.raw}, {"startedAtMs", 404}}}};
+        const std::vector<backend::BackendEvent> noIdEvents =
+            boundedReducer.translate(typed::Event{typed::ItemStarted{typed::Item{noId}, 404, noIdEnvelope}});
+        const auto* noIdUpsert = noIdEvents.size() == 1 ? std::get_if<backend::ItemUpserted>(&noIdEvents.front()) : nullptr;
+        result.expectTrue(noIdUpsert && noIdUpsert->threadId.value == "thread-no-id" && noIdUpsert->turnId.value == "turn-no-id",
+                          "an unknown item with a valid location but no stable ID reaches canonical ID validation");
+        if (noIdUpsert) {
+            boundedReducer.apply(noIdState, *noIdUpsert);
+        }
+        const backend::ExtensionRecord* noIdExtension =
+            noIdState.recentExtensions.size() == 1 ? &noIdState.recentExtensions.front() : nullptr;
+        result.expectTrue(noIdState.threads.empty() && noIdExtension && noIdExtension->method == "codex/item-without-id" &&
+                              noIdExtension->decodingError == "typed item has no stable id" &&
+                              noIdExtension->originalPayloadBytes.has_value() && noIdExtension->payload.value("truncated", false) &&
+                              noIdExtension->payload.value("omitted", false),
+                          "a truly ID-less item uses the bounded item-without-id extension fallback");
+
+        backend::BackendState missingLocationState;
+        typed::UnknownItem missingLocation;
+        missingLocation.type = "futureMissingLocation";
+        missingLocation.raw = Json{{"type", "futureMissingLocation"}, {"id", "unknown-missing-location"}};
+        missingLocation.metadata.id = typed::ItemId{"unknown-missing-location"};
+        missingLocation.metadata.threadId = typed::ThreadId{"thread-missing-location"};
+        const Json missingLocationEnvelope =
+            Json{{"method", "item/started"}, {"params", {{"threadId", "thread-missing-location"}, {"item", missingLocation.raw}}}};
+        const std::vector<backend::BackendEvent> missingLocationEvents =
+            reducer.translate(typed::Event{typed::ItemStarted{typed::Item{missingLocation}, 505, missingLocationEnvelope}});
+        const auto* locationExtension =
+            missingLocationEvents.size() == 1 ? std::get_if<backend::CodexExtensionReceived>(&missingLocationEvents.front()) : nullptr;
+        result.expectTrue(locationExtension && locationExtension->method == "item/started" &&
+                              locationExtension->payload == missingLocationEnvelope &&
+                              locationExtension->decodingError == "item event omitted threadId or turnId",
+                          "an item genuinely missing part of its envelope location retains the lifecycle extension fallback");
+        if (locationExtension) {
+            reducer.apply(missingLocationState, *locationExtension);
+        }
+        result.expectTrue(missingLocationState.threads.empty() && missingLocationState.recentExtensions.size() == 1,
+                          "an unusable item location is not inserted into canonical thread state");
+    }
+
     void testUnknownPreservationAndTranslation(tests::support::TestResult& result) {
         backend::ReducerOptions options;
         options.retainedExtensions = 2;
@@ -593,6 +761,8 @@ int main() {
     testThreadAndTurnHydration(result);
     testItemsAndHighVolumeDeltas(result);
     testCompletionFailureAndAuxiliaryUpdates(result);
+    testUserMessageLifecycle(result);
+    testUnknownItemCommonMetadataFallbacks(result);
     testUnknownPreservationAndTranslation(result);
     testPendingRequestsAndSessions(result);
     testSnapshotDeterminism(result);

--- a/tests/component/codex/CodexBackendReducerTest.cpp
+++ b/tests/component/codex/CodexBackendReducerTest.cpp
@@ -42,11 +42,16 @@ namespace {
         return item;
     }
 
-    typed::UserMessageItem
-    userMessageItem(const std::string& threadId, const std::string& turnId, const std::string& itemId, Json content, Json raw) {
+    typed::UserMessageItem userMessageItem(const std::string& threadId,
+                                           const std::string& turnId,
+                                           const std::string& itemId,
+                                           Json content,
+                                           Json raw,
+                                           std::optional<std::string> clientId = std::nullopt) {
         typed::UserMessageItem item;
         item.metadata = metadata(threadId, turnId, itemId);
         item.metadata.raw = std::move(raw);
+        item.clientId = std::move(clientId);
         item.content = std::move(content);
         return item;
     }
@@ -428,12 +433,17 @@ namespace {
             "userMessage completion updates the same canonical item and retains both lifecycle timestamps without extensions");
 
         const backend::Snapshot itemSnapshot = backend::makeSnapshot(state);
+        const Json& userMessageData = itemSnapshot.threads[0].turns[0].items[0].data;
         result.expectTrue(itemSnapshot.threads.size() == 1 && itemSnapshot.threads[0].turns.size() == 1 &&
                               itemSnapshot.threads[0].turns[0].items.size() == 1 &&
                               itemSnapshot.threads[0].turns[0].items[0].type == "user_message" &&
-                              itemSnapshot.threads[0].turns[0].items[0].data.at("content") == completedContent &&
-                              itemSnapshot.threads[0].turns[0].items[0].data.at("clientId").is_null(),
-                          "userMessage canonical snapshots retain structured content instead of flattening it");
+                              userMessageData.at("content").is_array() && userMessageData.at("content") == completedContent &&
+                              userMessageData.at("clientId").is_null() && !userMessageData.at("contentTruncated").get<bool>() &&
+                              userMessageData.at("originalContentBytes") == completedContent.dump().size() &&
+                              userMessageData.at("retainedContentBytes") == completedContent.dump().size() &&
+                              userMessageData.at("originalContentItems") == completedContent.size() &&
+                              userMessageData.at("retainedContentItems") == completedContent.size(),
+                          "small userMessage snapshots preserve array content and report equal original and retained bounds");
 
         typed::Turn terminalTurn =
             turn("thread-user", "turn-user", typed::TurnStatus::completed(), std::vector<typed::Item>{typed::Item{completedItem}});
@@ -442,6 +452,90 @@ namespace {
         result.expectTrue(completedState && completedState->lifecycle == backend::ItemLifecycle::Completed &&
                               completedState->startedAtMs == 101 && completedState->completedAtMs == 202,
                           "a later terminal turn snapshot does not erase item lifecycle timestamps");
+    }
+
+    void testUserMessageSnapshotBounding(tests::support::TestResult& result) {
+        backend::Reducer reducer;
+
+        backend::BackendState smallState;
+        const Json smallContent =
+            Json::array({Json{{"type", "text"}, {"text", "small"}}, Json{{"type", "future"}, {"nested", Json{{"kept", true}}}}});
+        typed::UserMessageItem smallItem =
+            userMessageItem("thread-small", "turn-small", "item-small", smallContent, Json{{"id", "item-small"}}, "client-small");
+        reducer.apply(smallState,
+                      backend::ItemUpserted{typed::ThreadId{"thread-small"},
+                                            typed::TurnId{"turn-small"},
+                                            typed::Item{smallItem},
+                                            backend::ItemLifecycle::Completed,
+                                            10});
+        const backend::Snapshot smallStateSnapshot = backend::makeSnapshot(smallState);
+        const backend::ItemSnapshot& smallSnapshot = smallStateSnapshot.threads[0].turns[0].items[0];
+        const Json& smallData = smallSnapshot.data;
+        result.expectTrue(
+            smallData.at("clientId") == "client-small" && smallData.at("content").is_array() && smallData.at("content") == smallContent &&
+                !smallData.at("contentTruncated").get<bool>() && smallData.at("originalContentBytes") == smallContent.dump().size() &&
+                smallData.at("retainedContentBytes") == smallContent.dump().size() &&
+                smallData.at("originalContentItems") == smallContent.size() && smallData.at("retainedContentItems") == smallContent.size(),
+            "small userMessage content and a non-null clientId remain lossless with complete bound metadata");
+
+        backend::BackendState largeState;
+        Json largeContent = Json::array();
+        largeContent.push_back(Json{{"type", "futureNested"}, {"payload", Json{{"unknown", Json::array({1, Json{{"deep", true}}})}}}});
+        for (std::size_t index = 0; index < 8; ++index) {
+            largeContent.push_back(Json{{"type", "futureChunk"},
+                                        {"index", index},
+                                        {"payload", std::string(12U * 1024U, static_cast<char>('a' + index))},
+                                        {"opaque", Json{{"index", index}, {"enabled", index % 2 == 0}}}});
+        }
+        typed::UserMessageItem largeItem =
+            userMessageItem("thread-large", "turn-large", "item-large", largeContent, Json{{"id", "item-large"}}, "client-large");
+        reducer.apply(largeState,
+                      backend::ItemUpserted{typed::ThreadId{"thread-large"},
+                                            typed::TurnId{"turn-large"},
+                                            typed::Item{largeItem},
+                                            backend::ItemLifecycle::Completed,
+                                            20});
+        const backend::Snapshot largeStateSnapshot = backend::makeSnapshot(largeState);
+        const backend::ItemSnapshot& largeSnapshot = largeStateSnapshot.threads[0].turns[0].items[0];
+        const Json& largeData = largeSnapshot.data;
+        const Json& retainedContent = largeData.at("content");
+        const std::size_t retainedItems = retainedContent.size();
+        bool retainedPrefixUnchanged = retainedItems > 0 && retainedItems < largeContent.size();
+        for (std::size_t index = 0; index < retainedItems; ++index) {
+            retainedPrefixUnchanged = retainedPrefixUnchanged && retainedContent[index] == largeContent[index] &&
+                                      retainedContent[index].dump() == largeContent[index].dump();
+        }
+        const backend::ItemState* canonicalLarge = findItem(largeState, "thread-large", "turn-large", "item-large");
+        const auto* canonicalLargeUser = canonicalLarge ? std::get_if<typed::UserMessageItem>(&canonicalLarge->item) : nullptr;
+        result.expectTrue(
+            largeContent.dump().size() > backend::MaxSerializedUserMessageDataBytes && retainedContent.is_array() &&
+                largeData.at("contentTruncated").get<bool>() && retainedPrefixUnchanged &&
+                largeData.at("originalContentItems") == largeContent.size() && largeData.at("retainedContentItems") == retainedItems &&
+                largeData.at("originalContentBytes") == largeContent.dump().size() &&
+                largeData.at("retainedContentBytes") == retainedContent.dump().size() &&
+                largeData.dump().size() <= backend::MaxSerializedUserMessageDataBytes && canonicalLargeUser &&
+                canonicalLargeUser->content == largeContent && !largeSnapshot.contentTruncated && largeSnapshot.droppedContentBytes == 0,
+            "large userMessage snapshots retain an unchanged ordered prefix of complete opaque entries within 64 KiB");
+
+        backend::BackendState oversizedFirstState;
+        const Json oversizedFirstContent = Json::array({Json{{"type", "futureHuge"}, {"payload", std::string(70U * 1024U, 'z')}}});
+        typed::UserMessageItem oversizedFirstItem =
+            userMessageItem("thread-first", "turn-first", "item-first", oversizedFirstContent, Json{{"id", "item-first"}});
+        reducer.apply(oversizedFirstState,
+                      backend::ItemUpserted{typed::ThreadId{"thread-first"},
+                                            typed::TurnId{"turn-first"},
+                                            typed::Item{oversizedFirstItem},
+                                            backend::ItemLifecycle::Completed,
+                                            30});
+        const backend::Snapshot oversizedFirstSnapshot = backend::makeSnapshot(oversizedFirstState);
+        const Json& oversizedFirstData = oversizedFirstSnapshot.threads[0].turns[0].items[0].data;
+        result.expectTrue(oversizedFirstData.at("content").is_array() && oversizedFirstData.at("content").empty() &&
+                              oversizedFirstData.at("contentTruncated").get<bool>() && oversizedFirstData.at("originalContentItems") == 1 &&
+                              oversizedFirstData.at("retainedContentItems") == 0 &&
+                              oversizedFirstData.at("originalContentBytes") == oversizedFirstContent.dump().size() &&
+                              oversizedFirstData.at("retainedContentBytes") == Json::array().dump().size() &&
+                              oversizedFirstData.dump().size() <= backend::MaxSerializedUserMessageDataBytes,
+                          "an oversized first userMessage entry yields an empty array without exposing partial JSON or text");
     }
 
     void testUnknownItemCommonMetadataFallbacks(tests::support::TestResult& result) {
@@ -762,6 +856,7 @@ int main() {
     testItemsAndHighVolumeDeltas(result);
     testCompletionFailureAndAuxiliaryUpdates(result);
     testUserMessageLifecycle(result);
+    testUserMessageSnapshotBounding(result);
     testUnknownItemCommonMetadataFallbacks(result);
     testUnknownPreservationAndTranslation(result);
     testPendingRequestsAndSessions(result);

--- a/tests/component/codex/CodexFrontendAdapterTest.cpp
+++ b/tests/component/codex/CodexFrontendAdapterTest.cpp
@@ -632,6 +632,32 @@ namespace {
                 {{"method", "item/completed"},
                  {"params",
                   {{"threadId", threadId}, {"turnId", turnId}, {"item", agentItemValue(itemId, expectedText)}, {"completedAtMs", 20}}}});
+            transport->inject(
+                {{"method", "item/started"},
+                 {"params",
+                  {{"threadId", threadId},
+                   {"turnId", turnId},
+                   {"item", {{"id", userMessageItemId}, {"type", "userMessage"}, {"clientId", nullptr}, {"content", userMessageContent}}},
+                   {"startedAtMs", userMessageStartedAtMs}}}});
+            transport->inject(
+                {{"method", "item/completed"},
+                 {"params",
+                  {{"threadId", threadId},
+                   {"turnId", turnId},
+                   {"item", {{"id", userMessageItemId}, {"type", "userMessage"}, {"clientId", nullptr}, {"content", userMessageContent}}},
+                   {"completedAtMs", userMessageCompletedAtMs}}}});
+            transport->inject({{"method", "item/started"},
+                               {"params",
+                                {{"threadId", threadId},
+                                 {"turnId", turnId},
+                                 {"item", {{"id", unknownItemId}, {"type", unknownItemType}, {"futureField", Json{{"value", 7}}}}},
+                                 {"startedAtMs", unknownItemStartedAtMs}}}});
+            transport->inject({{"method", "item/completed"},
+                               {"params",
+                                {{"threadId", threadId},
+                                 {"turnId", turnId},
+                                 {"item", {{"id", unknownItemId}, {"type", unknownItemType}, {"futureField", Json{{"value", 7}}}}},
+                                 {"completedAtMs", unknownItemCompletedAtMs}}}});
             transport->inject({{"method", "turn/completed"},
                                {"params", {{"threadId", threadId}, {"turn", tests::codex::turnValue(threadId, turnId, "completed")}}}});
 
@@ -639,7 +665,15 @@ namespace {
                 "1,000 typed deltas reach exact terminal frontend state",
                 [this]() {
                     return terminalBackendText() == expectedText && latestFrontendText(observerA) == expectedText &&
-                           latestFrontendText(observerB) == expectedText;
+                           latestFrontendText(observerB) == expectedText &&
+                           hasCompletedItemUpdate(
+                               observerA, userMessageItemId, "user_message", userMessageStartedAtMs, userMessageCompletedAtMs) &&
+                           hasCompletedItemUpdate(
+                               observerA, unknownItemId, unknownItemType, unknownItemStartedAtMs, unknownItemCompletedAtMs) &&
+                           hasCompletedItemUpdate(
+                               observerB, userMessageItemId, "user_message", userMessageStartedAtMs, userMessageCompletedAtMs) &&
+                           hasCompletedItemUpdate(
+                               observerB, unknownItemId, unknownItemType, unknownItemStartedAtMs, unknownItemCompletedAtMs);
                 },
                 [this]() {
                     verifyBurst();
@@ -766,6 +800,32 @@ namespace {
             return latest;
         }
 
+        bool isCompletedItemUpdate(const frontend::FrontendEvent& event,
+                                   const std::string& expectedItemId,
+                                   const std::string& expectedType,
+                                   std::int64_t expectedStartedAtMs,
+                                   std::int64_t expectedCompletedAtMs) const {
+            if (event.type != "item.updated" || event.data.value("threadId", "") != threadId || event.data.value("turnId", "") != turnId) {
+                return false;
+            }
+            const auto item = event.data.find("item");
+            return item != event.data.end() && item->is_object() && item->value("id", "") == expectedItemId &&
+                   item->value("type", "") == expectedType && item->value("status", "") == "completed" &&
+                   item->value("startedAtMs", std::int64_t{-1}) == expectedStartedAtMs &&
+                   item->value("completedAtMs", std::int64_t{-1}) == expectedCompletedAtMs;
+        }
+
+        bool hasCompletedItemUpdate(const Observations& observations,
+                                    const std::string& expectedItemId,
+                                    const std::string& expectedType,
+                                    std::int64_t expectedStartedAtMs,
+                                    std::int64_t expectedCompletedAtMs) const {
+            const std::vector<frontend::FrontendEvent> received = events(observations);
+            return std::any_of(received.begin(), received.end(), [&](const frontend::FrontendEvent& event) {
+                return isCompletedItemUpdate(event, expectedItemId, expectedType, expectedStartedAtMs, expectedCompletedAtMs);
+            });
+        }
+
         std::vector<frontend::FrontendEvent> burstEvents(const Observations& observations, std::size_t baseline) const {
             std::vector<frontend::FrontendEvent> received = events(observations);
             if (baseline >= received.size()) {
@@ -815,6 +875,49 @@ namespace {
             expect(latestFrontendText(observerA) == expectedText && latestFrontendText(observerB) == expectedText,
                    "coalescing preserves exact final text for every protocol session");
 
+            const auto countCompletedItemUpdates = [&](const std::string& expectedItemId,
+                                                       const std::string& expectedType,
+                                                       std::int64_t expectedStartedAtMs,
+                                                       std::int64_t expectedCompletedAtMs) {
+                return std::count_if(receivedA.begin(), receivedA.end(), [&](const frontend::FrontendEvent& event) {
+                    return isCompletedItemUpdate(event, expectedItemId, expectedType, expectedStartedAtMs, expectedCompletedAtMs);
+                });
+            };
+            expect(countCompletedItemUpdates(userMessageItemId, "user_message", userMessageStartedAtMs, userMessageCompletedAtMs) == 1,
+                   "userMessage start/completion coalesce into one canonical completed frontend item update");
+            expect(countCompletedItemUpdates(unknownItemId, unknownItemType, unknownItemStartedAtMs, unknownItemCompletedAtMs) == 1,
+                   "an unknown item with common metadata coalesces into one canonical completed frontend item update");
+            const auto userMessageUpdate = std::find_if(receivedA.begin(), receivedA.end(), [&](const frontend::FrontendEvent& event) {
+                return isCompletedItemUpdate(event, userMessageItemId, "user_message", userMessageStartedAtMs, userMessageCompletedAtMs);
+            });
+            const Json userMessageData =
+                userMessageUpdate == receivedA.end() ? Json::object() : userMessageUpdate->data.at("item").value("data", Json::object());
+            const bool userMessageDataPreserved = userMessageData.is_object() && userMessageData.contains("clientId") &&
+                                                  userMessageData.at("clientId").is_null() &&
+                                                  userMessageData.value("content", Json::array()) == userMessageContent;
+            expect(userMessageDataPreserved,
+                   "the canonical frontend user-message item preserves nullable clientId and complete heterogeneous content");
+            const auto unknownUpdate = std::find_if(receivedA.begin(), receivedA.end(), [&](const frontend::FrontendEvent& event) {
+                return isCompletedItemUpdate(event, unknownItemId, unknownItemType, unknownItemStartedAtMs, unknownItemCompletedAtMs);
+            });
+            const Json unknownData =
+                unknownUpdate == receivedA.end() ? Json::object() : unknownUpdate->data.at("item").value("data", Json::object());
+            expect(unknownData.is_object() && unknownData.value("codexType", "") == unknownItemType,
+                   "the canonical frontend unknown item preserves its future discriminator");
+
+            const bool hasItemLifecycleExtension =
+                std::any_of(receivedA.begin(), receivedA.end(), [](const frontend::FrontendEvent& event) {
+                    if (event.type != "codex.extension") {
+                        return false;
+                    }
+                    const std::string method = event.data.value("method", "");
+                    const std::string decodingError = event.data.value("decodingError", "");
+                    return method == "item/started" || method == "item/completed" ||
+                           decodingError.find("item event omitted threadId or turnId") != std::string::npos;
+                });
+            expect(!hasItemLifecycleExtension,
+                   "valid userMessage and unknown item lifecycle events never become location-error codex.extension events");
+
             adapter->close("burst test complete");
             backendCore->stop();
             waitUntil(
@@ -851,6 +954,16 @@ namespace {
         const std::string threadId = "thread-burst";
         const std::string turnId = "turn-burst";
         const std::string itemId = "item-burst";
+        const std::string userMessageItemId = "user-message-burst";
+        const Json userMessageContent =
+            Json::array({Json{{"type", "text"}, {"text", "adapter user message"}, {"text_elements", Json::array()}},
+                         Json{{"type", "futureContent"}, {"payload", Json{{"preserved", true}}}}});
+        static constexpr std::int64_t userMessageStartedAtMs = 30;
+        static constexpr std::int64_t userMessageCompletedAtMs = 40;
+        const std::string unknownItemId = "unknown-item-burst";
+        const std::string unknownItemType = "futureAdapterItem";
+        static constexpr std::int64_t unknownItemStartedAtMs = 50;
+        static constexpr std::int64_t unknownItemCompletedAtMs = 60;
 
         tests::support::TestResult& result;
         std::shared_ptr<tests::codex::FakeTransportState> transport;

--- a/tests/component/codex/CodexFrontendAdapterTest.cpp
+++ b/tests/component/codex/CodexFrontendAdapterTest.cpp
@@ -890,13 +890,31 @@ namespace {
             const auto userMessageUpdate = std::find_if(receivedA.begin(), receivedA.end(), [&](const frontend::FrontendEvent& event) {
                 return isCompletedItemUpdate(event, userMessageItemId, "user_message", userMessageStartedAtMs, userMessageCompletedAtMs);
             });
-            const Json userMessageData =
-                userMessageUpdate == receivedA.end() ? Json::object() : userMessageUpdate->data.at("item").value("data", Json::object());
-            const bool userMessageDataPreserved = userMessageData.is_object() && userMessageData.contains("clientId") &&
-                                                  userMessageData.at("clientId").is_null() &&
-                                                  userMessageData.value("content", Json::array()) == userMessageContent;
+            const Json userMessageItem =
+                userMessageUpdate == receivedA.end() ? Json::object() : userMessageUpdate->data.value("item", Json::object());
+            const Json userMessageData = userMessageItem.is_object() ? userMessageItem.value("data", Json::object()) : Json::object();
+            const Json retainedUserMessageContent = userMessageData.value("content", Json::object());
+            bool userMessagePrefixPreserved = retainedUserMessageContent.is_array() && !retainedUserMessageContent.empty() &&
+                                              retainedUserMessageContent.size() < userMessageContent.size();
+            if (retainedUserMessageContent.is_array()) {
+                for (std::size_t index = 0; index < retainedUserMessageContent.size(); ++index) {
+                    userMessagePrefixPreserved = userMessagePrefixPreserved &&
+                                                 retainedUserMessageContent[index] == userMessageContent[index] &&
+                                                 retainedUserMessageContent[index].dump() == userMessageContent[index].dump();
+                }
+            }
+            const bool userMessageDataPreserved =
+                userMessageData.is_object() && userMessageData.contains("clientId") && userMessageData.at("clientId").is_null() &&
+                userMessageContent.dump().size() > backend::MaxSerializedUserMessageDataBytes && userMessagePrefixPreserved &&
+                userMessageData.value("contentTruncated", false) &&
+                userMessageData.value("originalContentBytes", std::uint64_t{0}) == userMessageContent.dump().size() &&
+                userMessageData.value("retainedContentBytes", std::uint64_t{0}) == retainedUserMessageContent.dump().size() &&
+                userMessageData.value("originalContentItems", std::uint64_t{0}) == userMessageContent.size() &&
+                userMessageData.value("retainedContentItems", std::uint64_t{0}) == retainedUserMessageContent.size() &&
+                userMessageData.dump().size() <= backend::MaxSerializedUserMessageDataBytes &&
+                !userMessageItem.value("contentTruncated", true) && userMessageItem.value("droppedContentBytes", std::uint64_t{1}) == 0;
             expect(userMessageDataPreserved,
-                   "the canonical frontend user-message item preserves nullable clientId and complete heterogeneous content");
+                   "Decoder through BackendAdapter preserves a bounded array prefix and independent user-message truncation metadata");
             const auto unknownUpdate = std::find_if(receivedA.begin(), receivedA.end(), [&](const frontend::FrontendEvent& event) {
                 return isCompletedItemUpdate(event, unknownItemId, unknownItemType, unknownItemStartedAtMs, unknownItemCompletedAtMs);
             });
@@ -955,9 +973,18 @@ namespace {
         const std::string turnId = "turn-burst";
         const std::string itemId = "item-burst";
         const std::string userMessageItemId = "user-message-burst";
-        const Json userMessageContent =
-            Json::array({Json{{"type", "text"}, {"text", "adapter user message"}, {"text_elements", Json::array()}},
-                         Json{{"type", "futureContent"}, {"payload", Json{{"preserved", true}}}}});
+        const Json userMessageContent = []() {
+            Json content =
+                Json::array({Json{{"type", "futureContent"},
+                                  {"payload", Json{{"preserved", true}, {"nested", Json::array({1, Json{{"future", "value"}}})}}}}});
+            for (std::size_t index = 0; index < 8; ++index) {
+                content.push_back(Json{{"type", "futureLargeContent"},
+                                       {"index", index},
+                                       {"payload", std::string(12U * 1024U, static_cast<char>('a' + index))},
+                                       {"future", Json{{"nested", index}, {"preserved", true}}}});
+            }
+            return content;
+        }();
         static constexpr std::int64_t userMessageStartedAtMs = 30;
         static constexpr std::int64_t userMessageCompletedAtMs = 40;
         const std::string unknownItemId = "unknown-item-burst";

--- a/tests/component/codex/CodexFrontendProtocolV1Test.cpp
+++ b/tests/component/codex/CodexFrontendProtocolV1Test.cpp
@@ -13,8 +13,11 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <limits>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -53,6 +56,195 @@ namespace {
 
     Command command(std::string requestId, CommandParameters parameters) {
         return {std::move(requestId), std::move(parameters), Json::object(), Json::object()};
+    }
+
+    // Test-only evaluator for the draft-2020-12 keywords reached by FrontendEvent -> ItemState.
+    // It keeps the checked-in schema, rather than a duplicated C++ predicate, authoritative for these examples.
+    bool matchesJsonType(const Json& value, std::string_view type) {
+        if (type == "object") {
+            return value.is_object();
+        }
+        if (type == "array") {
+            return value.is_array();
+        }
+        if (type == "string") {
+            return value.is_string();
+        }
+        if (type == "boolean") {
+            return value.is_boolean();
+        }
+        if (type == "integer") {
+            return value.is_number_integer() || value.is_number_unsigned();
+        }
+        if (type == "number") {
+            return value.is_number();
+        }
+        if (type == "null") {
+            return value.is_null();
+        }
+        return false;
+    }
+
+    bool matchesSchema(const Json& root, const Json& schema, const Json& value, std::size_t depth = 0) {
+        if (depth > 64) {
+            return false;
+        }
+        if (schema.is_boolean()) {
+            return schema.get<bool>();
+        }
+        if (!schema.is_object()) {
+            return true;
+        }
+
+        if (const auto reference = schema.find("$ref"); reference != schema.end()) {
+            constexpr std::string_view definitionsPrefix = "#/$defs/";
+            if (!reference->is_string()) {
+                return false;
+            }
+            const std::string name = reference->get<std::string>();
+            if (!name.starts_with(definitionsPrefix)) {
+                return false;
+            }
+            const auto definitions = root.find("$defs");
+            const auto definition =
+                definitions != root.end() ? definitions->find(name.substr(definitionsPrefix.size())) : Json::const_iterator{};
+            if (definitions == root.end() || definition == definitions->end() || !matchesSchema(root, *definition, value, depth + 1)) {
+                return false;
+            }
+        }
+
+        if (const auto type = schema.find("type"); type != schema.end()) {
+            bool typeMatched = false;
+            if (type->is_string()) {
+                typeMatched = matchesJsonType(value, type->get<std::string>());
+            } else if (type->is_array()) {
+                for (const Json& candidate : *type) {
+                    typeMatched = typeMatched || (candidate.is_string() && matchesJsonType(value, candidate.get<std::string>()));
+                }
+            }
+            if (!typeMatched) {
+                return false;
+            }
+        }
+        if (const auto constant = schema.find("const"); constant != schema.end() && value != *constant) {
+            return false;
+        }
+        if (const auto enumeration = schema.find("enum");
+            enumeration != schema.end() && enumeration->is_array() &&
+            std::find(enumeration->begin(), enumeration->end(), value) == enumeration->end()) {
+            return false;
+        }
+        if (value.is_number()) {
+            if (const auto minimum = schema.find("minimum"); minimum != schema.end() && value < *minimum) {
+                return false;
+            }
+            if (const auto maximum = schema.find("maximum"); maximum != schema.end() && value > *maximum) {
+                return false;
+            }
+        }
+
+        if (value.is_object()) {
+            if (const auto required = schema.find("required"); required != schema.end() && required->is_array()) {
+                for (const Json& name : *required) {
+                    if (!name.is_string() || !value.contains(name.get<std::string>())) {
+                        return false;
+                    }
+                }
+            }
+            if (const auto properties = schema.find("properties"); properties != schema.end() && properties->is_object()) {
+                for (const auto& [name, propertySchema] : properties->items()) {
+                    if (const auto member = value.find(name);
+                        member != value.end() && !matchesSchema(root, propertySchema, *member, depth + 1)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        if (value.is_array()) {
+            if (const auto items = schema.find("items"); items != schema.end()) {
+                for (const Json& item : value) {
+                    if (!matchesSchema(root, *items, item, depth + 1)) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        if (const auto allOf = schema.find("allOf"); allOf != schema.end() && allOf->is_array()) {
+            for (const Json& memberSchema : *allOf) {
+                if (!matchesSchema(root, memberSchema, value, depth + 1)) {
+                    return false;
+                }
+            }
+        }
+        if (const auto condition = schema.find("if"); condition != schema.end()) {
+            const bool conditionMatched = matchesSchema(root, *condition, value, depth + 1);
+            const auto branch = schema.find(conditionMatched ? "then" : "else");
+            if (branch != schema.end() && !matchesSchema(root, *branch, value, depth + 1)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void testUserMessageDataSchema(tests::support::TestResult& result) {
+        const std::filesystem::path sourceRoot = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path().parent_path();
+        const std::filesystem::path schemaPath = sourceRoot / "docs/ai/openai/codex/frontend-protocol-v1.schema.json";
+        std::ifstream input(schemaPath);
+        result.expectTrue(input.good(), "the checked-in Frontend Protocol v1 schema is readable");
+        if (!input) {
+            return;
+        }
+
+        const Json schema = Json::parse(input, nullptr, false);
+        result.expectTrue(!schema.is_discarded() && schema.contains("$defs") && schema["$defs"].contains("UserMessageData"),
+                          "the schema defines normalized user-message data explicitly");
+        if (schema.is_discarded() || !schema.contains("$defs") || !schema["$defs"].contains("FrontendEvent")) {
+            return;
+        }
+
+        const Json content =
+            Json::array({Json{{"type", "text"}, {"text", "hello"}}, Json{{"type", "future"}, {"payload", Json{{"nested", true}}}}});
+        const auto contentBytes = static_cast<std::uint64_t>(content.dump().size());
+        const Json data = Json{{"clientId", nullptr},
+                               {"content", content},
+                               {"contentTruncated", false},
+                               {"originalContentBytes", contentBytes},
+                               {"retainedContentBytes", contentBytes},
+                               {"originalContentItems", std::uint64_t{2}},
+                               {"retainedContentItems", std::uint64_t{2}}};
+        const Json item = Json{{"id", "item-1"},
+                               {"type", "user_message"},
+                               {"status", "completed"},
+                               {"agentText", ""},
+                               {"reasoningText", ""},
+                               {"reasoningSummary", ""},
+                               {"commandOutput", ""},
+                               {"droppedContentBytes", std::uint64_t{0}},
+                               {"contentTruncated", false},
+                               {"data", data},
+                               {"extensions", Json::object()}};
+        const Json event = Json{{"sequence", std::uint64_t{1}},
+                                {"type", "item.updated"},
+                                {"data", Json{{"threadId", "thread-1"}, {"turnId", "turn-1"}, {"item", item}}}};
+        const Json& frontendEventSchema = schema["$defs"]["FrontendEvent"];
+        result.expectTrue(matchesSchema(schema, frontendEventSchema, event),
+                          "the schema accepts array-valued normalized user-message content");
+
+        Json invalidEvent = event;
+        invalidEvent["data"]["item"]["data"]["content"] = Json{{"truncated", true}};
+        result.expectTrue(!matchesSchema(schema, frontendEventSchema, invalidEvent),
+                          "the schema rejects object-valued normalized user-message content");
+
+        Json incompleteEvent = event;
+        incompleteEvent["data"]["item"]["data"].erase("retainedContentItems");
+        result.expectTrue(!matchesSchema(schema, frontendEventSchema, incompleteEvent),
+                          "the schema requires user-message truncation metadata");
+
+        Json futureItemEvent = invalidEvent;
+        futureItemEvent["data"]["item"]["type"] = "future_item";
+        result.expectTrue(matchesSchema(schema, frontendEventSchema, futureItemEvent),
+                          "the user-message condition leaves future item data shapes unrestricted");
     }
 
     void testDefaultReplayHeadroom(tests::support::TestResult& result) {
@@ -324,6 +516,7 @@ int main() {
                       "a single oversized update requests snapshot fallback");
 
     testDefaultReplayHeadroom(result);
+    testUserMessageDataSchema(result);
 
     return result.processResult();
 }

--- a/tests/component/codex/CodexTypedEventDecoderTest.cpp
+++ b/tests/component/codex/CodexTypedEventDecoderTest.cpp
@@ -35,6 +35,7 @@ namespace {
     using ai::openai::codex::typed::TurnStarted;
     using ai::openai::codex::typed::UnknownEvent;
     using ai::openai::codex::typed::UnknownItem;
+    using ai::openai::codex::typed::UserMessageItem;
 
     Notification makeNotification(std::string method, Json params, Json envelopeExtension = Json::object()) {
         Json raw = {
@@ -79,6 +80,20 @@ namespace {
             {"id", std::move(id)},
             {"text", "event text"},
             {"futureItemField", 7},
+        };
+    }
+
+    Json userMessageItem(std::string id = "user-message-event", Json clientId = nullptr) {
+        return {
+            {"type", "userMessage"},
+            {"id", std::move(id)},
+            {"clientId", std::move(clientId)},
+            {"content",
+             Json::array({
+                 Json{{"type", "text"}, {"text", "Answer just with OK!"}, {"text_elements", Json::array()}},
+                 Json{{"type", "futureInput"}, {"futurePayload", Json{{"kept", true}}}},
+             })},
+            {"futureItemField", Json::array({1, 2})},
         };
     }
 
@@ -171,14 +186,68 @@ namespace {
                                   completed->raw == completedNotification.raw,
                               "item/completed preserves maximum int64 timestamp and complete event raw");
 
-        const Json futureItem = {{"type", "futureItem"}, {"future", Json::array({1, 2, 3})}};
+        const Json futureItem = {{"type", "futureItem"}, {"id", "future-item"}, {"future", Json::array({1, 2, 3})}};
         const Notification futureItemNotification = makeNotification(
             "item/started", Json{{"threadId", "thread-event"}, {"turnId", "turn-event"}, {"item", futureItem}, {"startedAtMs", 17}});
         const Event futureItemEvent = decodeEvent(futureItemNotification);
         const ItemStarted* futureStarted = as<ItemStarted>(futureItemEvent);
         const UnknownItem* unknownItem = futureStarted ? std::get_if<UnknownItem>(&futureStarted->item) : nullptr;
-        testResult.expectTrue(unknownItem && unknownItem->type == "futureItem" && unknownItem->raw == futureItem,
-                              "unknown item discriminator remains a nonfatal UnknownItem inside a typed lifecycle event");
+        testResult.expectTrue(unknownItem && unknownItem->type == "futureItem" && unknownItem->raw == futureItem &&
+                                  unknownItem->metadata.id && unknownItem->metadata.id->value == "future-item" &&
+                                  unknownItem->metadata.threadId && unknownItem->metadata.threadId->value == "thread-event" &&
+                                  unknownItem->metadata.turnId && unknownItem->metadata.turnId->value == "turn-event" &&
+                                  !unknownItem->decodingError,
+                              "unknown item discriminator retains all common metadata inside a typed lifecycle event");
+
+        const Json missingIdItem = {{"type", "futureItem"}, {"future", true}};
+        const Notification missingIdNotification = makeNotification(
+            "item/started", Json{{"threadId", "thread-event"}, {"turnId", "turn-event"}, {"item", missingIdItem}, {"startedAtMs", 18}});
+        const Event missingIdEvent = decodeEvent(missingIdNotification);
+        const ItemStarted* missingIdStarted = as<ItemStarted>(missingIdEvent);
+        const UnknownItem* missingId = missingIdStarted ? std::get_if<UnknownItem>(&missingIdStarted->item) : nullptr;
+        testResult.expectTrue(missingId && !missingId->metadata.id && missingId->metadata.threadId &&
+                                  missingId->metadata.threadId->value == "thread-event" && missingId->metadata.turnId &&
+                                  missingId->metadata.turnId->value == "turn-event" && missingId->raw == missingIdItem &&
+                                  missingId->decodingError,
+                              "item lifecycle events retain envelope location when the item has no stable ID");
+    }
+
+    void testUserMessageItemEvents(tests::support::TestResult& testResult) {
+        const Json startedItem = userMessageItem("user-message-shared");
+        const Notification startedNotification = makeNotification("item/started",
+                                                                  Json{{"threadId", "thread-user-message"},
+                                                                       {"turnId", "turn-user-message"},
+                                                                       {"item", startedItem},
+                                                                       {"startedAtMs", 1784637396096}});
+        const Event startedEvent = decodeEvent(startedNotification);
+        const ItemStarted* started = as<ItemStarted>(startedEvent);
+        const UserMessageItem* startedUser = started ? std::get_if<UserMessageItem>(&started->item) : nullptr;
+        testResult.expectTrue(started && started->startedAtMs == 1784637396096 && started->raw == startedNotification.raw,
+                              "userMessage item/started preserves its lifecycle timestamp and complete event raw");
+        testResult.expectTrue(startedUser && startedUser->metadata.id.value == "user-message-shared" && startedUser->metadata.threadId &&
+                                  startedUser->metadata.threadId->value == "thread-user-message" && startedUser->metadata.turnId &&
+                                  startedUser->metadata.turnId->value == "turn-user-message" && !startedUser->clientId &&
+                                  startedUser->content == startedItem["content"] && startedUser->metadata.raw == startedItem,
+                              "userMessage item/started preserves ID, location, nullable clientId, opaque content, and item raw");
+
+        Json completedItem = userMessageItem("user-message-shared", "client-user-message");
+        completedItem["content"].push_back(Json{{"type", "localImage"}, {"path", "/tmp/input.png"}, {"detail", "original"}, {"future", 9}});
+        const Notification completedNotification = makeNotification("item/completed",
+                                                                    Json{{"threadId", "thread-user-message"},
+                                                                         {"turnId", "turn-user-message"},
+                                                                         {"item", completedItem},
+                                                                         {"completedAtMs", 1784637396123}});
+        const Event completedEvent = decodeEvent(completedNotification);
+        const ItemCompleted* completed = as<ItemCompleted>(completedEvent);
+        const UserMessageItem* completedUser = completed ? std::get_if<UserMessageItem>(&completed->item) : nullptr;
+        testResult.expectTrue(completed && completed->completedAtMs == 1784637396123 && completed->raw == completedNotification.raw,
+                              "userMessage item/completed preserves its lifecycle timestamp and complete event raw");
+        testResult.expectTrue(completedUser && completedUser->metadata.id.value == "user-message-shared" &&
+                                  completedUser->metadata.threadId && completedUser->metadata.threadId->value == "thread-user-message" &&
+                                  completedUser->metadata.turnId && completedUser->metadata.turnId->value == "turn-user-message" &&
+                                  completedUser->clientId == "client-user-message" && completedUser->content == completedItem["content"] &&
+                                  completedUser->metadata.raw == completedItem,
+                              "userMessage completion keeps the same canonical identity and preserves all content entries exactly");
     }
 
     void testDeltaEvents(tests::support::TestResult& testResult) {
@@ -297,10 +366,28 @@ namespace {
         };
         const Notification malformedItemNotification = makeNotification("item/completed", malformedItemParams);
         const Event malformedItemEvent = decodeEvent(malformedItemNotification);
-        const UnknownEvent* malformedItem = as<UnknownEvent>(malformedItemEvent);
-        testResult.expectTrue(malformedItem && malformedItem->decodingError && malformedItem->params == malformedItemParams &&
-                                  malformedItem->raw == malformedItemNotification.raw,
-                              "known malformed item payload becomes diagnosable UnknownEvent without losing raw data");
+        const ItemCompleted* malformedItem = as<ItemCompleted>(malformedItemEvent);
+        const UnknownItem* malformedTypedItem = malformedItem ? std::get_if<UnknownItem>(&malformedItem->item) : nullptr;
+        testResult.expectTrue(malformedItem && malformedItem->completedAtMs == 1 && malformedItem->raw == malformedItemNotification.raw &&
+                                  malformedTypedItem && malformedTypedItem->type == "agentMessage" && malformedTypedItem->metadata.id &&
+                                  malformedTypedItem->metadata.id->value == "bad-item" && malformedTypedItem->metadata.threadId &&
+                                  malformedTypedItem->metadata.threadId->value == "thread-event" && malformedTypedItem->metadata.turnId &&
+                                  malformedTypedItem->metadata.turnId->value == "turn-event" &&
+                                  malformedTypedItem->raw == malformedItemParams["item"] && malformedTypedItem->decodingError,
+                              "known malformed item detail remains a located typed lifecycle event with an item-local diagnostic");
+
+        const Json scalarItemParams = {
+            {"threadId", "thread-event"},
+            {"turnId", "turn-event"},
+            {"item", Json::array({1, 2})},
+            {"completedAtMs", 2},
+        };
+        const Notification scalarItemNotification = makeNotification("item/completed", scalarItemParams);
+        const Event scalarItemEvent = decodeEvent(scalarItemNotification);
+        const UnknownEvent* scalarItem = as<UnknownEvent>(scalarItemEvent);
+        testResult.expectTrue(scalarItem && scalarItem->decodingError && scalarItem->params == scalarItemParams &&
+                                  scalarItem->raw == scalarItemNotification.raw,
+                              "structurally unusable non-object item remains a diagnosable UnknownEvent");
 
         const Notification scalarParamsNotification = makeNotification("turn/started", Json::array({1, 2}));
         const Event scalarParamsEvent = decodeEvent(scalarParamsNotification);
@@ -328,6 +415,7 @@ int main() {
     testThreadEvents(testResult);
     testTurnEvents(testResult);
     testItemEvents(testResult);
+    testUserMessageItemEvents(testResult);
     testDeltaEvents(testResult);
     testAuxiliaryEvents(testResult);
     testUnknownAndMalformedEvents(testResult);

--- a/tests/component/codex/CodexTypedItemDecoderTest.cpp
+++ b/tests/component/codex/CodexTypedItemDecoderTest.cpp
@@ -26,6 +26,7 @@ namespace {
     using ai::openai::codex::typed::ToolCallItem;
     using ai::openai::codex::typed::TurnId;
     using ai::openai::codex::typed::UnknownItem;
+    using ai::openai::codex::typed::UserMessageItem;
     using ai::openai::codex::typed::WebSearchItem;
 
     std::optional<Item> decode(const Json& raw, std::string& error) {
@@ -46,6 +47,18 @@ namespace {
                                   metadata.turnId && metadata.turnId->value == "turn-typed",
                               description + " preserves typed item, thread, and turn identifiers");
         testResult.expectTrue(metadata.raw == raw, description + " preserves the exact raw item including future fields");
+    }
+
+    void expectUnknownMetadata(tests::support::TestResult& testResult,
+                               const UnknownItem& item,
+                               const std::optional<std::string>& id,
+                               const Json& raw,
+                               const std::string& description) {
+        const bool idMatches = id.has_value() ? item.metadata.id && item.metadata.id->value == *id : !item.metadata.id;
+        testResult.expectTrue(idMatches && item.metadata.threadId && item.metadata.threadId->value == "thread-typed" &&
+                                  item.metadata.turnId && item.metadata.turnId->value == "turn-typed",
+                              description + " preserves every usable common identifier");
+        testResult.expectTrue(item.raw == raw, description + " preserves the exact raw item");
     }
 
     void testAgentMessage(tests::support::TestResult& testResult) {
@@ -72,6 +85,75 @@ namespace {
         const std::optional<Item> decodedWithoutPhase = decode(withoutPhase, error);
         const AgentMessageItem* noPhase = as<AgentMessageItem>(decodedWithoutPhase);
         testResult.expectTrue(noPhase && !noPhase->phase, "agentMessage accepts an absent optional phase");
+    }
+
+    void testUserMessage(tests::support::TestResult& testResult) {
+        const Json content = Json::array({
+            Json{{"type", "text"}, {"text", "Answer just with OK!"}, {"text_elements", Json::array()}},
+            Json{{"type", "image"}, {"url", "https://example.invalid/input.png"}, {"detail", nullptr}},
+            Json{{"type", "futureInput"}, {"payload", Json{{"nested", Json::array({1, false, "kept"})}}}},
+        });
+        const Json raw = {
+            {"type", "userMessage"},
+            {"id", "user-message-1"},
+            {"clientId", nullptr},
+            {"content", content},
+            {"futureUserMessageField", Json{{"kept", true}}},
+        };
+        std::string error = "stale";
+        const std::optional<Item> decoded = decode(raw, error);
+        const UserMessageItem* item = as<UserMessageItem>(decoded);
+
+        testResult.expectTrue(item != nullptr, "userMessage item is classified");
+        testResult.expectTrue(item && !item->clientId, "userMessage accepts a nullable clientId");
+        testResult.expectTrue(item && item->content == content && item->content.size() == 3,
+                              "userMessage preserves multiple content entries exactly and in order");
+        testResult.expectTrue(item && item->content[0]["text"] == "Answer just with OK!" && item->content[2]["type"] == "futureInput" &&
+                                  item->content[2]["payload"] == content[2]["payload"],
+                              "userMessage preserves text and unfamiliar future content-entry variants losslessly");
+        testResult.expectTrue(error.empty(), "successful userMessage decoding clears a stale external error");
+        if (item) {
+            expectMetadata(testResult, item->metadata, "user-message-1", raw, "userMessage item");
+        }
+
+        Json withClientId = raw;
+        withClientId["id"] = "user-message-2";
+        withClientId["clientId"] = "client-message-2";
+        const std::optional<Item> decodedWithClientId = decode(withClientId, error);
+        const UserMessageItem* clientItem = as<UserMessageItem>(decodedWithClientId);
+        testResult.expectTrue(clientItem && clientItem->clientId == "client-message-2" && clientItem->content == content,
+                              "userMessage preserves a non-null clientId without changing content");
+
+        Json invalidContent = raw;
+        invalidContent["id"] = "user-message-invalid-content";
+        invalidContent["content"] = Json::object({{"text", "not an array"}});
+        const std::optional<Item> decodedInvalidContent = decode(invalidContent, error);
+        const UnknownItem* invalidContentItem = as<UnknownItem>(decodedInvalidContent);
+        testResult.expectTrue(invalidContentItem && invalidContentItem->type == "userMessage" && invalidContentItem->decodingError &&
+                                  error.empty(),
+                              "malformed userMessage content degrades locally to a diagnosable UnknownItem");
+        if (invalidContentItem) {
+            expectUnknownMetadata(testResult,
+                                  *invalidContentItem,
+                                  std::string("user-message-invalid-content"),
+                                  invalidContent,
+                                  "malformed userMessage content");
+        }
+
+        Json invalidClientId = raw;
+        invalidClientId["id"] = "user-message-invalid-client";
+        invalidClientId["clientId"] = Json::array({"not", "a", "string"});
+        const std::optional<Item> decodedInvalidClientId = decode(invalidClientId, error);
+        const UnknownItem* invalidClientItem = as<UnknownItem>(decodedInvalidClientId);
+        testResult.expectTrue(invalidClientItem && invalidClientItem->decodingError && error.empty(),
+                              "malformed userMessage clientId retains common metadata in an UnknownItem");
+        if (invalidClientItem) {
+            expectUnknownMetadata(testResult,
+                                  *invalidClientItem,
+                                  std::string("user-message-invalid-client"),
+                                  invalidClientId,
+                                  "malformed userMessage clientId");
+        }
     }
 
     void testReasoning(tests::support::TestResult& testResult) {
@@ -153,13 +235,28 @@ namespace {
 
         Json exitOverflow = optionalFieldsAbsent;
         exitOverflow["exitCode"] = static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()) + 1;
-        const std::optional<Item> rejectedExitOverflow = decode(exitOverflow, error);
-        testResult.expectTrue(!rejectedExitOverflow && !error.empty(), "commandExecution rejects exitCode outside int32 range");
+        const std::optional<Item> decodedExitOverflow = decode(exitOverflow, error);
+        const UnknownItem* exitOverflowItem = as<UnknownItem>(decodedExitOverflow);
+        testResult.expectTrue(exitOverflowItem && exitOverflowItem->decodingError && error.empty(),
+                              "commandExecution with exitCode outside int32 degrades to a diagnosable UnknownItem");
+        if (exitOverflowItem) {
+            expectUnknownMetadata(
+                testResult, *exitOverflowItem, std::string("command-optional"), exitOverflow, "commandExecution with overflowing exitCode");
+        }
 
         Json durationOverflow = optionalFieldsAbsent;
         durationOverflow["durationMs"] = std::numeric_limits<std::uint64_t>::max();
-        const std::optional<Item> rejectedDurationOverflow = decode(durationOverflow, error);
-        testResult.expectTrue(!rejectedDurationOverflow && !error.empty(), "commandExecution rejects durationMs outside int64 range");
+        const std::optional<Item> decodedDurationOverflow = decode(durationOverflow, error);
+        const UnknownItem* durationOverflowItem = as<UnknownItem>(decodedDurationOverflow);
+        testResult.expectTrue(durationOverflowItem && durationOverflowItem->decodingError && error.empty(),
+                              "commandExecution with durationMs outside int64 degrades to a diagnosable UnknownItem");
+        if (durationOverflowItem) {
+            expectUnknownMetadata(testResult,
+                                  *durationOverflowItem,
+                                  std::string("command-optional"),
+                                  durationOverflow,
+                                  "commandExecution with overflowing durationMs");
+        }
     }
 
     void testFileChange(tests::support::TestResult& testResult) {
@@ -253,25 +350,62 @@ namespace {
     void testUnknownAndMalformed(tests::support::TestResult& testResult) {
         const Json futureRaw = {
             {"type", "futureItem"},
+            {"id", "future-item-1"},
             {"futurePayload", Json::array({1, false, "three"})},
         };
-        std::string error;
+        std::string error = "stale";
         const std::optional<Item> decodedFuture = decode(futureRaw, error);
         const UnknownItem* future = as<UnknownItem>(decodedFuture);
-        testResult.expectTrue(future && future->type == "futureItem" && future->raw == futureRaw && !future->decodingError,
-                              "unknown item discriminator becomes UnknownItem with exact raw payload and no fatal error");
+        testResult.expectTrue(future && future->type == "futureItem" && !future->decodingError && error.empty(),
+                              "unknown item discriminator becomes a nonfatal UnknownItem and clears the external error");
+        if (future) {
+            expectUnknownMetadata(testResult, *future, std::string("future-item-1"), futureRaw, "unknown future item");
+        }
 
         const Json missingText = {{"type", "agentMessage"}, {"id", "bad-agent"}};
-        const std::optional<Item> rejectedMissingText = decode(missingText, error);
-        testResult.expectTrue(!rejectedMissingText && !error.empty(), "known item missing a required field reports a decoding error");
+        const std::optional<Item> decodedMissingText = decode(missingText, error);
+        const UnknownItem* missingTextItem = as<UnknownItem>(decodedMissingText);
+        testResult.expectTrue(missingTextItem && missingTextItem->type == "agentMessage" && missingTextItem->decodingError && error.empty(),
+                              "known item missing a detail field degrades to UnknownItem without a fatal external error");
+        if (missingTextItem) {
+            expectUnknownMetadata(testResult, *missingTextItem, std::string("bad-agent"), missingText, "agentMessage missing text");
+        }
 
         const Json invalidId = {{"type", "reasoning"}, {"id", 7}};
-        const std::optional<Item> rejectedInvalidId = decode(invalidId, error);
-        testResult.expectTrue(!rejectedInvalidId && !error.empty(), "known item with non-string ID reports a decoding error");
+        const std::optional<Item> decodedInvalidId = decode(invalidId, error);
+        const UnknownItem* invalidIdItem = as<UnknownItem>(decodedInvalidId);
+        testResult.expectTrue(invalidIdItem && invalidIdItem->type == "reasoning" && invalidIdItem->decodingError && error.empty(),
+                              "known item with non-string ID retains its raw object and an item-local decoding error");
+        if (invalidIdItem) {
+            expectUnknownMetadata(testResult, *invalidIdItem, std::nullopt, invalidId, "item with a non-string ID");
+        }
+
+        const Json missingId = {{"type", "futureItem"}, {"futurePayload", true}};
+        const std::optional<Item> decodedMissingId = decode(missingId, error);
+        const UnknownItem* missingIdItem = as<UnknownItem>(decodedMissingId);
+        testResult.expectTrue(missingIdItem && missingIdItem->decodingError && error.empty(),
+                              "unknown item missing its ID retains a bounded item-local diagnostic");
+        if (missingIdItem) {
+            expectUnknownMetadata(testResult, *missingIdItem, std::nullopt, missingId, "unknown item missing its ID");
+        }
+
+        const Json emptyId = {{"type", "futureItem"}, {"id", ""}, {"futurePayload", false}};
+        const std::optional<Item> decodedEmptyId = decode(emptyId, error);
+        const UnknownItem* emptyIdItem = as<UnknownItem>(decodedEmptyId);
+        testResult.expectTrue(emptyIdItem && !emptyIdItem->metadata.id && emptyIdItem->decodingError && error.empty(),
+                              "unknown item with an empty ID does not fabricate a stable identifier");
+        if (emptyIdItem) {
+            expectUnknownMetadata(testResult, *emptyIdItem, std::nullopt, emptyId, "unknown item with an empty ID");
+        }
 
         const Json missingType = {{"id", "missing-type"}};
-        const std::optional<Item> rejectedMissingType = decode(missingType, error);
-        testResult.expectTrue(!rejectedMissingType && !error.empty(), "item missing its discriminator reports a decoding error");
+        const std::optional<Item> decodedMissingType = decode(missingType, error);
+        const UnknownItem* missingTypeItem = as<UnknownItem>(decodedMissingType);
+        testResult.expectTrue(missingTypeItem && !missingTypeItem->type && missingTypeItem->decodingError && error.empty(),
+                              "item missing its discriminator retains common metadata with an item-local error");
+        if (missingTypeItem) {
+            expectUnknownMetadata(testResult, *missingTypeItem, std::string("missing-type"), missingType, "item missing its discriminator");
+        }
 
         const std::optional<Item> rejectedScalar = decode(Json::array({1, 2}), error);
         testResult.expectTrue(!rejectedScalar && !error.empty(), "non-object item reports a decoding error without throwing");
@@ -282,6 +416,7 @@ int main() {
     tests::support::TestResult testResult;
 
     testAgentMessage(testResult);
+    testUserMessage(testResult);
     testReasoning(testResult);
     testCommandExecution(testResult);
     testFileChange(testResult);


### PR DESCRIPTION
## Summary

- add typed `start` and `resume` commands with all existing Frontend Protocol v1 options
- add client-side `new` as a correlated two-stage `ThreadStart → TurnStart` operation
- preserve synchronization barriers, distinct request IDs, EOF draining, partial-failure diagnostics, and real JSONL protocol output
- add typed Codex `userMessage` items and preserve opaque heterogeneous content
- retain usable ID/thread/turn metadata for future unknown item types
- canonicalize valid unknown/user-message lifecycle events instead of emitting false location-error extensions
- document the explicit thread lifecycle and the corrected item model

## Confirmed root cause

The App Server lifecycle envelope decoder already read `threadId`, `turnId`, `item`, and the timestamp, then passed the location into `decodeItem()`. The defect was downstream:

1. `typed::Item` had no `userMessage` alternative.
2. `ItemDecoder` therefore produced `UnknownItem`.
3. `UnknownItem` retained only its discriminator, raw JSON, and optional error.
4. Reducer `itemLocation()` unconditionally rejected every `UnknownItem`.
5. A valid lifecycle notification was consequently demoted to `codex.extension` with the misleading `item event omitted threadId or turnId` diagnostic.

The nested notification seen in the extension was the retained original raw App Server notification, not a double-wrapped incoming message.

## Architecture

The public event flow remains unchanged:

```text
App Server notification
    → EventDecoder
    → ItemDecoder
    → typed::Event
    → Backend Reducer
    → Frontend Protocol v1 event
```

The fix is deliberately local to that path:

- `UserMessageItem` stores strict item metadata, nullable `clientId`, and the complete array-valued `content` JSON. Entry variants are not flattened or filtered.
- `UnknownItemMetadata` stores independently optional item/thread/turn IDs, allowing envelope location to survive even if the stable item ID is missing or malformed.
- Item-local schema failures degrade to a diagnosable `UnknownItem` when the object and common metadata remain useful.
- Valid ID + location produces an ordinary canonical item upsert.
- Valid location + no stable ID reaches the bounded `codex/item-without-id` fallback.
- Missing/empty thread or turn location retains the lifecycle extension fallback.
- Start and completion replace the same item-map entry, retain both timestamps, and no longer lose timestamps when a later terminal turn snapshot rehydrates the item.
- Backend snapshots expose `user_message` with nullable `clientId` and an ordered bounded prefix of complete content entries; BackendAdapter turns the canonical state change into the normal `item.updated` event.

No Frontend Protocol method/version was added. No client shutdown, signal, heartbeat, idle-timeout, connection-lifetime, controller, or `new` orchestration behavior changed in the canonicalization commit.

## Canonicalization fix files

- `src/ai/openai/codex/typed/Items.h`
- `src/ai/openai/codex/detail/ItemDecoder.cpp`
- `src/ai/openai/codex/backend/BackendState.cpp`
- `src/ai/openai/codex/backend/Reducer.cpp`
- `src/ai/openai/codex/backend/Snapshot.cpp`
- `tests/component/codex/CodexTypedItemDecoderTest.cpp`
- `tests/component/codex/CodexTypedEventDecoderTest.cpp`
- `tests/component/codex/CodexBackendReducerTest.cpp`
- `tests/component/codex/CodexFrontendAdapterTest.cpp`
- `docs/ai/openai/codex/typed-api.md`
- `docs/ai/openai/codex/backend-core.md`
- `docs/ai/openai/codex/frontend-protocol-v1.md`
- `docs/ai/openai/codex/frontend-protocol-v1.schema.json`

## Validation

Host capacity was checked before building: 28 logical CPUs, 62 GiB RAM, 49 GiB available.

- `cmake --build build --parallel 8`: passed
- typed item/event decoder tests: 2/2 passed
- reducer + frontend adapter tests: 2/2 passed
- Unix client/backend acceptance tests: 3/3 passed
- complete `ctest --test-dir build --output-on-failure`: 225 passed, 1 expected skip with the credential gate unset
- gated `SNODEC_RUN_CODEX_TYPED_INTEGRATION=1` real App Server test: passed
- live `acquire` + `new Answer just with OK!` run: completed `user_message` was canonical with content and timestamps; agent response was `OK!`; no false `item/started` or `item/completed` location extension appeared
- `UnixPhysicalSocketPathSafetyTest`: passed
- `git diff --check`: passed

The Unix acceptance tests initially reported `bind ... Operation not permitted` inside the restricted execution sandbox; the identical tests passed once temporary local-socket binding was permitted. There are no unrelated test failures.

## Compatibility

`Items.h` is installed public C++ API. Adding `UserMessageItem` extends the public `std::variant`, and adding common metadata enlarges `UnknownItem`; already-built consumers must be rebuilt. Existing variant indices are preserved by appending the new alternative, and the new unknown metadata member is appended with a default, preserving ordinary field access and existing three-field aggregate initialization at source level. Exhaustive visitors must add a `UserMessageItem` case.

Frontend Protocol v1 remains wire-compatible: this adds the normalized known item type `user_message` and its data, not a new method, event envelope, or protocol version.

## Remaining unsupported forms

Detailed schemas for future item discriminators remain intentionally opaque `UnknownItem` values, but valid common metadata now makes them canonical. Unknown/future user-content entry variants remain opaque JSON and are preserved losslessly. Non-object item payloads, items without a stable ID, and events without a usable thread/turn location continue through bounded diagnostic fallbacks rather than being fabricated or silently discarded.


## Review follow-up: shape-preserving user-message bounds

The generic `boundedJson()` projection preserved small arrays but replaced an oversized `UserMessageItem::content` array with a truncation object. That changed `user_message.data.content` from an array to an object and was inconsistent with the top-level accumulated-visible-text truncation fields.

The normalized user-message projection now has a dedicated 65,536-byte bound on the complete compact serialization of its `data` object, including `clientId` and all metadata. It retains an ordered prefix of complete, unmodified JSON entries; an entry is never split or serialized as a partial fragment. If the first entry cannot fit, the retained value is `[]`. The canonical typed `UserMessageItem::content` remains complete.

Every normalized `user_message.data` now contains:

- `clientId`: string or null
- `content`: always an array
- `contentTruncated`: whether complete entries were omitted
- `originalContentBytes` / `retainedContentBytes`: compact serialized array sizes, including brackets and commas (`[]` is 2 bytes)
- `originalContentItems` / `retainedContentItems`: array entry counts

The existing top-level `ItemSnapshot::contentTruncated` and `droppedContentBytes` retain their accumulated-visible-content meaning. The Frontend Protocol v1 schema conditionally requires the user-message data shape while leaving future item data unrestricted; the protocol version and envelopes are unchanged.

## Review follow-up: independent client acceptance scenarios

The former combined acceptance executable no longer forks and re-executes its thread workflow. CTest now starts two independent processes from the same executable:

- `CodexBackendClientRealBackendAcceptanceTest` with scenario `interactive`
- `CodexBackendClientThreadWorkflowAcceptanceTest` with scenario `thread-workflow`

Each has its own 20-second CTest timeout over the unchanged 10-second internal watchdog and 12-second event-loop limit. Both valid scenarios use the same root-without-`snodec`-group skip guard, and an unknown scenario fails clearly. All existing interactive and thread-workflow assertions remain in place.

## Follow-up files

- `src/ai/openai/codex/backend/Snapshot.h`
- `src/ai/openai/codex/backend/Snapshot.cpp`
- `tests/component/codex/CodexBackendReducerTest.cpp`
- `tests/component/codex/CodexFrontendAdapterTest.cpp`
- `tests/component/codex/CodexFrontendProtocolV1Test.cpp`
- `tests/component/codex/CodexBackendClientRealBackendAcceptanceTest.cpp`
- `tests/component/codex/CMakeLists.txt`
- `docs/ai/openai/codex/frontend-protocol-v1.schema.json`
- `docs/ai/openai/codex/frontend-protocol-v1.md`
- `docs/ai/openai/codex/typed-api.md`
- `docs/ai/openai/codex/backend-core.md`

## Follow-up validation

Host capacity: 28 logical CPUs, 62 GiB RAM, 48 GiB available.

- `cmake --build build --parallel 8`: passed
- requested focused Codex tests: 8/8 passed
- complete `ctest --test-dir build -R 'Codex|codex' --output-on-failure`: 63 total, 62 passed and `CodexTypedAppServerIntegrationTest` skipped under its credential/environment gate
- informational full suite: 227 total, 226 passed and the same one gated integration test skipped
- `UnixPhysicalSocketPathSafetyTest`: passed without investigation or modification
- `git diff --check`: passed
- formatter applied to every changed C++ file

The Unix acceptance tests require permission to bind temporary local sockets; their first restricted-sandbox attempts failed with `EPERM`, and the identical unrestricted focused and full-suite runs passed.

Follow-up commit: `e9fdb1158d09aac902ab0472388c37587825c443`.

No new command, Frontend Protocol version, heartbeat, idle-timeout, shutdown/signal, generic Unix path-safety, `SNode.C_VERSION`, or `SNODEC_SOVERSION` change is included. The follow-up adds only an inline constexpr bound and internal projection logic; it does not change the public `typed::Item` variant or `UnknownItem` layout again.
