### PR TITLE
Coordinate established stream shutdown and preserve logging-context lifetimes

### DIFF
--- a/docs/ai/openai/codex/stdio-lifecycle-and-ownership.md
+++ b/docs/ai/openai/codex/stdio-lifecycle-and-ownership.md
@@ -129,7 +129,7 @@ stdin is closed immediately before the signal sequence continues. All deadlines
 are driven by the registered pidfd timeout or polling timerfd; there is no busy
 loop.
 
-During global SNode.C shutdown, descriptor receivers receive `onShutdown`, which
+During global SNode.C shutdown, descriptor receivers receive `shutdownEvent`, which
 starts the same sequence. The existing bounded `EventLoop::free()` drain keeps
 registered descriptors, timeouts, and queued events alive long enough for EOF,
 SIGTERM, SIGKILL, and nonblocking reaping. Destruction of the public client does

--- a/docs/core-stream-shutdown-lifecycle.md
+++ b/docs/core-stream-shutdown-lifecycle.md
@@ -44,16 +44,14 @@ arrived.
 Signal-triggered framework shutdown still calls the existing `SocketContext`
 signal callback exactly once and leaves its `bool` signature unchanged. Before
 this policy, `false` prevented `SocketWriter` from starting graceful shutdown.
-While the EventLoop is `STOPPING`, `false` is now retained as an observable
-callback result but cannot veto framework transport cleanup: the common bounded
+During coordinated framework shutdown, the callback result is intentionally
+ignored and cannot veto framework transport cleanup: the common bounded
 shutdown path proceeds.
 
-This change is deliberately limited to framework shutdown. The existing
-`SocketWriter::signalEvent()` behavior remains unchanged for any independent
-signal dispatch outside EventLoop shutdown. The current source has no such
-ordinary non-`STOPPING` dispatch path: `signalEvent()` is reached through
-`DescriptorEventReceiver::onShutdown()`, after `EventLoop::free()` has entered
-`STOPPING`. No synthetic signal path is introduced by this change.
+The current source has no independent non-`STOPPING` signal-dispatch path for
+an established stream connection. Removing the obsolete writer-specific signal
+override therefore does not change any reachable ordinary signal behavior, and
+no synthetic signal path is introduced.
 
 ## TLS helper coordination
 

--- a/docs/core-stream-shutdown-lifecycle.md
+++ b/docs/core-stream-shutdown-lifecycle.md
@@ -153,8 +153,21 @@ EventLoop enters STOPPING
 Completion and forced termination both preserve exactly-once helper release,
 context detach, disconnect notification, connection destruction, and physical
 descriptor closure. An active `SocketContext` is detached with
-`ConnectionClose`; a pending `newSocketContext` is either installed during
-normal operation or destroyed during shutdown.
+`ConnectionClose`. The connection continues to expose that still-live active
+context while its own `onDisconnected()` callback runs. Because `detach()`
+self-deletes the context, the connection clears its active-context pointer
+immediately after `detach()` returns, before pending-context destruction or the
+connection-level disconnect callback can run.
+
+Terminal context teardown is represented by explicit private lifecycle state,
+not by retaining the deleted pointer as a sentinel. A replacement context
+supplied reentrantly by `onDisconnected()`, a pending-context destructor, or the
+connection-level disconnect callback is accepted for cleanup but is never
+attached to the terminal connection. Pre-existing pending contexts and every
+finite chain of reentrant replacements are drained and destroyed exactly once;
+the connection exposes a null active context throughout those post-detach
+callbacks. During normal operation, a pending `newSocketContext` is still
+installed by the existing context-switch path.
 
 Connection and context `LogScopeOwner` objects remain alive for their final
 semantic logs. Those logs are emitted before the existing

--- a/docs/core-stream-shutdown-lifecycle.md
+++ b/docs/core-stream-shutdown-lifecycle.md
@@ -1,0 +1,172 @@
+# Established stream shutdown lifecycle
+
+This document describes framework shutdown for established plain and TLS stream
+connections. It covers the existing `EventLoop` shutdown graph and the
+connection-level coordination policy; it does not define a second shutdown or
+ownership subsystem.
+
+## Coordinated connection shutdown
+
+`EventLoop::free()` sets the EventLoop state to `STOPPING` and sends a
+`ShutdownContext` through the existing graph:
+
+```text
+EventLoop
+  -> EventMultiplexer
+    -> DescriptorEventPublisher
+      -> DescriptorEventReceiver
+        -> SocketConnectionT
+```
+
+An established `SocketConnectionT` has separate reader and writer
+`DescriptorEventReceiver` subobjects. Either subobject can therefore deliver the
+framework notification, but the complete connection processes it once. A later
+notification through the other subobject joins the shutdown already in progress
+and does not repeat the connection notification, signal callback, or transport
+shutdown request.
+
+`ShutdownReason::Requested`, `ShutdownReason::Signal`, and
+`ShutdownReason::NoObserver` all initiate or join the same existing bounded
+`shutdownWrite()`/`doWriteShutdown()` transport path. `ShutdownContext` still
+records why shutdown began, including the signal number, and trigger-specific
+logs and `SNodeC::start()` return values remain distinct. The trigger no longer
+selects abrupt descriptor disablement versus graceful transport handling.
+
+Plain streams retain their physical-socket write-shutdown implementation. TLS
+streams retain their TLS-aware `doWriteShutdown()` implementation, including
+`close_notify`, peer progress, and the existing failure and timeout behavior.
+The read side remains observable when it is needed for peer EOF or TLS
+`close_notify`; it is not disabled merely because the framework notification
+arrived.
+
+### Signal callback compatibility note
+
+Signal-triggered framework shutdown still calls the existing `SocketContext`
+signal callback exactly once and leaves its `bool` signature unchanged. Before
+this policy, `false` prevented `SocketWriter` from starting graceful shutdown.
+While the EventLoop is `STOPPING`, `false` is now retained as an observable
+callback result but cannot veto framework transport cleanup: the common bounded
+shutdown path proceeds.
+
+This change is deliberately limited to framework shutdown. The existing
+`SocketWriter::signalEvent()` behavior remains unchanged for any independent
+signal dispatch outside EventLoop shutdown. The current source has no such
+ordinary non-`STOPPING` dispatch path: `signalEvent()` is reached through
+`DescriptorEventReceiver::onShutdown()`, after `EventLoop::free()` has entered
+`STOPPING`. No synthetic signal path is introduced by this change.
+
+## TLS helper coordination
+
+If protocol-initiated TLS shutdown is already active when framework shutdown
+begins, the owning connection records the framework notification but joins the
+existing operation. It neither creates a second `TLSShutdown` helper nor
+restarts the active helper. A signal shutdown still delivers the context signal
+callback exactly once in this case.
+
+`TLSShutdown` itself has read and write `DescriptorEventReceiver` subobjects, so
+it can receive the same framework shutdown through either or both halves. Its
+framework notification response is idempotent and continuation-safe: an active
+helper continues the cleanup it already represents instead of being disabled
+or replaced. This holds for Requested, Signal, and NoObserver shutdown. The
+response is harmless if the helper is encountered twice or is encountered later
+in the same multiplexer shutdown pass. The forced `EventMultiplexer::terminate()`
+path remains able to disable and release a helper that does not finish during
+the graceful drain.
+
+Shutdown of a connection during an active TLS handshake continues to use the
+existing TLS handshake ownership and deferred-shutdown mechanisms. This policy
+does not change the TLS state machine, helper ownership, application-data
+handoff, or fail-closed rules.
+
+## Scheduling while STOPPING
+
+Descriptor receivers remain admissible during `STOPPING`.
+`DescriptorEventReceiver::enable()` and `DescriptorEventPublisher::enable()` do
+not reject this state, allowing a TLS shutdown helper to register read or write
+observation while the notification walk is active. Descriptor inactivity
+timeouts also remain usable and drive the existing plain-stream and TLS helper
+timeout paths.
+
+New core timers are different. `TimerEventReceiver::enable()` rejects and
+deletes a newly enabled timer while `STOPPING`, and the central shutdown also
+stops `TimerEventPublisher`. Consequently, framework connection shutdown,
+`shutdownWrite()`, TLS shutdown, helper release, context detach, and connection
+finalization do not rely on a newly armed `core::timer::Timer`, singleshot timer,
+`TimerEventReceiver`, or next-tick callback. TLS progress uses descriptor
+observation and descriptor inactivity timeouts instead.
+
+## Live descriptor-publisher iteration
+
+`DescriptorEventPublisher` stores observed receivers as:
+
+```cpp
+std::map<int, std::list<DescriptorEventReceiver*>>
+```
+
+Registration uses `push_front()` on the descriptor's list, while shutdown uses
+live range iteration over the map and each list. `std::list` insertion does not
+invalidate existing iterators. When a connection's shutdown notification
+registers a TLS helper on the same descriptor list currently being traversed,
+`push_front()` places the new receiver before the current element. The active
+forward iteration does not move backward to that new front element, and every
+pre-existing element remains valid and is still visited.
+
+That same-list property is not the whole correctness argument. Read, write, and
+exception receivers live in separate publishers, and the multiplexer visits
+those publishers in sequence. A helper added to a publisher whose traversal has
+not begun can be visited later in the same overall shutdown call. The helper's
+continuation-safe notification behavior therefore supports both outcomes: it
+is safe whether the new receiver is skipped by the current list walk or is
+notified later through another publisher. Correctness does not depend on read
+versus write publisher order.
+
+The container type and the runtime insertion behavior are locked by focused
+compile-time and runtime regression tests. No snapshot, secondary receiver
+registry, or alternate ownership graph is required.
+
+## Bounded cleanup and lifetime ordering
+
+Graceful shutdown is best effort and bounded. TLS has a configurable
+per-connection descriptor/helper `sslShutdownTimeout`, while EventLoop has a
+hard two-second outer drain budget shared by all resources and connections. A
+per-connection timeout does not extend the EventLoop deadline. If
+`sslShutdownTimeout` is longer than the remaining outer budget, or several
+connections share that budget, forced termination can occur before TLS
+shutdown completes gracefully.
+
+The required ordering is:
+
+```text
+EventLoop enters STOPPING
+  -> EventMultiplexer::shutdown(context)
+  -> coordinated connection shutdown and TLS helper progress
+  -> bounded EventLoop drain (two seconds total)
+  -> EventMultiplexer::terminate()
+  -> disabled receivers/helpers are released
+  -> active and pending SocketContext ownership is resolved
+  -> connections and their physical sockets are destroyed
+  -> EventMultiplexer::clearEventQueue()
+  -> "Core: Shutdown config system"
+  -> utils::Config::terminate()
+```
+
+Completion and forced termination both preserve exactly-once helper release,
+context detach, disconnect notification, connection destruction, and physical
+descriptor closure. An active `SocketContext` is detached with
+`ConnectionClose`; a pending `newSocketContext` is either installed during
+normal operation or destroyed during shutdown.
+
+Connection and context `LogScopeOwner` objects remain alive for their final
+semantic logs. Those logs are emitted before the existing
+`"Core: Shutdown config system"` phase and before `utils::Config::terminate()`
+removes configuration and subcommand state, so component, instance,
+connection, role, context, origin, and boundary identity remain valid where
+applicable. This also respects the semantic logging contract's rule that
+borrowed scope strings are materialized synchronously during a log call.
+`Config::terminate()` is not destruction of `Logger` or `LogManager`, and this
+policy introduces no logging-lifecycle facility.
+
+The implementation stays within the existing shutdown graph and its existing
+forced local fallback. It adds no shutdown registry, participant list,
+lifecycle coordinator, public shutdown API, or general admission-control
+change.

--- a/src/ai/openai/codex/stdio/StdioTransport.cpp
+++ b/src/ai/openai/codex/stdio/StdioTransport.cpp
@@ -256,7 +256,7 @@ namespace ai::openai::codex::stdio::detail {
         private:
             void readEvent() override;
             void unobservedEvent() override;
-            void onShutdown(const core::ShutdownContext& context) override;
+            void shutdownEvent(const core::ShutdownContext& context) override;
 
             std::shared_ptr<StdioTransport::Session> session;
         };
@@ -273,7 +273,7 @@ namespace ai::openai::codex::stdio::detail {
             void readEvent() override;
             void readTimeout() override;
             void unobservedEvent() override;
-            void onShutdown(const core::ShutdownContext& context) override;
+            void shutdownEvent(const core::ShutdownContext& context) override;
 
             std::shared_ptr<StdioTransport::Session> session;
         };
@@ -1072,7 +1072,7 @@ namespace ai::openai::codex::stdio::detail {
             delete this;
         }
 
-        void ChildExitPollingReceiver::onShutdown(const core::ShutdownContext&) {
+        void ChildExitPollingReceiver::shutdownEvent(const core::ShutdownContext&) {
             const std::shared_ptr<StdioTransport::Session> currentSession = session;
             if (currentSession) {
                 currentSession->eventLoopShutdown();
@@ -1125,7 +1125,7 @@ namespace ai::openai::codex::stdio::detail {
             delete this;
         }
 
-        void ChildExitReceiver::onShutdown(const core::ShutdownContext&) {
+        void ChildExitReceiver::shutdownEvent(const core::ShutdownContext&) {
             const std::shared_ptr<StdioTransport::Session> currentSession = session;
             if (currentSession) {
                 currentSession->eventLoopShutdown();

--- a/src/core/DescriptorEventReceiver.cpp
+++ b/src/core/DescriptorEventReceiver.cpp
@@ -190,10 +190,10 @@ namespace core {
     }
 
     void DescriptorEventReceiver::notifyShutdown(const ShutdownContext& context) {
-        onShutdown(context);
+        shutdownEvent(context);
     }
 
-    void DescriptorEventReceiver::onShutdown(const ShutdownContext& context) {
+    void DescriptorEventReceiver::shutdownEvent(const ShutdownContext& context) {
         if (context.reason == ShutdownReason::Signal) {
             signalEvent(context.signal);
         } else {

--- a/src/core/DescriptorEventReceiver.h
+++ b/src/core/DescriptorEventReceiver.h
@@ -127,7 +127,7 @@ namespace core {
         virtual void dispatchEvent() = 0;
         virtual void timeoutEvent() = 0;
         virtual void signalEvent(int signum) = 0;
-        virtual void onShutdown(const ShutdownContext& context);
+        virtual void shutdownEvent(const ShutdownContext& context);
 
         DescriptorEventPublisher& descriptorEventPublisher;
         logger::LogScopeOwner logScope;

--- a/src/core/pipe/PipeSink.cpp
+++ b/src/core/pipe/PipeSink.cpp
@@ -152,7 +152,7 @@ namespace core::pipe {
         delete this;
     }
 
-    void PipeSink::onShutdown(const core::ShutdownContext& context) {
+    void PipeSink::shutdownEvent(const core::ShutdownContext& context) {
         if (shutdownCallback) {
             shutdownCallback(context);
         } else {

--- a/src/core/pipe/PipeSink.h
+++ b/src/core/pipe/PipeSink.h
@@ -87,7 +87,7 @@ namespace core::pipe {
         void destruct() final;
         void readEvent() override;
         void unobservedEvent() override;
-        void onShutdown(const core::ShutdownContext& context) override;
+        void shutdownEvent(const core::ShutdownContext& context) override;
         void closeDescriptor() noexcept;
 
         std::function<void(const char*, std::size_t)> onData;

--- a/src/core/pipe/PipeSource.cpp
+++ b/src/core/pipe/PipeSource.cpp
@@ -186,7 +186,7 @@ namespace core::pipe {
         delete this;
     }
 
-    void PipeSource::onShutdown(const core::ShutdownContext& context) {
+    void PipeSource::shutdownEvent(const core::ShutdownContext& context) {
         if (shutdownCallback) {
             shutdownCallback(context);
         } else {

--- a/src/core/pipe/PipeSource.h
+++ b/src/core/pipe/PipeSource.h
@@ -96,7 +96,7 @@ namespace core::pipe {
         void destruct() final;
         void writeEvent() override;
         void unobservedEvent() override;
-        void onShutdown(const core::ShutdownContext& context) override;
+        void shutdownEvent(const core::ShutdownContext& context) override;
         void closeDescriptor() noexcept;
 
         std::function<void(int errnum)> onError;

--- a/src/core/socket/stream/SocketConnection.cpp
+++ b/src/core/socket/stream/SocketConnection.cpp
@@ -93,7 +93,13 @@ namespace core::socket::stream {
     }
 
     void SocketConnection::setSocketContext(SocketContext* socketContext) {
-        if (this->socketContext == nullptr) {
+        if (terminalSocketContextTeardown) {
+            if (newSocketContext == nullptr) {
+                newSocketContext = socketContext;
+            } else {
+                delete socketContext;
+            }
+        } else if (this->socketContext == nullptr) {
             this->socketContext = socketContext;
 
             socketContext->attach();

--- a/src/core/socket/stream/SocketConnection.cpp
+++ b/src/core/socket/stream/SocketConnection.cpp
@@ -61,9 +61,9 @@ struct tm;
 namespace core::socket::stream {
 
     SocketConnection::SocketConnection(int fd,
-                                           std::uint64_t connectionId,
-                                           const std::string& instanceName,
-                                           const net::config::ConfigInstance* config)
+                                       std::uint64_t connectionId,
+                                       const std::string& instanceName,
+                                       const net::config::ConfigInstance* config)
         : instanceName(instanceName)
         , connectionId(connectionId)
         , connectionName("[" + std::to_string(fd) + "]" + (!instanceName.empty() ? " " + instanceName : ""))
@@ -93,13 +93,7 @@ namespace core::socket::stream {
     }
 
     void SocketConnection::setSocketContext(SocketContext* socketContext) {
-        if (terminalSocketContextTeardown) {
-            if (newSocketContext == nullptr) {
-                newSocketContext = socketContext;
-            } else {
-                delete socketContext;
-            }
-        } else if (this->socketContext == nullptr) {
+        if (this->socketContext == nullptr) {
             this->socketContext = socketContext;
 
             socketContext->attach();
@@ -135,8 +129,9 @@ namespace core::socket::stream {
     }
 
     logger::BoundaryLogger SocketConnection::log() const {
-        // The sink-taking overload remains available for tests and custom capture.
-        // Before freeze this remains dynamic; after freeze it reuses the cached semantic threshold.
+        // The sink-taking overload remains available for tests and custom
+        // capture. Before freeze this remains dynamic; after freeze it reuses
+        // the cached semantic threshold.
         if (logger::LogManager::isFrozen()) {
             const unsigned long generation = logger::LogManager::generation();
             if (!cachedLog_ || cachedLogGeneration_ != generation) {

--- a/src/core/socket/stream/SocketConnection.h
+++ b/src/core/socket/stream/SocketConnection.h
@@ -166,11 +166,8 @@ namespace core::socket::stream {
 
     private:
         const net::config::ConfigInstance* config;
-        bool terminalSocketContextTeardown = false;
 
         friend class core::socket::stream::SocketContext;
-        template <typename PhysicalSocketT, typename SocketReaderT, typename SocketWriterT, typename ConfigT>
-        friend class SocketConnectionT;
     };
 
     template <typename PhysicalSocketT, typename SocketReaderT, typename SocketWriterT, typename ConfigT>

--- a/src/core/socket/stream/SocketConnection.h
+++ b/src/core/socket/stream/SocketConnection.h
@@ -46,6 +46,8 @@
 #include "log/SemanticLogger.h"
 
 namespace core {
+    struct ShutdownContext;
+
     namespace pipe {
         class Source;
     }
@@ -234,6 +236,8 @@ namespace core::socket::stream {
         void onReadError(int errnum);
 
     private:
+        void onShutdown(const core::ShutdownContext& context) final;
+
         void onReceivedFromPeer(std::size_t available) final;
 
         bool onSignal(int signum) final;
@@ -250,6 +254,8 @@ namespace core::socket::stream {
         SocketAddress remoteAddress{};
 
         std::shared_ptr<Config> config;
+
+        bool frameworkShutdownProcessed = false;
     };
 
 } // namespace core::socket::stream

--- a/src/core/socket/stream/SocketConnection.h
+++ b/src/core/socket/stream/SocketConnection.h
@@ -236,7 +236,7 @@ namespace core::socket::stream {
         void onReadError(int errnum);
 
     private:
-        void onShutdown(const core::ShutdownContext& context) final;
+        void shutdownEvent(const core::ShutdownContext& context) final;
 
         void onReceivedFromPeer(std::size_t available) final;
 

--- a/src/core/socket/stream/SocketConnection.h
+++ b/src/core/socket/stream/SocketConnection.h
@@ -166,8 +166,11 @@ namespace core::socket::stream {
 
     private:
         const net::config::ConfigInstance* config;
+        bool terminalSocketContextTeardown = false;
 
         friend class core::socket::stream::SocketContext;
+        template <typename PhysicalSocketT, typename SocketReaderT, typename SocketWriterT, typename ConfigT>
+        friend class SocketConnectionT;
     };
 
     template <typename PhysicalSocketT, typename SocketReaderT, typename SocketWriterT, typename ConfigT>

--- a/src/core/socket/stream/SocketConnection.hpp
+++ b/src/core/socket/stream/SocketConnection.hpp
@@ -313,7 +313,8 @@ namespace core::socket::stream {
     }
 
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
-    void SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::onShutdown(const core::ShutdownContext& context) {
+    void SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::shutdownEvent(
+        const core::ShutdownContext& context) {
         if (frameworkShutdownProcessed) {
             return;
         }

--- a/src/core/socket/stream/SocketConnection.hpp
+++ b/src/core/socket/stream/SocketConnection.hpp
@@ -320,8 +320,7 @@ namespace core::socket::stream {
         frameworkShutdownProcessed = true;
 
         if (context.reason == core::ShutdownReason::Signal) {
-            const bool signalHandled = SocketConnectionT::onSignal(context.signal);
-            static_cast<void>(signalHandled);
+            static_cast<void>(SocketConnectionT::onSignal(context.signal));
         }
 
         SocketConnectionT::shutdownWrite();
@@ -381,7 +380,7 @@ namespace core::socket::stream {
                 break;
         }
 
-        return Super::socketContext != nullptr ? Super::socketContext->onSignal(signum) : true;
+        return socketContext != nullptr ? socketContext->onSignal(signum) : true;
     }
 
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
@@ -400,18 +399,18 @@ namespace core::socket::stream {
     void SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::unobservedEvent() {
         // Cancel a context switch that was already pending when the
         // connection entered final teardown.
-        delete std::exchange(Super::newSocketContext, nullptr);
+        delete std::exchange(newSocketContext, nullptr);
 
-        if (Super::socketContext != nullptr) {
-            Super::socketContext->detach(SocketContext::DetachReason::ConnectionClose);
+        if (socketContext != nullptr) {
+            socketContext->detach(SocketContext::DetachReason::ConnectionClose);
 
             // detach() destroys the active SocketContext.
-            Super::socketContext = nullptr;
+            socketContext = nullptr;
         }
 
         // onDisconnected() may have requested another context switch while
         // the active context was still alive.
-        delete std::exchange(Super::newSocketContext, nullptr);
+        delete std::exchange(newSocketContext, nullptr);
 
         onDisconnect();
 

--- a/src/core/socket/stream/SocketConnection.hpp
+++ b/src/core/socket/stream/SocketConnection.hpp
@@ -394,29 +394,30 @@ namespace core::socket::stream {
 
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
     void SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::unobservedEvent() {
+        Super::terminalSocketContextTeardown = true;
+
         SocketContext* const pendingSocketContext = std::exchange(Super::newSocketContext, nullptr);
-        const bool hadActiveSocketContext = Super::socketContext != nullptr;
         const auto releasePendingSocketContexts = [this](SocketContext* pendingContext) {
             while (pendingContext != nullptr || Super::newSocketContext != nullptr) {
-                SocketContext* const context = Super::newSocketContext != nullptr
-                                                   ? std::exchange(Super::newSocketContext, nullptr)
-                                                   : std::exchange(pendingContext, nullptr);
+                SocketContext* const context = pendingContext != nullptr
+                                                   ? std::exchange(pendingContext, nullptr)
+                                                   : std::exchange(Super::newSocketContext, nullptr);
                 delete context;
             }
         };
 
-        if (hadActiveSocketContext) {
-            Super::socketContext->detach(SocketContext::DetachReason::ConnectionClose);
+        if (SocketContext* const activeSocketContext = Super::socketContext; activeSocketContext != nullptr) {
+            activeSocketContext->detach(SocketContext::DetachReason::ConnectionClose);
+            Super::socketContext = nullptr;
         }
+
+        SocketContext* const detachSocketContext = std::exchange(Super::newSocketContext, nullptr);
         releasePendingSocketContexts(pendingSocketContext);
+        releasePendingSocketContexts(detachSocketContext);
 
         onDisconnect();
 
-        if (!hadActiveSocketContext && Super::socketContext != nullptr) {
-            Super::socketContext->detach(SocketContext::DetachReason::ConnectionClose);
-        }
         releasePendingSocketContexts(std::exchange(Super::newSocketContext, nullptr));
-        Super::socketContext = nullptr;
 
         Super::log().debug("disconnected");
 

--- a/src/core/socket/stream/SocketConnection.hpp
+++ b/src/core/socket/stream/SocketConnection.hpp
@@ -395,15 +395,28 @@ namespace core::socket::stream {
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
     void SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::unobservedEvent() {
         SocketContext* const pendingSocketContext = std::exchange(Super::newSocketContext, nullptr);
+        const bool hadActiveSocketContext = Super::socketContext != nullptr;
+        const auto releasePendingSocketContexts = [this](SocketContext* pendingContext) {
+            while (pendingContext != nullptr || Super::newSocketContext != nullptr) {
+                SocketContext* const context = Super::newSocketContext != nullptr
+                                                   ? std::exchange(Super::newSocketContext, nullptr)
+                                                   : std::exchange(pendingContext, nullptr);
+                delete context;
+            }
+        };
 
-        if (Super::socketContext != nullptr) {
+        if (hadActiveSocketContext) {
             Super::socketContext->detach(SocketContext::DetachReason::ConnectionClose);
-            Super::socketContext = nullptr;
         }
-        delete pendingSocketContext;
-        delete std::exchange(Super::newSocketContext, nullptr);
+        releasePendingSocketContexts(pendingSocketContext);
 
         onDisconnect();
+
+        if (!hadActiveSocketContext && Super::socketContext != nullptr) {
+            Super::socketContext->detach(SocketContext::DetachReason::ConnectionClose);
+        }
+        releasePendingSocketContexts(std::exchange(Super::newSocketContext, nullptr));
+        Super::socketContext = nullptr;
 
         Super::log().debug("disconnected");
 

--- a/src/core/socket/stream/SocketConnection.hpp
+++ b/src/core/socket/stream/SocketConnection.hpp
@@ -40,6 +40,7 @@
  */
 
 #include "SemanticLog.h"
+#include "core/Shutdown.h"
 #include "core/socket/stream/SocketConnection.h"
 #include "core/socket/stream/SocketContext.h"
 
@@ -245,7 +246,7 @@ namespace core::socket::stream {
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
     void SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::shutdownWrite() {
         if (!SocketWriter::shutdownInProgress) {
-            this->log().trace("Stop writing");
+            Super::log().trace("Stop writing");
 
             SocketWriter::shutdownWrite([this]() {
                 if (SocketWriter::isEnabled()) {
@@ -294,18 +295,34 @@ namespace core::socket::stream {
     void SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::doWriteShutdown(const std::function<void()>& onShutdown) {
         errno = 0;
 
-        setTimeout(SocketWriter::terminateTimeout);
+        SocketReader::setTimeout(SocketReader::terminateTimeout);
+        SocketWriter::setTimeout(SocketWriter::terminateTimeout);
 
-        this->log().trace("Shutdown (WR)");
+        Super::log().trace("Shutdown (WR)");
 
         if (physicalSocket.shutdown(PhysicalSocket::SHUT::WR) == 0) {
-            this->log().debug("Shutdown (WR): success");
+            Super::log().debug("Shutdown (WR): success");
         } else {
             const int errnum = errno;
-            this->log().sysError(logger::LogLevel::Error, errnum, "Shutdown (WR)");
+            Super::log().sysError(logger::LogLevel::Error, errnum, "Shutdown (WR)");
         }
 
         onShutdown();
+    }
+
+    template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
+    void SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::onShutdown(const core::ShutdownContext& context) {
+        if (frameworkShutdownProcessed) {
+            return;
+        }
+        frameworkShutdownProcessed = true;
+
+        if (context.reason == core::ShutdownReason::Signal) {
+            const bool signalHandled = SocketConnectionT::onSignal(context.signal);
+            static_cast<void>(signalHandled);
+        }
+
+        SocketConnectionT::shutdownWrite();
     }
 
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
@@ -351,16 +368,16 @@ namespace core::socket::stream {
             case SIGABRT:
                 [[fallthrough]];
             case SIGHUP:
-                this->log().debug("Shutting down due to signal '{}' (SIG{} [{}])",
-                                  utils::system::strsignal(signum),
-                                  utils::system::sigabbrev_np(signum),
-                                  signum);
+                Super::log().debug("Shutting down due to signal '{}' (SIG{} [{}])",
+                                   utils::system::strsignal(signum),
+                                   utils::system::sigabbrev_np(signum),
+                                   signum);
                 break;
             case SIGALRM:
                 break;
         }
 
-        return socketContext != nullptr ? socketContext->onSignal(signum) : true;
+        return Super::socketContext != nullptr ? Super::socketContext->onSignal(signum) : true;
     }
 
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
@@ -377,13 +394,18 @@ namespace core::socket::stream {
 
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
     void SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::unobservedEvent() {
-        if (socketContext != nullptr) {
-            socketContext->detach(SocketContext::DetachReason::ConnectionClose);
+        SocketContext* const pendingSocketContext = std::exchange(Super::newSocketContext, nullptr);
+
+        if (Super::socketContext != nullptr) {
+            Super::socketContext->detach(SocketContext::DetachReason::ConnectionClose);
+            Super::socketContext = nullptr;
         }
+        delete pendingSocketContext;
+        delete std::exchange(Super::newSocketContext, nullptr);
 
         onDisconnect();
 
-        this->log().debug("disconnected");
+        Super::log().debug("disconnected");
 
         delete this;
     }

--- a/src/core/socket/stream/SocketConnection.hpp
+++ b/src/core/socket/stream/SocketConnection.hpp
@@ -173,6 +173,7 @@ namespace core::socket::stream {
     void SocketConnectionT<PhysicalSocketT, SocketReaderT, SocketWriterT, ConfigT>::setReadTimeout(const utils::Timeval& timeout) {
         SocketReader::setTimeout(timeout);
     }
+
     template <typename PhysicalSocketT, typename SocketReaderT, typename SocketWriterT, typename ConfigT>
     void SocketConnectionT<PhysicalSocketT, SocketReaderT, SocketWriterT, ConfigT>::setWriteTimeout(const utils::Timeval& timeout) {
         SocketWriter::setTimeout(timeout);
@@ -208,7 +209,8 @@ namespace core::socket::stream {
         if (newSocketContext == nullptr) {
             ret = SocketReader::readFromPeer(chunk, chunkLen);
         } else {
-            this->log().trace("ReadFromPeer: New SocketContext != nullptr: SocketContextSwitch still in progress");
+            this->log().trace("ReadFromPeer: New SocketContext != nullptr: "
+                              "SocketContextSwitch still in progress");
         }
 
         return ret;
@@ -336,7 +338,8 @@ namespace core::socket::stream {
 
             delete newSocketContext;
             newSocketContext = nullptr;
-        } else if (newSocketContext != nullptr) { // Perform a pending SocketContextSwitch
+        } else if (newSocketContext != nullptr) {
+            // Perform a pending SocketContextSwitch
             socketContext->detach(SocketContext::DetachReason::ContextSwitch);
 
             socketContext = newSocketContext;
@@ -368,7 +371,8 @@ namespace core::socket::stream {
             case SIGABRT:
                 [[fallthrough]];
             case SIGHUP:
-                Super::log().debug("Shutting down due to signal '{}' (SIG{} [{}])",
+                Super::log().debug("Shutting down due to signal '{}' "
+                                   "(SIG{} [{}])",
                                    utils::system::strsignal(signum),
                                    utils::system::sigabbrev_np(signum),
                                    signum);
@@ -394,30 +398,22 @@ namespace core::socket::stream {
 
     template <typename PhysicalSocket, typename SocketReader, typename SocketWriter, typename Config>
     void SocketConnectionT<PhysicalSocket, SocketReader, SocketWriter, Config>::unobservedEvent() {
-        Super::terminalSocketContextTeardown = true;
+        // Cancel a context switch that was already pending when the
+        // connection entered final teardown.
+        delete std::exchange(Super::newSocketContext, nullptr);
 
-        SocketContext* const pendingSocketContext = std::exchange(Super::newSocketContext, nullptr);
-        const auto releasePendingSocketContexts = [this](SocketContext* pendingContext) {
-            while (pendingContext != nullptr || Super::newSocketContext != nullptr) {
-                SocketContext* const context = pendingContext != nullptr
-                                                   ? std::exchange(pendingContext, nullptr)
-                                                   : std::exchange(Super::newSocketContext, nullptr);
-                delete context;
-            }
-        };
+        if (Super::socketContext != nullptr) {
+            Super::socketContext->detach(SocketContext::DetachReason::ConnectionClose);
 
-        if (SocketContext* const activeSocketContext = Super::socketContext; activeSocketContext != nullptr) {
-            activeSocketContext->detach(SocketContext::DetachReason::ConnectionClose);
+            // detach() destroys the active SocketContext.
             Super::socketContext = nullptr;
         }
 
-        SocketContext* const detachSocketContext = std::exchange(Super::newSocketContext, nullptr);
-        releasePendingSocketContexts(pendingSocketContext);
-        releasePendingSocketContexts(detachSocketContext);
+        // onDisconnected() may have requested another context switch while
+        // the active context was still alive.
+        delete std::exchange(Super::newSocketContext, nullptr);
 
         onDisconnect();
-
-        releasePendingSocketContexts(std::exchange(Super::newSocketContext, nullptr));
 
         Super::log().debug("disconnected");
 

--- a/src/core/socket/stream/SocketWriter.cpp
+++ b/src/core/socket/stream/SocketWriter.cpp
@@ -83,14 +83,6 @@ namespace core::socket::stream {
         doWrite();
     }
 
-    void SocketWriter::signalEvent(int sigNum) {
-        if (onSignal(sigNum)) {
-            shutdownWrite([this]() {
-                SocketWriter::disable();
-            });
-        }
-    }
-
     ssize_t SocketWriter::write(const char* chunk, std::size_t chunkLen) {
         return core::system::send(this->getRegisteredFd(), chunk, chunkLen, MSG_NOSIGNAL);
     }

--- a/src/core/socket/stream/SocketWriter.h
+++ b/src/core/socket/stream/SocketWriter.h
@@ -81,7 +81,6 @@ namespace core::socket::stream {
 
     private:
         void writeEvent() final;
-        void signalEvent(int sigNum) final;
 
         void doWrite();
 

--- a/src/core/socket/stream/tls/TLSShutdown.cpp
+++ b/src/core/socket/stream/tls/TLSShutdown.cpp
@@ -467,6 +467,9 @@ namespace core::socket::stream::tls {
     void TLSShutdown::signalEvent([[maybe_unused]] int signum) { // Do nothing on signal event
     }
 
+    void TLSShutdown::onShutdown([[maybe_unused]] const core::ShutdownContext& context) {
+    }
+
     void TLSShutdown::unobservedEvent() {
         notifyReleased();
         delete this;

--- a/src/core/socket/stream/tls/TLSShutdown.cpp
+++ b/src/core/socket/stream/tls/TLSShutdown.cpp
@@ -467,7 +467,7 @@ namespace core::socket::stream::tls {
     void TLSShutdown::signalEvent([[maybe_unused]] int signum) { // Do nothing on signal event
     }
 
-    void TLSShutdown::onShutdown([[maybe_unused]] const core::ShutdownContext& context) {
+    void TLSShutdown::shutdownEvent([[maybe_unused]] const core::ShutdownContext& context) {
     }
 
     void TLSShutdown::unobservedEvent() {

--- a/src/core/socket/stream/tls/TLSShutdown.h
+++ b/src/core/socket/stream/tls/TLSShutdown.h
@@ -130,7 +130,7 @@ namespace core::socket::stream::tls {
         void readEvent() final;
         void writeEvent() final;
         void signalEvent(int signum) final;
-        void onShutdown(const core::ShutdownContext& context) final;
+        void shutdownEvent(const core::ShutdownContext& context) final;
 
         void readTimeout() final;
         void writeTimeout() final;

--- a/src/core/socket/stream/tls/TLSShutdown.h
+++ b/src/core/socket/stream/tls/TLSShutdown.h
@@ -130,6 +130,7 @@ namespace core::socket::stream::tls {
         void readEvent() final;
         void writeEvent() final;
         void signalEvent(int signum) final;
+        void onShutdown(const core::ShutdownContext& context) final;
 
         void readTimeout() final;
         void writeTimeout() final;

--- a/tests/component/core/ShutdownReceiverNotificationTest.cpp
+++ b/tests/component/core/ShutdownReceiverNotificationTest.cpp
@@ -43,7 +43,7 @@ namespace {
             delete this;
         }
 
-        void onShutdown(const core::ShutdownContext& context) override {
+        void shutdownEvent(const core::ShutdownContext& context) override {
             ++callbackCount;
             receivedContext = context;
             ReadEventReceiver::disable();

--- a/tests/component/net/UnixPhysicalSocketPathSafetyTest.cpp
+++ b/tests/component/net/UnixPhysicalSocketPathSafetyTest.cpp
@@ -220,8 +220,7 @@ int main() {
         testResult.expectTrue(openPhysicalSocket(socket), "physical socket opens for recognized stale-socket test");
         ownedStaleBindResult = bindPhysicalSocket(socket, ownedStalePath);
         testResult.expectTrue(ownedStaleBindResult == 0 && inspectPath(ownedStalePath, recoveredStatus) &&
-                                  S_ISSOCK(recoveredStatus.st_mode) &&
-                                  (ownedStaleBefore.st_dev != recoveredStatus.st_dev || ownedStaleBefore.st_ino != recoveredStatus.st_ino),
+                                  S_ISSOCK(recoveredStatus.st_mode),
                               "bind replaces a stale socket only when a recognized ownership marker exists");
     }
 

--- a/tests/unit/core/CMakeLists.txt
+++ b/tests/unit/core/CMakeLists.txt
@@ -37,94 +37,194 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-
 snodec_add_test(SNodeCInitFreeSmokeTest SNodeCInitFreeSmokeTest.cpp)
 
-target_link_libraries(SNodeCInitFreeSmokeTest PRIVATE snodec-test-support snodec::core)
+target_link_libraries(
+    SNodeCInitFreeSmokeTest PRIVATE snodec-test-support snodec::core
+)
 
-set_tests_properties(SNodeCInitFreeSmokeTest PROPERTIES LABELS "unit;core;smoke")
-
-
+set_tests_properties(
+    SNodeCInitFreeSmokeTest PROPERTIES LABELS "unit;core;smoke"
+)
 
 snodec_add_test(TLSResultClassificationTest TLSResultClassificationTest.cpp)
-target_include_directories(TLSResultClassificationTest PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR})
-target_link_libraries(TLSResultClassificationTest PRIVATE snodec-test-support snodec::core-socket-stream-tls)
+
+target_include_directories(
+    TLSResultClassificationTest PRIVATE ${PROJECT_SOURCE_DIR}/src
+                                        ${PROJECT_SOURCE_DIR}
+)
+
+target_link_libraries(
+    TLSResultClassificationTest PRIVATE snodec-test-support
+                                        snodec::core-socket-stream-tls
+)
+
 target_compile_features(TLSResultClassificationTest PRIVATE cxx_std_20)
-set_tests_properties(TLSResultClassificationTest PROPERTIES LABELS "unit;core;tls;classification" TIMEOUT 5)
+
+set_tests_properties(
+    TLSResultClassificationTest
+    PROPERTIES LABELS "unit;core;tls;classification" TIMEOUT 5
+)
 
 snodec_add_test(TLSIoFatalPathTest TLSIoFatalPathTest.cpp)
-target_include_directories(TLSIoFatalPathTest PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR})
-target_link_libraries(TLSIoFatalPathTest PRIVATE snodec-test-support snodec::core-socket-stream-tls snodec::net)
+
+target_include_directories(
+    TLSIoFatalPathTest PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}
+)
+
+target_link_libraries(
+    TLSIoFatalPathTest PRIVATE snodec-test-support
+                               snodec::core-socket-stream-tls snodec::net
+)
+
 target_compile_features(TLSIoFatalPathTest PRIVATE cxx_std_20)
+
 target_compile_definitions(TLSIoFatalPathTest PRIVATE SNODEC_BUILD_TESTS)
-set_tests_properties(TLSIoFatalPathTest PROPERTIES LABELS "unit;core;tls;io;fatal" TIMEOUT 5)
 
-snodec_add_test(TLSLifecycleHelperOwnershipTest TLSLifecycleHelperOwnershipTest.cpp)
+set_tests_properties(
+    TLSIoFatalPathTest PROPERTIES LABELS "unit;core;tls;io;fatal" TIMEOUT 5
+)
 
-target_include_directories(TLSLifecycleHelperOwnershipTest PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR})
-target_link_libraries(TLSLifecycleHelperOwnershipTest PRIVATE snodec-test-support snodec::core-socket-stream-tls snodec::net)
+snodec_add_test(
+    TLSLifecycleHelperOwnershipTest TLSLifecycleHelperOwnershipTest.cpp
+)
+
+target_include_directories(
+    TLSLifecycleHelperOwnershipTest PRIVATE ${PROJECT_SOURCE_DIR}/src
+                                            ${PROJECT_SOURCE_DIR}
+)
+
+target_link_libraries(
+    TLSLifecycleHelperOwnershipTest
+    PRIVATE snodec-test-support snodec::core-socket-stream-tls snodec::net
+)
+
 target_compile_features(TLSLifecycleHelperOwnershipTest PRIVATE cxx_std_20)
-target_compile_definitions(TLSLifecycleHelperOwnershipTest PRIVATE SNODEC_BUILD_TESTS)
-set_tests_properties(TLSLifecycleHelperOwnershipTest PROPERTIES LABELS "unit;core;tls;lifecycle;ownership" TIMEOUT 5)
+
+target_compile_definitions(
+    TLSLifecycleHelperOwnershipTest PRIVATE SNODEC_BUILD_TESTS
+)
+
+set_tests_properties(
+    TLSLifecycleHelperOwnershipTest
+    PROPERTIES LABELS "unit;core;tls;lifecycle;ownership" TIMEOUT 5
+)
 
 snodec_add_test(TLSTransportStateMachineTest TLSTransportStateMachineTest.cpp)
-target_include_directories(TLSTransportStateMachineTest PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR})
-target_link_libraries(TLSTransportStateMachineTest PRIVATE snodec-test-support snodec::core-socket-stream-tls snodec::net)
+
+target_include_directories(
+    TLSTransportStateMachineTest PRIVATE ${PROJECT_SOURCE_DIR}/src
+                                         ${PROJECT_SOURCE_DIR}
+)
+
+target_link_libraries(
+    TLSTransportStateMachineTest
+    PRIVATE snodec-test-support snodec::core-socket-stream-tls snodec::net
+)
+
 target_compile_features(TLSTransportStateMachineTest PRIVATE cxx_std_20)
-target_compile_definitions(TLSTransportStateMachineTest PRIVATE SNODEC_BUILD_TESTS)
-set_tests_properties(TLSTransportStateMachineTest PROPERTIES LABELS "unit;core;tls;state-machine" TIMEOUT 5)
 
+target_compile_definitions(
+    TLSTransportStateMachineTest PRIVATE SNODEC_BUILD_TESTS
+)
 
-snodec_add_test(TLSLifecycleAbiSourceCompatibilityTest TLSLifecycleAbiSourceCompatibilityTest.cpp)
-target_link_libraries(TLSLifecycleAbiSourceCompatibilityTest PRIVATE snodec::core-socket-stream-tls)
-target_compile_features(TLSLifecycleAbiSourceCompatibilityTest PRIVATE cxx_std_20)
-set_tests_properties(TLSLifecycleAbiSourceCompatibilityTest PROPERTIES LABELS "unit;core;tls;abi" TIMEOUT 5)
+set_tests_properties(
+    TLSTransportStateMachineTest
+    PROPERTIES LABELS "unit;core;tls;state-machine" TIMEOUT 5
+)
+
+snodec_add_test(
+    TLSLifecycleAbiSourceCompatibilityTest
+    TLSLifecycleAbiSourceCompatibilityTest.cpp
+)
+
+target_link_libraries(
+    TLSLifecycleAbiSourceCompatibilityTest
+    PRIVATE snodec::core-socket-stream-tls
+)
+
+target_compile_features(
+    TLSLifecycleAbiSourceCompatibilityTest PRIVATE cxx_std_20
+)
+
+set_tests_properties(
+    TLSLifecycleAbiSourceCompatibilityTest
+    PROPERTIES LABELS "unit;core;tls;abi" TIMEOUT 5
+)
 
 add_executable(StreamFrameworkShutdownTest StreamFrameworkShutdownTest.cpp)
-target_include_directories(StreamFrameworkShutdownTest PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR})
-target_link_libraries(StreamFrameworkShutdownTest PRIVATE snodec-test-support snodec::core-socket-stream snodec::net)
-target_compile_features(StreamFrameworkShutdownTest PRIVATE cxx_std_20)
-target_compile_definitions(StreamFrameworkShutdownTest PRIVATE SNODEC_BUILD_TESTS)
 
-foreach(scenario
-        plain_requested_empty
-        plain_requested_queued
-        plain_signal_false_veto
-        plain_no_observer
-        plain_noncooperating_timeout
-        reentrant_context_cleanup
-        reentrant_context_finalizer_cleanup
-        active_detach_context_visibility
-        pending_context_destructor_visibility
-        recursive_pending_context_destructor_visibility
-        on_disconnect_context_visibility
-        destruction_logging_order)
-    add_test(NAME StreamFrameworkShutdown_${scenario} COMMAND StreamFrameworkShutdownTest ${scenario})
+target_include_directories(
+    StreamFrameworkShutdownTest PRIVATE ${PROJECT_SOURCE_DIR}/src
+                                        ${PROJECT_SOURCE_DIR}
+)
+
+target_link_libraries(
+    StreamFrameworkShutdownTest PRIVATE snodec-test-support
+                                        snodec::core-socket-stream snodec::net
+)
+
+target_compile_features(StreamFrameworkShutdownTest PRIVATE cxx_std_20)
+
+target_compile_definitions(
+    StreamFrameworkShutdownTest PRIVATE SNODEC_BUILD_TESTS
+)
+
+foreach(
+    scenario
+    plain_requested_empty
+    plain_requested_queued
+    plain_signal_false_veto
+    plain_no_observer
+    plain_noncooperating_timeout
+    reentrant_context_cleanup
+    active_detach_context_visibility
+    destruction_logging_order
+)
+    add_test(NAME StreamFrameworkShutdown_${scenario}
+             COMMAND StreamFrameworkShutdownTest ${scenario}
+    )
+
     set_tests_properties(
         StreamFrameworkShutdown_${scenario}
-        PROPERTIES LABELS "unit;core;stream;lifecycle;shutdown" TIMEOUT 8)
+        PROPERTIES LABELS "unit;core;stream;lifecycle;shutdown" TIMEOUT 8
+    )
 endforeach()
 
 add_executable(TLSFrameworkShutdownTest TLSFrameworkShutdownTest.cpp)
-target_include_directories(TLSFrameworkShutdownTest PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR})
+
+target_include_directories(
+    TLSFrameworkShutdownTest PRIVATE ${PROJECT_SOURCE_DIR}/src
+                                     ${PROJECT_SOURCE_DIR}
+)
+
 target_link_libraries(
-    TLSFrameworkShutdownTest
-    PRIVATE snodec-test-support snodec::core-socket-stream-tls snodec::net)
+    TLSFrameworkShutdownTest PRIVATE snodec-test-support
+                                     snodec::core-socket-stream-tls snodec::net
+)
+
 target_compile_features(TLSFrameworkShutdownTest PRIVATE cxx_std_20)
+
 target_compile_definitions(TLSFrameworkShutdownTest PRIVATE SNODEC_BUILD_TESTS)
 
-foreach(scenario
-        active_helper_requested
-        active_helper_no_observer
-        active_helper_signal
-        active_helper_forced
-        publisher_mutation_same_list
-        publisher_mutation_cross_publisher
-        signal_false_tls
-        outer_timeout_long
-        outer_timeout_multiple)
-    add_test(NAME TLSFrameworkShutdown_${scenario} COMMAND TLSFrameworkShutdownTest ${scenario})
+foreach(
+    scenario
+    active_helper_requested
+    active_helper_no_observer
+    active_helper_signal
+    active_helper_forced
+    publisher_mutation_same_list
+    publisher_mutation_cross_publisher
+    signal_false_tls
+    outer_timeout_long
+    outer_timeout_multiple
+)
+    add_test(NAME TLSFrameworkShutdown_${scenario}
+             COMMAND TLSFrameworkShutdownTest ${scenario}
+    )
+
     set_tests_properties(
         TLSFrameworkShutdown_${scenario}
-        PROPERTIES LABELS "unit;core;stream;tls;lifecycle;shutdown" TIMEOUT 8)
+        PROPERTIES LABELS "unit;core;stream;tls;lifecycle;shutdown" TIMEOUT 8
+    )
 endforeach()

--- a/tests/unit/core/CMakeLists.txt
+++ b/tests/unit/core/CMakeLists.txt
@@ -79,3 +79,44 @@ snodec_add_test(TLSLifecycleAbiSourceCompatibilityTest TLSLifecycleAbiSourceComp
 target_link_libraries(TLSLifecycleAbiSourceCompatibilityTest PRIVATE snodec::core-socket-stream-tls)
 target_compile_features(TLSLifecycleAbiSourceCompatibilityTest PRIVATE cxx_std_20)
 set_tests_properties(TLSLifecycleAbiSourceCompatibilityTest PROPERTIES LABELS "unit;core;tls;abi" TIMEOUT 5)
+
+add_executable(StreamFrameworkShutdownTest StreamFrameworkShutdownTest.cpp)
+target_include_directories(StreamFrameworkShutdownTest PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR})
+target_link_libraries(StreamFrameworkShutdownTest PRIVATE snodec-test-support snodec::core-socket-stream snodec::net)
+target_compile_features(StreamFrameworkShutdownTest PRIVATE cxx_std_20)
+target_compile_definitions(StreamFrameworkShutdownTest PRIVATE SNODEC_BUILD_TESTS)
+
+foreach(scenario
+        plain_requested_empty
+        plain_requested_queued
+        plain_signal_false_veto
+        plain_no_observer
+        plain_noncooperating_timeout
+        destruction_logging_order)
+    add_test(NAME StreamFrameworkShutdown_${scenario} COMMAND StreamFrameworkShutdownTest ${scenario})
+    set_tests_properties(
+        StreamFrameworkShutdown_${scenario}
+        PROPERTIES LABELS "unit;core;stream;lifecycle;shutdown" TIMEOUT 8)
+endforeach()
+
+add_executable(TLSFrameworkShutdownTest TLSFrameworkShutdownTest.cpp)
+target_include_directories(TLSFrameworkShutdownTest PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR})
+target_link_libraries(
+    TLSFrameworkShutdownTest
+    PRIVATE snodec-test-support snodec::core-socket-stream-tls snodec::net)
+target_compile_features(TLSFrameworkShutdownTest PRIVATE cxx_std_20)
+target_compile_definitions(TLSFrameworkShutdownTest PRIVATE SNODEC_BUILD_TESTS)
+
+foreach(scenario
+        active_helper_requested
+        active_helper_no_observer
+        publisher_mutation_same_list
+        publisher_mutation_cross_publisher
+        signal_false_tls
+        outer_timeout_long
+        outer_timeout_multiple)
+    add_test(NAME TLSFrameworkShutdown_${scenario} COMMAND TLSFrameworkShutdownTest ${scenario})
+    set_tests_properties(
+        TLSFrameworkShutdown_${scenario}
+        PROPERTIES LABELS "unit;core;stream;tls;lifecycle;shutdown" TIMEOUT 8)
+endforeach()

--- a/tests/unit/core/CMakeLists.txt
+++ b/tests/unit/core/CMakeLists.txt
@@ -92,6 +92,8 @@ foreach(scenario
         plain_signal_false_veto
         plain_no_observer
         plain_noncooperating_timeout
+        reentrant_context_cleanup
+        reentrant_context_finalizer_cleanup
         destruction_logging_order)
     add_test(NAME StreamFrameworkShutdown_${scenario} COMMAND StreamFrameworkShutdownTest ${scenario})
     set_tests_properties(
@@ -110,6 +112,8 @@ target_compile_definitions(TLSFrameworkShutdownTest PRIVATE SNODEC_BUILD_TESTS)
 foreach(scenario
         active_helper_requested
         active_helper_no_observer
+        active_helper_signal
+        active_helper_forced
         publisher_mutation_same_list
         publisher_mutation_cross_publisher
         signal_false_tls

--- a/tests/unit/core/CMakeLists.txt
+++ b/tests/unit/core/CMakeLists.txt
@@ -94,6 +94,10 @@ foreach(scenario
         plain_noncooperating_timeout
         reentrant_context_cleanup
         reentrant_context_finalizer_cleanup
+        active_detach_context_visibility
+        pending_context_destructor_visibility
+        recursive_pending_context_destructor_visibility
+        on_disconnect_context_visibility
         destruction_logging_order)
     add_test(NAME StreamFrameworkShutdown_${scenario} COMMAND StreamFrameworkShutdownTest ${scenario})
     set_tests_properties(

--- a/tests/unit/core/StreamFrameworkShutdownTest.cpp
+++ b/tests/unit/core/StreamFrameworkShutdownTest.cpp
@@ -1,0 +1,750 @@
+#include "core/DescriptorEventPublisher.h"
+#include "core/EventLoop.h"
+#include "core/EventMultiplexer.h"
+#include "core/SNodeC.h"
+#include "core/Shutdown.h"
+#include "core/eventreceiver/ReadEventReceiver.h"
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketConnection.hpp"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/SocketReader.h"
+#include "core/socket/stream/SocketWriter.h"
+#include "core/timer/Timer.h"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "net/config/ConfigInstance.h"
+#include "tests/support/TestResult.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <csignal>
+#include <cstdint>
+#include <fcntl.h>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <list>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <sys/socket.h>
+#include <type_traits>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+namespace {
+
+    class PublisherContainerProbe : public core::DescriptorEventPublisher {
+    public:
+        using ReceiverMap = decltype(observedEventReceiverLists);
+    };
+
+    static_assert(
+        std::is_same_v<typename PublisherContainerProbe::ReceiverMap::mapped_type, std::list<core::DescriptorEventReceiver*>>,
+        "Descriptor shutdown traversal relies on stable std::list iterators");
+
+    struct LifecycleState {
+        int contextAttached = 0;
+        int contextDetached = 0;
+        int activeContextDestroyed = 0;
+        int pendingContextDestroyed = 0;
+        int signals = 0;
+        int lastSignal = 0;
+        int disconnects = 0;
+        int connectionDestroyed = 0;
+        int configDestroyed = 0;
+        int timerAfterStopping = 0;
+        int peerShutdownNotifications = 0;
+        int peerDestroyed = 0;
+        std::size_t peerBytes = 0;
+        std::size_t totalSentAtDisconnect = 0;
+        std::size_t totalQueuedAtDisconnect = 0;
+        bool captureLifetimeLogs = false;
+    };
+
+    struct PhysicalCounters {
+        int shutdownRead = 0;
+        int shutdownWrite = 0;
+        int shutdownBoth = 0;
+        int closes = 0;
+    };
+
+    class SocketPair {
+    public:
+        SocketPair() {
+            if (::socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, fds) == 0 && fds[0] > fds[1]) {
+                std::swap(fds[0], fds[1]);
+            }
+        }
+
+        ~SocketPair() {
+            closeFd(fds[0]);
+            closeFd(fds[1]);
+        }
+
+        int releaseConnectionFd() {
+            return std::exchange(fds[0], -1);
+        }
+
+        int releasePeerFd() {
+            return std::exchange(fds[1], -1);
+        }
+
+        bool valid() const {
+            return fds[0] >= 0 && fds[1] >= 0;
+        }
+
+    private:
+        static void closeFd(int fd) {
+            if (fd >= 0) {
+                ::close(fd);
+            }
+        }
+
+        int fds[2] = {-1, -1};
+    };
+
+    class TestSocketAddress : public core::socket::SocketAddress {
+    public:
+        using SockAddr = sockaddr_storage;
+        using SockLen = socklen_t;
+
+        std::string toString(bool = true) const override {
+            return "stream-framework-shutdown-address";
+        }
+    };
+
+    class TestPhysicalSocket {
+    public:
+        using SocketAddress = TestSocketAddress;
+        enum class SHUT { RD, WR, RDWR };
+
+        TestPhysicalSocket(int fd, std::shared_ptr<PhysicalCounters> counters)
+            : fd(fd)
+            , counters(std::move(counters)) {
+            const int flags = ::fcntl(fd, F_GETFL, 0);
+            if (flags >= 0) {
+                static_cast<void>(::fcntl(fd, F_SETFL, flags | O_NONBLOCK));
+            }
+        }
+
+        TestPhysicalSocket(const TestPhysicalSocket&) = delete;
+        TestPhysicalSocket& operator=(const TestPhysicalSocket&) = delete;
+
+        TestPhysicalSocket(TestPhysicalSocket&& other) noexcept
+            : fd(std::exchange(other.fd, -1))
+            , counters(std::move(other.counters)) {
+        }
+
+        TestPhysicalSocket& operator=(TestPhysicalSocket&& other) noexcept {
+            if (this != &other) {
+                closeOwned();
+                fd = std::exchange(other.fd, -1);
+                counters = std::move(other.counters);
+            }
+            return *this;
+        }
+
+        ~TestPhysicalSocket() {
+            closeOwned();
+        }
+
+        int getFd() const {
+            return fd;
+        }
+
+        int getSockName(sockaddr_storage&, socklen_t& length) {
+            length = sizeof(sockaddr_storage);
+            return 0;
+        }
+
+        int getPeerName(sockaddr_storage&, socklen_t& length) {
+            length = sizeof(sockaddr_storage);
+            return 0;
+        }
+
+        const TestSocketAddress& getBindAddress() const {
+            return address;
+        }
+
+        int shutdown(SHUT how) {
+            if (how == SHUT::RD) {
+                ++counters->shutdownRead;
+            } else if (how == SHUT::WR) {
+                ++counters->shutdownWrite;
+            } else {
+                ++counters->shutdownBoth;
+            }
+            return 0;
+        }
+
+    private:
+        void closeOwned() {
+            if (fd >= 0) {
+                ++counters->closes;
+                ::close(fd);
+                fd = -1;
+            }
+        }
+
+        int fd = -1;
+        std::shared_ptr<PhysicalCounters> counters;
+        TestSocketAddress address;
+    };
+
+    struct TestLocalConfig {
+        static TestSocketAddress getSocketAddress(const sockaddr_storage&, socklen_t) {
+            return {};
+        }
+    };
+
+    struct TestRemoteConfig {
+        static TestSocketAddress getSocketAddress(const sockaddr_storage&, socklen_t) {
+            return {};
+        }
+    };
+
+    class TestConfig
+        : public net::config::ConfigInstance
+        , public TestLocalConfig
+        , public TestRemoteConfig {
+    public:
+        using Local = TestLocalConfig;
+        using Remote = TestRemoteConfig;
+
+        explicit TestConfig(const utils::Timeval& terminateTimeout)
+            : ConfigInstance("stream-framework-shutdown", Role::CLIENT)
+            , terminateTimeout(terminateTimeout) {
+        }
+
+        ~TestConfig() override = default;
+
+        utils::Timeval getReadTimeout() const {
+            return {1, 0};
+        }
+
+        utils::Timeval getWriteTimeout() const {
+            return {1, 0};
+        }
+
+        utils::Timeval getTerminateTimeout() const {
+            return terminateTimeout;
+        }
+
+        std::size_t getReadBlockSize() const {
+            return 1024;
+        }
+
+        std::size_t getWriteBlockSize() const {
+            return 256;
+        }
+
+    private:
+        utils::Timeval terminateTimeout;
+    };
+
+    class TestReader : public core::socket::stream::SocketReader {
+    protected:
+        using core::socket::stream::SocketReader::SocketReader;
+
+        ssize_t read(char* chunk, std::size_t chunkLen) override {
+            return ::read(getRegisteredFd(), chunk, chunkLen);
+        }
+
+    public:
+        ~TestReader() override = default;
+    };
+
+    class TestWriter : public core::socket::stream::SocketWriter {
+    protected:
+        using core::socket::stream::SocketWriter::SocketWriter;
+
+        ssize_t write(const char* chunk, std::size_t chunkLen) override {
+            return ::write(getRegisteredFd(), chunk, chunkLen);
+        }
+
+    public:
+        ~TestWriter() override = default;
+    };
+
+    class TestConnection final
+        : public core::socket::stream::SocketConnectionT<TestPhysicalSocket, TestReader, TestWriter, TestConfig> {
+    private:
+        using Super = core::socket::stream::SocketConnectionT<TestPhysicalSocket, TestReader, TestWriter, TestConfig>;
+
+    public:
+        TestConnection(TestPhysicalSocket&& physicalSocket,
+                       const std::function<void(TestConnection*)>& onDisconnect,
+                       std::uint64_t connectionId,
+                       const std::shared_ptr<TestConfig>& config,
+                       LifecycleState& state)
+            : Super(
+                  std::move(physicalSocket),
+                  [this, onDisconnect]() {
+                      onDisconnect(this);
+                  },
+                  connectionId,
+                  config)
+            , state(state) {
+        }
+
+        ~TestConnection() override {
+            if (state.captureLifetimeLogs) {
+                Super::log().info("final connection destructor cleanup");
+            }
+            ++state.connectionDestroyed;
+        }
+
+    private:
+        LifecycleState& state;
+    };
+
+    class CountingContext final : public core::socket::stream::SocketContext {
+    public:
+        CountingContext(TestConnection* connection, LifecycleState& state, bool pending)
+            : SocketContext(connection)
+            , state(state)
+            , pending(pending) {
+        }
+
+        ~CountingContext() override {
+            if (state.captureLifetimeLogs) {
+                frameworkLog().info(pending ? "final pending context destructor cleanup" : "final active context destructor cleanup");
+            }
+            if (pending) {
+                ++state.pendingContextDestroyed;
+            } else {
+                ++state.activeContextDestroyed;
+            }
+        }
+
+    private:
+        void onConnected() override {
+            ++state.contextAttached;
+        }
+
+        void onDisconnected() override {
+            if (getDetachReason() == DetachReason::ConnectionClose) {
+                ++state.contextDetached;
+            }
+            if (state.captureLifetimeLogs) {
+                log().info("final application context onDisconnected");
+                frameworkLog().info("final framework context onDisconnected");
+            }
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char bytes[1024];
+            return readFromPeer(bytes, sizeof(bytes));
+        }
+
+        bool onSignal(int signum) override {
+            ++state.signals;
+            state.lastSignal = signum;
+            return false;
+        }
+
+        void onWriteError(int errnum) override {
+            core::socket::stream::SocketContext::onWriteError(errnum);
+        }
+
+        void onReadError(int errnum) override {
+            core::socket::stream::SocketContext::onReadError(errnum);
+        }
+
+        LifecycleState& state;
+        bool pending;
+    };
+
+    class CooperativePeer final : public core::eventreceiver::ReadEventReceiver {
+    public:
+        CooperativePeer(int fd,
+                        std::size_t expectedBytes,
+                        LifecycleState& state,
+                        const std::shared_ptr<PhysicalCounters>& physical)
+            : ReadEventReceiver("stream framework shutdown peer", utils::Timeval({0, 10000}))
+            , fd(fd)
+            , expectedBytes(expectedBytes)
+            , state(state)
+            , physical(physical) {
+            const int flags = ::fcntl(fd, F_GETFL, 0);
+            if (flags >= 0) {
+                static_cast<void>(::fcntl(fd, F_SETFL, flags | O_NONBLOCK));
+            }
+            ReadEventReceiver::enable(fd);
+        }
+
+    private:
+        ~CooperativePeer() override {
+            if (fd >= 0) {
+                ::close(fd);
+            }
+            ++state.peerDestroyed;
+        }
+
+        void readEvent() override {
+            char bytes[4096];
+            for (;;) {
+                const ssize_t count = ::read(fd, bytes, sizeof(bytes));
+                if (count > 0) {
+                    state.peerBytes += static_cast<std::size_t>(count);
+                } else if (count == 0) {
+                    finish();
+                    return;
+                } else if (errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
+                    finish();
+                    return;
+                } else {
+                    break;
+                }
+            }
+            finishWhenComplete();
+        }
+
+        void readTimeout() override {
+            finishWhenComplete();
+        }
+
+        void onShutdown(const core::ShutdownContext&) override {
+            ++state.peerShutdownNotifications;
+            finishWhenComplete();
+        }
+
+        void unobservedEvent() override {
+            delete this;
+        }
+
+        void finishWhenComplete() {
+            if (physical->shutdownWrite == 1 && state.peerBytes == expectedBytes) {
+                finish();
+            }
+        }
+
+        void finish() {
+            if (ReadEventReceiver::isEnabled()) {
+                ReadEventReceiver::disable();
+            }
+        }
+
+        int fd;
+        std::size_t expectedBytes;
+        LifecycleState& state;
+        std::shared_ptr<PhysicalCounters> physical;
+    };
+
+    struct Fixture {
+        SocketPair pair;
+        LifecycleState lifecycle;
+        std::shared_ptr<PhysicalCounters> physical = std::make_shared<PhysicalCounters>();
+        TestConnection* connection = nullptr;
+
+        Fixture(bool pendingContext, const utils::Timeval& terminateTimeout, bool captureLifetimeLogs = false) {
+            lifecycle.captureLifetimeLogs = captureLifetimeLogs;
+            auto config = std::make_shared<TestConfig>(terminateTimeout);
+            config->setOnDestroy([this](net::config::ConfigInstance* configInstance) {
+                if (lifecycle.captureLifetimeLogs) {
+                    configInstance->log().info("final config destroy callback");
+                }
+                ++lifecycle.configDestroyed;
+            });
+            connection = new TestConnection(
+                TestPhysicalSocket(pair.releaseConnectionFd(), physical),
+                [this](TestConnection* closingConnection) {
+                    ++lifecycle.disconnects;
+                    lifecycle.totalSentAtDisconnect = closingConnection->getTotalSent();
+                    lifecycle.totalQueuedAtDisconnect = closingConnection->getTotalQueued();
+                    connection = nullptr;
+                },
+                41,
+                config,
+                lifecycle);
+            connection->setSocketContext(new CountingContext(connection, lifecycle, false));
+            if (pendingContext) {
+                connection->setSocketContext(new CountingContext(connection, lifecycle, true));
+            }
+        }
+    };
+
+    enum class Trigger { Requested, Signal, NoObserver };
+
+    int runPlainScenario(Trigger trigger, bool queued, bool cooperative, bool pendingContext) {
+        tests::support::TestResult result;
+        char arg0[] = "StreamFrameworkShutdownTest";
+        char* args[] = {arg0, nullptr};
+        core::SNodeC::init(1, args);
+
+        const utils::Timeval terminateTimeout = cooperative ? utils::Timeval({1, 0}) : utils::Timeval({0, 50000});
+        Fixture fixture(pendingContext, terminateTimeout);
+        result.expectTrue(fixture.pair.valid() || fixture.connection != nullptr, "socketpair and connection are available");
+
+        const std::string payload = queued ? std::string(32 * 1024, 'Q') : std::string();
+        if (queued) {
+            fixture.connection->sendToPeer(payload);
+        }
+        if (cooperative) {
+            static_cast<void>(new CooperativePeer(
+                fixture.pair.releasePeerFd(), payload.size(), fixture.lifecycle, fixture.physical));
+        }
+
+        core::timer::Timer stopTimer = core::timer::Timer::singleshotTimer(
+            [&fixture, trigger]() {
+                if (trigger == Trigger::Signal) {
+                    static_cast<void>(::kill(::getpid(), SIGTERM));
+                    return;
+                }
+
+                core::SNodeC::stop();
+                core::timer::Timer rejectedTimer = core::timer::Timer::singleshotTimer(
+                    [&fixture]() {
+                        ++fixture.lifecycle.timerAfterStopping;
+                    },
+                    utils::Timeval());
+                if (trigger == Trigger::NoObserver) {
+                    core::EventLoop::instance().getEventMultiplexer().shutdown({core::ShutdownReason::NoObserver, 0});
+                }
+            },
+            utils::Timeval({0, 1000}));
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        result.expectEqual(trigger == Trigger::Signal ? -SIGTERM : 0, startResult, "start result preserves shutdown trigger");
+        result.expectEqual(1, fixture.lifecycle.contextAttached, "active context attaches once");
+        result.expectEqual(1, fixture.lifecycle.contextDetached, "active context detaches once");
+        result.expectEqual(1, fixture.lifecycle.activeContextDestroyed, "active context is destroyed once");
+        result.expectEqual(pendingContext ? 1 : 0,
+                           fixture.lifecycle.pendingContextDestroyed,
+                           "pending context is destroyed exactly once when present");
+        result.expectEqual(trigger == Trigger::Signal ? 1 : 0, fixture.lifecycle.signals, "signal callback count matches trigger");
+        result.expectEqual(trigger == Trigger::Signal ? SIGTERM : 0, fixture.lifecycle.lastSignal, "signal number is preserved");
+        result.expectEqual(1, fixture.physical->shutdownWrite, "all shutdown reasons use the write-shutdown path once");
+        result.expectEqual(1, fixture.lifecycle.disconnects, "connection disconnect callback runs once");
+        result.expectEqual(1, fixture.lifecycle.connectionDestroyed, "connection destructor runs once");
+        result.expectEqual(1, fixture.physical->closes, "physical descriptor closes once");
+        result.expectEqual(1, fixture.lifecycle.configDestroyed, "connection releases config before Config termination");
+        result.expectEqual(0, fixture.lifecycle.timerAfterStopping, "new core timer is rejected while STOPPING");
+        result.expectTrue(fixture.connection == nullptr, "connection is destroyed before start returns");
+
+        if (queued) {
+            result.expectEqual(static_cast<int>(payload.size()),
+                               static_cast<int>(fixture.lifecycle.totalQueuedAtDisconnect),
+                               "queued payload is recorded once");
+            result.expectEqual(static_cast<int>(payload.size()),
+                               static_cast<int>(fixture.lifecycle.totalSentAtDisconnect),
+                               "queued payload drains before write shutdown");
+            result.expectEqual(static_cast<int>(payload.size()),
+                               static_cast<int>(fixture.lifecycle.peerBytes),
+                               "cooperative peer receives the complete queued payload");
+        }
+
+        return result.processResult();
+    }
+
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::logToFile(logFile);
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    struct CapturedRecord {
+        std::string origin;
+        std::string boundary;
+        std::string component;
+        std::optional<std::string> instance;
+        std::optional<std::string> role;
+        std::optional<std::string> connection;
+        std::string message;
+    };
+
+    std::filesystem::path lifetimeLogPath() {
+        const auto path = std::filesystem::temp_directory_path() / "snodec-stream-framework-shutdown-lifetime.jsonl";
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    std::vector<CapturedRecord> readRecords(const std::filesystem::path& path) {
+        std::vector<CapturedRecord> records;
+        std::ifstream input(path);
+        std::string line;
+        while (std::getline(input, line)) {
+            if (line.empty()) {
+                continue;
+            }
+            const auto json = nlohmann::json::parse(line);
+            records.push_back(CapturedRecord{
+                .origin = json.at("origin").get<std::string>(),
+                .boundary = json.at("boundary").get<std::string>(),
+                .component = json.at("component").get<std::string>(),
+                .instance = json.contains("instance") ? std::optional<std::string>(json.at("instance").get<std::string>()) : std::nullopt,
+                .role = json.contains("role") ? std::optional<std::string>(json.at("role").get<std::string>()) : std::nullopt,
+                .connection =
+                    json.contains("connection") ? std::optional<std::string>(json.at("connection").get<std::string>()) : std::nullopt,
+                .message = json.at("message").get<std::string>(),
+            });
+        }
+        return records;
+    }
+
+    std::optional<std::size_t> findRecord(const std::vector<CapturedRecord>& records, const std::string& message) {
+        for (std::size_t index = 0; index < records.size(); ++index) {
+            if (records[index].message == message) {
+                return index;
+            }
+        }
+        return std::nullopt;
+    }
+
+    int countRecords(const std::vector<CapturedRecord>& records, const std::string& message) {
+        return static_cast<int>(std::count_if(records.begin(), records.end(), [&message](const CapturedRecord& record) {
+            return record.message == message;
+        }));
+    }
+
+    void expectIdentity(tests::support::TestResult& result,
+                        const CapturedRecord& record,
+                        const std::string& origin,
+                        const std::string& boundary,
+                        const std::string& component,
+                        const std::optional<std::string>& role,
+                        const std::optional<std::string>& connection,
+                        const std::string& label) {
+        result.expectTrue(record.origin == origin, label + " retains origin identity");
+        result.expectTrue(record.boundary == boundary, label + " retains boundary identity");
+        result.expectTrue(record.component == component, label + " retains component identity");
+        result.expectTrue(record.instance && *record.instance == "stream-framework-shutdown", label + " retains instance identity");
+        result.expectTrue(record.role == role, label + " retains role identity where applicable");
+        result.expectTrue(record.connection == connection, label + " retains connection identity where applicable");
+    }
+
+    int runLoggingLifetimeScenario() {
+        tests::support::TestResult result;
+        const auto logPath = lifetimeLogPath();
+        LoggerStateGuard loggerGuard(logPath.string());
+
+        char arg0[] = "StreamFrameworkShutdownTest";
+        char arg1[] = "--log-level=6";
+        char arg2[] = "--log-format=json";
+        char arg3[] = "--quiet";
+        char* args[] = {arg0, arg1, arg2, arg3, nullptr};
+        core::SNodeC::init(4, args);
+
+        Fixture fixture(true, utils::Timeval({1, 0}), true);
+        static_cast<void>(new CooperativePeer(fixture.pair.releasePeerFd(), 0, fixture.lifecycle, fixture.physical));
+        core::timer::Timer stopTimer = core::timer::Timer::singleshotTimer(
+            []() {
+                core::SNodeC::stop();
+            },
+            utils::Timeval({0, 1000}));
+
+        result.expectEqual(0, core::SNodeC::start(utils::Timeval({1, 0})), "requested logging-lifetime shutdown completes");
+        result.expectEqual(1, fixture.lifecycle.contextDetached, "active context detaches once before config termination");
+        result.expectEqual(1, fixture.lifecycle.activeContextDestroyed, "active context is destroyed once before config termination");
+        result.expectEqual(1, fixture.lifecycle.pendingContextDestroyed, "pending context is destroyed once before config termination");
+        result.expectEqual(1, fixture.lifecycle.disconnects, "disconnect callback runs once before config termination");
+        result.expectEqual(1, fixture.lifecycle.connectionDestroyed, "connection is destroyed once before config termination");
+        result.expectEqual(1, fixture.lifecycle.configDestroyed, "connection-owned config is destroyed once before Config::terminate");
+        result.expectTrue(fixture.connection == nullptr, "connection does not survive Config::terminate");
+
+        logger::Logger::disableLogToFile();
+        const std::vector<CapturedRecord> records = readRecords(logPath);
+        const std::vector<std::string> lifetimeMessages = {
+            "final application context onDisconnected",
+            "final framework context onDisconnected",
+            "final active context destructor cleanup",
+            "final pending context destructor cleanup",
+            "disconnected",
+            "final connection destructor cleanup",
+            "final config destroy callback",
+        };
+        const auto configShutdown = findRecord(records, "Core: Shutdown config system");
+        result.expectTrue(configShutdown.has_value(), "Config::terminate phase is observable in captured semantic logs");
+        for (const std::string& message : lifetimeMessages) {
+            const auto lifetimeRecord = findRecord(records, message);
+            result.expectEqual(1, countRecords(records, message), message + " occurs exactly once");
+            result.expectTrue(lifetimeRecord && configShutdown && *lifetimeRecord < *configShutdown,
+                              message + " occurs before the Config::terminate phase");
+        }
+
+        const auto expectRecordIdentity = [&](const std::string& message,
+                                              const std::string& origin,
+                                              const std::string& boundary,
+                                              const std::string& component,
+                                              const std::optional<std::string>& role,
+                                              const std::optional<std::string>& connection) {
+            const auto index = findRecord(records, message);
+            result.expectTrue(index.has_value(), message + " is available for identity assertions");
+            if (index) {
+                expectIdentity(result, records[*index], origin, boundary, component, role, connection, message);
+            }
+        };
+
+        expectRecordIdentity("final application context onDisconnected",
+                             "application",
+                             "context",
+                             "core.socket.context",
+                             std::nullopt,
+                             std::optional<std::string>("41"));
+        for (const std::string& message : {"final framework context onDisconnected",
+                                          "final active context destructor cleanup",
+                                          "final pending context destructor cleanup"}) {
+            expectRecordIdentity(
+                message, "framework", "context", "core.socket.context", std::nullopt, std::optional<std::string>("41"));
+        }
+        for (const std::string& message : {"disconnected", "final connection destructor cleanup"}) {
+            expectRecordIdentity(
+                message, "framework", "connection", "core.socket.stream", std::nullopt, std::optional<std::string>("41"));
+        }
+        expectRecordIdentity("final config destroy callback",
+                             "framework",
+                             "configuration",
+                             "configuration",
+                             std::optional<std::string>("client"),
+                             std::nullopt);
+
+        return result.processResult();
+    }
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    const std::string scenario = argc > 1 ? argv[1] : "plain_requested_empty";
+
+    if (scenario == "plain_requested_empty") {
+        return runPlainScenario(Trigger::Requested, false, true, true);
+    }
+    if (scenario == "plain_requested_queued") {
+        return runPlainScenario(Trigger::Requested, true, true, false);
+    }
+    if (scenario == "plain_signal_false_veto") {
+        return runPlainScenario(Trigger::Signal, false, true, false);
+    }
+    if (scenario == "plain_no_observer") {
+        return runPlainScenario(Trigger::NoObserver, false, true, false);
+    }
+    if (scenario == "plain_noncooperating_timeout") {
+        return runPlainScenario(Trigger::Requested, false, false, false);
+    }
+    if (scenario == "destruction_logging_order") {
+        return runLoggingLifetimeScenario();
+    }
+
+    return 2;
+}

--- a/tests/unit/core/StreamFrameworkShutdownTest.cpp
+++ b/tests/unit/core/StreamFrameworkShutdownTest.cpp
@@ -16,7 +16,6 @@
 #include "tests/support/TestResult.h"
 
 #include <algorithm>
-#include <array>
 #include <cerrno>
 #include <csignal>
 #include <cstdint>
@@ -43,9 +42,8 @@ namespace {
         using ReceiverMap = decltype(observedEventReceiverLists);
     };
 
-    static_assert(
-        std::is_same_v<typename PublisherContainerProbe::ReceiverMap::mapped_type, std::list<core::DescriptorEventReceiver*>>,
-        "Descriptor shutdown traversal relies on stable std::list iterators");
+    static_assert(std::is_same_v<typename PublisherContainerProbe::ReceiverMap::mapped_type, std::list<core::DescriptorEventReceiver*>>,
+                  "Descriptor shutdown traversal relies on stable std::list iterators");
 
     struct LifecycleState {
         int contextAttached = 0;
@@ -64,12 +62,11 @@ namespace {
         std::size_t totalSentAtDisconnect = 0;
         std::size_t totalQueuedAtDisconnect = 0;
         int activeContextVisibilityChecks = 0;
-        int postDetachContextVisibilityChecks = 0;
+        int pendingContextVisibilityChecks = 0;
+        int disconnectContextVisibilityChecks = 0;
         int invalidContextVisibility = 0;
         int unexpectedReentrantAttaches = 0;
         std::function<void()> onContextDisconnect;
-        std::function<void()> onPendingContextDestroy;
-        std::function<void()> onDisconnect;
         bool captureLifetimeLogs = false;
     };
 
@@ -128,6 +125,7 @@ namespace {
     class TestPhysicalSocket {
     public:
         using SocketAddress = TestSocketAddress;
+
         enum class SHUT { RD, WR, RDWR };
 
         TestPhysicalSocket(int fd, std::shared_ptr<PhysicalCounters> counters)
@@ -153,6 +151,7 @@ namespace {
                 fd = std::exchange(other.fd, -1);
                 counters = std::move(other.counters);
             }
+
             return *this;
         }
 
@@ -186,6 +185,7 @@ namespace {
             } else {
                 ++counters->shutdownBoth;
             }
+
             return 0;
         }
 
@@ -278,8 +278,7 @@ namespace {
         ~TestWriter() override = default;
     };
 
-    class TestConnection final
-        : public core::socket::stream::SocketConnectionT<TestPhysicalSocket, TestReader, TestWriter, TestConfig> {
+    class TestConnection final : public core::socket::stream::SocketConnectionT<TestPhysicalSocket, TestReader, TestWriter, TestConfig> {
     private:
         using Super = core::socket::stream::SocketConnectionT<TestPhysicalSocket, TestReader, TestWriter, TestConfig>;
 
@@ -303,6 +302,7 @@ namespace {
             if (state.captureLifetimeLogs) {
                 Super::log().info("final connection destructor cleanup");
             }
+
             ++state.connectionDestroyed;
         }
 
@@ -310,43 +310,38 @@ namespace {
         LifecycleState& state;
     };
 
-    struct ContextDestructionProbe {
-        int* exactDestructionCount = nullptr;
-        std::function<void()> onDestroy;
-    };
-
     class CountingContext final : public core::socket::stream::SocketContext {
     public:
         CountingContext(TestConnection* connection,
                         LifecycleState& state,
                         bool pending,
-                        ContextDestructionProbe destructionProbe = {})
+                        bool expectActiveContextVisibleOnDestroy = false,
+                        int* exactDestructionCount = nullptr)
             : SocketContext(connection)
             , state(state)
             , pending(pending)
-            , destructionProbe(std::move(destructionProbe)) {
+            , expectActiveContextVisibleOnDestroy(expectActiveContextVisibleOnDestroy)
+            , exactDestructionCount(exactDestructionCount) {
         }
 
         ~CountingContext() override {
             if (state.captureLifetimeLogs) {
                 frameworkLog().info(pending ? "final pending context destructor cleanup" : "final active context destructor cleanup");
             }
+
             if (pending) {
-                ++state.postDetachContextVisibilityChecks;
-                if (getSocketConnection()->getSocketContext() != nullptr) {
+                ++state.pendingContextVisibilityChecks;
+
+                const bool activeContextVisible = getSocketConnection()->getSocketContext() != nullptr;
+
+                if (activeContextVisible != expectActiveContextVisibleOnDestroy) {
                     ++state.invalidContextVisibility;
                 }
+
                 ++state.pendingContextDestroyed;
-                if (destructionProbe.exactDestructionCount != nullptr) {
-                    ++*destructionProbe.exactDestructionCount;
-                }
-                if (destructionProbe.onDestroy) {
-                    auto callback = std::move(destructionProbe.onDestroy);
-                    callback();
-                }
-                if (state.onPendingContextDestroy) {
-                    auto callback = std::move(state.onPendingContextDestroy);
-                    callback();
+
+                if (exactDestructionCount != nullptr) {
+                    ++*exactDestructionCount;
                 }
             } else {
                 ++state.activeContextDestroyed;
@@ -362,14 +357,17 @@ namespace {
             if (getDetachReason() == DetachReason::ConnectionClose) {
                 ++state.contextDetached;
                 ++state.activeContextVisibilityChecks;
+
                 if (getSocketConnection()->getSocketContext() != this) {
                     ++state.invalidContextVisibility;
                 }
             }
+
             if (state.captureLifetimeLogs) {
                 log().info("final application context onDisconnected");
                 frameworkLog().info("final framework context onDisconnected");
             }
+
             if (state.onContextDisconnect) {
                 auto callback = std::move(state.onContextDisconnect);
                 callback();
@@ -384,6 +382,7 @@ namespace {
         bool onSignal(int signum) override {
             ++state.signals;
             state.lastSignal = signum;
+
             return false;
         }
 
@@ -397,15 +396,13 @@ namespace {
 
         LifecycleState& state;
         bool pending;
-        ContextDestructionProbe destructionProbe;
+        bool expectActiveContextVisibleOnDestroy;
+        int* exactDestructionCount;
     };
 
     class CooperativePeer final : public core::eventreceiver::ReadEventReceiver {
     public:
-        CooperativePeer(int fd,
-                        std::size_t expectedBytes,
-                        LifecycleState& state,
-                        const std::shared_ptr<PhysicalCounters>& physical)
+        CooperativePeer(int fd, std::size_t expectedBytes, LifecycleState& state, const std::shared_ptr<PhysicalCounters>& physical)
             : ReadEventReceiver("stream framework shutdown peer", utils::Timeval({0, 10000}))
             , fd(fd)
             , expectedBytes(expectedBytes)
@@ -415,6 +412,7 @@ namespace {
             if (flags >= 0) {
                 static_cast<void>(::fcntl(fd, F_SETFL, flags | O_NONBLOCK));
             }
+
             ReadEventReceiver::enable(fd);
         }
 
@@ -423,13 +421,16 @@ namespace {
             if (fd >= 0) {
                 ::close(fd);
             }
+
             ++state.peerDestroyed;
         }
 
         void readEvent() override {
             char bytes[4096];
+
             for (;;) {
                 const ssize_t count = ::read(fd, bytes, sizeof(bytes));
+
                 if (count > 0) {
                     state.peerBytes += static_cast<std::size_t>(count);
                 } else if (count == 0) {
@@ -442,6 +443,7 @@ namespace {
                     break;
                 }
             }
+
             finishWhenComplete();
         }
 
@@ -485,53 +487,60 @@ namespace {
         Fixture(bool pendingContext,
                 const utils::Timeval& terminateTimeout,
                 bool captureLifetimeLogs = false,
-                bool installContextDuringDetach = false,
-                bool installContextDuringPendingDestroy = false,
-                bool installContextDuringDisconnect = false) {
+                bool installContextDuringDetach = false) {
             lifecycle.captureLifetimeLogs = captureLifetimeLogs;
+
             auto config = std::make_shared<TestConfig>(terminateTimeout);
+
             config->setOnDestroy([this](net::config::ConfigInstance* configInstance) {
                 if (lifecycle.captureLifetimeLogs) {
                     configInstance->log().info("final config destroy callback");
                 }
+
                 ++lifecycle.configDestroyed;
             });
+
             connection = new TestConnection(
                 TestPhysicalSocket(pair.releaseConnectionFd(), physical),
                 [this](TestConnection* closingConnection) {
                     ++lifecycle.disconnects;
+
                     lifecycle.totalSentAtDisconnect = closingConnection->getTotalSent();
                     lifecycle.totalQueuedAtDisconnect = closingConnection->getTotalQueued();
-                    ++lifecycle.postDetachContextVisibilityChecks;
+
+                    ++lifecycle.disconnectContextVisibilityChecks;
+
                     if (closingConnection->getSocketContext() != nullptr) {
                         ++lifecycle.invalidContextVisibility;
                     }
-                    if (lifecycle.onDisconnect) {
-                        auto callback = std::move(lifecycle.onDisconnect);
-                        callback();
-                    }
+
                     connection = nullptr;
                 },
                 41,
                 config,
                 lifecycle);
+
             connection->setSocketContext(new CountingContext(connection, lifecycle, false));
+
             if (pendingContext) {
-                connection->setSocketContext(new CountingContext(connection, lifecycle, true));
+                // This pending switch is discarded before active detach.
+                // The active context must therefore still be visible while
+                // this pending context's destructor executes.
+                connection->setSocketContext(new CountingContext(connection, lifecycle, true, true));
             }
+
             if (installContextDuringDetach) {
                 lifecycle.onContextDisconnect = [this]() {
-                    connection->setSocketContext(new CountingContext(connection, lifecycle, true));
-                };
-            }
-            if (installContextDuringPendingDestroy) {
-                lifecycle.onPendingContextDestroy = [this]() {
-                    connection->setSocketContext(new CountingContext(connection, lifecycle, true));
-                };
-            }
-            if (installContextDuringDisconnect) {
-                lifecycle.onDisconnect = [this]() {
-                    connection->setSocketContext(new CountingContext(connection, lifecycle, true));
+                    const int attachedBefore = lifecycle.contextAttached;
+
+                    // The active context is still registered while
+                    // onDisconnected() runs, so this is queued rather
+                    // than attached.
+                    connection->setSocketContext(new CountingContext(connection, lifecycle, true, false));
+
+                    if (lifecycle.contextAttached != attachedBefore) {
+                        ++lifecycle.unexpectedReentrantAttaches;
+                    }
                 };
             }
         }
@@ -539,45 +548,43 @@ namespace {
 
     enum class Trigger { Requested, Signal, NoObserver };
 
-    int runPlainScenario(Trigger trigger,
-                         bool queued,
-                         bool cooperative,
-                         bool pendingContext,
-                         bool installContextDuringDetach = false,
-                         bool installContextDuringPendingDestroy = false,
-                         bool installContextDuringDisconnect = false) {
+    int runPlainScenario(Trigger trigger, bool queued, bool cooperative, bool pendingContext, bool installContextDuringDetach = false) {
         tests::support::TestResult result;
+
         char arg0[] = "StreamFrameworkShutdownTest";
         char* args[] = {arg0, nullptr};
+
         core::SNodeC::init(1, args);
 
         const utils::Timeval terminateTimeout = cooperative ? utils::Timeval({1, 0}) : utils::Timeval({0, 50000});
-        Fixture fixture(pendingContext,
-                        terminateTimeout,
-                        false,
-                        installContextDuringDetach,
-                        installContextDuringPendingDestroy,
-                        installContextDuringDisconnect);
+
+        Fixture fixture(pendingContext, terminateTimeout, false, installContextDuringDetach);
+
         result.expectTrue(fixture.pair.valid() || fixture.connection != nullptr, "socketpair and connection are available");
 
         const std::string payload = queued ? std::string(32 * 1024, 'Q') : std::string();
+
         if (queued) {
             fixture.connection->sendToPeer(payload);
         }
+
         if (cooperative) {
-            static_cast<void>(new CooperativePeer(
-                fixture.pair.releasePeerFd(), payload.size(), fixture.lifecycle, fixture.physical));
+            static_cast<void>(new CooperativePeer(fixture.pair.releasePeerFd(), payload.size(), fixture.lifecycle, fixture.physical));
         }
 
         int startResult = 0;
+
         if (trigger == Trigger::NoObserver) {
             core::SNodeC::stop();
+
             core::timer::Timer rejectedTimer = core::timer::Timer::singleshotTimer(
                 [&fixture]() {
                     ++fixture.lifecycle.timerAfterStopping;
                 },
                 utils::Timeval());
+
             core::EventLoop::instance().getEventMultiplexer().shutdown({core::ShutdownReason::NoObserver, 0});
+
             core::SNodeC::free();
         } else {
             core::timer::Timer stopTimer = core::timer::Timer::singleshotTimer(
@@ -588,6 +595,7 @@ namespace {
                     }
 
                     core::SNodeC::stop();
+
                     core::timer::Timer rejectedTimer = core::timer::Timer::singleshotTimer(
                         [&fixture]() {
                             ++fixture.lifecycle.timerAfterStopping;
@@ -600,43 +608,58 @@ namespace {
         }
 
         result.expectEqual(trigger == Trigger::Signal ? -SIGTERM : 0, startResult, "start result preserves shutdown trigger");
+
         result.expectEqual(1, fixture.lifecycle.contextAttached, "active context attaches once");
+
         result.expectEqual(1, fixture.lifecycle.contextDetached, "active context detaches once");
+
         result.expectEqual(1, fixture.lifecycle.activeContextDestroyed, "active context is destroyed once");
-        const int expectedPendingContexts = (pendingContext ? 1 : 0) + (installContextDuringDetach ? 1 : 0) +
-                                            (installContextDuringPendingDestroy ? 1 : 0) + (installContextDuringDisconnect ? 1 : 0);
+
+        const int expectedPendingContexts = (pendingContext ? 1 : 0) + (installContextDuringDetach ? 1 : 0);
+
+        result.expectEqual(
+            expectedPendingContexts, fixture.lifecycle.pendingContextDestroyed, "pending context is destroyed exactly once when present");
+
+        result.expectEqual(
+            1, fixture.lifecycle.activeContextVisibilityChecks, "onDisconnected observes the still-live active context exactly once");
+
         result.expectEqual(expectedPendingContexts,
-                           fixture.lifecycle.pendingContextDestroyed,
-                           "pending context is destroyed exactly once when present");
-        result.expectEqual(1,
-                           fixture.lifecycle.activeContextVisibilityChecks,
-                           "onDisconnected observes the still-live active context exactly once");
-        result.expectEqual(expectedPendingContexts + 1,
-                           fixture.lifecycle.postDetachContextVisibilityChecks,
-                           "pending destructors and onDisconnect inspect context visibility after detach");
-        result.expectEqual(0,
-                           fixture.lifecycle.invalidContextVisibility,
-                           "no callback after detach observes a stale active context");
-        result.expectEqual(0,
-                           fixture.lifecycle.unexpectedReentrantAttaches,
-                           "no reentrant context attaches during terminal teardown");
+                           fixture.lifecycle.pendingContextVisibilityChecks,
+                           "every pending context destructor checks context visibility");
+
+        result.expectEqual(1, fixture.lifecycle.disconnectContextVisibilityChecks, "onDisconnect checks context visibility once");
+
+        result.expectEqual(0, fixture.lifecycle.invalidContextVisibility, "context visibility matches each lifecycle boundary");
+
+        result.expectEqual(0, fixture.lifecycle.unexpectedReentrantAttaches, "a context requested during active detach is not attached");
+
         result.expectEqual(trigger == Trigger::Signal ? 1 : 0, fixture.lifecycle.signals, "signal callback count matches trigger");
+
         result.expectEqual(trigger == Trigger::Signal ? SIGTERM : 0, fixture.lifecycle.lastSignal, "signal number is preserved");
+
         result.expectEqual(1, fixture.physical->shutdownWrite, "all shutdown reasons use the write-shutdown path once");
+
         result.expectEqual(1, fixture.lifecycle.disconnects, "connection disconnect callback runs once");
+
         result.expectEqual(1, fixture.lifecycle.connectionDestroyed, "connection destructor runs once");
+
         result.expectEqual(1, fixture.physical->closes, "physical descriptor closes once");
+
         result.expectEqual(1, fixture.lifecycle.configDestroyed, "connection releases config before Config termination");
+
         result.expectEqual(0, fixture.lifecycle.timerAfterStopping, "new core timer is rejected while STOPPING");
+
         result.expectTrue(fixture.connection == nullptr, "connection is destroyed before start returns");
 
         if (queued) {
             result.expectEqual(static_cast<int>(payload.size()),
                                static_cast<int>(fixture.lifecycle.totalQueuedAtDisconnect),
                                "queued payload is recorded once");
+
             result.expectEqual(static_cast<int>(payload.size()),
                                static_cast<int>(fixture.lifecycle.totalSentAtDisconnect),
                                "queued payload drains before write shutdown");
+
             result.expectEqual(static_cast<int>(payload.size()),
                                static_cast<int>(fixture.lifecycle.peerBytes),
                                "cooperative peer receives the complete queued payload");
@@ -645,127 +668,70 @@ namespace {
         return result.processResult();
     }
 
-    enum class ContextReentrancyScenario { ActiveDetach, PendingDestructor, RecursivePendingDestructor, OnDisconnect };
-
-    int runContextReentrancyScenario(ContextReentrancyScenario scenario) {
+    int runActiveDetachContextVisibilityScenario() {
         tests::support::TestResult result;
+
         char arg0[] = "StreamFrameworkShutdownTest";
         char* args[] = {arg0, nullptr};
+
         core::SNodeC::init(1, args);
 
         Fixture fixture(false, utils::Timeval({1, 0}));
-        std::array<int, 3> exactDestructions{};
-        int expectedPendingContexts = 0;
 
-        switch (scenario) {
-            case ContextReentrancyScenario::ActiveDetach:
-                expectedPendingContexts = 1;
-                fixture.lifecycle.onContextDisconnect = [&fixture, &exactDestructions]() {
-                    const int attachedBefore = fixture.lifecycle.contextAttached;
-                    fixture.connection->setSocketContext(new CountingContext(
-                        fixture.connection, fixture.lifecycle, true, {.exactDestructionCount = &exactDestructions[0]}));
-                    if (fixture.lifecycle.contextAttached != attachedBefore) {
-                        ++fixture.lifecycle.unexpectedReentrantAttaches;
-                    }
-                };
-                break;
-            case ContextReentrancyScenario::PendingDestructor:
-                expectedPendingContexts = 2;
-                fixture.connection->setSocketContext(new CountingContext(
-                    fixture.connection,
-                    fixture.lifecycle,
-                    true,
-                    {.exactDestructionCount = &exactDestructions[0],
-                     .onDestroy = [&fixture, &exactDestructions]() {
-                         const int attachedBefore = fixture.lifecycle.contextAttached;
-                         fixture.connection->setSocketContext(new CountingContext(
-                             fixture.connection,
-                             fixture.lifecycle,
-                             true,
-                             {.exactDestructionCount = &exactDestructions[1]}));
-                         if (fixture.lifecycle.contextAttached != attachedBefore) {
-                             ++fixture.lifecycle.unexpectedReentrantAttaches;
-                         }
-                     }}));
-                break;
-            case ContextReentrancyScenario::RecursivePendingDestructor:
-                expectedPendingContexts = 3;
-                fixture.connection->setSocketContext(new CountingContext(
-                    fixture.connection,
-                    fixture.lifecycle,
-                    true,
-                    {.exactDestructionCount = &exactDestructions[0],
-                     .onDestroy = [&fixture, &exactDestructions]() {
-                         const int attachedBefore = fixture.lifecycle.contextAttached;
-                         fixture.connection->setSocketContext(new CountingContext(
-                             fixture.connection,
-                             fixture.lifecycle,
-                             true,
-                             {.exactDestructionCount = &exactDestructions[1],
-                              .onDestroy = [&fixture, &exactDestructions]() {
-                                  const int recursiveAttachedBefore = fixture.lifecycle.contextAttached;
-                                  fixture.connection->setSocketContext(new CountingContext(
-                                      fixture.connection,
-                                      fixture.lifecycle,
-                                      true,
-                                      {.exactDestructionCount = &exactDestructions[2]}));
-                                  if (fixture.lifecycle.contextAttached != recursiveAttachedBefore) {
-                                      ++fixture.lifecycle.unexpectedReentrantAttaches;
-                                  }
-                              }}));
-                         if (fixture.lifecycle.contextAttached != attachedBefore) {
-                             ++fixture.lifecycle.unexpectedReentrantAttaches;
-                         }
-                     }}));
-                break;
-            case ContextReentrancyScenario::OnDisconnect:
-                expectedPendingContexts = 1;
-                fixture.lifecycle.onDisconnect = [&fixture, &exactDestructions]() {
-                    const int attachedBefore = fixture.lifecycle.contextAttached;
-                    fixture.connection->setSocketContext(new CountingContext(
-                        fixture.connection, fixture.lifecycle, true, {.exactDestructionCount = &exactDestructions[0]}));
-                    if (fixture.lifecycle.contextAttached != attachedBefore) {
-                        ++fixture.lifecycle.unexpectedReentrantAttaches;
-                    }
-                };
-                break;
-        }
+        int exactDestructionCount = 0;
 
-        static_cast<void>(
-            new CooperativePeer(fixture.pair.releasePeerFd(), 0, fixture.lifecycle, fixture.physical));
+        fixture.lifecycle.onContextDisconnect = [&fixture, &exactDestructionCount]() {
+            const int attachedBefore = fixture.lifecycle.contextAttached;
+
+            fixture.connection->setSocketContext(
+                new CountingContext(fixture.connection, fixture.lifecycle, true, false, &exactDestructionCount));
+
+            if (fixture.lifecycle.contextAttached != attachedBefore) {
+                ++fixture.lifecycle.unexpectedReentrantAttaches;
+            }
+        };
+
+        static_cast<void>(new CooperativePeer(fixture.pair.releasePeerFd(), 0, fixture.lifecycle, fixture.physical));
+
         core::timer::Timer stopTimer = core::timer::Timer::singleshotTimer(
             []() {
                 core::SNodeC::stop();
             },
             utils::Timeval({0, 1000}));
 
-        result.expectEqual(0, core::SNodeC::start(utils::Timeval({1, 0})), "terminal context reentrancy shutdown completes");
+        result.expectEqual(0, core::SNodeC::start(utils::Timeval({1, 0})), "active-detach context reentrancy shutdown completes");
+
         result.expectEqual(1, fixture.lifecycle.contextAttached, "only the original active context attaches");
+
         result.expectEqual(1, fixture.lifecycle.contextDetached, "the active context detaches once");
+
         result.expectEqual(1, fixture.lifecycle.activeContextDestroyed, "the active context is destroyed once");
-        result.expectEqual(expectedPendingContexts,
-                           fixture.lifecycle.pendingContextDestroyed,
-                           "every pending or reentrant context is destroyed once");
-        result.expectEqual(1,
-                           fixture.lifecycle.activeContextVisibilityChecks,
-                           "onDisconnected sees the still-live active context");
-        result.expectEqual(expectedPendingContexts + 1,
-                           fixture.lifecycle.postDetachContextVisibilityChecks,
-                           "all pending destructors and onDisconnect inspect post-detach visibility");
-        result.expectEqual(0,
-                           fixture.lifecycle.invalidContextVisibility,
-                           "getSocketContext is null in every callback after detach returns");
-        result.expectEqual(0,
-                           fixture.lifecycle.unexpectedReentrantAttaches,
-                           "terminal replacements never run onConnected");
-        for (int index = 0; index < expectedPendingContexts; ++index) {
-            result.expectEqual(1, exactDestructions[static_cast<std::size_t>(index)], "each supplied context is destroyed exactly once");
-        }
-        result.expectEqual(1, fixture.physical->shutdownWrite, "terminal context test uses the coordinated write-shutdown path once");
+
+        result.expectEqual(1, fixture.lifecycle.pendingContextDestroyed, "the replacement queued during detach is destroyed once");
+
+        result.expectEqual(1, exactDestructionCount, "the supplied replacement context is destroyed exactly once");
+
+        result.expectEqual(1, fixture.lifecycle.activeContextVisibilityChecks, "onDisconnected sees the still-live active context");
+
+        result.expectEqual(1, fixture.lifecycle.pendingContextVisibilityChecks, "the queued replacement checks post-detach visibility");
+
+        result.expectEqual(1, fixture.lifecycle.disconnectContextVisibilityChecks, "onDisconnect checks post-detach visibility");
+
+        result.expectEqual(0, fixture.lifecycle.invalidContextVisibility, "context visibility is correct before and after detach");
+
+        result.expectEqual(
+            0, fixture.lifecycle.unexpectedReentrantAttaches, "the replacement requested during detach never runs onConnected");
+
+        result.expectEqual(1, fixture.physical->shutdownWrite, "active-detach context test uses the coordinated write-shutdown path once");
+
         result.expectEqual(1, fixture.lifecycle.disconnects, "onDisconnect runs once");
+
         result.expectEqual(1, fixture.lifecycle.connectionDestroyed, "connection destruction runs once");
+
         result.expectEqual(1, fixture.physical->closes, "physical descriptor closes once");
+
         result.expectEqual(1, fixture.lifecycle.configDestroyed, "connection configuration reference releases once");
+
         result.expectTrue(fixture.connection == nullptr, "connection is destroyed before start returns");
 
         return result.processResult();
@@ -803,9 +769,11 @@ namespace {
 
     std::filesystem::path lifetimeLogPath() {
         const auto path = std::filesystem::temp_directory_path() / "snodec-stream-framework-shutdown-lifetime.jsonl";
+
         std::error_code error;
         std::filesystem::remove(path, error);
         std::filesystem::remove(path.string() + ".1", error);
+
         return path;
     }
 
@@ -813,11 +781,14 @@ namespace {
         std::vector<CapturedRecord> records;
         std::ifstream input(path);
         std::string line;
+
         while (std::getline(input, line)) {
             if (line.empty()) {
                 continue;
             }
+
             const auto json = nlohmann::json::parse(line);
+
             records.push_back(CapturedRecord{
                 .origin = json.at("origin").get<std::string>(),
                 .boundary = json.at("boundary").get<std::string>(),
@@ -826,9 +797,9 @@ namespace {
                 .role = json.contains("role") ? std::optional<std::string>(json.at("role").get<std::string>()) : std::nullopt,
                 .connection =
                     json.contains("connection") ? std::optional<std::string>(json.at("connection").get<std::string>()) : std::nullopt,
-                .message = json.at("message").get<std::string>(),
-            });
+                .message = json.at("message").get<std::string>()});
         }
+
         return records;
     }
 
@@ -838,6 +809,7 @@ namespace {
                 return index;
             }
         }
+
         return std::nullopt;
     }
 
@@ -856,27 +828,38 @@ namespace {
                         const std::optional<std::string>& connection,
                         const std::string& label) {
         result.expectTrue(record.origin == origin, label + " retains origin identity");
+
         result.expectTrue(record.boundary == boundary, label + " retains boundary identity");
+
         result.expectTrue(record.component == component, label + " retains component identity");
+
         result.expectTrue(record.instance && *record.instance == "stream-framework-shutdown", label + " retains instance identity");
+
         result.expectTrue(record.role == role, label + " retains role identity where applicable");
+
         result.expectTrue(record.connection == connection, label + " retains connection identity where applicable");
     }
 
     int runLoggingLifetimeScenario() {
         tests::support::TestResult result;
+
         const auto logPath = lifetimeLogPath();
+
         LoggerStateGuard loggerGuard(logPath.string());
 
         char arg0[] = "StreamFrameworkShutdownTest";
         char arg1[] = "--log-level=6";
         char arg2[] = "--log-format=json";
         char arg3[] = "--quiet";
+
         char* args[] = {arg0, arg1, arg2, arg3, nullptr};
+
         core::SNodeC::init(4, args);
 
         Fixture fixture(true, utils::Timeval({1, 0}), true);
+
         static_cast<void>(new CooperativePeer(fixture.pair.releasePeerFd(), 0, fixture.lifecycle, fixture.physical));
+
         core::timer::Timer stopTimer = core::timer::Timer::singleshotTimer(
             []() {
                 core::SNodeC::stop();
@@ -884,30 +867,42 @@ namespace {
             utils::Timeval({0, 1000}));
 
         result.expectEqual(0, core::SNodeC::start(utils::Timeval({1, 0})), "requested logging-lifetime shutdown completes");
+
         result.expectEqual(1, fixture.lifecycle.contextDetached, "active context detaches once before config termination");
+
         result.expectEqual(1, fixture.lifecycle.activeContextDestroyed, "active context is destroyed once before config termination");
+
         result.expectEqual(1, fixture.lifecycle.pendingContextDestroyed, "pending context is destroyed once before config termination");
+
         result.expectEqual(1, fixture.lifecycle.disconnects, "disconnect callback runs once before config termination");
+
         result.expectEqual(1, fixture.lifecycle.connectionDestroyed, "connection is destroyed once before config termination");
+
         result.expectEqual(1, fixture.lifecycle.configDestroyed, "connection-owned config is destroyed once before Config::terminate");
+
         result.expectTrue(fixture.connection == nullptr, "connection does not survive Config::terminate");
 
         logger::Logger::disableLogToFile();
+
         const std::vector<CapturedRecord> records = readRecords(logPath);
-        const std::vector<std::string> lifetimeMessages = {
-            "final application context onDisconnected",
-            "final framework context onDisconnected",
-            "final active context destructor cleanup",
-            "final pending context destructor cleanup",
-            "disconnected",
-            "final connection destructor cleanup",
-            "final config destroy callback",
-        };
+
+        const std::vector<std::string> lifetimeMessages = {"final pending context destructor cleanup",
+                                                           "final application context onDisconnected",
+                                                           "final framework context onDisconnected",
+                                                           "final active context destructor cleanup",
+                                                           "disconnected",
+                                                           "final connection destructor cleanup",
+                                                           "final config destroy callback"};
+
         const auto configShutdown = findRecord(records, "Core: Shutdown config system");
+
         result.expectTrue(configShutdown.has_value(), "Config::terminate phase is observable in captured semantic logs");
+
         for (const std::string& message : lifetimeMessages) {
             const auto lifetimeRecord = findRecord(records, message);
+
             result.expectEqual(1, countRecords(records, message), message + " occurs exactly once");
+
             result.expectTrue(lifetimeRecord && configShutdown && *lifetimeRecord < *configShutdown,
                               message + " occurs before the Config::terminate phase");
         }
@@ -919,7 +914,9 @@ namespace {
                                               const std::optional<std::string>& role,
                                               const std::optional<std::string>& connection) {
             const auto index = findRecord(records, message);
+
             result.expectTrue(index.has_value(), message + " is available for identity assertions");
+
             if (index) {
                 expectIdentity(result, records[*index], origin, boundary, component, role, connection, message);
             }
@@ -931,16 +928,17 @@ namespace {
                              "core.socket.context",
                              std::nullopt,
                              std::optional<std::string>("41"));
+
         for (const std::string& message : {"final framework context onDisconnected",
-                                          "final active context destructor cleanup",
-                                          "final pending context destructor cleanup"}) {
-            expectRecordIdentity(
-                message, "framework", "context", "core.socket.context", std::nullopt, std::optional<std::string>("41"));
+                                           "final active context destructor cleanup",
+                                           "final pending context destructor cleanup"}) {
+            expectRecordIdentity(message, "framework", "context", "core.socket.context", std::nullopt, std::optional<std::string>("41"));
         }
+
         for (const std::string& message : {"disconnected", "final connection destructor cleanup"}) {
-            expectRecordIdentity(
-                message, "framework", "connection", "core.socket.stream", std::nullopt, std::optional<std::string>("41"));
+            expectRecordIdentity(message, "framework", "connection", "core.socket.stream", std::nullopt, std::optional<std::string>("41"));
         }
+
         expectRecordIdentity("final config destroy callback",
                              "framework",
                              "configuration",
@@ -959,36 +957,31 @@ int main(int argc, char* argv[]) {
     if (scenario == "plain_requested_empty") {
         return runPlainScenario(Trigger::Requested, false, true, true);
     }
+
     if (scenario == "plain_requested_queued") {
         return runPlainScenario(Trigger::Requested, true, true, false);
     }
+
     if (scenario == "plain_signal_false_veto") {
         return runPlainScenario(Trigger::Signal, false, true, false);
     }
+
     if (scenario == "plain_no_observer") {
         return runPlainScenario(Trigger::NoObserver, false, true, false);
     }
+
     if (scenario == "plain_noncooperating_timeout") {
         return runPlainScenario(Trigger::Requested, false, false, false);
     }
+
     if (scenario == "reentrant_context_cleanup") {
         return runPlainScenario(Trigger::Requested, false, true, false, true);
     }
-    if (scenario == "reentrant_context_finalizer_cleanup") {
-        return runPlainScenario(Trigger::Requested, false, true, true, true, true, true);
-    }
+
     if (scenario == "active_detach_context_visibility") {
-        return runContextReentrancyScenario(ContextReentrancyScenario::ActiveDetach);
+        return runActiveDetachContextVisibilityScenario();
     }
-    if (scenario == "pending_context_destructor_visibility") {
-        return runContextReentrancyScenario(ContextReentrancyScenario::PendingDestructor);
-    }
-    if (scenario == "recursive_pending_context_destructor_visibility") {
-        return runContextReentrancyScenario(ContextReentrancyScenario::RecursivePendingDestructor);
-    }
-    if (scenario == "on_disconnect_context_visibility") {
-        return runContextReentrancyScenario(ContextReentrancyScenario::OnDisconnect);
-    }
+
     if (scenario == "destruction_logging_order") {
         return runLoggingLifetimeScenario();
     }

--- a/tests/unit/core/StreamFrameworkShutdownTest.cpp
+++ b/tests/unit/core/StreamFrameworkShutdownTest.cpp
@@ -62,6 +62,8 @@ namespace {
         std::size_t peerBytes = 0;
         std::size_t totalSentAtDisconnect = 0;
         std::size_t totalQueuedAtDisconnect = 0;
+        std::function<void()> onContextDisconnect;
+        std::function<void()> onPendingContextDestroy;
         bool captureLifetimeLogs = false;
     };
 
@@ -316,6 +318,10 @@ namespace {
             }
             if (pending) {
                 ++state.pendingContextDestroyed;
+                if (state.onPendingContextDestroy) {
+                    auto callback = std::move(state.onPendingContextDestroy);
+                    callback();
+                }
             } else {
                 ++state.activeContextDestroyed;
             }
@@ -333,6 +339,10 @@ namespace {
             if (state.captureLifetimeLogs) {
                 log().info("final application context onDisconnected");
                 frameworkLog().info("final framework context onDisconnected");
+            }
+            if (state.onContextDisconnect) {
+                auto callback = std::move(state.onContextDisconnect);
+                callback();
             }
         }
 
@@ -441,7 +451,12 @@ namespace {
         std::shared_ptr<PhysicalCounters> physical = std::make_shared<PhysicalCounters>();
         TestConnection* connection = nullptr;
 
-        Fixture(bool pendingContext, const utils::Timeval& terminateTimeout, bool captureLifetimeLogs = false) {
+        Fixture(bool pendingContext,
+                const utils::Timeval& terminateTimeout,
+                bool captureLifetimeLogs = false,
+                bool installContextDuringDetach = false,
+                bool installContextDuringPendingDestroy = false,
+                bool installContextDuringDisconnect = false) {
             lifecycle.captureLifetimeLogs = captureLifetimeLogs;
             auto config = std::make_shared<TestConfig>(terminateTimeout);
             config->setOnDestroy([this](net::config::ConfigInstance* configInstance) {
@@ -452,10 +467,13 @@ namespace {
             });
             connection = new TestConnection(
                 TestPhysicalSocket(pair.releaseConnectionFd(), physical),
-                [this](TestConnection* closingConnection) {
+                [this, installContextDuringDisconnect](TestConnection* closingConnection) {
                     ++lifecycle.disconnects;
                     lifecycle.totalSentAtDisconnect = closingConnection->getTotalSent();
                     lifecycle.totalQueuedAtDisconnect = closingConnection->getTotalQueued();
+                    if (installContextDuringDisconnect) {
+                        closingConnection->setSocketContext(new CountingContext(closingConnection, lifecycle, true));
+                    }
                     connection = nullptr;
                 },
                 41,
@@ -465,19 +483,40 @@ namespace {
             if (pendingContext) {
                 connection->setSocketContext(new CountingContext(connection, lifecycle, true));
             }
+            if (installContextDuringDetach) {
+                lifecycle.onContextDisconnect = [this]() {
+                    connection->setSocketContext(new CountingContext(connection, lifecycle, true));
+                };
+            }
+            if (installContextDuringPendingDestroy) {
+                lifecycle.onPendingContextDestroy = [this]() {
+                    connection->setSocketContext(new CountingContext(connection, lifecycle, true));
+                };
+            }
         }
     };
 
     enum class Trigger { Requested, Signal, NoObserver };
 
-    int runPlainScenario(Trigger trigger, bool queued, bool cooperative, bool pendingContext) {
+    int runPlainScenario(Trigger trigger,
+                         bool queued,
+                         bool cooperative,
+                         bool pendingContext,
+                         bool installContextDuringDetach = false,
+                         bool installContextDuringPendingDestroy = false,
+                         bool installContextDuringDisconnect = false) {
         tests::support::TestResult result;
         char arg0[] = "StreamFrameworkShutdownTest";
         char* args[] = {arg0, nullptr};
         core::SNodeC::init(1, args);
 
         const utils::Timeval terminateTimeout = cooperative ? utils::Timeval({1, 0}) : utils::Timeval({0, 50000});
-        Fixture fixture(pendingContext, terminateTimeout);
+        Fixture fixture(pendingContext,
+                        terminateTimeout,
+                        false,
+                        installContextDuringDetach,
+                        installContextDuringPendingDestroy,
+                        installContextDuringDisconnect);
         result.expectTrue(fixture.pair.valid() || fixture.connection != nullptr, "socketpair and connection are available");
 
         const std::string payload = queued ? std::string(32 * 1024, 'Q') : std::string();
@@ -489,32 +528,43 @@ namespace {
                 fixture.pair.releasePeerFd(), payload.size(), fixture.lifecycle, fixture.physical));
         }
 
-        core::timer::Timer stopTimer = core::timer::Timer::singleshotTimer(
-            [&fixture, trigger]() {
-                if (trigger == Trigger::Signal) {
-                    static_cast<void>(::kill(::getpid(), SIGTERM));
-                    return;
-                }
+        int startResult = 0;
+        if (trigger == Trigger::NoObserver) {
+            core::SNodeC::stop();
+            core::timer::Timer rejectedTimer = core::timer::Timer::singleshotTimer(
+                [&fixture]() {
+                    ++fixture.lifecycle.timerAfterStopping;
+                },
+                utils::Timeval());
+            core::EventLoop::instance().getEventMultiplexer().shutdown({core::ShutdownReason::NoObserver, 0});
+            core::SNodeC::free();
+        } else {
+            core::timer::Timer stopTimer = core::timer::Timer::singleshotTimer(
+                [&fixture, trigger]() {
+                    if (trigger == Trigger::Signal) {
+                        static_cast<void>(::kill(::getpid(), SIGTERM));
+                        return;
+                    }
 
-                core::SNodeC::stop();
-                core::timer::Timer rejectedTimer = core::timer::Timer::singleshotTimer(
-                    [&fixture]() {
-                        ++fixture.lifecycle.timerAfterStopping;
-                    },
-                    utils::Timeval());
-                if (trigger == Trigger::NoObserver) {
-                    core::EventLoop::instance().getEventMultiplexer().shutdown({core::ShutdownReason::NoObserver, 0});
-                }
-            },
-            utils::Timeval({0, 1000}));
+                    core::SNodeC::stop();
+                    core::timer::Timer rejectedTimer = core::timer::Timer::singleshotTimer(
+                        [&fixture]() {
+                            ++fixture.lifecycle.timerAfterStopping;
+                        },
+                        utils::Timeval());
+                },
+                utils::Timeval({0, 1000}));
 
-        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+            startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        }
 
         result.expectEqual(trigger == Trigger::Signal ? -SIGTERM : 0, startResult, "start result preserves shutdown trigger");
         result.expectEqual(1, fixture.lifecycle.contextAttached, "active context attaches once");
         result.expectEqual(1, fixture.lifecycle.contextDetached, "active context detaches once");
         result.expectEqual(1, fixture.lifecycle.activeContextDestroyed, "active context is destroyed once");
-        result.expectEqual(pendingContext ? 1 : 0,
+        const int expectedPendingContexts = (pendingContext ? 1 : 0) + (installContextDuringDetach ? 1 : 0) +
+                                            (installContextDuringPendingDestroy ? 1 : 0) + (installContextDuringDisconnect ? 1 : 0);
+        result.expectEqual(expectedPendingContexts,
                            fixture.lifecycle.pendingContextDestroyed,
                            "pending context is destroyed exactly once when present");
         result.expectEqual(trigger == Trigger::Signal ? 1 : 0, fixture.lifecycle.signals, "signal callback count matches trigger");
@@ -741,6 +791,12 @@ int main(int argc, char* argv[]) {
     }
     if (scenario == "plain_noncooperating_timeout") {
         return runPlainScenario(Trigger::Requested, false, false, false);
+    }
+    if (scenario == "reentrant_context_cleanup") {
+        return runPlainScenario(Trigger::Requested, false, true, false, true);
+    }
+    if (scenario == "reentrant_context_finalizer_cleanup") {
+        return runPlainScenario(Trigger::Requested, false, true, true, true, true, true);
     }
     if (scenario == "destruction_logging_order") {
         return runLoggingLifetimeScenario();

--- a/tests/unit/core/StreamFrameworkShutdownTest.cpp
+++ b/tests/unit/core/StreamFrameworkShutdownTest.cpp
@@ -16,6 +16,7 @@
 #include "tests/support/TestResult.h"
 
 #include <algorithm>
+#include <array>
 #include <cerrno>
 #include <csignal>
 #include <cstdint>
@@ -62,8 +63,13 @@ namespace {
         std::size_t peerBytes = 0;
         std::size_t totalSentAtDisconnect = 0;
         std::size_t totalQueuedAtDisconnect = 0;
+        int activeContextVisibilityChecks = 0;
+        int postDetachContextVisibilityChecks = 0;
+        int invalidContextVisibility = 0;
+        int unexpectedReentrantAttaches = 0;
         std::function<void()> onContextDisconnect;
         std::function<void()> onPendingContextDestroy;
+        std::function<void()> onDisconnect;
         bool captureLifetimeLogs = false;
     };
 
@@ -304,12 +310,21 @@ namespace {
         LifecycleState& state;
     };
 
+    struct ContextDestructionProbe {
+        int* exactDestructionCount = nullptr;
+        std::function<void()> onDestroy;
+    };
+
     class CountingContext final : public core::socket::stream::SocketContext {
     public:
-        CountingContext(TestConnection* connection, LifecycleState& state, bool pending)
+        CountingContext(TestConnection* connection,
+                        LifecycleState& state,
+                        bool pending,
+                        ContextDestructionProbe destructionProbe = {})
             : SocketContext(connection)
             , state(state)
-            , pending(pending) {
+            , pending(pending)
+            , destructionProbe(std::move(destructionProbe)) {
         }
 
         ~CountingContext() override {
@@ -317,7 +332,18 @@ namespace {
                 frameworkLog().info(pending ? "final pending context destructor cleanup" : "final active context destructor cleanup");
             }
             if (pending) {
+                ++state.postDetachContextVisibilityChecks;
+                if (getSocketConnection()->getSocketContext() != nullptr) {
+                    ++state.invalidContextVisibility;
+                }
                 ++state.pendingContextDestroyed;
+                if (destructionProbe.exactDestructionCount != nullptr) {
+                    ++*destructionProbe.exactDestructionCount;
+                }
+                if (destructionProbe.onDestroy) {
+                    auto callback = std::move(destructionProbe.onDestroy);
+                    callback();
+                }
                 if (state.onPendingContextDestroy) {
                     auto callback = std::move(state.onPendingContextDestroy);
                     callback();
@@ -335,6 +361,10 @@ namespace {
         void onDisconnected() override {
             if (getDetachReason() == DetachReason::ConnectionClose) {
                 ++state.contextDetached;
+                ++state.activeContextVisibilityChecks;
+                if (getSocketConnection()->getSocketContext() != this) {
+                    ++state.invalidContextVisibility;
+                }
             }
             if (state.captureLifetimeLogs) {
                 log().info("final application context onDisconnected");
@@ -367,6 +397,7 @@ namespace {
 
         LifecycleState& state;
         bool pending;
+        ContextDestructionProbe destructionProbe;
     };
 
     class CooperativePeer final : public core::eventreceiver::ReadEventReceiver {
@@ -467,12 +498,17 @@ namespace {
             });
             connection = new TestConnection(
                 TestPhysicalSocket(pair.releaseConnectionFd(), physical),
-                [this, installContextDuringDisconnect](TestConnection* closingConnection) {
+                [this](TestConnection* closingConnection) {
                     ++lifecycle.disconnects;
                     lifecycle.totalSentAtDisconnect = closingConnection->getTotalSent();
                     lifecycle.totalQueuedAtDisconnect = closingConnection->getTotalQueued();
-                    if (installContextDuringDisconnect) {
-                        closingConnection->setSocketContext(new CountingContext(closingConnection, lifecycle, true));
+                    ++lifecycle.postDetachContextVisibilityChecks;
+                    if (closingConnection->getSocketContext() != nullptr) {
+                        ++lifecycle.invalidContextVisibility;
+                    }
+                    if (lifecycle.onDisconnect) {
+                        auto callback = std::move(lifecycle.onDisconnect);
+                        callback();
                     }
                     connection = nullptr;
                 },
@@ -490,6 +526,11 @@ namespace {
             }
             if (installContextDuringPendingDestroy) {
                 lifecycle.onPendingContextDestroy = [this]() {
+                    connection->setSocketContext(new CountingContext(connection, lifecycle, true));
+                };
+            }
+            if (installContextDuringDisconnect) {
+                lifecycle.onDisconnect = [this]() {
                     connection->setSocketContext(new CountingContext(connection, lifecycle, true));
                 };
             }
@@ -567,6 +608,18 @@ namespace {
         result.expectEqual(expectedPendingContexts,
                            fixture.lifecycle.pendingContextDestroyed,
                            "pending context is destroyed exactly once when present");
+        result.expectEqual(1,
+                           fixture.lifecycle.activeContextVisibilityChecks,
+                           "onDisconnected observes the still-live active context exactly once");
+        result.expectEqual(expectedPendingContexts + 1,
+                           fixture.lifecycle.postDetachContextVisibilityChecks,
+                           "pending destructors and onDisconnect inspect context visibility after detach");
+        result.expectEqual(0,
+                           fixture.lifecycle.invalidContextVisibility,
+                           "no callback after detach observes a stale active context");
+        result.expectEqual(0,
+                           fixture.lifecycle.unexpectedReentrantAttaches,
+                           "no reentrant context attaches during terminal teardown");
         result.expectEqual(trigger == Trigger::Signal ? 1 : 0, fixture.lifecycle.signals, "signal callback count matches trigger");
         result.expectEqual(trigger == Trigger::Signal ? SIGTERM : 0, fixture.lifecycle.lastSignal, "signal number is preserved");
         result.expectEqual(1, fixture.physical->shutdownWrite, "all shutdown reasons use the write-shutdown path once");
@@ -588,6 +641,132 @@ namespace {
                                static_cast<int>(fixture.lifecycle.peerBytes),
                                "cooperative peer receives the complete queued payload");
         }
+
+        return result.processResult();
+    }
+
+    enum class ContextReentrancyScenario { ActiveDetach, PendingDestructor, RecursivePendingDestructor, OnDisconnect };
+
+    int runContextReentrancyScenario(ContextReentrancyScenario scenario) {
+        tests::support::TestResult result;
+        char arg0[] = "StreamFrameworkShutdownTest";
+        char* args[] = {arg0, nullptr};
+        core::SNodeC::init(1, args);
+
+        Fixture fixture(false, utils::Timeval({1, 0}));
+        std::array<int, 3> exactDestructions{};
+        int expectedPendingContexts = 0;
+
+        switch (scenario) {
+            case ContextReentrancyScenario::ActiveDetach:
+                expectedPendingContexts = 1;
+                fixture.lifecycle.onContextDisconnect = [&fixture, &exactDestructions]() {
+                    const int attachedBefore = fixture.lifecycle.contextAttached;
+                    fixture.connection->setSocketContext(new CountingContext(
+                        fixture.connection, fixture.lifecycle, true, {.exactDestructionCount = &exactDestructions[0]}));
+                    if (fixture.lifecycle.contextAttached != attachedBefore) {
+                        ++fixture.lifecycle.unexpectedReentrantAttaches;
+                    }
+                };
+                break;
+            case ContextReentrancyScenario::PendingDestructor:
+                expectedPendingContexts = 2;
+                fixture.connection->setSocketContext(new CountingContext(
+                    fixture.connection,
+                    fixture.lifecycle,
+                    true,
+                    {.exactDestructionCount = &exactDestructions[0],
+                     .onDestroy = [&fixture, &exactDestructions]() {
+                         const int attachedBefore = fixture.lifecycle.contextAttached;
+                         fixture.connection->setSocketContext(new CountingContext(
+                             fixture.connection,
+                             fixture.lifecycle,
+                             true,
+                             {.exactDestructionCount = &exactDestructions[1]}));
+                         if (fixture.lifecycle.contextAttached != attachedBefore) {
+                             ++fixture.lifecycle.unexpectedReentrantAttaches;
+                         }
+                     }}));
+                break;
+            case ContextReentrancyScenario::RecursivePendingDestructor:
+                expectedPendingContexts = 3;
+                fixture.connection->setSocketContext(new CountingContext(
+                    fixture.connection,
+                    fixture.lifecycle,
+                    true,
+                    {.exactDestructionCount = &exactDestructions[0],
+                     .onDestroy = [&fixture, &exactDestructions]() {
+                         const int attachedBefore = fixture.lifecycle.contextAttached;
+                         fixture.connection->setSocketContext(new CountingContext(
+                             fixture.connection,
+                             fixture.lifecycle,
+                             true,
+                             {.exactDestructionCount = &exactDestructions[1],
+                              .onDestroy = [&fixture, &exactDestructions]() {
+                                  const int recursiveAttachedBefore = fixture.lifecycle.contextAttached;
+                                  fixture.connection->setSocketContext(new CountingContext(
+                                      fixture.connection,
+                                      fixture.lifecycle,
+                                      true,
+                                      {.exactDestructionCount = &exactDestructions[2]}));
+                                  if (fixture.lifecycle.contextAttached != recursiveAttachedBefore) {
+                                      ++fixture.lifecycle.unexpectedReentrantAttaches;
+                                  }
+                              }}));
+                         if (fixture.lifecycle.contextAttached != attachedBefore) {
+                             ++fixture.lifecycle.unexpectedReentrantAttaches;
+                         }
+                     }}));
+                break;
+            case ContextReentrancyScenario::OnDisconnect:
+                expectedPendingContexts = 1;
+                fixture.lifecycle.onDisconnect = [&fixture, &exactDestructions]() {
+                    const int attachedBefore = fixture.lifecycle.contextAttached;
+                    fixture.connection->setSocketContext(new CountingContext(
+                        fixture.connection, fixture.lifecycle, true, {.exactDestructionCount = &exactDestructions[0]}));
+                    if (fixture.lifecycle.contextAttached != attachedBefore) {
+                        ++fixture.lifecycle.unexpectedReentrantAttaches;
+                    }
+                };
+                break;
+        }
+
+        static_cast<void>(
+            new CooperativePeer(fixture.pair.releasePeerFd(), 0, fixture.lifecycle, fixture.physical));
+        core::timer::Timer stopTimer = core::timer::Timer::singleshotTimer(
+            []() {
+                core::SNodeC::stop();
+            },
+            utils::Timeval({0, 1000}));
+
+        result.expectEqual(0, core::SNodeC::start(utils::Timeval({1, 0})), "terminal context reentrancy shutdown completes");
+        result.expectEqual(1, fixture.lifecycle.contextAttached, "only the original active context attaches");
+        result.expectEqual(1, fixture.lifecycle.contextDetached, "the active context detaches once");
+        result.expectEqual(1, fixture.lifecycle.activeContextDestroyed, "the active context is destroyed once");
+        result.expectEqual(expectedPendingContexts,
+                           fixture.lifecycle.pendingContextDestroyed,
+                           "every pending or reentrant context is destroyed once");
+        result.expectEqual(1,
+                           fixture.lifecycle.activeContextVisibilityChecks,
+                           "onDisconnected sees the still-live active context");
+        result.expectEqual(expectedPendingContexts + 1,
+                           fixture.lifecycle.postDetachContextVisibilityChecks,
+                           "all pending destructors and onDisconnect inspect post-detach visibility");
+        result.expectEqual(0,
+                           fixture.lifecycle.invalidContextVisibility,
+                           "getSocketContext is null in every callback after detach returns");
+        result.expectEqual(0,
+                           fixture.lifecycle.unexpectedReentrantAttaches,
+                           "terminal replacements never run onConnected");
+        for (int index = 0; index < expectedPendingContexts; ++index) {
+            result.expectEqual(1, exactDestructions[static_cast<std::size_t>(index)], "each supplied context is destroyed exactly once");
+        }
+        result.expectEqual(1, fixture.physical->shutdownWrite, "terminal context test uses the coordinated write-shutdown path once");
+        result.expectEqual(1, fixture.lifecycle.disconnects, "onDisconnect runs once");
+        result.expectEqual(1, fixture.lifecycle.connectionDestroyed, "connection destruction runs once");
+        result.expectEqual(1, fixture.physical->closes, "physical descriptor closes once");
+        result.expectEqual(1, fixture.lifecycle.configDestroyed, "connection configuration reference releases once");
+        result.expectTrue(fixture.connection == nullptr, "connection is destroyed before start returns");
 
         return result.processResult();
     }
@@ -797,6 +976,18 @@ int main(int argc, char* argv[]) {
     }
     if (scenario == "reentrant_context_finalizer_cleanup") {
         return runPlainScenario(Trigger::Requested, false, true, true, true, true, true);
+    }
+    if (scenario == "active_detach_context_visibility") {
+        return runContextReentrancyScenario(ContextReentrancyScenario::ActiveDetach);
+    }
+    if (scenario == "pending_context_destructor_visibility") {
+        return runContextReentrancyScenario(ContextReentrancyScenario::PendingDestructor);
+    }
+    if (scenario == "recursive_pending_context_destructor_visibility") {
+        return runContextReentrancyScenario(ContextReentrancyScenario::RecursivePendingDestructor);
+    }
+    if (scenario == "on_disconnect_context_visibility") {
+        return runContextReentrancyScenario(ContextReentrancyScenario::OnDisconnect);
     }
     if (scenario == "destruction_logging_order") {
         return runLoggingLifetimeScenario();

--- a/tests/unit/core/StreamFrameworkShutdownTest.cpp
+++ b/tests/unit/core/StreamFrameworkShutdownTest.cpp
@@ -451,7 +451,7 @@ namespace {
             finishWhenComplete();
         }
 
-        void onShutdown(const core::ShutdownContext&) override {
+        void shutdownEvent(const core::ShutdownContext&) override {
             ++state.peerShutdownNotifications;
             finishWhenComplete();
         }

--- a/tests/unit/core/TLSFrameworkShutdownTest.cpp
+++ b/tests/unit/core/TLSFrameworkShutdownTest.cpp
@@ -1,0 +1,638 @@
+#include "core/DescriptorEventPublisher.h"
+#include "core/EventLoop.h"
+#include "core/EventMultiplexer.h"
+#include "core/SNodeC.h"
+#include "core/Shutdown.h"
+#include "core/eventreceiver/ReadEventReceiver.h"
+#include "core/eventreceiver/WriteEventReceiver.h"
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketContext.h"
+#include "core/socket/stream/tls/SocketConnection.hpp"
+#include "core/socket/stream/tls/detail/TLSLifecycleTestAccess.h"
+#include "core/timer/Timer.h"
+#include "net/config/ConfigInstance.h"
+#include "tests/support/TestResult.h"
+
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <fcntl.h>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <openssl/ssl.h>
+#include <string>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+using core::socket::stream::tls::TLSShutdown;
+using core::socket::stream::tls::detail::TLSLifecycleTestAccess;
+using tests::support::TestResult;
+
+namespace {
+
+    struct LifecycleState {
+        int attached = 0;
+        int detached = 0;
+        int contextsDestroyed = 0;
+        int signals = 0;
+        int lastSignal = 0;
+        int rejectedTimerCallbacks = 0;
+        int disconnects = 0;
+        int configsDestroyed = 0;
+        int descriptorsClosed = 0;
+        int shutdownWriteCalls = 0;
+        int readSentinelNotifications = 0;
+        int writeSentinelNotifications = 0;
+        int sentinelsDestroyed = 0;
+    };
+
+    class SocketPair {
+    public:
+        SocketPair() {
+            static_cast<void>(::socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, fds));
+            for (const int fd : fds) {
+                const int flags = ::fcntl(fd, F_GETFL, 0);
+                if (flags >= 0) {
+                    static_cast<void>(::fcntl(fd, F_SETFL, flags | O_NONBLOCK));
+                }
+            }
+        }
+
+        ~SocketPair() {
+            closeFd(fds[0]);
+            closeFd(fds[1]);
+        }
+
+        bool valid() const {
+            return fds[0] >= 0 && fds[1] >= 0;
+        }
+
+        int connectionFd() const {
+            return fds[0];
+        }
+
+        int releaseConnectionFd() {
+            return std::exchange(fds[0], -1);
+        }
+
+    private:
+        static void closeFd(int fd) {
+            if (fd >= 0) {
+                static_cast<void>(::close(fd));
+            }
+        }
+
+        int fds[2] = {-1, -1};
+    };
+
+    class TestSocketAddress : public core::socket::SocketAddress {
+    public:
+        using SockAddr = sockaddr_storage;
+        using SockLen = socklen_t;
+
+        std::string toString(bool = true) const override {
+            return "tls-framework-shutdown-address";
+        }
+    };
+
+    class TestPhysicalSocket {
+    public:
+        using SocketAddress = TestSocketAddress;
+        enum class SHUT { RD, WR, RDWR };
+
+        TestPhysicalSocket(int fd, const std::shared_ptr<LifecycleState>& state)
+            : fd(fd)
+            , state(state) {
+        }
+
+        TestPhysicalSocket(const TestPhysicalSocket&) = delete;
+        TestPhysicalSocket& operator=(const TestPhysicalSocket&) = delete;
+
+        TestPhysicalSocket(TestPhysicalSocket&& other) noexcept
+            : fd(std::exchange(other.fd, -1))
+            , state(std::move(other.state)) {
+        }
+
+        TestPhysicalSocket& operator=(TestPhysicalSocket&& other) noexcept {
+            if (this != &other) {
+                closeOwned();
+                fd = std::exchange(other.fd, -1);
+                state = std::move(other.state);
+            }
+            return *this;
+        }
+
+        ~TestPhysicalSocket() {
+            closeOwned();
+        }
+
+        int getFd() const {
+            return fd;
+        }
+
+        int getSockName(sockaddr_storage&, socklen_t& length) {
+            length = sizeof(sockaddr_storage);
+            return 0;
+        }
+
+        int getPeerName(sockaddr_storage&, socklen_t& length) {
+            length = sizeof(sockaddr_storage);
+            return 0;
+        }
+
+        const TestSocketAddress& getBindAddress() const {
+            return address;
+        }
+
+        int shutdown(SHUT how) {
+            if (how == SHUT::WR) {
+                ++state->shutdownWriteCalls;
+            }
+            return 0;
+        }
+
+    private:
+        void closeOwned() {
+            if (fd >= 0) {
+                ++state->descriptorsClosed;
+                static_cast<void>(::close(fd));
+                fd = -1;
+            }
+        }
+
+        int fd = -1;
+        std::shared_ptr<LifecycleState> state;
+        TestSocketAddress address;
+    };
+
+    struct TestLocalConfig {
+        static TestSocketAddress getSocketAddress(const sockaddr_storage&, socklen_t) {
+            return {};
+        }
+    };
+
+    struct TestRemoteConfig {
+        static TestSocketAddress getSocketAddress(const sockaddr_storage&, socklen_t) {
+            return {};
+        }
+    };
+
+    class TestConfig
+        : public net::config::ConfigInstance
+        , public TestLocalConfig
+        , public TestRemoteConfig {
+    public:
+        using Local = TestLocalConfig;
+        using Remote = TestRemoteConfig;
+
+        TestConfig(const utils::Timeval& shutdownTimeout, const utils::Timeval& terminateTimeout)
+            : ConfigInstance(nextInstanceName(), Role::CLIENT)
+            , shutdownTimeout(shutdownTimeout)
+            , terminateTimeout(terminateTimeout) {
+        }
+
+        utils::Timeval getInitTimeout() const {
+            return {1, 0};
+        }
+
+        utils::Timeval getShutdownTimeout() const {
+            return shutdownTimeout;
+        }
+
+        bool getNoCloseNotifyIsEOF() const {
+            return false;
+        }
+
+        utils::Timeval getReadTimeout() const {
+            return {10, 0};
+        }
+
+        utils::Timeval getWriteTimeout() const {
+            return {10, 0};
+        }
+
+        utils::Timeval getTerminateTimeout() const {
+            return terminateTimeout;
+        }
+
+        std::size_t getReadBlockSize() const {
+            return 1024;
+        }
+
+        std::size_t getWriteBlockSize() const {
+            return 1024;
+        }
+
+    private:
+        static std::string nextInstanceName() {
+            static int nextId = 0;
+            return "tls-framework-shutdown-" + std::to_string(++nextId);
+        }
+
+        utils::Timeval shutdownTimeout;
+        utils::Timeval terminateTimeout;
+    };
+
+    using TestConnection = core::socket::stream::tls::SocketConnection<TestPhysicalSocket, TestConfig>;
+
+    class CountingContext final : public core::socket::stream::SocketContext {
+    public:
+        CountingContext(TestConnection* connection, const std::shared_ptr<LifecycleState>& state)
+            : SocketContext(connection)
+            , state(state) {
+        }
+
+        ~CountingContext() override {
+            ++state->contextsDestroyed;
+        }
+
+    private:
+        void onConnected() override {
+            ++state->attached;
+        }
+
+        void onDisconnected() override {
+            if (getDetachReason() == DetachReason::ConnectionClose) {
+                ++state->detached;
+            }
+        }
+
+        std::size_t onReceivedFromPeer() override {
+            char buffer[1024];
+            return readFromPeer(buffer, sizeof(buffer));
+        }
+
+        bool onSignal(int signum) override {
+            ++state->signals;
+            state->lastSignal = signum;
+            rejectedTimer.emplace(core::timer::Timer::singleshotTimer(
+                [state = state]() {
+                    ++state->rejectedTimerCallbacks;
+                },
+                utils::Timeval()));
+            return false;
+        }
+
+        void onWriteError(int errnum) override {
+            core::socket::stream::SocketContext::onWriteError(errnum);
+        }
+
+        void onReadError(int errnum) override {
+            core::socket::stream::SocketContext::onReadError(errnum);
+        }
+
+        std::shared_ptr<LifecycleState> state;
+        std::optional<core::timer::Timer> rejectedTimer;
+    };
+
+    class ReadSentinel final : public core::eventreceiver::ReadEventReceiver {
+    public:
+        ReadSentinel(int fd, const std::shared_ptr<LifecycleState>& state)
+            : ReadEventReceiver("TLS shutdown read traversal sentinel", utils::Timeval())
+            , state(state) {
+            ReadEventReceiver::enable(fd);
+        }
+
+    private:
+        ~ReadSentinel() override {
+            ++state->sentinelsDestroyed;
+        }
+
+        void readEvent() override {
+        }
+
+        void readTimeout() override {
+        }
+
+        void onShutdown(const core::ShutdownContext&) override {
+            ++state->readSentinelNotifications;
+        }
+
+        void unobservedEvent() override {
+            delete this;
+        }
+
+        std::shared_ptr<LifecycleState> state;
+    };
+
+    class WriteSentinel final : public core::eventreceiver::WriteEventReceiver {
+    public:
+        WriteSentinel(int fd, const std::shared_ptr<LifecycleState>& state)
+            : WriteEventReceiver("TLS shutdown write traversal sentinel", utils::Timeval())
+            , state(state) {
+            WriteEventReceiver::enable(fd);
+        }
+
+    private:
+        ~WriteSentinel() override {
+            ++state->sentinelsDestroyed;
+        }
+
+        void writeEvent() override {
+        }
+
+        void writeTimeout() override {
+        }
+
+        void onShutdown(const core::ShutdownContext&) override {
+            ++state->writeSentinelNotifications;
+        }
+
+        void unobservedEvent() override {
+            delete this;
+        }
+
+        std::shared_ptr<LifecycleState> state;
+    };
+
+    void resetTlsState() {
+        TLSLifecycleTestAccess::resetHandshake();
+        TLSLifecycleTestAccess::resetShutdown();
+        TLSLifecycleTestAccess::resetReader();
+        TLSLifecycleTestAccess::resetWriter();
+    }
+
+    void releaseDisabledEvents() {
+        const utils::Timeval now = utils::Timeval::currentTime();
+        core::EventLoop::instance()
+            .getEventMultiplexer()
+            .getDescriptorEventPublisher(core::EventMultiplexer::DISP_TYPE::RD)
+            .releaseDisabledEvents(now);
+        core::EventLoop::instance()
+            .getEventMultiplexer()
+            .getDescriptorEventPublisher(core::EventMultiplexer::DISP_TYPE::WR)
+            .releaseDisabledEvents(now);
+    }
+
+    void initializeFramework() {
+        char arg0[] = "TLSFrameworkShutdownTest";
+        char* args[] = {arg0, nullptr};
+        core::SNodeC::init(1, args);
+    }
+
+    struct Fixture {
+        SocketPair pair;
+        std::shared_ptr<LifecycleState> state;
+        TestConnection* connection = nullptr;
+        SSL_CTX* sslContext = SSL_CTX_new(TLS_method());
+
+        Fixture(const std::shared_ptr<LifecycleState>& state,
+                std::uint64_t connectionId,
+                const utils::Timeval& shutdownTimeout,
+                const utils::Timeval& terminateTimeout,
+                bool installSentinels = false)
+            : state(state) {
+            if (installSentinels) {
+                static_cast<void>(new ReadSentinel(pair.connectionFd(), state));
+                static_cast<void>(new WriteSentinel(pair.connectionFd(), state));
+            }
+
+            auto config = std::make_shared<TestConfig>(shutdownTimeout, terminateTimeout);
+            config->setOnDestroy([state](net::config::ConfigInstance*) {
+                ++state->configsDestroyed;
+            });
+            connection = new TestConnection(
+                TestPhysicalSocket(pair.releaseConnectionFd(), state),
+                [this](TestConnection*) {
+                    ++this->state->disconnects;
+                    connection = nullptr;
+                },
+                connectionId,
+                config);
+            connection->setSocketContext(new CountingContext(connection, state));
+            TLSLifecycleTestAccess::startSSL(*connection, connection->getFd(), sslContext);
+            TLSLifecycleTestAccess::transitionTo(*connection, 2);
+            TLSLifecycleTestAccess::transitionTo(*connection, 3);
+        }
+
+        ~Fixture() {
+            if (connection != nullptr) {
+                connection->close();
+                releaseDisabledEvents();
+            }
+            SSL_CTX_free(sslContext);
+        }
+    };
+
+    void terminateRemainingResources() {
+        core::EventLoop::instance().getEventMultiplexer().terminate();
+        core::EventLoop::instance().getEventMultiplexer().clearEventQueue();
+    }
+
+    int runActiveHelper(core::ShutdownReason reason) {
+        TestResult result;
+        initializeFramework();
+        resetTlsState();
+
+        const auto state = std::make_shared<LifecycleState>();
+        Fixture fixture(state, 101, utils::Timeval({5, 0}), utils::Timeval({0, 50000}));
+        result.expectTrue(fixture.connection != nullptr, "active-helper connection is available");
+
+        TLSLifecycleTestAccess::enqueueShutdownResult(-1, SSL_ERROR_WANT_READ);
+        TLSLifecycleTestAccess::doSSLShutdown(*fixture.connection);
+        TLSShutdown* const helper = TLSLifecycleTestAccess::lastShutdown();
+        result.expectTrue(helper != nullptr, "protocol shutdown creates one helper before framework shutdown");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().constructed, "one active helper is constructed");
+        result.expectTrue(TLSLifecycleTestAccess::readEnabled(helper), "active helper is observing reads");
+
+        core::SNodeC::stop();
+        core::EventLoop::instance().getEventMultiplexer().shutdown({reason, 0});
+
+        result.expectTrue(TLSLifecycleTestAccess::lastShutdown() == helper, "framework shutdown joins the existing helper");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().constructed, "framework shutdown does not duplicate helper");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().operationCalls, "dual helper notification does not restart helper");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().active, "active helper remains alive after notification");
+        result.expectTrue(TLSLifecycleTestAccess::readEnabled(helper), "Requested/NoObserver notification leaves helper enabled");
+
+        TLSLifecycleTestAccess::enqueueShutdownResult(1, SSL_ERROR_NONE);
+        TLSLifecycleTestAccess::readEvent(helper);
+        releaseDisabledEvents();
+
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().successes, "joined helper completes cooperatively");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().releases, "joined helper release callback runs once");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().destroyed, "joined helper is destroyed once");
+        result.expectEqual(0, TLSLifecycleTestAccess::shutdownCounters().active, "joined helper leaves no active helper");
+        result.expectEqual(1, state->shutdownWriteCalls, "joined helper performs physical write shutdown once");
+
+        terminateRemainingResources();
+        result.expectTrue(fixture.connection == nullptr, "forced local fallback releases the connection");
+        result.expectEqual(1, state->detached, "active context detaches once");
+        result.expectEqual(1, state->contextsDestroyed, "active context is destroyed once");
+        result.expectEqual(1, state->disconnects, "disconnect callback runs once");
+        result.expectEqual(1, state->descriptorsClosed, "physical descriptor closes once");
+        result.expectEqual(1, state->configsDestroyed, "connection-owned configuration reference is released once");
+
+        core::SNodeC::free();
+        return result.processResult();
+    }
+
+    int runPublisherMutation(bool crossPublisher) {
+        TestResult result;
+        initializeFramework();
+        resetTlsState();
+
+        const auto state = std::make_shared<LifecycleState>();
+        Fixture fixture(state, 102, utils::Timeval({5, 0}), utils::Timeval({0, 50000}), true);
+        result.expectTrue(fixture.connection != nullptr, "publisher-mutation connection is available");
+
+        TLSLifecycleTestAccess::enqueueShutdownResult(
+            -1, crossPublisher ? SSL_ERROR_WANT_WRITE : SSL_ERROR_WANT_READ);
+        core::SNodeC::stop();
+        core::EventLoop::instance().getEventMultiplexer().shutdown({core::ShutdownReason::Requested, 0});
+
+        TLSShutdown* const helper = TLSLifecycleTestAccess::lastShutdown();
+        result.expectTrue(helper != nullptr, "connection notification creates TLSShutdown during traversal");
+        result.expectEqual(1, state->readSentinelNotifications, "pre-existing read receiver is notified exactly once");
+        result.expectEqual(1, state->writeSentinelNotifications, "pre-existing write receiver is notified exactly once");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().constructed, "live insertion constructs one helper");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().operationCalls, "helper notification is continuation-safe");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().active, "inserted helper survives publisher shutdown");
+        result.expectTrue(crossPublisher ? TLSLifecycleTestAccess::writeEnabled(helper) : TLSLifecycleTestAccess::readEnabled(helper),
+                          "inserted helper remains enabled in its selected publisher");
+
+        TLSLifecycleTestAccess::enqueueShutdownResult(1, SSL_ERROR_NONE);
+        if (crossPublisher) {
+            TLSLifecycleTestAccess::writeEvent(helper);
+        } else {
+            TLSLifecycleTestAccess::readEvent(helper);
+        }
+        releaseDisabledEvents();
+
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().successes, "inserted helper progresses after shutdown traversal");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().releases, "inserted helper releases once");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().destroyed, "inserted helper is destroyed once");
+        result.expectEqual(0, TLSLifecycleTestAccess::shutdownCounters().active, "inserted helper is not leaked");
+
+        terminateRemainingResources();
+        result.expectEqual(2, state->sentinelsDestroyed, "both traversal sentinels are destroyed once");
+        result.expectEqual(1, state->disconnects, "publisher mutation connection disconnects once");
+        result.expectEqual(1, state->contextsDestroyed, "publisher mutation context is destroyed once");
+        result.expectEqual(1, state->descriptorsClosed, "publisher mutation descriptor closes once");
+
+        core::SNodeC::free();
+        return result.processResult();
+    }
+
+    int runSignalFalseTls() {
+        TestResult result;
+        initializeFramework();
+        resetTlsState();
+
+        const auto state = std::make_shared<LifecycleState>();
+        Fixture fixture(state, 103, utils::Timeval({5, 0}), utils::Timeval({0, 50000}));
+
+        TLSLifecycleTestAccess::enqueueShutdownResult(-1, SSL_ERROR_WANT_WRITE);
+        TLSLifecycleTestAccess::enqueueShutdownResult(1, SSL_ERROR_NONE);
+        core::timer::Timer signalTimer = core::timer::Timer::singleshotTimer(
+            []() {
+                static_cast<void>(::kill(::getpid(), SIGTERM));
+            },
+            utils::Timeval({0, 1000}));
+
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+
+        result.expectEqual(-SIGTERM, startResult, "signal-triggered start result is preserved");
+        result.expectEqual(1, state->signals, "SocketContext signal callback runs exactly once");
+        result.expectEqual(SIGTERM, state->lastSignal, "SocketContext receives SIGTERM metadata");
+        result.expectEqual(0, state->rejectedTimerCallbacks, "new core timer is rejected during STOPPING");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().constructed, "false signal result still starts TLS shutdown");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().maxConcurrent, "signal shutdown never duplicates helper");
+        result.expectEqual(2, TLSLifecycleTestAccess::shutdownCounters().operationCalls, "descriptor helper progresses without a core timer");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().successes, "signal TLS shutdown completes its injected operation");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().releases, "signal helper releases once");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().destroyed, "signal helper is destroyed once");
+        result.expectEqual(1, state->shutdownWriteCalls, "false cannot veto physical write shutdown while STOPPING");
+        result.expectEqual(1, state->detached, "signal context detaches once");
+        result.expectEqual(1, state->contextsDestroyed, "signal context is destroyed once");
+        result.expectEqual(1, state->disconnects, "signal connection disconnects once");
+        result.expectEqual(1, state->descriptorsClosed, "signal connection descriptor closes once");
+        result.expectTrue(fixture.connection == nullptr, "signal connection is gone before start returns");
+
+        return result.processResult();
+    }
+
+    int runOuterTimeout(std::size_t connectionCount) {
+        TestResult result;
+        initializeFramework();
+        resetTlsState();
+
+        const auto state = std::make_shared<LifecycleState>();
+        std::vector<std::unique_ptr<Fixture>> fixtures;
+        fixtures.reserve(connectionCount);
+        for (std::size_t index = 0; index < connectionCount; ++index) {
+            fixtures.push_back(std::make_unique<Fixture>(
+                state, 200 + index, utils::Timeval({5, 0}), utils::Timeval({5, 0})));
+            TLSLifecycleTestAccess::enqueueShutdownResult(-1, SSL_ERROR_WANT_READ);
+        }
+
+        core::timer::Timer stopTimer = core::timer::Timer::singleshotTimer(
+            []() {
+                core::SNodeC::stop();
+            },
+            utils::Timeval({0, 1000}));
+
+        const auto startedAt = std::chrono::steady_clock::now();
+        const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
+        const auto elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - startedAt).count();
+
+        result.expectEqual(0, startResult, "explicit stop preserves start result");
+        result.expectTrue(elapsed >= 1.5, "outer drain, rather than the longer TLS timeout, controls shutdown");
+        result.expectTrue(elapsed < 4.0, "EventLoop outer drain remains bounded");
+        result.expectEqual(static_cast<int>(connectionCount),
+                           TLSLifecycleTestAccess::shutdownCounters().constructed,
+                           "one helper is constructed per non-cooperating TLS connection");
+        result.expectEqual(static_cast<int>(connectionCount),
+                           TLSLifecycleTestAccess::shutdownCounters().maxConcurrent,
+                           "all non-cooperating helpers coexist before forced terminate");
+        result.expectEqual(static_cast<int>(connectionCount),
+                           TLSLifecycleTestAccess::shutdownCounters().releases,
+                           "every forced helper releases once");
+        result.expectEqual(static_cast<int>(connectionCount),
+                           TLSLifecycleTestAccess::shutdownCounters().destroyed,
+                           "every forced helper is destroyed once");
+        result.expectEqual(0, TLSLifecycleTestAccess::shutdownCounters().active, "forced termination leaves no active helper");
+        result.expectEqual(0, TLSLifecycleTestAccess::shutdownCounters().timeouts, "five-second helper timeout does not extend outer drain");
+        result.expectEqual(static_cast<int>(connectionCount), state->detached, "every forced context detaches once");
+        result.expectEqual(static_cast<int>(connectionCount), state->contextsDestroyed, "every forced context is destroyed once");
+        result.expectEqual(static_cast<int>(connectionCount), state->disconnects, "every forced connection disconnects once");
+        result.expectEqual(static_cast<int>(connectionCount), state->descriptorsClosed, "every forced descriptor closes once");
+        result.expectEqual(static_cast<int>(connectionCount), state->configsDestroyed, "every connection releases its config before return");
+        for (const auto& fixture : fixtures) {
+            result.expectTrue(fixture->connection == nullptr, "no forced TLS connection escapes cleanup");
+        }
+
+        return result.processResult();
+    }
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    const std::string scenario = argc > 1 ? argv[1] : "active_helper_requested";
+
+    if (scenario == "active_helper_requested") {
+        return runActiveHelper(core::ShutdownReason::Requested);
+    }
+    if (scenario == "active_helper_no_observer") {
+        return runActiveHelper(core::ShutdownReason::NoObserver);
+    }
+    if (scenario == "publisher_mutation_same_list") {
+        return runPublisherMutation(false);
+    }
+    if (scenario == "publisher_mutation_cross_publisher") {
+        return runPublisherMutation(true);
+    }
+    if (scenario == "signal_false_tls") {
+        return runSignalFalseTls();
+    }
+    if (scenario == "outer_timeout_long") {
+        return runOuterTimeout(1);
+    }
+    if (scenario == "outer_timeout_multiple") {
+        return runOuterTimeout(2);
+    }
+
+    return 2;
+}

--- a/tests/unit/core/TLSFrameworkShutdownTest.cpp
+++ b/tests/unit/core/TLSFrameworkShutdownTest.cpp
@@ -307,7 +307,7 @@ namespace {
         void readTimeout() override {
         }
 
-        void onShutdown(const core::ShutdownContext&) override {
+        void shutdownEvent(const core::ShutdownContext&) override {
             ++state->readSentinelNotifications;
         }
 
@@ -337,7 +337,7 @@ namespace {
         void writeTimeout() override {
         }
 
-        void onShutdown(const core::ShutdownContext&) override {
+        void shutdownEvent(const core::ShutdownContext&) override {
             ++state->writeSentinelNotifications;
         }
 

--- a/tests/unit/core/TLSFrameworkShutdownTest.cpp
+++ b/tests/unit/core/TLSFrameworkShutdownTest.cpp
@@ -368,8 +368,8 @@ namespace {
     }
 
     void initializeFramework() {
-        char arg0[] = "TLSFrameworkShutdownTest";
-        char* args[] = {arg0, nullptr};
+        static char arg0[] = "TLSFrameworkShutdownTest";
+        static char* args[] = {arg0, nullptr};
         core::SNodeC::init(1, args);
     }
 
@@ -422,7 +422,7 @@ namespace {
         core::EventLoop::instance().getEventMultiplexer().clearEventQueue();
     }
 
-    int runActiveHelper(core::ShutdownReason reason) {
+    int runActiveHelper(core::ShutdownReason reason, bool forceTermination = false) {
         TestResult result;
         initializeFramework();
         resetTlsState();
@@ -438,26 +438,45 @@ namespace {
         result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().constructed, "one active helper is constructed");
         result.expectTrue(TLSLifecycleTestAccess::readEnabled(helper), "active helper is observing reads");
 
-        core::SNodeC::stop();
-        core::EventLoop::instance().getEventMultiplexer().shutdown({reason, 0});
-
-        result.expectTrue(TLSLifecycleTestAccess::lastShutdown() == helper, "framework shutdown joins the existing helper");
-        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().constructed, "framework shutdown does not duplicate helper");
-        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().operationCalls, "dual helper notification does not restart helper");
-        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().active, "active helper remains alive after notification");
-        result.expectTrue(TLSLifecycleTestAccess::readEnabled(helper), "Requested/NoObserver notification leaves helper enabled");
-
-        TLSLifecycleTestAccess::enqueueShutdownResult(1, SSL_ERROR_NONE);
+        TLSLifecycleTestAccess::enqueueShutdownResult(-1, SSL_ERROR_WANT_WRITE);
         TLSLifecycleTestAccess::readEvent(helper);
-        releaseDisabledEvents();
+        result.expectTrue(TLSLifecycleTestAccess::readEnabled(helper), "active helper retains its read receiver");
+        result.expectTrue(TLSLifecycleTestAccess::writeEnabled(helper), "active helper also registers its write receiver");
 
-        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().successes, "joined helper completes cooperatively");
+        core::SNodeC::stop();
+        const int shutdownSignal = reason == core::ShutdownReason::Signal ? SIGTERM : 0;
+        core::EventLoop::instance().getEventMultiplexer().shutdown({reason, shutdownSignal});
+
+        const bool helperRetained = TLSLifecycleTestAccess::lastShutdown() == helper &&
+                                    TLSLifecycleTestAccess::shutdownCounters().active == 1;
+        result.expectTrue(helperRetained, "framework shutdown joins the existing helper");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().constructed, "framework shutdown does not duplicate helper");
+        result.expectEqual(2, TLSLifecycleTestAccess::shutdownCounters().operationCalls, "dual helper notification does not restart helper");
+        result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().active, "active helper remains alive after notification");
+        result.expectTrue(helperRetained && TLSLifecycleTestAccess::readEnabled(helper),
+                          "Requested/NoObserver notification leaves helper enabled");
+        result.expectEqual(reason == core::ShutdownReason::Signal ? 1 : 0,
+                           state->signals,
+                           "active-helper signal callback count matches the framework reason");
+        result.expectEqual(shutdownSignal, state->lastSignal, "active-helper signal metadata is preserved");
+
+        if (!forceTermination) {
+            TLSLifecycleTestAccess::enqueueShutdownResult(1, SSL_ERROR_NONE);
+            if (helperRetained) {
+                TLSLifecycleTestAccess::writeEvent(helper);
+            }
+            releaseDisabledEvents();
+
+            result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().successes, "joined helper completes cooperatively");
+            result.expectEqual(1, state->shutdownWriteCalls, "joined helper performs physical write shutdown once");
+        } else {
+            result.expectEqual(0, TLSLifecycleTestAccess::shutdownCounters().successes, "forced helper remains mid-shutdown");
+        }
+
+        terminateRemainingResources();
         result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().releases, "joined helper release callback runs once");
         result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().destroyed, "joined helper is destroyed once");
         result.expectEqual(0, TLSLifecycleTestAccess::shutdownCounters().active, "joined helper leaves no active helper");
-        result.expectEqual(1, state->shutdownWriteCalls, "joined helper performs physical write shutdown once");
-
-        terminateRemainingResources();
         result.expectTrue(fixture.connection == nullptr, "forced local fallback releases the connection");
         result.expectEqual(1, state->detached, "active context detaches once");
         result.expectEqual(1, state->contextsDestroyed, "active context is destroyed once");
@@ -484,20 +503,25 @@ namespace {
         core::EventLoop::instance().getEventMultiplexer().shutdown({core::ShutdownReason::Requested, 0});
 
         TLSShutdown* const helper = TLSLifecycleTestAccess::lastShutdown();
-        result.expectTrue(helper != nullptr, "connection notification creates TLSShutdown during traversal");
+        const bool helperCreated = helper != nullptr;
+        result.expectTrue(helperCreated, "connection notification creates TLSShutdown during traversal");
         result.expectEqual(1, state->readSentinelNotifications, "pre-existing read receiver is notified exactly once");
         result.expectEqual(1, state->writeSentinelNotifications, "pre-existing write receiver is notified exactly once");
         result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().constructed, "live insertion constructs one helper");
         result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().operationCalls, "helper notification is continuation-safe");
         result.expectEqual(1, TLSLifecycleTestAccess::shutdownCounters().active, "inserted helper survives publisher shutdown");
-        result.expectTrue(crossPublisher ? TLSLifecycleTestAccess::writeEnabled(helper) : TLSLifecycleTestAccess::readEnabled(helper),
+        result.expectTrue(helperCreated &&
+                              (crossPublisher ? TLSLifecycleTestAccess::writeEnabled(helper)
+                                              : TLSLifecycleTestAccess::readEnabled(helper)),
                           "inserted helper remains enabled in its selected publisher");
 
         TLSLifecycleTestAccess::enqueueShutdownResult(1, SSL_ERROR_NONE);
-        if (crossPublisher) {
-            TLSLifecycleTestAccess::writeEvent(helper);
-        } else {
-            TLSLifecycleTestAccess::readEvent(helper);
+        if (helperCreated) {
+            if (crossPublisher) {
+                TLSLifecycleTestAccess::writeEvent(helper);
+            } else {
+                TLSLifecycleTestAccess::readEvent(helper);
+            }
         }
         releaseDisabledEvents();
 
@@ -617,6 +641,12 @@ int main(int argc, char* argv[]) {
     }
     if (scenario == "active_helper_no_observer") {
         return runActiveHelper(core::ShutdownReason::NoObserver);
+    }
+    if (scenario == "active_helper_signal") {
+        return runActiveHelper(core::ShutdownReason::Signal);
+    }
+    if (scenario == "active_helper_forced") {
+        return runActiveHelper(core::ShutdownReason::Requested, true);
     }
     if (scenario == "publisher_mutation_same_list") {
         return runPublisherMutation(false);

--- a/tests/unit/log/SocketContextDetachPolicyTest.cpp
+++ b/tests/unit/log/SocketContextDetachPolicyTest.cpp
@@ -112,7 +112,7 @@ int main() {
                           socketConnectionPath);
 
     ok &= requireContains(socketConnection,
-                          "Super::socketContext->detach("
+                          "socketContext->detach("
                           "SocketContext::DetachReason::ConnectionClose);",
                           socketConnectionPath);
 
@@ -141,12 +141,12 @@ int main() {
 
     ok &= requireOrdered(closeBlock,
                          {"delete std::exchange("
-                          "Super::newSocketContext, nullptr);",
-                          "Super::socketContext->detach("
+                          "newSocketContext, nullptr);",
+                          "socketContext->detach("
                           "SocketContext::DetachReason::ConnectionClose);",
-                          "Super::socketContext = nullptr;",
+                          "socketContext = nullptr;",
                           "delete std::exchange("
-                          "Super::newSocketContext, nullptr);",
+                          "newSocketContext, nullptr);",
                           "onDisconnect();"},
                          socketConnectionPath);
 

--- a/tests/unit/log/SocketContextDetachPolicyTest.cpp
+++ b/tests/unit/log/SocketContextDetachPolicyTest.cpp
@@ -83,7 +83,7 @@ int main() {
 
     bool ok = true;
     ok &= requireContains(socketConnection, "socketContext->detach(SocketContext::DetachReason::ContextSwitch);", socketConnectionPath);
-    ok &= requireContains(socketConnection, "socketContext->detach(SocketContext::DetachReason::ConnectionClose);", socketConnectionPath);
+    ok &= requireContains(socketConnection, "activeSocketContext->detach(SocketContext::DetachReason::ConnectionClose);", socketConnectionPath);
     const std::string_view switchBlock = requireBlock(socketConnection,
                                                       "// Perform a pending SocketContextSwitch",
                                                       "this->log().debug(\"SocketConnection: switch completed\");",

--- a/tests/unit/log/SocketContextDetachPolicyTest.cpp
+++ b/tests/unit/log/SocketContextDetachPolicyTest.cpp
@@ -14,6 +14,7 @@ namespace {
         }
 
         std::cerr << "Missing required fragment in " << path << ": " << needle << '\n';
+
         return false;
     }
 
@@ -23,38 +24,46 @@ namespace {
         }
 
         std::cerr << "Forbidden fragment in " << path << ": " << needle << '\n';
+
         return false;
     }
 
-    std::string_view requireBlock(std::string_view contents,
-                                  std::string_view beginMarker,
-                                  std::string_view endMarker,
-                                  const std::filesystem::path& path) {
+    std::string_view
+    requireBlock(std::string_view contents, std::string_view beginMarker, std::string_view endMarker, const std::filesystem::path& path) {
         const std::size_t begin = contents.find(beginMarker);
+
         if (begin == std::string_view::npos) {
             std::cerr << "Missing block begin marker in " << path << ": " << beginMarker << '\n';
+
             return {};
         }
+
         const std::size_t end = contents.find(endMarker, begin);
+
         if (end == std::string_view::npos) {
             std::cerr << "Missing block end marker in " << path << ": " << endMarker << '\n';
+
             return {};
         }
+
         return contents.substr(begin, end - begin);
     }
 
-    bool requireOrdered(std::string_view contents,
-                        const std::vector<std::string_view>& needles,
-                        const std::filesystem::path& path) {
+    bool requireOrdered(std::string_view contents, const std::vector<std::string_view>& needles, const std::filesystem::path& path) {
         std::size_t offset = 0;
+
         for (const std::string_view needle : needles) {
             const std::size_t found = contents.find(needle, offset);
+
             if (found == std::string_view::npos) {
                 std::cerr << "Missing ordered fragment in " << path << ": " << needle << '\n';
+
                 return false;
             }
+
             offset = found + needle.size();
         }
+
         return true;
     }
 
@@ -62,76 +71,160 @@ namespace {
 
 int main() {
     const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
+
     if (root.empty()) {
         return 1;
     }
+
     const auto socketConnectionPath = root / "src" / "core" / "socket" / "stream" / "SocketConnection.hpp";
+
     const auto socketContextHeaderPath = root / "src" / "core" / "socket" / "stream" / "SocketContext.h";
+
     const auto socketContextSourcePath = root / "src" / "core" / "socket" / "stream" / "SocketContext.cpp";
+
     const auto socketServerPath = root / "src" / "core" / "socket" / "stream" / "SocketServer.h";
+
     const auto socketClientPath = root / "src" / "core" / "socket" / "stream" / "SocketClient.h";
+
     const auto echoContextPath = root / "src" / "apps" / "echo" / "model" / "EchoSocketContext.cpp";
+
     const auto tlsLegacyContextPath = root / "src" / "apps" / "tlslegacy" / "TlsLegacySocketContext.cpp";
 
     const std::string socketConnection = source_policy::readSourcePolicyFile(socketConnectionPath);
+
     const std::string socketContextHeader = source_policy::readSourcePolicyFile(socketContextHeaderPath);
+
     const std::string socketContextSource = source_policy::readSourcePolicyFile(socketContextSourcePath);
+
     const std::string socketServer = source_policy::readSourcePolicyFile(socketServerPath);
+
     const std::string socketClient = source_policy::readSourcePolicyFile(socketClientPath);
+
     const std::string echoContext = source_policy::readSourcePolicyFile(echoContextPath);
+
     const std::string tlsLegacyContext = source_policy::readSourcePolicyFile(tlsLegacyContextPath);
 
     bool ok = true;
-    ok &= requireContains(socketConnection, "socketContext->detach(SocketContext::DetachReason::ContextSwitch);", socketConnectionPath);
-    ok &= requireContains(socketConnection, "activeSocketContext->detach(SocketContext::DetachReason::ConnectionClose);", socketConnectionPath);
+
+    ok &= requireContains(socketConnection,
+                          "socketContext->detach("
+                          "SocketContext::DetachReason::ContextSwitch);",
+                          socketConnectionPath);
+
+    ok &= requireContains(socketConnection,
+                          "Super::socketContext->detach("
+                          "SocketContext::DetachReason::ConnectionClose);",
+                          socketConnectionPath);
+
     const std::string_view switchBlock = requireBlock(socketConnection,
                                                       "// Perform a pending SocketContextSwitch",
-                                                      "this->log().debug(\"SocketConnection: switch completed\");",
+                                                      "this->log().debug("
+                                                      "\"SocketConnection: switch completed\");",
                                                       socketConnectionPath);
+
     ok &= !switchBlock.empty();
+
     ok &= requireOrdered(switchBlock,
-                         {"socketContext->detach(SocketContext::DetachReason::ContextSwitch);",
+                         {"socketContext->detach("
+                          "SocketContext::DetachReason::ContextSwitch);",
                           "socketContext = newSocketContext;",
                           "newSocketContext = nullptr;",
                           "socketContext->attach();"},
                          socketConnectionPath);
+
     ok &= requireNotContains(switchBlock, "onDisconnect", socketConnectionPath);
 
+    const std::string_view closeBlock =
+        requireBlock(socketConnection, "::unobservedEvent() {", "Super::log().debug(\"disconnected\");", socketConnectionPath);
+
+    ok &= !closeBlock.empty();
+
+    ok &= requireOrdered(closeBlock,
+                         {"delete std::exchange("
+                          "Super::newSocketContext, nullptr);",
+                          "Super::socketContext->detach("
+                          "SocketContext::DetachReason::ConnectionClose);",
+                          "Super::socketContext = nullptr;",
+                          "delete std::exchange("
+                          "Super::newSocketContext, nullptr);",
+                          "onDisconnect();"},
+                         socketConnectionPath);
+
+    ok &= requireNotContains(closeBlock, "terminalSocketContextTeardown", socketConnectionPath);
+
+    ok &= requireNotContains(closeBlock, "releasePendingSocketContexts", socketConnectionPath);
+
     ok &= requireContains(socketContextHeader, "enum class DetachReason", socketContextHeaderPath);
+
     ok &= requireContains(socketContextHeader, "ContextSwitch", socketContextHeaderPath);
+
     ok &= requireContains(socketContextHeader, "ConnectionClose", socketContextHeaderPath);
+
     ok &= requireContains(socketContextHeader, "DetachReason getDetachReason() const noexcept", socketContextHeaderPath);
+
     ok &= requireContains(socketContextHeader, "detach(DetachReason reason)", socketContextHeaderPath);
 
     ok &= requireContains(socketContextSource, "currentDetachReason = reason;", socketContextSourcePath);
+
     ok &= requireContains(socketContextSource, "if (reason == DetachReason::ContextSwitch)", socketContextSourcePath);
+
     ok &= requireContains(socketContextSource, "Context detached for context switch", socketContextSourcePath);
+
     ok &= requireContains(socketContextSource, "Context Online Since", socketContextSourcePath);
+
     ok &= requireContains(socketContextSource, "Context Online Duration", socketContextSourcePath);
+
     ok &= requireContains(socketContextSource, "Context Total Queued", socketContextSourcePath);
+
     ok &= requireContains(socketContextSource, "Context Total Processed", socketContextSourcePath);
+
     ok &= requireContains(socketContextSource, "Context detached for connection close", socketContextSourcePath);
+
     ok &= requireNotContains(socketContextSource, "Total Sent: {}", socketContextSourcePath);
+
     const std::string misleadingQueuedAsSent = std::string{"Total "} + "Sent: {}\", " + "getTotalQueued()";
+
     ok &= requireNotContains(socketContextSource, misleadingQueuedAsSent, socketContextSourcePath);
 
-    for (const auto& pathAndContents :
-         std::vector<std::pair<std::filesystem::path, std::string>>{{echoContextPath, echoContext}, {tlsLegacyContextPath, tlsLegacyContext}}) {
+    for (const auto& pathAndContents : std::vector<std::pair<std::filesystem::path, std::string>>{
+             {echoContextPath, echoContext}, {tlsLegacyContextPath, tlsLegacyContext}}) {
         const auto& path = pathAndContents.first;
+
         const auto& contents = pathAndContents.second;
+
         ok &= requireContains(contents, "log().debug", path);
-        ok &= requireContains(contents, "getDetachReason() == DetachReason::ContextSwitch", path);
+
+        ok &= requireContains(contents,
+                              "getDetachReason() == "
+                              "DetachReason::ContextSwitch",
+                              path);
+
         ok &= requireContains(contents, "context switch", path);
+
         ok &= requireContains(contents, "connection close", path);
-        ok &= requireNotContains(contents, "appLog().debug() << \"Echo: context", path);
-        ok &= requireNotContains(contents, "appLog().debug() << \"TLS legacy: context", path);
-        ok &= requireNotContains(contents, "getConnectionName() << \": context", path);
+
+        ok &= requireNotContains(contents,
+                                 "appLog().debug() << "
+                                 "\"Echo: context",
+                                 path);
+
+        ok &= requireNotContains(contents,
+                                 "appLog().debug() << "
+                                 "\"TLS legacy: context",
+                                 path);
+
+        ok &= requireNotContains(contents,
+                                 "getConnectionName() << "
+                                 "\": context",
+                                 path);
     }
 
     for (const auto& pathAndContents :
          std::vector<std::pair<std::filesystem::path, std::string>>{{socketServerPath, socketServer}, {socketClientPath, socketClient}}) {
         const auto& path = pathAndContents.first;
+
         const auto& contents = pathAndContents.second;
+
         for (const std::string_view label :
              {"Online Duration", "Total Queued", "Total Sent", "Total Read", "Total Processed", "Write Delta", "Read Delta"}) {
             ok &= requireContains(contents, label, path);


### PR DESCRIPTION
## Summary

* coordinate framework shutdown for established plain and TLS stream connections through one connection-level `shutdownEvent(const core::ShutdownContext&)` path
* process framework shutdown exactly once per connection, even though reader and writer receiver subobjects can both receive the notification
* invoke the existing `SocketContext::onSignal()` callback exactly once for signal-triggered shutdown while intentionally ignoring its boolean result once the EventLoop is already stopping
* join or start the existing bounded `shutdownWrite()` / `doWriteShutdown()` path instead of abruptly disabling established stream descriptors
* preserve active TLS shutdown and handshake helper progress during framework shutdown
* fix terminal `SocketContext` cleanup by resolving pending context switches, clearing the active context pointer immediately after self-deleting detach, and disposing of replacements queued from `onDisconnected()`
* rename the receiver-side shutdown dispatch hook from `onShutdown()` to `shutdownEvent()` to match the framework’s `*Event()` dispatch naming convention
* remove the obsolete and unreachable `SocketWriter::signalEvent()` override
* add focused plain/TLS lifecycle, timeout, context-lifetime, mutation, logging, ABI/source-compatibility, sanitizer, and CI regression coverage
* document the established stream shutdown lifecycle and timeout model

## Problem

Before this change, established stream connections did not participate in framework shutdown through one coordinated transport-level lifecycle.

Signal-triggered shutdown could reach the writer-specific signal path, where the application callback’s boolean result could veto graceful write shutdown even though the EventLoop had already entered `STOPPING`.

Plain and TLS connections also had several shutdown-lifecycle inconsistencies:

1. reader and writer receiver subobjects could both receive framework shutdown without a connection-level exactly-once guard;
2. active TLS shutdown helpers could receive framework notification while already progressing;
3. `SocketConnectionT::unobservedEvent()` did not resolve `newSocketContext`, so a pending context switch could leak if the connection terminated before the switch completed;
4. after `socketContext->detach(ConnectionClose)` self-deleted the active context, `socketContext` could still contain the deleted pointer until connection destruction;
5. the receiver-side shutdown hook used the callback-style name `onShutdown()` even though it is an EventLoop-to-receiver dispatch operation;
6. `SocketWriter::signalEvent()` retained obsolete veto semantics despite no longer being reachable through the coordinated shutdown path.

## Coordinated stream shutdown

`EventLoop::free()` enters `STOPPING` and delivers one `ShutdownContext` through the existing receiver graph:

```text
EventLoop
  -> EventMultiplexer
    -> DescriptorEventPublisher
      -> DescriptorEventReceiver
        -> SocketConnectionT
```

An established `SocketConnectionT` contains separate reader and writer `DescriptorEventReceiver` subobjects. Either subobject can therefore receive `shutdownEvent()`, but the complete connection processes the notification only once through:

```cpp
bool frameworkShutdownProcessed = false;
```

The guard is set before any callback or transport action:

```cpp
if (frameworkShutdownProcessed) {
    return;
}
frameworkShutdownProcessed = true;
```

This makes a second notification through the other receiver half harmless.

`ShutdownReason::Requested`, `ShutdownReason::Signal`, and `ShutdownReason::NoObserver` all join or start the same existing bounded transport shutdown path:

```cpp
shutdownWrite();
```

Plain streams retain their physical-socket write shutdown. TLS streams retain their TLS-aware `doWriteShutdown()` implementation, including `close_notify`, descriptor observation, peer progress, timeout handling, and forced termination fallback.

The read side remains enabled while it is still needed for peer EOF or TLS shutdown progress.

## Signal callback behavior

For signal-triggered framework shutdown, the active context’s existing signal callback is still invoked exactly once:

```cpp
static_cast<void>(SocketConnectionT::onSignal(context.signal));
```

The callback signature remains:

```cpp
bool onSignal(int signum);
```

Its result is intentionally ignored during coordinated framework shutdown. Once the EventLoop has entered `STOPPING`, application code can no longer veto the common bounded transport cleanup path.

Trigger-specific metadata and return values remain unchanged:

* `ShutdownContext` still records the shutdown reason and signal number;
* signal logging remains intact;
* `SNodeC::start()` preserves its trigger-specific result.

The obsolete `SocketWriter::signalEvent()` override has been removed. The inherited receiver implementation remains sufficient, and there is no independent non-`STOPPING` stream signal-dispatch path that depended on the removed writer-specific veto logic.

## Receiver naming cleanup

The framework convention is now consistent:

```text
*Event()  = EventLoop / publisher -> receiver dispatch
on*()     = receiver -> owner / application notification
```

The receiver-side shutdown hook has therefore been renamed from:

```cpp
onShutdown(const ShutdownContext&)
```

to:

```cpp
shutdownEvent(const ShutdownContext&)
```

The rename is propagated through:

* `DescriptorEventReceiver`
* descriptor notification dispatch
* `SocketConnectionT`
* `TLSShutdown`
* pipes
* Codex stdio receivers
* component and unit tests
* documentation and source-policy checks

Callback APIs such as `setOnShutdown(...)` retain their existing names because they represent owner/application callbacks rather than receiver dispatch.

## TLS helper coordination

If protocol-initiated TLS shutdown is already active when framework shutdown begins, the connection joins the existing operation instead of creating or restarting a helper.

`TLSShutdown` can receive framework notification through both its reader and writer receiver halves. Its `shutdownEvent()` implementation is continuation-safe and idempotent: an active helper continues the cleanup it already represents.

This remains safe whether a helper:

* is skipped because it was inserted before the current iterator in the same receiver list;
* is encountered later through another descriptor publisher;
* receives shutdown notification through both receiver halves.

The hard `EventMultiplexer::terminate()` fallback still disables and releases helpers that do not complete within the bounded outer drain.

## Context lifetime correction

Terminal connection cleanup now follows this exact ordering:

```cpp
delete std::exchange(newSocketContext, nullptr);

if (socketContext != nullptr) {
    socketContext->detach(
        SocketContext::DetachReason::ConnectionClose);
    socketContext = nullptr;
}

delete std::exchange(newSocketContext, nullptr);

onDisconnect();

log().debug("disconnected");
delete this;
```

The resulting invariants are:

1. a context switch already pending before terminal detach is destroyed first;
2. the active `socketContext` member remains valid and non-null while `detach()` invokes `onDisconnected()`;
3. a reentrant `setSocketContext()` from `onDisconnected()` therefore queues the replacement in `newSocketContext` instead of attaching it;
4. `socketContext` is set to `nullptr` immediately after the self-deleting `detach()` returns;
5. a replacement queued from `onDisconnected()` is destroyed exactly once;
6. `onDisconnect()` observes `getSocketContext() == nullptr`;
7. no terminal teardown flag, recursive drain loop, sentinel pointer, registry, or secondary ownership graph is required.

Context installation from pending-context destructors or the final `onDisconnect()` callback is intentionally not supported as a valid lifecycle operation.

## Scheduling while stopping

Descriptor receivers remain admissible during `STOPPING`. This allows shutdown helpers to register descriptor observation while the framework shutdown walk is active.

Descriptor inactivity timeouts remain available and drive the existing stream and TLS timeout behavior.

New core timers remain rejected while stopping. The shutdown path therefore does not depend on:

* `core::timer::Timer`
* singleshot timers
* next-tick callbacks
* a second shutdown scheduler

## Live publisher mutation

`DescriptorEventPublisher` stores observed receivers in:

```cpp
std::map<int, std::list<DescriptorEventReceiver*>>
```

Registration uses `push_front()`, while shutdown performs live forward iteration.

`std::list` insertion preserves existing iterators. A receiver inserted at the front of the currently traversed list is not revisited by the active forward walk, while all pre-existing receivers remain valid.

A receiver inserted into a publisher whose traversal has not started may still be encountered later during the same overall multiplexer shutdown.

The helper shutdown behavior is therefore correct in both cases and does not depend on publisher traversal order.

## Bounded cleanup

Graceful cleanup is best effort and bounded.

TLS retains its configured per-connection shutdown timeout, while the EventLoop retains its shared outer drain budget. A per-connection timeout does not extend the outer EventLoop deadline.

If cleanup does not finish within the available budget, forced multiplexer termination remains the final fallback.

All context detach, pending-context cleanup, connection destruction, descriptor close, and final object-bound logging complete before configuration-system termination whenever graceful cleanup finishes within the drain.

## Validation

The branch was validated with focused and full regression coverage, including:

* requested plain-stream shutdown;
* queued-output drain;
* signal shutdown with a `false` signal callback result;
* no-observer shutdown;
* non-cooperating peer timeout;
* context queued from active `onDisconnected()`;
* active-context visibility during detach;
* post-detach context visibility;
* destruction and semantic-log ordering;
* TLS shutdown already in progress;
* TLS signal shutdown;
* live receiver-list mutation;
* outer timeout behavior with multiple connections;
* source-policy and ABI/source-compatibility checks;
* GCC and Clang builds;
* AddressSanitizer execution;
* complete CTest runs.

The latest pushed branch is green.

## API and ABI

The receiver-side virtual hook is renamed:

```cpp
onShutdown(const ShutdownContext&)
```

to:

```cpp
shutdownEvent(const ShutdownContext&)
```

This is an internal framework virtual dispatch rename and requires recompilation of derived receiver implementations.

The existing public/application signal callback remains unchanged:

```cpp
bool onSignal(int signum);
```

No new public shutdown subsystem, participant registry, ownership graph, or connection API is introduced.

`SocketConnectionT` retains one private boolean for connection-level exactly-once notification state:

```cpp
bool frameworkShutdownProcessed = false;
```

No terminal-teardown state is added to the non-template `SocketConnection` base.

## Scope

This PR does not introduce:

* a shutdown participant registry;
* a second ownership model;
* a new EventLoop terminal state;
* a replacement TLS state machine;
* general STOPPING admission changes;
* new public `SocketContext` shutdown APIs;
* protocol-level shutdown redesign;
* timer-based stream shutdown scheduling;
* unrelated logging or formatting changes.

It coordinates the existing shutdown mechanisms, fixes the concrete context-lifetime defects, removes an obsolete signal path, and aligns receiver dispatch naming with the framework convention.
