### PR TITLE
Normalize transport and attempt lifecycle logging

### DIFF
--- a/docs/logging/phase-2-transport-attempt-lifecycle.md
+++ b/docs/logging/phase-2-transport-attempt-lifecycle.md
@@ -1,0 +1,208 @@
+# Logging lifecycle Phase 2: transport and attempt consistency
+
+## Status and relationship to earlier work
+
+This document is the reviewed production-call-site audit and implementation
+report for logging lifecycle Phase 2. It builds on, and does not replace, the
+contracts in:
+
+- `semantic-logging-contract.md`;
+- `phase-1-context-lifecycle-correctness.md`;
+- `semantic-identity-callsite-audit.md`; and
+- `../core-stream-shutdown-lifecycle.md`.
+
+The Phase 1 framework-context lifecycle remains `attached` / `detached`.
+Attachment is not a transport connection, and detachment is not a transport
+disconnection.
+
+## Audit method and accounting
+
+The audit searched all production files under `src/`, first for logging calls
+and then more broadly for callbacks, state transitions, and messages containing
+`connect`, `disconnect`, `accept`, `listen`, `open`, `close`, `ready`, `retry`,
+`reconnect`, `timeout`, `cancel`, `spawn`, `child`, `exit`, `terminate`, `pipe`,
+`handshake`, and `shutdown`. The broad review produced 488 candidate source
+locations in 93 files. Every candidate was inspected in its owning state
+machine; the numbers are search-review counts, not a claim that every textual
+match is a lifecycle record.
+
+The resulting accounting is:
+
+| Disposition | Count | Meaning |
+| --- | ---: | --- |
+| Phase 2 lifecycle decisions/emissions changed or introduced | 43 | Canonical listener, attempt, transport, continuation, TLS-ready, child-process, and stdio records, including distinct terminal branches |
+| Phase 2 owner-scope records retained | 96 | Detailed socket/TLS/descriptor/process progress, diagnostics, policy decisions, and summaries in core socket/pipe/eventreceiver, network, and Codex stdio code |
+| Phase 3 or application-facing candidates deferred/retained | 237 | Protocol/session/request vocabulary and application messages selected by the broad protocol/application review |
+| Not lifecycle log records | 112 | Declarations, callbacks, exceptions, state names, comments, and non-log textual matches |
+| **Total classified** | **488** | No broad-search candidate is left unclassified |
+
+The reproducible count for the final canonical Phase 2 sites is the number of
+production matches for the exact vocabulary listed below. The 96 retained
+owner-scope records are the remaining broad logging-call matches in
+`src/core/socket`, `src/core/pipe`, `src/core/eventreceiver`, `src/net`, and
+`src/ai/openai/codex/stdio`. The larger broad search supplies the deferred and
+not-a-log classifications. Grouping related specializations in the tables
+below avoids turning this report into a generated search dump.
+
+## Canonical vocabulary and severity
+
+| Lifecycle | Records | Level |
+| --- | --- | --- |
+| Listener | `listener started`, `listener stopped` | Info |
+| Listener startup terminal | `listener start failed` | Debug |
+| Connection attempt | `connection attempt started`, `connection attempt succeeded`, `connection attempt failed`, `connection attempt timed out`, `connection attempt cancelled` | Debug |
+| Established transport | `transport connected`, `transport disconnected` | Info |
+| TLS preparation completion | `transport ready` | Info |
+| Retry | `retry scheduled`, `retry dispatched`, `retry cancelled` | Debug |
+| Reconnect | `reconnect scheduled`, `reconnect dispatched`, `reconnect cancelled` | Debug |
+| Child process | `child process spawned`, `child process exited`, `child process terminated` | Info |
+| Child spawn terminal | `child process spawn failed` | Debug |
+| Codex stdio transport | `stdio transport started`, `stdio transport stopped` | Info |
+| Codex stdio startup terminal | `stdio transport start failed` | Debug |
+
+Long-lived, externally meaningful resource boundaries are visible at Info.
+Attempt and timer mechanics are Debug. Trace continues to carry syscall and
+state-machine progress. Warn and Error remain separate diagnostics; an error
+does not change the level of a canonical lifecycle end record.
+
+`listener start timed out` and `listener start cancelled` are not emitted
+because the current listener architecture has neither a startup timer nor an
+asynchronous cancellation state. They are intentionally not fabricated.
+
+## Semantic ownership and identity
+
+| Owner | Logger and identity | Why it owns the record |
+| --- | --- | --- |
+| `SocketAcceptor` | Endpoint instance scope, server role | Owns listener admission and the registered accept receiver |
+| `SocketConnector` | Endpoint instance scope, client role | Owns one dispatched physical connection candidate and its terminal outcome |
+| `SocketConnection` | Connection scope with instance, role, and connection id | Exists only after an accepted or outgoing physical transport is established and remains alive through final teardown |
+| TLS acceptor/connector callbacks | The same connection logger | Successful handshake is the point at which TLS becomes application-ready |
+| Client/server continuation context | Endpoint instance scope with client/server role | Owns retry/reconnect timer scheduling and dispatch counters |
+| Codex stdio `Session` | Existing `ai.openai.codex.stdio` connection scope | Already owns descriptors, child observation, shutdown escalation, and reaping |
+
+`SocketConnection::getConnectionName()` remains a compatibility/display value.
+It is not redefined and is not copied into the new transport message text.
+Connection roles now come from the existing configuration role so both ends of
+the lifecycle have the same full semantic identity.
+
+## Reviewed core transport call sites
+
+| Owner and call site | Previous record / level / logger | Classification | Pair or alternatives and duplication risk | Final action |
+| --- | --- | --- | --- | --- |
+| `SocketAcceptor::init`, successful descriptor enable | Low-level `open`/`bind`/`listen`/`enable` details through the static core logger | `LIFECYCLE_START` plus retained `PROGRESS` | Startup can fail before registration; internal operations are not separate resources | Add endpoint Info `listener started`; retain detailed diagnostics |
+| `SocketAcceptor::init`, all unsuccessful completion paths, including TLS context setup | Error/debug syscall and TLS details | `TERMINAL_ALTERNATIVE` and `DIAGNOSTIC` | A failed candidate must not later stop | Add endpoint Debug `listener start failed`; retain the cause separately |
+| `SocketAcceptor::unobservedEvent` | No canonical listener end | `LIFECYCLE_END` | Only a successfully registered receiver reaches this existing exactly-once owner | Emit endpoint Info `listener stopped` immediately before destruction |
+| `SocketAcceptor::acceptEvent` after connection construction | Static `accept ... success` Debug detail | `LIFECYCLE_START` plus retained `PROGRESS` | Accepted connection must share identity with final teardown | Add connection-bound Info `transport connected`; retain accept/address detail |
+| `SocketConnector::init` and `connectEvent` | Static connect/open/bind/getsockopt details with status callback terminals | `LIFECYCLE_START`, `TERMINAL_ALTERNATIVE`, `PROGRESS`, `DIAGNOSTIC` | Immediate, asynchronous, timeout, address-fallback, disable, and teardown paths converge differently | Add one endpoint Debug attempt start and exactly one success/failure/timeout/cancel terminal per candidate |
+| `SocketConnector` immediate and event success | Static `connect ... success` Debug | `LIFECYCLE_START` | A constructed connection is established; a failed candidate constructs none | Emit connection-bound Info `transport connected` after attempt success |
+| `SocketConnection::unobservedEvent` | Bare `disconnected` Debug on connection logger | `LIFECYCLE_END` | Reader/writer halves, repeated shutdown, and framework shutdown already converge on this one unobserved owner | Replace with connection-bound Info `transport disconnected`, once, after context detach and the existing disconnect callback, before destruction |
+| Plain stream connection callbacks | No separate readiness record | Intentionally not paired | Plain transport is usable at connection construction | Do not add redundant `transport ready` |
+| TLS handshake success callbacks | `SSL/TLS: Handshake success` Debug | `PROGRESS` plus readiness `LIFECYCLE_START` | Generic physical connection already emitted; handshake failure must never be ready | Retain handshake detail and add connection-bound Info `transport ready` only on success |
+| TLS handshake/shutdown failures and close-notify progress | Error/Warn/Trace details | `DIAGNOSTIC` / `PROGRESS` | These report causes and state-machine progress, not extra lifecycle objects | Retain unchanged apart from canonical lifecycle companions |
+| Client/server retry timer admission and callback | Info `Retry ... in`, counter increment on dispatch | Continuation lifecycle | Timer admission is not a dispatch; shutdown/config changes can cancel it | Emit Debug scheduled/dispatched/cancelled; move timing detail to Trace; increment existing counter only on dispatch |
+| Client reconnect timer admission and callback | Info `Reconnect in`, counter increment on dispatch | Continuation lifecycle | Same distinction as retry | Emit Debug scheduled/dispatched/cancelled; preserve counter and policy |
+| Client/server `OnConnect`/`OnConnected`/`OnDisconnect` address/statistics messages | Debug endpoint callback details including connection display name | `DIAGNOSTIC` | Compatibility/debug callback surface, not canonical state ownership | Retain; do not promote or mechanically rewrite |
+| Stream reader/writer close, half-close, drain, timeout, and descriptor messages | Trace/Warn/Error | `PROGRESS` / `DIAGNOSTIC` | Coordinated stream shutdown owns behavior; these are not independent transports | Retain and rely on common connection end owner |
+
+The connector uses one private `attemptActive` flag. The status callback could
+not be used as an ownership token because the architecture deliberately copies
+it to the next address candidate. The flag is reset in the copy so every
+candidate starts and ends once; it changes no callback, timeout, or fallback
+behavior and creates no second ownership graph.
+
+## Network specializations, pipes, and event-loop infrastructure
+
+| Area | Classification | Decision |
+| --- | --- | --- |
+| `net/in`, `net/in6`, `net/un`, `net/rc`, and `net/l2` stream specializations | `PROGRESS`, `DIAGNOSTIC`, or no local lifecycle record | The common acceptor, connector, connection, and TLS layers own canonical records; no duplicate specialization records were added |
+| Unix path locking/unlinking and address selection | `DIAGNOSTIC` / `POLICY_DECISION` | Retained as physical-address detail |
+| `core/pipe` source, sink, and pipe helper | `NOT_A_LOG_RECORD` for construction/close paths; exceptions are diagnostics | Pipe halves are temporary descriptor helpers, including inside Codex stdio, and are not independently presented as long-lived transports; no noisy pipe pair was invented |
+| Descriptor receivers and multiplexer admission/removal | `PROGRESS` / `DIAGNOSTIC` | Retained at low level; existing registration facts provide exactly-once ownership |
+| EventLoop start/stop/shutdown records | `SUMMARY` / `PROGRESS` outside Phase 2 | Retained; EventLoop shutdown semantics are unchanged |
+
+## Codex stdio and child-process audit
+
+| Call site | Classification | Final action and exactly-once basis |
+| --- | --- | --- |
+| Successful `posix_spawn` followed by parent ownership setup | Child `LIFECYCLE_START` | Info `child process spawned` after a real pid is owned; pid detail remains Trace |
+| `posix_spawn` error | `TERMINAL_ALTERNATIVE` plus `DIAGNOSTIC` | Debug `child process spawn failed`; existing Error carries errno/text; no child exit is possible |
+| Descriptor/pidfd/poll setup failure after spawn | Stdio startup terminal plus process cleanup | Debug `stdio transport start failed`; spawned child still gets its actual reaped process terminal record |
+| All descriptor sides successfully registered | Stdio `LIFECYCLE_START` | Info `stdio transport started` once |
+| Reaped `WIFEXITED` status | Child `LIFECYCLE_END` | Info `child process exited`; status and requested-shutdown detail remain Debug |
+| Reaped `WIFSIGNALED` status | Child terminal alternative | Info `child process terminated`; signal/requested/forced detail remains Debug |
+| First framework SIGTERM | `POLICY_DECISION` | Debug `child process termination requested` |
+| First escalation to SIGKILL | `POLICY_DECISION` / abnormal diagnostic | Warn `child process forced termination requested` |
+| Final descriptor teardown after a started transport | Stdio `LIFECYCLE_END` | Info `stdio transport stopped` once, guarded by the session's private started fact |
+| Launch rejected or setup failure | Stdio startup terminal | Debug `stdio transport start failed`; detailed Error remains separate; never emits a fictional stop |
+
+The existing `childPid = -1`, observer detachment, and reaped-state flow remain
+the single child terminal owner. Pidfd and polling fallback both feed that same
+path, so they cannot emit duplicate exits. Descriptor closure is deliberately
+not called process exit. A process is only `exited` or `terminated` after
+`waitpid` has reaped it.
+
+## Exactly-once proof summary
+
+- An acceptor startup failure calls direct destruction; only an observed,
+  registered acceptor reaches `unobservedEvent` and emits `listener stopped`.
+- Each connector candidate sets `attemptActive` at dispatch and exchanges it
+  to false in every terminal helper. Destruction can therefore add cancellation
+  only when no earlier terminal path ran.
+- A `SocketConnection` is constructed only after accept/connect success.
+  Consequently failed attempts cannot reach the common transport-disconnect
+  owner.
+- Both stream receiver halves converge on the connection's existing
+  unobserved event. Coordinated shutdown, an already active shutdown, and later
+  destructor cleanup do not create another end site.
+- TLS readiness exists only inside the successful handshake callback. TLS
+  shutdown remains generic transport teardown and cannot add another end.
+- Retry/reconnect booleans are consumed by dispatch or cancellation. Existing
+  counters are called only from dispatch.
+- Codex process terminals are emitted only from the reaped-status path;
+  `transportStarted` permits one stdio stop and forbids stop after startup
+  failure.
+
+## Compatibility and behavior preservation
+
+This phase changes log message vocabulary, severity, and the completeness of
+semantic role metadata. It does not change EventLoop shutdown, coordinated
+stream shutdown, callback ordering, context attach/detach ordering or lifetime,
+retry/reconnect policy, timeout values, timer or descriptor admission, TLS
+handshake/shutdown behavior, connection/process ownership, child reaping,
+public callbacks, public socket APIs, the logger backend/schema/formatters, the
+global logging policy, ABI, or SOVERSION.
+
+The only new state is private lifecycle bookkeeping: one connector-candidate
+boolean and three Codex session booleans. No public or protected API is added.
+
+## Deliberate Phase 3 deferrals
+
+The following reviewed records remain intentionally unchanged unless they were
+merely transport duplicates:
+
+- MQTT protocol engine and MQTT session `Connected` / `Disconnected` records;
+- HTTP request/response and HTTP protocol-engine lifecycle;
+- EventSource protocol lifecycle;
+- WebSocket protocol and subprotocol lifecycle;
+- database protocol/command/session lifecycle;
+- Codex app-server protocol/session lifecycle, JSON-RPC requests and
+  notifications, threads, turns, model/session/user-message state, and
+  cancellation;
+- application-domain sessions and ordinary user-facing application messages.
+
+Reference applications may still say that they are listening or connected as
+user-facing status. Those messages neither own nor replace the framework
+records and are classified `APPLICATION_USER_FACING`.
+
+## Validation surface
+
+Runtime JSON capture tests cover accepted and outgoing plain transports,
+attempt success/failure without fictional disconnect, listener success/failure
+and stop, graceful/dual-receiver shutdown, retry/reconnect schedule and
+dispatch, and Codex spawn/setup/normal-exit/termination/fallback behavior.
+Narrow source-policy tests cover terminal placement that is impractical to
+force deterministically, including timeout/cancellation convergence, TLS-ready
+placement, Phase 1 vocabulary preservation, and the absence of obsolete bare
+transport records. Exact build, CTest, compiler, sanitizer, and CI results are
+reported in the pull request because they describe the tested revision rather
+than the semantic contract.

--- a/docs/logging/phase-2-transport-attempt-lifecycle.md
+++ b/docs/logging/phase-2-transport-attempt-lifecycle.md
@@ -170,10 +170,17 @@ stream shutdown, callback ordering, context attach/detach ordering or lifetime,
 retry/reconnect policy, timeout values, timer or descriptor admission, TLS
 handshake/shutdown behavior, connection/process ownership, child reaping,
 public callbacks, public socket APIs, the logger backend/schema/formatters, the
-global logging policy, ABI, or SOVERSION.
+global logging policy, or SOVERSION.
 
-The only new state is private lifecycle bookkeeping: one connector-candidate
-boolean and three Codex session booleans. No public or protected API is added.
+There is no public or protected source API change and no callback signature
+change. The private layout of the public `SocketConnector` template changes
+because its installed header now contains the attempt lifecycle state.
+Affected dependent code and template instantiations must be rebuilt; binary
+compatibility is not claimed. The internal `SocketClient` and `SocketServer`
+shared context layouts also change because of private continuation lifecycle
+state, but those contexts are not intended public ABI surfaces. The remaining
+new state is private Codex session lifecycle bookkeeping. No semantic log
+schema, backend, text/JSON format, or filtering contract changes.
 
 ## Deliberate Phase 3 deferrals
 
@@ -197,9 +204,11 @@ records and are classified `APPLICATION_USER_FACING`.
 ## Validation surface
 
 Runtime JSON capture tests cover accepted and outgoing plain transports,
-attempt success/failure without fictional disconnect, listener success/failure
-and stop, graceful/dual-receiver shutdown, retry/reconnect schedule and
-dispatch, and Codex spawn/setup/normal-exit/termination/fallback behavior.
+attempt success/failure without fictional disconnect, deterministic listener
+startup failure in `ListenerLifecyclePhase2Test`, the successful listener pair
+in `InetLegacyServerClientDisconnectLifecycleTest`, graceful/dual-receiver
+shutdown, retry/reconnect schedule and dispatch, and Codex
+spawn/setup/normal-exit/termination/fallback behavior.
 Narrow source-policy tests cover terminal placement that is impractical to
 force deterministically, including timeout/cancellation convergence, TLS-ready
 placement, Phase 1 vocabulary preservation, and the absence of obsolete bare

--- a/src/ai/openai/codex/stdio/StdioTransport.cpp
+++ b/src/ai/openai/codex/stdio/StdioTransport.cpp
@@ -305,14 +305,14 @@ namespace ai::openai::codex::stdio::detail {
 
         void start() {
             if (core::SNodeC::state() == core::State::STOPPING) {
-                reportError({Error::Category::Launch, ECANCELED, "codex app-server launch rejected during event-loop shutdown"});
+                reportStartError({Error::Category::Launch, ECANCELED, "codex app-server launch rejected during event-loop shutdown"});
                 return;
             }
 
             StandardDescriptorReservations standardDescriptors;
             if (!standardDescriptors.isValid()) {
                 const int errnum = standardDescriptors.getError();
-                reportError({Error::Category::Launch, errnum, errorText("unable to reserve standard descriptors", errnum)});
+                reportStartError({Error::Category::Launch, errnum, errorText("unable to reserve standard descriptors", errnum)});
                 return;
             }
 
@@ -329,7 +329,7 @@ namespace ai::openai::codex::stdio::detail {
                 const int errnum = !completePipe(stdinPipe)    ? stdinPipe.getError()
                                    : !completePipe(stdoutPipe) ? stdoutPipe.getError()
                                                                : stderrPipe.getError();
-                reportError({Error::Category::Launch, errnum, errorText("unable to create app-server pipes", errnum)});
+                reportStartError({Error::Category::Launch, errnum, errorText("unable to create app-server pipes", errnum)});
                 return;
             }
 
@@ -338,14 +338,14 @@ namespace ai::openai::codex::stdio::detail {
             };
             if (!endpointsAreAboveStandardDescriptors(stdinPipe) || !endpointsAreAboveStandardDescriptors(stdoutPipe) ||
                 !endpointsAreAboveStandardDescriptors(stderrPipe)) {
-                reportError({Error::Category::Launch, EINVAL, "app-server pipe endpoint collided with a standard descriptor"});
+                reportStartError({Error::Category::Launch, EINVAL, "app-server pipe endpoint collided with a standard descriptor"});
                 return;
             }
 
             posix_spawn_file_actions_t fileActions{};
             const int actionsInitResult = posix_spawn_file_actions_init(&fileActions);
             if (actionsInitResult != 0) {
-                reportError(
+                reportStartError(
                     {Error::Category::Launch, actionsInitResult, errorText("posix_spawn_file_actions_init failed", actionsInitResult)});
                 return;
             }
@@ -409,12 +409,14 @@ namespace ai::openai::codex::stdio::detail {
             }
 
             pid_t spawnedPid = -1;
+            bool spawnDispatched = false;
             if (setupResult == 0 && core::SNodeC::state() == core::State::STOPPING) {
                 setupResult = ECANCELED;
             }
             if (setupResult == 0) {
                 try {
                     std::vector<char*> argv = buildArgv(executable, arguments);
+                    spawnDispatched = true;
                     setupResult = posix_spawnp(&spawnedPid, executable.c_str(), &fileActions, &attributes, argv.data(), environ);
                 } catch (...) {
                     setupResult = ENOMEM;
@@ -428,15 +430,20 @@ namespace ai::openai::codex::stdio::detail {
 
             if (setupResult != 0) {
                 detachExitObservers();
+                if (spawnDispatched) {
+                    logScope.logger(logger::Logger::semanticSink()).debug("child process spawn failed");
+                }
                 if (!observerSetupError.empty()) {
-                    reportError({Error::Category::Launch, setupResult, std::move(observerSetupError)});
+                    reportStartError({Error::Category::Launch, setupResult, std::move(observerSetupError)});
                 } else {
-                    reportError({Error::Category::Launch, setupResult, errorText("unable to launch codex app-server", setupResult)});
+                    reportStartError({Error::Category::Launch, setupResult, errorText("unable to launch codex app-server", setupResult)});
                 }
                 return;
             }
 
             childPid = spawnedPid;
+            logScope.logger(logger::Logger::semanticSink()).info("child process spawned");
+            logScope.logger(logger::Logger::semanticSink()).trace("child process pid={}", childPid);
             try {
                 selfKeepAlive = shared_from_this();
 
@@ -540,7 +547,8 @@ namespace ai::openai::codex::stdio::detail {
                     }
                 });
 
-                logScope.logger(logger::Logger::semanticSink()).trace("Spawned codex app-server: pid={}", childPid);
+                transportStarted = true;
+                logScope.logger(logger::Logger::semanticSink()).info("stdio transport started");
                 const std::function<void()> callback = callbacks.onStarted;
                 if (callback) {
                     callback();
@@ -630,9 +638,18 @@ namespace ai::openai::codex::stdio::detail {
                 if (WIFEXITED(status)) {
                     exitStatus.exited = true;
                     exitStatus.exitCode = WEXITSTATUS(status);
+                    logScope.logger(logger::Logger::semanticSink()).info("child process exited");
+                    logScope.logger(logger::Logger::semanticSink())
+                        .debug("child process exit status: code={} requested={}", exitStatus.exitCode, stopping);
                 } else if (WIFSIGNALED(status)) {
                     exitStatus.signaled = true;
                     exitStatus.signalNumber = WTERMSIG(status);
+                    logScope.logger(logger::Logger::semanticSink()).info("child process terminated");
+                    logScope.logger(logger::Logger::semanticSink())
+                        .debug("child process termination status: signal={} requested={} forced={}",
+                               exitStatus.signalNumber,
+                               terminationRequested,
+                               forcedTerminationRequested);
                 }
             } else {
                 const int waitError = errno;
@@ -720,6 +737,18 @@ namespace ai::openai::codex::stdio::detail {
         }
 
         void signalChildProcessGroup(int signalNumber) {
+            if (childPid <= 0) {
+                return;
+            }
+
+            if (signalNumber == SIGTERM && !terminationRequested) {
+                terminationRequested = true;
+                logScope.logger(logger::Logger::semanticSink()).debug("child process termination requested");
+            } else if (signalNumber == SIGKILL && !forcedTerminationRequested) {
+                forcedTerminationRequested = true;
+                logScope.logger(logger::Logger::semanticSink()).warn("child process forced termination requested");
+            }
+
             if (childPid > 0 && ::kill(-childPid, signalNumber) != 0 && errno == ESRCH) {
                 static_cast<void>(::kill(childPid, signalNumber));
             }
@@ -775,7 +804,7 @@ namespace ai::openai::codex::stdio::detail {
                 processObserver->pollUntilExit();
             }
             signalChildProcessGroup(SIGKILL);
-            reportError(std::move(error));
+            reportStartError(std::move(error));
             childMayHaveExited(nullptr);
         }
 
@@ -949,10 +978,22 @@ namespace ai::openai::codex::stdio::detail {
             }
         }
 
+        void reportStartError(Error error) {
+            if (!errorReported) {
+                logScope.logger(logger::Logger::semanticSink()).debug("stdio transport start failed");
+            }
+            reportError(std::move(error));
+        }
+
         void finalizeExit(const codex::detail::ProcessExit& status) {
             const std::shared_ptr<Session> keepAlive = shared_from_this();
             detachExitObservers();
             closeEndpoints();
+
+            if (transportStarted) {
+                transportStarted = false;
+                logScope.logger(logger::Logger::semanticSink()).info("stdio transport stopped");
+            }
 
             const std::function<void(codex::detail::ProcessExit)> callback = callbacks.onExited;
             selfKeepAlive.reset();
@@ -1016,6 +1057,9 @@ namespace ai::openai::codex::stdio::detail {
         bool stopping = false;
         bool errorReported = false;
         bool stdinFlushTimedOut = false;
+        bool transportStarted = false;
+        bool terminationRequested = false;
+        bool forcedTerminationRequested = false;
         StopPhase stopPhase = StopPhase::Running;
         utils::Timeval stopDeadline;
 

--- a/src/core/socket/stream/SocketAcceptor.hpp
+++ b/src/core/socket/stream/SocketAcceptor.hpp
@@ -180,6 +180,7 @@ namespace core::socket::stream {
                             if (enable(physicalServerSocket.getFd())) {
                                 snode::semantic::coreSocketLog().debug() << config->getInstanceName() << " enable "
                                                                          << physicalServerSocket.getBindAddress().toString() << ": success";
+                                log().info("listener started");
                             } else {
                                 snode::semantic::coreSocketLog().error()
                                     << config->getInstanceName() << " enable " << physicalServerSocket.getBindAddress().toString()
@@ -189,6 +190,10 @@ namespace core::socket::stream {
                             }
                         }
                     }
+                }
+
+                if (getRegisteredFd() < 0) {
+                    log().debug("listener start failed");
                 }
 
                 SocketAddress currentLocalAddress = bindSucceeded ? physicalServerSocket.getBindAddress() : configuredAddress;
@@ -208,6 +213,7 @@ namespace core::socket::stream {
 
                 snode::semantic::coreSocketLog().error() << state.what();
 
+                log().debug("listener start failed");
                 onStatus({}, state);
             }
         } else {
@@ -241,6 +247,8 @@ namespace core::socket::stream {
                     SocketConnection* socketConnection =
                         new SocketConnection(std::move(connectedPhysicalSocket), onDisconnect, connectionId, config);
 
+                    socketConnection->log().info("transport connected");
+
                     snode::semantic::coreSocketLog().debug()
                         << config->getInstanceName() << " accept " << physicalServerSocket.getBindAddress().toString() << ": success";
                     snode::semantic::coreSocketLog().debug() << "  " << socketConnection->getRemoteAddress().toString() << " -> "
@@ -260,6 +268,7 @@ namespace core::socket::stream {
               typename Config,
               template <typename ConfigT, typename PhysicalSocketServerT> typename SocketConnection>
     void SocketAcceptor<PhysicalSocketServer, Config, SocketConnection>::unobservedEvent() {
+        log().info("listener stopped");
         destruct();
     }
 

--- a/src/core/socket/stream/SocketClient.h
+++ b/src/core/socket/stream/SocketClient.h
@@ -105,6 +105,15 @@ namespace core::socket::stream {
                 , onConnect(onConnect)
                 , onConnected(onConnected)
                 , onDisconnect(onDisconnect) {
+                flowController.setOnFlowTerminated([this](ClientFlowController*) {
+                    cancelRetry();
+                    cancelReconnect();
+                });
+            }
+
+            ~Context() {
+                cancelRetry();
+                cancelReconnect();
             }
 
             ClientFlowController flowController;
@@ -113,6 +122,50 @@ namespace core::socket::stream {
 
             std::uint64_t allocateConnectionId() noexcept {
                 return ++connectionsCreated;
+            }
+
+            void scheduleRetry() {
+                retryScheduled = true;
+                logScope.logger(logger::Logger::semanticSink()).debug("retry scheduled");
+            }
+
+            bool dispatchRetry() {
+                if (!retryScheduled) {
+                    return false;
+                }
+                retryScheduled = false;
+                logScope.logger(logger::Logger::semanticSink()).debug("retry dispatched");
+                flowController.reportFlowRetry();
+                return true;
+            }
+
+            void cancelRetry() {
+                if (retryScheduled) {
+                    retryScheduled = false;
+                    logScope.logger(logger::Logger::semanticSink()).debug("retry cancelled");
+                }
+            }
+
+            void scheduleReconnect() {
+                reconnectScheduled = true;
+                logScope.logger(logger::Logger::semanticSink()).debug("reconnect scheduled");
+            }
+
+            bool dispatchReconnect() {
+                if (!reconnectScheduled) {
+                    return false;
+                }
+                reconnectScheduled = false;
+                logScope.logger(logger::Logger::semanticSink()).debug("reconnect dispatched");
+                flowController.reportFlowReconnect();
+                return true;
+            }
+
+            void cancelReconnect() {
+                if (reconnectScheduled) {
+                    reconnectScheduled = false;
+                    logScope.logger(logger::Logger::semanticSink()).debug("reconnect cancelled");
+                }
             }
 
             void emitTerminationSummary() const {
@@ -131,6 +184,8 @@ namespace core::socket::stream {
             }
 
             bool terminationSummaryEmitted{false};
+            bool retryScheduled{false};
+            bool reconnectScheduled{false};
 
             std::shared_ptr<SocketContextFactory> socketContextFactory;
 
@@ -234,18 +289,23 @@ namespace core::socket::stream {
                                         core::eventLoopState() == core::State::RUNNING) {
                                         double relativeReconnectTimeout = config->getReconnectTime();
 
-                                        log.info("Reconnect in {} seconds", relativeReconnectTimeout);
+                                        sharedContext->scheduleReconnect();
+                                        log.trace("Reconnect in {} seconds", relativeReconnectTimeout);
 
                                         sharedContext->flowController.armReconnectTimer(
                                             relativeReconnectTimeout, [config, sharedContext, log, /*generation,*/ onStatus]() {
                                                 if (!sharedContext->flowController.isReconnectEnabled()) {
+                                                    sharedContext->cancelReconnect();
                                                     return;
                                                 }
                                                 if (config->getReconnect()) {
-                                                    sharedContext->flowController.reportFlowReconnect();
-                                                    SocketClient(config, sharedContext).realConnect(onStatus, 0, config->getRetryBase());
+                                                    if (sharedContext->dispatchReconnect()) {
+                                                        SocketClient(config, sharedContext)
+                                                            .realConnect(onStatus, 0, config->getRetryBase());
+                                                    }
                                                 } else {
-                                                    log.info("Reconnect disabled during wait");
+                                                    sharedContext->cancelReconnect();
+                                                    log.trace("Reconnect disabled during wait");
                                                 }
                                             });
                                     } else if (core::eventLoopState() == core::State::RUNNING &&
@@ -276,7 +336,8 @@ namespace core::socket::stream {
                                             utils::Random::getInRange(-config->getRetryJitter(), config->getRetryJitter()) *
                                             relativeRetryTimeout / 100.;
 
-                                        log.info("Retry connect in {} seconds", relativeRetryTimeout);
+                                        sharedContext->scheduleRetry();
+                                        log.trace("Retry connect in {} seconds", relativeRetryTimeout);
 
                                         sharedContext->flowController.armRetryTimer(
                                             relativeRetryTimeout,
@@ -287,19 +348,22 @@ namespace core::socket::stream {
                                              tries,
                                              retryTimeoutScale]() {
                                                 if (!sharedContext->flowController.isRetryEnabled()) {
+                                                    sharedContext->cancelRetry();
                                                     return;
                                                 }
                                                 if (config->getRetry()) {
-                                                    sharedContext->flowController.reportFlowRetry();
-                                                    SocketClient(config, sharedContext)
-                                                        .realConnect(onStatus, tries + 1, retryTimeoutScale * config->getRetryBase());
+                                                    if (sharedContext->dispatchRetry()) {
+                                                        SocketClient(config, sharedContext)
+                                                            .realConnect(onStatus, tries + 1, retryTimeoutScale * config->getRetryBase());
+                                                    }
                                                 } else {
-                                                    log.info("Retry connect disabled during wait");
+                                                    sharedContext->cancelRetry();
+                                                    log.trace("Retry connect disabled during wait");
                                                 }
                                             });
-                                    } else if (retryFlag &&
-                                               (state == core::socket::State::ERROR || state == core::socket::State::FATAL) &&
-                                               core::SNodeC::state() == core::State::RUNNING && sharedContext->flowController.terminateFlow()) {
+                                    } else if (retryFlag && (state == core::socket::State::ERROR || state == core::socket::State::FATAL) &&
+                                               core::SNodeC::state() == core::State::RUNNING &&
+                                               sharedContext->flowController.terminateFlow()) {
                                         sharedContext->emitTerminationSummaryOnce();
                                     }
                                 },

--- a/src/core/socket/stream/SocketConnection.cpp
+++ b/src/core/socket/stream/SocketConnection.cpp
@@ -43,6 +43,7 @@
 
 #include "core/socket/stream/SocketContext.h"
 #include "core/socket/stream/SocketContextFactory.h"
+#include "net/config/ConfigInstance.h"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
@@ -71,7 +72,10 @@ namespace core::socket::stream {
                    logger::LogBoundary::Connection,
                    "core.socket.stream",
                    instanceName.empty() ? std::nullopt : std::optional<std::string>(instanceName),
-                   std::nullopt,
+                   config != nullptr
+                       ? std::optional<logger::LogRole>(config->role == net::config::ConfigInstance::Role::SERVER ? logger::LogRole::Server
+                                                                                                                  : logger::LogRole::Client)
+                       : std::nullopt,
                    std::to_string(connectionId))
         , onlineSinceTimePoint(std::chrono::system_clock::now())
         , config(config) {

--- a/src/core/socket/stream/SocketConnection.hpp
+++ b/src/core/socket/stream/SocketConnection.hpp
@@ -415,7 +415,7 @@ namespace core::socket::stream {
 
         onDisconnect();
 
-        Super::log().debug("disconnected");
+        Super::log().info("transport disconnected");
 
         delete this;
     }

--- a/src/core/socket/stream/SocketConnector.h
+++ b/src/core/socket/stream/SocketConnector.h
@@ -109,6 +109,10 @@ namespace core::socket::stream {
         virtual void useNextSocketAddress() = 0;
 
     private:
+        void startAttempt();
+        void finishAttempt(const char* outcome);
+        void finishAttempt(const char* outcome, const SocketAddress& socketAddress, core::socket::State state);
+
         void connectEvent() final;
 
         void unobservedEvent() final;
@@ -141,6 +145,11 @@ namespace core::socket::stream {
 
         logger::LogScopeOwner logScope;
         std::shared_ptr<Config> config = nullptr;
+        bool attemptActive{false};
+
+#ifdef SNODEC_BUILD_TESTS
+        friend struct SocketConnectorLifecycleTestAccess;
+#endif
     };
 
 } // namespace core::socket::stream

--- a/src/core/socket/stream/SocketConnector.hpp
+++ b/src/core/socket/stream/SocketConnector.hpp
@@ -91,7 +91,8 @@ namespace core::socket::stream {
         , onStatus(socketConnector.onStatus)
         , allocateConnectionId(socketConnector.allocateConnectionId)
         , logScope(socketConnector.logScope)
-        , config(socketConnector.config) {
+        , config(socketConnector.config)
+        , attemptActive(false) {
     }
 
     template <typename PhysicalSocketClient,
@@ -105,6 +106,7 @@ namespace core::socket::stream {
               template <typename ConfigT, typename PhysicalSocketClientT> typename SocketConnection>
     void SocketConnector<PhysicalSocketClient, Config, SocketConnection>::init() {
         if (!config->getDisabled()) {
+            startAttempt();
             try {
                 core::socket::State state = core::socket::STATE_OK;
 
@@ -132,7 +134,7 @@ namespace core::socket::stream {
                                 break;
                         }
 
-                        onStatus(configuredLocalAddress, state);
+                        finishAttempt("connection attempt failed", configuredLocalAddress, state);
                     } else {
                         snode::semantic::coreSocketLog().trace()
                             << config->getInstanceName() << " open " << configuredLocalAddress.toString() << ": success";
@@ -151,7 +153,7 @@ namespace core::socket::stream {
                                     break;
                             }
 
-                            onStatus(configuredLocalAddress, state);
+                            finishAttempt("connection attempt failed", configuredLocalAddress, state);
                         } else {
                             const std::string configuredLocalAddressString = configuredLocalAddress.toString();
                             const std::string effectiveBindAddressString = physicalClientSocket.getBindAddress().toString();
@@ -184,14 +186,14 @@ namespace core::socket::stream {
 
                                 SocketAddress currentRemoteAddress = remoteAddress;
                                 if (remoteAddress.useNext()) {
-                                    onStatus(currentRemoteAddress, state | core::socket::State::NO_RETRY);
+                                    finishAttempt("connection attempt failed", currentRemoteAddress, state | core::socket::State::NO_RETRY);
 
                                     snode::semantic::coreSocketLog().info()
                                         << config->getInstanceName() << ": Using next SocketAddress: " << remoteAddress.toString();
 
                                     useNextSocketAddress();
                                 } else {
-                                    onStatus(currentRemoteAddress, state);
+                                    finishAttempt("connection attempt failed", currentRemoteAddress, state);
                                 }
                             } else {
                                 snode::semantic::coreSocketLog().trace()
@@ -208,7 +210,7 @@ namespace core::socket::stream {
 
                                         state = core::socket::STATE(core::socket::STATE_FATAL, ECANCELED, "SocketConnector not enabled");
 
-                                        onStatus(remoteAddress, state);
+                                        finishAttempt("connection attempt failed", remoteAddress, state);
                                     }
                                 } else {
                                     SocketConnection* socketConnection =
@@ -219,7 +221,9 @@ namespace core::socket::stream {
                                     snode::semantic::coreSocketLog().debug() << "  " << socketConnection->getLocalAddress().toString()
                                                                              << " -> " << socketConnection->getRemoteAddress().toString();
 
-                                    onStatus(remoteAddress, state);
+                                    finishAttempt("connection attempt succeeded", remoteAddress, state);
+
+                                    socketConnection->log().info("transport connected");
 
                                     onConnect(socketConnection);
                                     onConnected(socketConnection);
@@ -233,7 +237,7 @@ namespace core::socket::stream {
 
                     snode::semantic::coreSocketLog().error() << state.what();
 
-                    onStatus({}, state);
+                    finishAttempt("connection attempt failed", {}, state);
                 }
             } catch (const typename SocketAddress::BadSocketAddress& badSocketAddress) {
                 core::socket::State state =
@@ -241,7 +245,7 @@ namespace core::socket::stream {
 
                 snode::semantic::coreSocketLog().error() << state.what();
 
-                onStatus({}, state);
+                finishAttempt("connection attempt failed", {}, state);
             }
         } else {
             snode::semantic::coreSocketLog().debug() << config->getInstanceName() << ": disabled";
@@ -275,7 +279,9 @@ namespace core::socket::stream {
                 snode::semantic::coreSocketLog().debug()
                     << "  " << socketConnection->getLocalAddress().toString() << " -> " << socketConnection->getRemoteAddress().toString();
 
-                onStatus(remoteAddress, core::socket::STATE_OK);
+                finishAttempt("connection attempt succeeded", remoteAddress, core::socket::STATE_OK);
+
+                socketConnection->log().info("transport connected");
 
                 onConnect(socketConnection);
                 onConnected(socketConnection);
@@ -307,7 +313,7 @@ namespace core::socket::stream {
                     snode::semantic::sysError(snode::semantic::coreSocketLog(), logger::LogLevel::Debug, errnum)
                         << config->getInstanceName() << " connect '" << remoteAddress.toString();
 
-                    onStatus(currentRemoteAddress, (state | core::socket::State::NO_RETRY));
+                    finishAttempt("connection attempt failed", currentRemoteAddress, state | core::socket::State::NO_RETRY);
 
                     snode::semantic::coreSocketLog().debug()
                         << config->getInstanceName() << " using next SocketAddress: " << config->Remote::getSocketAddress().toString();
@@ -319,7 +325,7 @@ namespace core::socket::stream {
                     snode::semantic::sysError(snode::semantic::coreSocketLog(), logger::LogLevel::Debug, errnum)
                         << config->getInstanceName() << " connect " << remoteAddress.toString();
 
-                    onStatus(currentRemoteAddress, state);
+                    finishAttempt("connection attempt failed", currentRemoteAddress, state);
 
                     disable();
                 }
@@ -329,7 +335,7 @@ namespace core::socket::stream {
             snode::semantic::sysError(snode::semantic::coreSocketLog(), logger::LogLevel::Debug, errnum)
                 << config->getInstanceName() << " getsockopt syscall error: '" << remoteAddress.toString() << "'";
 
-            onStatus(remoteAddress, core::socket::STATE_FATAL);
+            finishAttempt("connection attempt failed", remoteAddress, core::socket::STATE_FATAL);
             disable();
         }
     }
@@ -349,6 +355,7 @@ namespace core::socket::stream {
 
         SocketAddress currentRemoteAddress = remoteAddress;
         if (remoteAddress.useNext()) {
+            finishAttempt("connection attempt timed out");
             snode::semantic::coreSocketLog().debug()
                 << config->getInstanceName() << " using next SocketAddress: '" << config->Remote::getSocketAddress().toString() << "'";
 
@@ -358,7 +365,7 @@ namespace core::socket::stream {
                 << config->getInstanceName() << " connect timeout '" << remoteAddress.toString() << "'";
             errno = ETIMEDOUT;
 
-            onStatus(currentRemoteAddress, core::socket::STATE_ERROR);
+            finishAttempt("connection attempt timed out", currentRemoteAddress, core::socket::STATE_ERROR);
         }
 
         core::eventreceiver::ConnectEventReceiver::connectTimeout();
@@ -368,11 +375,44 @@ namespace core::socket::stream {
               typename Config,
               template <typename ConfigT, typename PhysicalSocketClientT> typename SocketConnection>
     void SocketConnector<PhysicalSocketClient, Config, SocketConnection>::destruct() {
+        finishAttempt("connection attempt cancelled");
+
         if (!config->getDisabled()) {
             onInitState(this);
         }
 
         delete this;
+    }
+
+    template <typename PhysicalSocketClient,
+              typename Config,
+              template <typename ConfigT, typename PhysicalSocketClientT> typename SocketConnection>
+    void SocketConnector<PhysicalSocketClient, Config, SocketConnection>::startAttempt() {
+        if (!attemptActive) {
+            attemptActive = true;
+            log().debug("connection attempt started");
+        }
+    }
+
+    template <typename PhysicalSocketClient,
+              typename Config,
+              template <typename ConfigT, typename PhysicalSocketClientT> typename SocketConnection>
+    void SocketConnector<PhysicalSocketClient, Config, SocketConnection>::finishAttempt(const char* outcome) {
+        if (std::exchange(attemptActive, false)) {
+            log().debug(outcome);
+        }
+    }
+
+    template <typename PhysicalSocketClient,
+              typename Config,
+              template <typename ConfigT, typename PhysicalSocketClientT> typename SocketConnection>
+    void SocketConnector<PhysicalSocketClient, Config, SocketConnection>::finishAttempt(const char* outcome,
+                                                                                        const SocketAddress& socketAddress,
+                                                                                        core::socket::State state) {
+        if (std::exchange(attemptActive, false)) {
+            log().debug(outcome);
+            onStatus(socketAddress, state);
+        }
     }
 
 } // namespace core::socket::stream

--- a/src/core/socket/stream/SocketServer.h
+++ b/src/core/socket/stream/SocketServer.h
@@ -100,6 +100,13 @@ namespace core::socket::stream {
                 , onConnect(onConnect)
                 , onConnected(onConnected)
                 , onDisconnect(onDisconnect) {
+                flowController.setOnFlowTerminated([this](ServerFlowController*) {
+                    cancelRetry();
+                });
+            }
+
+            ~Context() {
+                cancelRetry();
             }
 
             ServerFlowController flowController;
@@ -108,6 +115,28 @@ namespace core::socket::stream {
 
             std::uint64_t allocateConnectionId() noexcept {
                 return ++connectionsCreated;
+            }
+
+            void scheduleRetry() {
+                retryScheduled = true;
+                logScope.logger(logger::Logger::semanticSink()).debug("retry scheduled");
+            }
+
+            bool dispatchRetry() {
+                if (!retryScheduled) {
+                    return false;
+                }
+                retryScheduled = false;
+                logScope.logger(logger::Logger::semanticSink()).debug("retry dispatched");
+                flowController.reportFlowRetry();
+                return true;
+            }
+
+            void cancelRetry() {
+                if (retryScheduled) {
+                    retryScheduled = false;
+                    logScope.logger(logger::Logger::semanticSink()).debug("retry cancelled");
+                }
             }
 
             void emitTerminationSummary() const {
@@ -123,6 +152,7 @@ namespace core::socket::stream {
             }
 
             bool terminationSummaryEmitted{false};
+            bool retryScheduled{false};
 
             std::shared_ptr<SocketContextFactory> socketContextFactory;
 
@@ -243,20 +273,24 @@ namespace core::socket::stream {
                                             utils::Random::getInRange(-config->getRetryJitter(), config->getRetryJitter()) *
                                             relativeRetryTimeout / 100.;
 
-                                        log.info("Retry listen in {} seconds", relativeRetryTimeout);
+                                        sharedContext->scheduleRetry();
+                                        log.trace("Retry listen in {} seconds", relativeRetryTimeout);
 
                                         sharedContext->flowController.armRetryTimer(
                                             relativeRetryTimeout,
                                             [config, sharedContext, log, /*generation,*/ onStatus, tries, retryTimeoutScale]() {
                                                 if (!sharedContext->flowController.isRetryEnabled()) {
+                                                    sharedContext->cancelRetry();
                                                     return;
                                                 }
                                                 if (config->getRetry()) {
-                                                    sharedContext->flowController.reportFlowRetry();
-                                                    SocketServer(config, sharedContext)
-                                                        .realListen(onStatus, tries + 1, retryTimeoutScale * config->getRetryBase());
+                                                    if (sharedContext->dispatchRetry()) {
+                                                        SocketServer(config, sharedContext)
+                                                            .realListen(onStatus, tries + 1, retryTimeoutScale * config->getRetryBase());
+                                                    }
                                                 } else {
-                                                    log.info("Retry listen disabled during wait");
+                                                    sharedContext->cancelRetry();
+                                                    log.trace("Retry listen disabled during wait");
                                                 }
                                             });
                                     } else if (retryFlag &&

--- a/src/core/socket/stream/tls/SocketAcceptor.hpp
+++ b/src/core/socket/stream/tls/SocketAcceptor.hpp
@@ -83,6 +83,7 @@ namespace core::socket::stream::tls {
                            socketConnection,
                            log = static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log()]() { // onSuccess
                               log.debug("SSL/TLS: Handshake success");
+                              log.info("transport ready");
 
                               onConnected(socketConnection);
 
@@ -148,6 +149,7 @@ namespace core::socket::stream::tls {
                 Super::init();
             } else {
                 this->log().error("SSL/TLS: SSL/TLS creation failed");
+                this->log().debug("listener start failed");
 
                 Super::onStatus(Super::config->Local::getSocketAddress(), core::socket::STATE_ERROR);
                 Super::destruct();

--- a/src/core/socket/stream/tls/SocketConnector.hpp
+++ b/src/core/socket/stream/tls/SocketConnector.hpp
@@ -86,6 +86,7 @@ namespace core::socket::stream::tls {
                            socketConnection,
                            log = static_cast<core::socket::stream::SocketConnection*>(socketConnection)->log()]() { // onSuccess
                               log.debug("SSL/TLS: Handshake success");
+                              log.info("transport ready");
 
                               onConnected(socketConnection);
 

--- a/src/net/config/ConfigInstance.h
+++ b/src/net/config/ConfigInstance.h
@@ -49,6 +49,10 @@ namespace net::config {
     class ConfigSection;
 }
 
+namespace core::socket::stream {
+    class SocketConnection;
+}
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #include <functional>
@@ -109,6 +113,7 @@ namespace net::config {
         std::function<void(ConfigInstance*)> onDestroy;
 
         friend class net::config::ConfigSection;
+        friend class core::socket::stream::SocketConnection;
     };
 
 } // namespace net::config

--- a/tests/component/codex/CodexStdioScenarioTest.cpp
+++ b/tests/component/codex/CodexStdioScenarioTest.cpp
@@ -12,6 +12,7 @@
 #include "core/SNodeC.h"
 #include "core/pipe/PipeSource.h"
 #include "core/timer/Timer.h"
+#include "log/Logger.h"
 #include "support/DescriptorRegistrationFailure.h"
 #include "support/TestResult.h"
 #include "utils/Timeval.h"
@@ -20,7 +21,9 @@
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <optional>
 #include <set>
 #include <string>
@@ -121,8 +124,20 @@ int main(int argc, char* argv[]) {
         return tests::support::cTestSkipReturnCode;
     }
 
-    char* snodeArguments[] = {argv[0], nullptr};
-    core::SNodeC::init(1, snodeArguments);
+    const auto lifecycleLogPath = std::filesystem::temp_directory_path() / ("snodec-codex-phase2-" + scenario + ".jsonl");
+    std::error_code lifecycleLogRemoveError;
+    std::filesystem::remove(lifecycleLogPath, lifecycleLogRemoveError);
+    logger::Logger::init();
+    logger::LogManager::init();
+    logger::Logger::setQuiet(true);
+    logger::Logger::setDisableColor(true);
+    logger::Logger::logToFile(lifecycleLogPath.string());
+
+    char logLevel[] = "--log-level=6";
+    char logFormat[] = "--log-format=json";
+    char quiet[] = "--quiet";
+    char* snodeArguments[] = {argv[0], logLevel, logFormat, quiet, nullptr};
+    core::SNodeC::init(4, snodeArguments);
 
     const std::size_t descriptorsBefore = descriptorCount();
     const std::size_t pipesBefore = uniquePipeCount();
@@ -445,5 +460,69 @@ int main(int argc, char* argv[]) {
     }
 
     core::SNodeC::free();
+    logger::Logger::disableLogToFile();
+
+    int processSpawned = 0;
+    int processExited = 0;
+    int processTerminated = 0;
+    int processSpawnFailed = 0;
+    int transportStarted = 0;
+    int transportStopped = 0;
+    int transportStartFailed = 0;
+    int forcedTerminationRequested = 0;
+    std::ifstream lifecycleLog(lifecycleLogPath);
+    std::string lifecycleLine;
+    while (std::getline(lifecycleLog, lifecycleLine)) {
+        if (lifecycleLine.empty()) {
+            continue;
+        }
+        const auto record = nlohmann::json::parse(lifecycleLine);
+        const std::string message = record.at("message").get<std::string>();
+        const bool canonicalProcessRecord = message == "child process spawned" || message == "child process exited" ||
+                                            message == "child process terminated" || message == "child process spawn failed";
+        const bool canonicalTransportRecord =
+            message == "stdio transport started" || message == "stdio transport stopped" || message == "stdio transport start failed";
+        if (canonicalProcessRecord || canonicalTransportRecord) {
+            testResult.expectTrue(record.at("origin") == "framework" && record.at("boundary") == "connection" &&
+                                      record.at("component") == "ai.openai.codex.stdio" && !record.contains("connection"),
+                                  scenario + ": " + message + " retains the existing Codex stdio identity");
+        }
+        processSpawned += message == "child process spawned" ? 1 : 0;
+        processExited += message == "child process exited" ? 1 : 0;
+        processTerminated += message == "child process terminated" ? 1 : 0;
+        processSpawnFailed += message == "child process spawn failed" ? 1 : 0;
+        transportStarted += message == "stdio transport started" ? 1 : 0;
+        transportStopped += message == "stdio transport stopped" ? 1 : 0;
+        transportStartFailed += message == "stdio transport start failed" ? 1 : 0;
+        forcedTerminationRequested += message == "child process forced termination requested" ? 1 : 0;
+    }
+
+    if (scenario == "launch-failure") {
+        testResult.expectEqual(1, processSpawnFailed, "spawn failure emits one child spawn terminal record");
+        testResult.expectEqual(0, processSpawned, "spawn failure emits no child spawned record");
+        testResult.expectEqual(0, processExited + processTerminated, "spawn failure emits no fictional child terminal record");
+        testResult.expectEqual(1, transportStartFailed, "spawn failure emits one stdio startup failure");
+        testResult.expectEqual(0, transportStarted + transportStopped, "failed stdio startup has no start/stop pair");
+    } else if (scenario == "post-spawn-setup-failure") {
+        testResult.expectEqual(1, processSpawned, "post-spawn rollback records the real spawn once");
+        testResult.expectEqual(1, processExited + processTerminated, "post-spawn rollback records one reaped child outcome");
+        testResult.expectEqual(1, transportStartFailed, "post-spawn parent setup failure records startup failure once");
+        testResult.expectEqual(0, transportStarted + transportStopped, "parent setup failure never claims stdio transport activation");
+    } else if (scenario == "forced-fallback-normal") {
+        testResult.expectEqual(1, processSpawned, "polling fallback records one child spawn");
+        testResult.expectEqual(1, processExited, "polling fallback records one normal child exit");
+        testResult.expectEqual(0, processTerminated, "normal polling fallback is not mislabeled as termination");
+        testResult.expectEqual(1, transportStarted, "polling fallback starts stdio transport once");
+        testResult.expectEqual(1, transportStopped, "polling fallback stops stdio transport once");
+    } else if (scenario == "forced-fallback-ignore-shutdown" || scenario == "ignore-shutdown" || scenario == "blocked-ignore-shutdown") {
+        testResult.expectEqual(1, processSpawned, "forced shutdown records one child spawn");
+        testResult.expectEqual(1, processExited + processTerminated, "forced shutdown records one reaped child outcome");
+        testResult.expectEqual(1, forcedTerminationRequested, "forced shutdown distinguishes SIGKILL escalation once");
+        testResult.expectEqual(1, transportStarted, "forced shutdown starts stdio transport once");
+        testResult.expectEqual(1, transportStopped, "forced shutdown stops stdio transport once");
+    }
+
+    logger::Logger::init();
+    logger::LogManager::init();
     return testResult.processResult();
 }

--- a/tests/component/net/InetLegacyClientConnectFailureTest.cpp
+++ b/tests/component/net/InetLegacyClientConnectFailureTest.cpp
@@ -44,6 +44,7 @@
 #include "core/socket/stream/SocketConnection.h"
 #include "core/socket/stream/SocketContext.h"
 #include "core/socket/stream/SocketContextFactory.h"
+#include "log/Logger.h"
 #include "net/in/SocketAddress.h"
 #include "net/in/stream/legacy/SocketClient.h"
 #include "support/TestResult.h"
@@ -53,6 +54,10 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <string>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -122,7 +127,21 @@ int main(int argc, char* argv[]) {
     } else {
         TestState testState;
 
-        core::SNodeC::init(argc, argv);
+        const auto logPath = std::filesystem::temp_directory_path() / "snodec-phase2-ipv4-attempt-failure.jsonl";
+        std::error_code removeError;
+        std::filesystem::remove(logPath, removeError);
+        logger::Logger::init();
+        logger::LogManager::init();
+        logger::Logger::setQuiet(true);
+        logger::Logger::setDisableColor(true);
+        logger::Logger::logToFile(logPath.string());
+
+        char arg0[] = "InetLegacyClientConnectFailureTest";
+        char arg1[] = "--log-level=6";
+        char arg2[] = "--log-format=json";
+        char arg3[] = "--quiet";
+        char* logArgs[] = {arg0, arg1, arg2, arg3, nullptr};
+        core::SNodeC::init(4, logArgs);
 
         net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv4-connect-failure-client", testState);
 
@@ -150,9 +169,42 @@ int main(int argc, char* argv[]) {
         testResult.expectEqual(0, testState.clientConnectedCount, "client socket context never reaches onConnected");
         testResult.expectEqual(0, testState.unexpectedStateCount, "connect callback reports no unexpected states");
 
-        result = testResult.processResult();
-
         core::SNodeC::free();
+        logger::Logger::disableLogToFile();
+
+        int attemptStarted = 0;
+        int attemptFailed = 0;
+        int attemptTimedOut = 0;
+        int transportDisconnected = 0;
+        std::ifstream input(logPath);
+        std::string line;
+        while (std::getline(input, line)) {
+            if (line.empty()) {
+                continue;
+            }
+            const auto record = nlohmann::json::parse(line);
+            const std::string message = record.at("message").get<std::string>();
+            if (message == "connection attempt started" || message == "connection attempt failed") {
+                testResult.expectTrue(record.at("level") == "debug" && record.at("origin") == "framework" &&
+                                          record.at("boundary") == "instance" && record.at("component") == "core.socket.stream" &&
+                                          record.at("instance") == "ipv4-connect-failure-client" && record.at("role") == "client" &&
+                                          !record.contains("connection"),
+                                      message + " carries client endpoint identity at Debug");
+            }
+            attemptStarted += message == "connection attempt started" ? 1 : 0;
+            attemptFailed += message == "connection attempt failed" ? 1 : 0;
+            attemptTimedOut += message == "connection attempt timed out" ? 1 : 0;
+            transportDisconnected += message == "transport disconnected" ? 1 : 0;
+        }
+
+        testResult.expectEqual(1, attemptStarted, "failed connection emits one attempt start");
+        testResult.expectEqual(1, attemptFailed, "failed connection emits one terminal failure");
+        testResult.expectEqual(0, attemptTimedOut, "failed connection does not also time out");
+        testResult.expectEqual(0, transportDisconnected, "failed connection attempt emits no fictional transport disconnect");
+
+        logger::Logger::init();
+        logger::LogManager::init();
+        result = testResult.processResult();
     }
 
     return result;

--- a/tests/component/net/InetLegacyServerClientDisconnectLifecycleTest.cpp
+++ b/tests/component/net/InetLegacyServerClientDisconnectLifecycleTest.cpp
@@ -44,6 +44,7 @@
 #include "core/socket/stream/SocketConnection.h"
 #include "core/socket/stream/SocketContext.h"
 #include "core/socket/stream/SocketContextFactory.h"
+#include "log/Logger.h"
 #include "net/in/SocketAddress.h"
 #include "net/in/stream/legacy/SocketClient.h"
 #include "net/in/stream/legacy/SocketServer.h"
@@ -52,20 +53,68 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 namespace {
+
+    struct CapturedRecord {
+        std::string level;
+        std::string boundary;
+        std::string component;
+        std::optional<std::string> instance;
+        std::optional<std::string> role;
+        std::optional<std::string> connection;
+        std::string message;
+    };
+
+    std::vector<CapturedRecord> readLogRecords(const std::filesystem::path& path) {
+        std::vector<CapturedRecord> records;
+        std::ifstream input(path);
+        std::string line;
+        while (std::getline(input, line)) {
+            if (!line.empty()) {
+                const auto json = nlohmann::json::parse(line);
+                records.push_back(
+                    {.level = json.at("level").get<std::string>(),
+                     .boundary = json.at("boundary").get<std::string>(),
+                     .component = json.at("component").get<std::string>(),
+                     .instance =
+                         json.contains("instance") ? std::optional<std::string>(json.at("instance").get<std::string>()) : std::nullopt,
+                     .role = json.contains("role") ? std::optional<std::string>(json.at("role").get<std::string>()) : std::nullopt,
+                     .connection =
+                         json.contains("connection") ? std::optional<std::string>(json.at("connection").get<std::string>()) : std::nullopt,
+                     .message = json.at("message").get<std::string>()});
+            }
+        }
+        return records;
+    }
+
+    std::vector<CapturedRecord> recordsFor(const std::vector<CapturedRecord>& records, const std::string& message) {
+        std::vector<CapturedRecord> matches;
+        std::copy_if(records.begin(), records.end(), std::back_inserter(matches), [&message](const CapturedRecord& record) {
+            return record.message == message;
+        });
+        return matches;
+    }
 
     constexpr std::string_view clientPayload = "snodec-ipv4-disconnect-request";
     constexpr std::string_view serverPayload = "snodec-ipv4-disconnect-ack";
 
     struct TestState {
         int serverListenOkCount = 0;
+        int conflictingListenFailureCount = 0;
         int effectiveListenPortOkCount = 0;
         int zeroEffectiveListenPortCount = 0;
         int clientConnectOkCount = 0;
@@ -223,47 +272,77 @@ int main(int argc, char* argv[]) {
     } else {
         TestState testState;
 
-        core::SNodeC::init(argc, argv);
+        const auto logPath = std::filesystem::temp_directory_path() / "snodec-phase2-ipv4-transport.jsonl";
+        std::error_code removeError;
+        std::filesystem::remove(logPath, removeError);
+        logger::Logger::init();
+        logger::LogManager::init();
+        logger::Logger::setQuiet(true);
+        logger::Logger::setDisableColor(true);
+        logger::Logger::logToFile(logPath.string());
+
+        char arg0[] = "InetLegacyServerClientDisconnectLifecycleTest";
+        char arg1[] = "--log-level=6";
+        char arg2[] = "--log-format=json";
+        char arg3[] = "--quiet";
+        char* logArgs[] = {arg0, arg1, arg2, arg3, nullptr};
+        core::SNodeC::init(4, logArgs);
 
         net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv4-disconnect-client",
                                                                                                        testState);
         const net::in::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("ipv4-disconnect-server",
                                                                                                              testState);
+        const net::in::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> conflictingSocketServer(
+            "ipv4-conflicting-server", testState);
 
         socketClient.getConfig()->Instance::forceUnrequired();
         socketServer.getConfig()->Instance::forceUnrequired();
+        conflictingSocketServer.getConfig()->Instance::forceUnrequired();
 
-        socketServer.listen(net::in::SocketAddress("127.0.0.1", 0),
-                            [&socketClient, &testState](const net::in::SocketAddress& socketAddress, core::socket::State state) {
-                                if (state == core::socket::State::OK) {
-                                    ++testState.serverListenOkCount;
+        socketServer.listen(
+            net::in::SocketAddress("127.0.0.1", 0),
+            [&socketClient, &conflictingSocketServer, &testState](const net::in::SocketAddress& socketAddress, core::socket::State state) {
+                if (state == core::socket::State::OK) {
+                    ++testState.serverListenOkCount;
 
-                                    const std::uint16_t effectivePort = socketAddress.getPort();
-                                    if (effectivePort != 0) {
-                                        ++testState.effectiveListenPortOkCount;
-                                        socketClient.connect(net::in::SocketAddress("127.0.0.1", effectivePort),
-                                                             [&testState](const net::in::SocketAddress&, core::socket::State connectState) {
-                                                                 if (connectState == core::socket::State::OK) {
-                                                                     ++testState.clientConnectOkCount;
-                                                                 } else {
-                                                                     ++testState.unexpectedStateCount;
-                                                                     core::SNodeC::stop();
-                                                                 }
-                                                             });
-                                    } else {
-                                        ++testState.zeroEffectiveListenPortCount;
-                                        core::SNodeC::stop();
-                                    }
+                    const std::uint16_t effectivePort = socketAddress.getPort();
+                    if (effectivePort != 0) {
+                        ++testState.effectiveListenPortOkCount;
+                        conflictingSocketServer.listen(
+                            net::in::SocketAddress("127.0.0.1", effectivePort),
+                            [&socketClient, &testState, effectivePort](const net::in::SocketAddress&,
+                                                                       core::socket::State conflictingState) {
+                                if (conflictingState != core::socket::State::OK) {
+                                    ++testState.conflictingListenFailureCount;
+                                    socketClient.connect(net::in::SocketAddress("127.0.0.1", effectivePort),
+                                                         [&testState](const net::in::SocketAddress&, core::socket::State connectState) {
+                                                             if (connectState == core::socket::State::OK) {
+                                                                 ++testState.clientConnectOkCount;
+                                                             } else {
+                                                                 ++testState.unexpectedStateCount;
+                                                                 core::SNodeC::stop();
+                                                             }
+                                                         });
                                 } else {
                                     ++testState.unexpectedStateCount;
                                     core::SNodeC::stop();
                                 }
                             });
+                    } else {
+                        ++testState.zeroEffectiveListenPortCount;
+                        core::SNodeC::stop();
+                    }
+                } else {
+                    ++testState.unexpectedStateCount;
+                    core::SNodeC::stop();
+                }
+            });
 
         const int startResult = core::SNodeC::start(utils::Timeval({1, 0}));
 
         testResult.expectEqual(0, startResult, "event loop stops successfully after controlled IPv4 disconnect lifecycle");
         testResult.expectEqual(1, testState.serverListenOkCount, "IPv4 legacy server listen callback reports OK exactly once");
+        testResult.expectEqual(1, testState.conflictingListenFailureCount, "conflicting IPv4 listener reports one startup failure");
         testResult.expectEqual(1, testState.effectiveListenPortOkCount, "IPv4 legacy listen callback reports one non-zero effective port");
         testResult.expectEqual(0, testState.zeroEffectiveListenPortCount, "IPv4 legacy listen callback never reports port zero");
         testResult.expectEqual(1, testState.clientConnectOkCount, "IPv4 legacy client connect callback reports OK exactly once");
@@ -279,9 +358,68 @@ int main(int argc, char* argv[]) {
         testResult.expectEqual(0, testState.unexpectedStateCount, "listen and connect callbacks report no unexpected states");
         testResult.expectEqual(0, testState.unexpectedPayloadCount, "server and client receive no unexpected payloads");
 
-        result = testResult.processResult();
-
         core::SNodeC::free();
+        logger::Logger::disableLogToFile();
+
+        const auto records = readLogRecords(logPath);
+        const auto listenerStarted = recordsFor(records, "listener started");
+        const auto listenerStopped = recordsFor(records, "listener stopped");
+        const auto listenerStartFailed = recordsFor(records, "listener start failed");
+        const auto attemptStarted = recordsFor(records, "connection attempt started");
+        const auto attemptSucceeded = recordsFor(records, "connection attempt succeeded");
+        const auto connected = recordsFor(records, "transport connected");
+        const auto disconnected = recordsFor(records, "transport disconnected");
+
+        testResult.expectEqual(1, static_cast<int>(listenerStarted.size()), "listener start is emitted once");
+        testResult.expectEqual(1, static_cast<int>(listenerStopped.size()), "listener stop is emitted once");
+        testResult.expectEqual(1, static_cast<int>(listenerStartFailed.size()), "failed listener emits one startup terminal record");
+        testResult.expectEqual(1, static_cast<int>(attemptStarted.size()), "client attempt start is emitted once");
+        testResult.expectEqual(1, static_cast<int>(attemptSucceeded.size()), "client attempt success is emitted once");
+        testResult.expectEqual(2, static_cast<int>(connected.size()), "client and accepted server transports each connect once");
+        testResult.expectEqual(2, static_cast<int>(disconnected.size()), "client and accepted server transports each disconnect once");
+
+        for (const auto& record : listenerStarted) {
+            testResult.expectTrue(record.level == "info" && record.boundary == "instance" && record.component == "core.socket.stream" &&
+                                      record.instance == std::optional<std::string>("ipv4-disconnect-server") &&
+                                      record.role == std::optional<std::string>("server") && !record.connection,
+                                  "listener start carries server endpoint identity at Info");
+        }
+        for (const auto& record : listenerStopped) {
+            testResult.expectTrue(record.level == "info" && record.instance == std::optional<std::string>("ipv4-disconnect-server") &&
+                                      record.role == std::optional<std::string>("server"),
+                                  "listener stop carries matching server endpoint identity at Info");
+        }
+        for (const auto& record : listenerStartFailed) {
+            testResult.expectTrue(record.level == "debug" && record.boundary == "instance" &&
+                                      record.instance == std::optional<std::string>("ipv4-conflicting-server") &&
+                                      record.role == std::optional<std::string>("server"),
+                                  "listener startup failure carries server endpoint identity at Debug");
+        }
+        for (const auto& record : attemptStarted) {
+            testResult.expectTrue(record.level == "debug" && record.boundary == "instance" &&
+                                      record.instance == std::optional<std::string>("ipv4-disconnect-client") &&
+                                      record.role == std::optional<std::string>("client") && !record.connection,
+                                  "attempt start carries client endpoint identity at Debug");
+        }
+        for (const auto& record : attemptSucceeded) {
+            testResult.expectTrue(record.level == "debug" && record.instance == std::optional<std::string>("ipv4-disconnect-client") &&
+                                      record.role == std::optional<std::string>("client"),
+                                  "attempt success carries matching client endpoint identity at Debug");
+        }
+        for (const auto& record : connected) {
+            testResult.expectTrue(record.level == "info" && record.boundary == "connection" && record.component == "core.socket.stream" &&
+                                      record.connection == std::optional<std::string>("1") && record.role.has_value(),
+                                  "transport start carries role-aware connection identity at Info");
+        }
+        for (const auto& record : disconnected) {
+            testResult.expectTrue(record.level == "info" && record.boundary == "connection" && record.component == "core.socket.stream" &&
+                                      record.connection == std::optional<std::string>("1") && record.role.has_value(),
+                                  "transport end carries role-aware connection identity at Info");
+        }
+
+        logger::Logger::init();
+        logger::LogManager::init();
+        result = testResult.processResult();
     }
 
     return result;

--- a/tests/component/net/InetLegacyServerClientDisconnectLifecycleTest.cpp
+++ b/tests/component/net/InetLegacyServerClientDisconnectLifecycleTest.cpp
@@ -71,6 +71,7 @@ namespace {
 
     struct CapturedRecord {
         std::string level;
+        std::string origin;
         std::string boundary;
         std::string component;
         std::optional<std::string> instance;
@@ -88,6 +89,7 @@ namespace {
                 const auto json = nlohmann::json::parse(line);
                 records.push_back(
                     {.level = json.at("level").get<std::string>(),
+                     .origin = json.at("origin").get<std::string>(),
                      .boundary = json.at("boundary").get<std::string>(),
                      .component = json.at("component").get<std::string>(),
                      .instance =
@@ -105,6 +107,15 @@ namespace {
         std::vector<CapturedRecord> matches;
         std::copy_if(records.begin(), records.end(), std::back_inserter(matches), [&message](const CapturedRecord& record) {
             return record.message == message;
+        });
+        return matches;
+    }
+
+    std::vector<CapturedRecord>
+    recordsFor(const std::vector<CapturedRecord>& records, const std::string& message, const std::string& instance) {
+        std::vector<CapturedRecord> matches;
+        std::copy_if(records.begin(), records.end(), std::back_inserter(matches), [&message, &instance](const CapturedRecord& record) {
+            return record.message == message && record.instance == std::optional<std::string>(instance);
         });
         return matches;
     }
@@ -288,8 +299,7 @@ int main(int argc, char* argv[]) {
         char* logArgs[] = {arg0, arg1, arg2, arg3, nullptr};
         core::SNodeC::init(4, logArgs);
 
-        net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv4-disconnect-client",
-                                                                                                       testState);
+        net::in::stream::legacy::SocketClient<TestClientSocketContextFactory, TestState&> socketClient("ipv4-disconnect-client", testState);
         const net::in::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> socketServer("ipv4-disconnect-server",
                                                                                                              testState);
         const net::in::stream::legacy::SocketServer<TestServerSocketContextFactory, TestState&> conflictingSocketServer(
@@ -362,9 +372,10 @@ int main(int argc, char* argv[]) {
         logger::Logger::disableLogToFile();
 
         const auto records = readLogRecords(logPath);
-        const auto listenerStarted = recordsFor(records, "listener started");
-        const auto listenerStopped = recordsFor(records, "listener stopped");
-        const auto listenerStartFailed = recordsFor(records, "listener start failed");
+        const auto listenerStarted = recordsFor(records, "listener started", "ipv4-disconnect-server");
+        const auto listenerStopped = recordsFor(records, "listener stopped", "ipv4-disconnect-server");
+        const auto successfulListenerStartFailed = recordsFor(records, "listener start failed", "ipv4-disconnect-server");
+        const auto listenerStartFailed = recordsFor(records, "listener start failed", "ipv4-conflicting-server");
         const auto attemptStarted = recordsFor(records, "connection attempt started");
         const auto attemptSucceeded = recordsFor(records, "connection attempt succeeded");
         const auto connected = recordsFor(records, "transport connected");
@@ -372,6 +383,8 @@ int main(int argc, char* argv[]) {
 
         testResult.expectEqual(1, static_cast<int>(listenerStarted.size()), "listener start is emitted once");
         testResult.expectEqual(1, static_cast<int>(listenerStopped.size()), "listener stop is emitted once");
+        testResult.expectEqual(
+            0, static_cast<int>(successfulListenerStartFailed.size()), "successful listener emits no startup failure record");
         testResult.expectEqual(1, static_cast<int>(listenerStartFailed.size()), "failed listener emits one startup terminal record");
         testResult.expectEqual(1, static_cast<int>(attemptStarted.size()), "client attempt start is emitted once");
         testResult.expectEqual(1, static_cast<int>(attemptSucceeded.size()), "client attempt success is emitted once");
@@ -379,14 +392,17 @@ int main(int argc, char* argv[]) {
         testResult.expectEqual(2, static_cast<int>(disconnected.size()), "client and accepted server transports each disconnect once");
 
         for (const auto& record : listenerStarted) {
-            testResult.expectTrue(record.level == "info" && record.boundary == "instance" && record.component == "core.socket.stream" &&
+            testResult.expectTrue(record.level == "info" && record.origin == "framework" && record.boundary == "instance" &&
+                                      record.component == "core.socket.stream" &&
                                       record.instance == std::optional<std::string>("ipv4-disconnect-server") &&
                                       record.role == std::optional<std::string>("server") && !record.connection,
                                   "listener start carries server endpoint identity at Info");
         }
         for (const auto& record : listenerStopped) {
-            testResult.expectTrue(record.level == "info" && record.instance == std::optional<std::string>("ipv4-disconnect-server") &&
-                                      record.role == std::optional<std::string>("server"),
+            testResult.expectTrue(record.level == "info" && record.origin == "framework" && record.boundary == "instance" &&
+                                      record.component == "core.socket.stream" &&
+                                      record.instance == std::optional<std::string>("ipv4-disconnect-server") &&
+                                      record.role == std::optional<std::string>("server") && !record.connection,
                                   "listener stop carries matching server endpoint identity at Info");
         }
         for (const auto& record : listenerStartFailed) {

--- a/tests/unit/core/StreamFrameworkShutdownTest.cpp
+++ b/tests/unit/core/StreamFrameworkShutdownTest.cpp
@@ -758,6 +758,7 @@ namespace {
     };
 
     struct CapturedRecord {
+        std::string level;
         std::string origin;
         std::string boundary;
         std::string component;
@@ -790,6 +791,7 @@ namespace {
             const auto json = nlohmann::json::parse(line);
 
             records.push_back(CapturedRecord{
+                .level = json.at("level").get<std::string>(),
                 .origin = json.at("origin").get<std::string>(),
                 .boundary = json.at("boundary").get<std::string>(),
                 .component = json.at("component").get<std::string>(),
@@ -890,7 +892,7 @@ namespace {
                                                            "final application context onDisconnected",
                                                            "final framework context onDisconnected",
                                                            "final active context destructor cleanup",
-                                                           "disconnected",
+                                                           "transport disconnected",
                                                            "final connection destructor cleanup",
                                                            "final config destroy callback"};
 
@@ -935,8 +937,19 @@ namespace {
             expectRecordIdentity(message, "framework", "context", "core.socket.context", std::nullopt, std::optional<std::string>("41"));
         }
 
-        for (const std::string& message : {"disconnected", "final connection destructor cleanup"}) {
-            expectRecordIdentity(message, "framework", "connection", "core.socket.stream", std::nullopt, std::optional<std::string>("41"));
+        for (const std::string& message : {"transport disconnected", "final connection destructor cleanup"}) {
+            expectRecordIdentity(message,
+                                 "framework",
+                                 "connection",
+                                 "core.socket.stream",
+                                 std::optional<std::string>("client"),
+                                 std::optional<std::string>("41"));
+        }
+
+        const auto disconnected = findRecord(records, "transport disconnected");
+        result.expectTrue(disconnected.has_value(), "framework shutdown emits the canonical transport disconnect exactly once");
+        if (disconnected) {
+            result.expectTrue(records[*disconnected].level == "info", "transport disconnected uses Info");
         }
 
         expectRecordIdentity("final config destroy callback",

--- a/tests/unit/core/TLSTransportStateMachineTest.cpp
+++ b/tests/unit/core/TLSTransportStateMachineTest.cpp
@@ -17,9 +17,12 @@
 #include <openssl/rsa.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
+#include <optional>
 #include <string>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <utility>
+#include <vector>
 
 using core::socket::stream::tls::TLSHandshake;
 using core::socket::stream::tls::TLSShutdown;
@@ -384,7 +387,8 @@ namespace {
         }
     }
 
-    bool driveProductionHandshake(TestFixture& f, SSL* peerSsl, int& callbacks) {
+    bool
+    driveProductionHandshake(TestFixture& f, SSL* peerSsl, int& callbacks, std::vector<logger::LogRecord>* readinessRecords = nullptr) {
         SSL* connectionSsl = f.connection->getSSL();
         SSL_set_connect_state(connectionSsl);
         bool peerDone = false;
@@ -394,6 +398,13 @@ namespace {
                 [&] {
                     ++callbacks;
                     connectionDone = true;
+                    if (readinessRecords != nullptr) {
+                        f.connection
+                            ->log([readinessRecords](logger::LogRecord record) {
+                                readinessRecords->push_back(std::move(record));
+                            })
+                            .info("transport ready");
+                    }
                 },
                 [] {
                 },
@@ -905,10 +916,18 @@ namespace {
         resetTlsTestState();
         {
             TestFixture f(true);
+            int successCallbacks = 0;
+            std::vector<logger::LogRecord> readinessRecords;
             TLSLifecycleTestAccess::enqueueHandshakeResult(-1, SSL_ERROR_WANT_READ);
             TLSLifecycleTestAccess::doSSLHandshake(
                 *f.connection,
-                [] {
+                [&] {
+                    ++successCallbacks;
+                    f.connection
+                        ->log([&readinessRecords](logger::LogRecord record) {
+                            readinessRecords.push_back(std::move(record));
+                        })
+                        .info("transport ready");
                 },
                 [] {
                 },
@@ -922,6 +941,8 @@ namespace {
             result.expectEqual(0,
                                TLSLifecycleTestAccess::shutdownCounters().constructed,
                                "handshake failure with pending shutdown starts no shutdown helper");
+            result.expectEqual(0, successCallbacks, "failed TLS handshake has no readiness callback");
+            result.expectTrue(readinessRecords.empty(), "failed TLS handshake emits no transport ready record");
             result.expectEqual(1, f.disconnects, "handshake failure with pending shutdown closes once");
         }
     }
@@ -1332,8 +1353,18 @@ namespace {
             result.expectEqual(f.pipeFd.fd(), SSL_get_fd(connectionSsl), "connection SSL uses fixture socket fd");
             result.expectEqual(f.pipeFd.writeFd(), SSL_get_fd(peer.ssl), "peer SSL uses fixture peer fd");
             int handshakeCallbacks = 0;
-            result.expectTrue(driveProductionHandshake(f, peer.ssl, handshakeCallbacks), "same-socket production TLS handshake completes");
+            std::vector<logger::LogRecord> readinessRecords;
+            result.expectTrue(driveProductionHandshake(f, peer.ssl, handshakeCallbacks, &readinessRecords),
+                              "same-socket production TLS handshake completes");
             result.expectEqual(1, handshakeCallbacks, "connection handshake callback occurs once");
+            result.expectTrue(readinessRecords.size() == 1 && readinessRecords.front().message == "transport ready" &&
+                                  readinessRecords.front().level == logger::LogLevel::Info &&
+                                  readinessRecords.front().origin == logger::LogOrigin::Framework &&
+                                  readinessRecords.front().boundary == logger::LogBoundary::Connection &&
+                                  readinessRecords.front().component == "core.socket.stream" &&
+                                  readinessRecords.front().role == std::optional<logger::LogRole>(logger::LogRole::Client) &&
+                                  readinessRecords.front().connection == std::optional<std::string>("1"),
+                              "successful production TLS handshake emits one connection-bound Info readiness record");
             result.expectEqual(3, TLSLifecycleTestAccess::transportState(*f.connection), "connection is TlsActive after real handshake");
             result.expectTrue(TLSLifecycleTestAccess::sslAttached(*f.connection), "SSL remains attached after real handshake");
             const std::string tlsVersion = SSL_get_version(connectionSsl);

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -64,6 +64,7 @@ set_tests_properties(SocketConnectionMigration01Test PROPERTIES LABELS "unit;log
 snodec_add_test(SocketConnectorAcceptorMigration02Test SocketConnectorAcceptorMigration02Test.cpp)
 target_include_directories(SocketConnectorAcceptorMigration02Test PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(SocketConnectorAcceptorMigration02Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
+target_compile_definitions(SocketConnectorAcceptorMigration02Test PRIVATE SNODEC_BUILD_TESTS SNODEC_INTREE_BUILD)
 set_tests_properties(SocketConnectorAcceptorMigration02Test PROPERTIES LABELS "unit;log;migration02")
 
 snodec_add_test(SocketServerClientMigration03Test SocketServerClientMigration03Test.cpp)
@@ -154,6 +155,10 @@ set_tests_properties(ContextLifecyclePhase1Test PROPERTIES LABELS "unit;log;sock
 snodec_add_test(SocketContextDetachPolicyTest SocketContextDetachPolicyTest.cpp)
 target_compile_features(SocketContextDetachPolicyTest PRIVATE cxx_std_20)
 snodec_set_source_policy_test_properties(SocketContextDetachPolicyTest "unit;log;socketcontext")
+
+snodec_add_test(TransportLifecyclePhase2PolicyTest TransportLifecyclePhase2PolicyTest.cpp)
+target_compile_features(TransportLifecyclePhase2PolicyTest PRIVATE cxx_std_20)
+snodec_set_source_policy_test_properties(TransportLifecyclePhase2PolicyTest "unit;log;transport;lifecycle;source-policy")
 
 snodec_add_test(SensitiveLoggingRedactionTest SensitiveLoggingRedactionTest.cpp)
 target_compile_features(SensitiveLoggingRedactionTest PRIVATE cxx_std_20)

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -67,6 +67,12 @@ target_link_libraries(SocketConnectorAcceptorMigration02Test PRIVATE snodec-test
 target_compile_definitions(SocketConnectorAcceptorMigration02Test PRIVATE SNODEC_BUILD_TESTS SNODEC_INTREE_BUILD)
 set_tests_properties(SocketConnectorAcceptorMigration02Test PROPERTIES LABELS "unit;log;migration02")
 
+snodec_add_test(ListenerLifecyclePhase2Test ListenerLifecyclePhase2Test.cpp)
+target_include_directories(ListenerLifecyclePhase2Test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(ListenerLifecyclePhase2Test PRIVATE snodec-test-support snodec::net snodec::core-socket-stream)
+target_compile_definitions(ListenerLifecyclePhase2Test PRIVATE SNODEC_INTREE_BUILD)
+set_tests_properties(ListenerLifecyclePhase2Test PROPERTIES LABELS "unit;log;lifecycle;listener")
+
 snodec_add_test(SocketServerClientMigration03Test SocketServerClientMigration03Test.cpp)
 target_include_directories(SocketServerClientMigration03Test PRIVATE ${PROJECT_SOURCE_DIR})
 target_compile_features(SocketServerClientMigration03Test PRIVATE cxx_std_20)

--- a/tests/unit/log/EndpointLifetimeCountersTest.cpp
+++ b/tests/unit/log/EndpointLifetimeCountersTest.cpp
@@ -1,4 +1,5 @@
 #include "core/EventLoop.h"
+#include "core/EventReceiver.h"
 #include "core/SNodeC.h"
 #include "core/eventreceiver/AcceptEventReceiver.h"
 #include "core/eventreceiver/ConnectEventReceiver.h"
@@ -15,8 +16,8 @@
 #include "utils/Timeval.h"
 
 #include <cerrno>
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -57,8 +58,10 @@ namespace {
     public:
         SNodeCGuard() {
             argv[0] = arg0;
-            argv[1] = nullptr;
-            core::SNodeC::init(1, argv);
+            argv[1] = logLevel;
+            argv[2] = quiet;
+            argv[3] = nullptr;
+            core::SNodeC::init(3, argv);
         }
 
         ~SNodeCGuard() {
@@ -67,7 +70,9 @@ namespace {
 
     private:
         char arg0[29] = "EndpointLifetimeCountersTest";
-        char* argv[2]{};
+        char logLevel[14] = "--log-level=6";
+        char quiet[8] = "--quiet";
+        char* argv[4]{};
     };
 
     std::filesystem::path tempLogPath(const std::string& name) {
@@ -497,8 +502,14 @@ namespace {
 int main(int argc, char* argv[]) {
     const std::vector<std::string> scenarios = {
         "server-terminal",
+        "server-retry",
+        "server-retry-cancelled",
         "client-terminal",
+        "client-retry",
+        "client-retry-cancelled",
         "client-disconnect-terminal",
+        "client-reconnect-accepted",
+        "client-reconnect-cancelled",
         "server-sequence",
         "client-sequence",
         "expired-weak-context",
@@ -554,7 +565,9 @@ int main(int argc, char* argv[]) {
         result.expectEqual(1, static_cast<int>(server.getFlowController()->getRetryCount()),
                            "real server retry dispatch increments retryCount once");
         result.expectEqual(1, static_cast<int>(retrySeenByObserver), "server retry observer sees incremented retryCount");
-        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=1")), "accepted server retry emits graceful shutdown summary with accumulated counter");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "retry scheduled")), "server retry is scheduled once");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "retry dispatched")), "server retry is dispatched once");
+        result.expectEqual(0, static_cast<int>(countOccurrences(log, "retry cancelled")), "dispatched server retry is not cancelled");
     }
 
     if (scenario == "server-no-retry") {
@@ -570,6 +583,26 @@ int main(int argc, char* argv[]) {
         const auto log = readFile(logPath);
         result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=0")),
                            "server NO_RETRY address fallback emits graceful shutdown summary");
+    }
+
+    if (scenario == "server-retry-cancelled") {
+        const auto logPath = tempLogPath("snodec-endpoint-server-retry-cancelled.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestAcceptEventReceiver::reset({ServerAction::ErrorThenStopBeforePolicy});
+        TestSocketServer server("endpoint-server-retry-cancelled");
+        server.getConfig()->setRetry(true)->setRetryTimeout(30)->setRetryTries(1);
+        server.listen([](const TestSocketAddress&, core::socket::State) {
+        });
+        runLoopOnce();
+        server.getFlowController()->terminateFlow();
+        logger::Logger::disableLogToFile();
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "retry scheduled")), "server retry cancellation starts scheduled");
+        result.expectEqual(0, static_cast<int>(countOccurrences(log, "retry dispatched")), "cancelled server retry is never dispatched");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "retry cancelled")), "scheduled server retry is cancelled once");
+        result.expectEqual(
+            0, static_cast<int>(server.getFlowController()->getRetryCount()), "cancelled server retry does not increment counter");
     }
 
     if (scenario == "server-shutdown") {
@@ -626,7 +659,9 @@ int main(int argc, char* argv[]) {
         result.expectEqual(1, static_cast<int>(client.getFlowController()->getRetryCount()),
                            "real client retry dispatch increments retryCount once");
         result.expectEqual(1, static_cast<int>(retrySeenByObserver), "client retry observer sees incremented retryCount");
-        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=1 reconnects=0")), "accepted client retry emits graceful shutdown summary with accumulated counter");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "retry scheduled")), "client retry is scheduled once");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "retry dispatched")), "client retry is dispatched once");
+        result.expectEqual(0, static_cast<int>(countOccurrences(log, "retry cancelled")), "dispatched client retry is not cancelled");
     }
 
     if (scenario == "client-no-retry") {
@@ -642,6 +677,26 @@ int main(int argc, char* argv[]) {
         const auto log = readFile(logPath);
         result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=0 retries=0 reconnects=0")),
                            "client NO_RETRY address fallback emits graceful shutdown summary");
+    }
+
+    if (scenario == "client-retry-cancelled") {
+        const auto logPath = tempLogPath("snodec-endpoint-client-retry-cancelled.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestConnectEventReceiver::reset({ClientAction::ErrorThenStopBeforePolicy});
+        TestSocketClient client("endpoint-client-retry-cancelled");
+        client.getConfig()->setRetry(true)->setRetryTimeout(30)->setRetryTries(1);
+        client.connect([](const TestSocketAddress&, core::socket::State) {
+        });
+        runLoopOnce();
+        client.getFlowController()->terminateFlow();
+        logger::Logger::disableLogToFile();
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "retry scheduled")), "client retry cancellation starts scheduled");
+        result.expectEqual(0, static_cast<int>(countOccurrences(log, "retry dispatched")), "cancelled client retry is never dispatched");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "retry cancelled")), "scheduled client retry is cancelled once");
+        result.expectEqual(
+            0, static_cast<int>(client.getFlowController()->getRetryCount()), "cancelled client retry does not increment counter");
     }
 
     if (scenario == "client-shutdown") {
@@ -701,9 +756,11 @@ int main(int argc, char* argv[]) {
         result.expectEqual(1, static_cast<int>(client.getFlowController()->getReconnectCount()),
                            "real client reconnect dispatch increments reconnectCount once");
         result.expectEqual(1, static_cast<int>(reconnectSeenByObserver), "reconnect observer sees incremented reconnectCount");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "reconnect scheduled")), "reconnect is scheduled once");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "reconnect dispatched")), "reconnect is dispatched once");
+        result.expectEqual(0, static_cast<int>(countOccurrences(log, "reconnect cancelled")), "dispatched reconnect is not cancelled");
         result.expectTrue(connectionIds.size() == 2 && connectionIds[0] == 1 && connectionIds[1] == 2,
                           "reconnect-created client connections continue the same shared sequence");
-        result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=2 retries=0 reconnects=1")), "accepted client reconnect emits graceful shutdown summary with accumulated counters");
     }
 
     if (scenario == "client-disconnect-stopping") {
@@ -719,6 +776,29 @@ int main(int argc, char* argv[]) {
         const auto log = readFile(logPath);
         result.expectEqual(1, static_cast<int>(countOccurrences(log, "Instance terminated: connections=1 retries=0 reconnects=0")),
                            "client disconnect while STOPPING emits graceful shutdown summary");
+    }
+
+    if (scenario == "client-reconnect-cancelled") {
+        const auto logPath = tempLogPath("snodec-endpoint-client-reconnect-cancelled.log");
+        LoggerStateGuard loggerGuard(logPath.string());
+        SNodeCGuard snodeGuard;
+        TestConnectEventReceiver::reset({ClientAction::ConnectedThenDisconnect});
+        TestSocketClient client("endpoint-client-reconnect-cancelled");
+        client.getConfig()->setReconnect(true)->setReconnectTime(30);
+        client.connect([](const TestSocketAddress&, core::socket::State) {
+        });
+        core::EventReceiver::atNextTick([]() {
+            core::SNodeC::stop();
+        });
+        runLoopOnce();
+        client.getFlowController()->terminateFlow();
+        logger::Logger::disableLogToFile();
+        const auto log = readFile(logPath);
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "reconnect scheduled")), "reconnect cancellation starts scheduled");
+        result.expectEqual(0, static_cast<int>(countOccurrences(log, "reconnect dispatched")), "cancelled reconnect is never dispatched");
+        result.expectEqual(1, static_cast<int>(countOccurrences(log, "reconnect cancelled")), "scheduled reconnect is cancelled once");
+        result.expectEqual(
+            0, static_cast<int>(client.getFlowController()->getReconnectCount()), "cancelled reconnect does not increment counter");
     }
 
     if (scenario == "server-sequence") {

--- a/tests/unit/log/ListenerLifecyclePhase2Test.cpp
+++ b/tests/unit/log/ListenerLifecyclePhase2Test.cpp
@@ -1,0 +1,231 @@
+#include "core/socket/SocketAddress.h"
+#include "core/socket/stream/SocketAcceptor.h"
+#include "core/socket/stream/SocketAcceptor.hpp"
+#include "log/Logger.h"
+#include "log/SemanticLogger.h"
+#include "net/config/ConfigInstance.h"
+#include "tests/support/TestResult.h"
+#include "utils/Timeval.h"
+
+#include <cerrno>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <system_error>
+#include <utility>
+
+namespace {
+    class LoggerStateGuard {
+    public:
+        explicit LoggerStateGuard(const std::string& logFile) {
+            logger::Logger::init();
+            logger::LogManager::init();
+            logger::Logger::setLogLevel(6);
+            logger::Logger::setVerboseLevel(0);
+            logger::Logger::setQuiet(true);
+            logger::Logger::setDisableColor(true);
+            logger::Logger::logToFile(logFile);
+            logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+            logger::LogManager::setFormat(logger::LogManager::Format::Json);
+            logger::LogManager::freeze();
+        }
+
+        ~LoggerStateGuard() {
+            logger::Logger::disableLogToFile();
+            logger::Logger::init();
+            logger::LogManager::init();
+            errno = 0;
+        }
+    };
+
+    std::filesystem::path tempLogPath() {
+        const auto path = std::filesystem::temp_directory_path() / "snodec-phase2-listener-start-failure.jsonl";
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(path.string() + ".1", error);
+        return path;
+    }
+
+    class TestSocketAddress : public core::socket::SocketAddress {
+    public:
+        std::string toString(bool = true) const override {
+            return "deterministic-listener-address";
+        }
+    };
+
+    struct TestAddressConfig {
+        TestSocketAddress getSocketAddress() const {
+            return {};
+        }
+    };
+
+    class TestConfig
+        : public net::config::ConfigInstance
+        , public TestAddressConfig {
+    public:
+        using Local = TestAddressConfig;
+
+        explicit TestConfig(const std::string& instanceName)
+            : ConfigInstance(instanceName, Role::SERVER) {
+        }
+
+        ~TestConfig() override = default;
+
+        int getSocketOptions() const {
+            return 0;
+        }
+
+        int getBacklog() const {
+            return 1;
+        }
+
+        int getAcceptsPerTick() const {
+            return 1;
+        }
+
+        utils::Timeval getAcceptTimeout() const {
+            return {};
+        }
+    };
+
+    class FailingPhysicalSocketServer {
+    public:
+        using SocketAddress = TestSocketAddress;
+
+        enum class Flags { NONBLOCK };
+
+        FailingPhysicalSocketServer() = default;
+
+        FailingPhysicalSocketServer(int, const SocketAddress&) {
+        }
+
+        int open(int, Flags) {
+            errno = EACCES;
+            return -1;
+        }
+
+        int bind(const SocketAddress&) {
+            return 0;
+        }
+
+        int listen(int) {
+            return 0;
+        }
+
+        int accept4(Flags) {
+            errno = EAGAIN;
+            return -1;
+        }
+
+        bool isValid() const {
+            return false;
+        }
+
+        int getFd() const {
+            return -1;
+        }
+
+        SocketAddress getBindAddress() const {
+            return {};
+        }
+    };
+
+    template <typename PhysicalSocket, typename Config>
+    class TestSocketConnection {
+    public:
+        using Self = TestSocketConnection<PhysicalSocket, Config>;
+
+        TestSocketConnection(PhysicalSocket&&, const std::function<void(Self*)>&, std::uint64_t, const std::shared_ptr<Config>&) {
+        }
+
+        logger::BoundaryLogger log() const {
+            return logger::LogScopeOwner(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "core.socket.stream")
+                .logger(logger::Logger::semanticSink());
+        }
+
+        TestSocketAddress getLocalAddress() const {
+            return {};
+        }
+
+        TestSocketAddress getRemoteAddress() const {
+            return {};
+        }
+    };
+
+    class FailingAcceptor : public core::socket::stream::SocketAcceptor<FailingPhysicalSocketServer, TestConfig, TestSocketConnection> {
+    private:
+        using Super = core::socket::stream::SocketAcceptor<FailingPhysicalSocketServer, TestConfig, TestSocketConnection>;
+
+    public:
+        FailingAcceptor(const std::shared_ptr<TestConfig>& config, int& statusCallbacks, int& initStateCallbacks)
+            : Super(
+                  {},
+                  {},
+                  {},
+                  [&initStateCallbacks](core::eventreceiver::AcceptEventReceiver*) {
+                      ++initStateCallbacks;
+                  },
+                  [&statusCallbacks](const TestSocketAddress&, core::socket::State) {
+                      ++statusCallbacks;
+                  },
+                  [] {
+                      return std::uint64_t{1};
+                  },
+                  config) {
+        }
+
+    private:
+        void useNextSocketAddress() override {
+        }
+    };
+} // namespace
+
+int main() {
+    tests::support::TestResult result;
+    const auto logPath = tempLogPath();
+    int statusCallbacks = 0;
+    int initStateCallbacks = 0;
+
+    {
+        LoggerStateGuard guard(logPath.string());
+        auto config = std::make_shared<TestConfig>("phase2-failing-listener");
+        auto* acceptor = new FailingAcceptor(config, statusCallbacks, initStateCallbacks);
+        acceptor->init();
+    }
+
+    int startFailed = 0;
+    int started = 0;
+    int stopped = 0;
+    std::ifstream input(logPath);
+    std::string line;
+    while (std::getline(input, line)) {
+        if (line.empty()) {
+            continue;
+        }
+        const auto record = nlohmann::json::parse(line);
+        const std::string message = record.at("message").get<std::string>();
+        if (message == "listener start failed") {
+            ++startFailed;
+            result.expectTrue(record.at("level") == "debug" && record.at("origin") == "framework" && record.at("boundary") == "instance" &&
+                                  record.at("component") == "core.socket.stream" && record.at("instance") == "phase2-failing-listener" &&
+                                  record.at("role") == "server" && !record.contains("connection"),
+                              "listener startup failure carries server endpoint identity at Debug");
+        } else if (message == "listener started") {
+            ++started;
+        } else if (message == "listener stopped") {
+            ++stopped;
+        }
+    }
+
+    result.expectEqual(1, statusCallbacks, "deterministic open failure reports status exactly once");
+    result.expectEqual(1, initStateCallbacks, "failed acceptor cleanup reports final init state exactly once");
+    result.expectEqual(1, startFailed, "failed listener emits exactly one startup terminal record");
+    result.expectEqual(0, started, "failed listener emits no listener started record");
+    result.expectEqual(0, stopped, "failed listener emits no listener stopped record");
+
+    return result.processResult();
+}

--- a/tests/unit/log/SocketConnectorAcceptorMigration02Test.cpp
+++ b/tests/unit/log/SocketConnectorAcceptorMigration02Test.cpp
@@ -1,14 +1,18 @@
 #include "core/socket/SocketAddress.h"
 #include "core/socket/stream/SocketAcceptor.h"
 #include "core/socket/stream/SocketConnector.h"
+#include "core/socket/stream/SocketConnector.hpp"
 #include "log/Logger.h"
 #include "log/SemanticLogger.h"
 #include "net/config/ConfigInstance.h"
 #include "tests/support/TestResult.h"
+#include "utils/Timeval.h"
 
 #include <cerrno>
 #include <filesystem>
 #include <fstream>
+#include <memory>
+#include <nlohmann/json.hpp>
 #include <ostream>
 #include <string>
 #include <system_error>
@@ -62,14 +66,6 @@ namespace {
         return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
     }
 
-    class TestConfigInstance : public net::config::ConfigInstance {
-    public:
-        explicit TestConfigInstance(const std::string& instanceName)
-            : ConfigInstance(instanceName, Role::SERVER) {
-        }
-        ~TestConfigInstance() override = default;
-    };
-
     class TestSocketAddress : public core::socket::SocketAddress {
     public:
         std::string toString(bool = true) const override {
@@ -77,13 +73,90 @@ namespace {
         }
     };
 
+    struct TestAddressConfig {
+        TestSocketAddress getSocketAddress() const {
+            return {};
+        }
+    };
+
+    class TestConfigInstance
+        : public net::config::ConfigInstance
+        , public TestAddressConfig {
+    public:
+        using Local = TestAddressConfig;
+        using Remote = TestAddressConfig;
+
+        explicit TestConfigInstance(const std::string& instanceName, Role role = Role::SERVER)
+            : ConfigInstance(instanceName, role) {
+        }
+        ~TestConfigInstance() override = default;
+
+        int getSocketOptions() const {
+            return 0;
+        }
+
+        utils::Timeval getConnectTimeout() const {
+            return {};
+        }
+    };
+
     class TestPhysicalSocket {
     public:
         using SocketAddress = TestSocketAddress;
+
+        enum class Flags { NONBLOCK };
+
+        int open(int, Flags) {
+            return -1;
+        }
+
+        int bind(const SocketAddress&) {
+            return -1;
+        }
+
+        int connect(const SocketAddress&) {
+            return -1;
+        }
+
+        static bool connectInProgress(int) {
+            return false;
+        }
+
+        int getFd() const {
+            return -1;
+        }
+
+        int getSockError(int& socketError) const {
+            socketError = 0;
+            return 0;
+        }
+
+        SocketAddress getBindAddress() const {
+            return {};
+        }
     };
 
     template <typename PhysicalSocket, typename Config>
-    class TestTemplatedSocketConnection;
+    class TestTemplatedSocketConnection {
+    public:
+        using Self = TestTemplatedSocketConnection<PhysicalSocket, Config>;
+
+        TestTemplatedSocketConnection(PhysicalSocket&&, const std::function<void(Self*)>&, std::uint64_t, const std::shared_ptr<Config>&) {
+        }
+
+        logger::BoundaryLogger log() const {
+            return logger::LogScopeOwner(logger::LogOrigin::Framework, logger::LogBoundary::Connection, "core.socket.stream")
+                .logger(logger::Logger::semanticSink());
+        }
+
+        TestSocketAddress getLocalAddress() const {
+            return {};
+        }
+
+        TestSocketAddress getRemoteAddress() const {
+            return {};
+        }
+    };
 
     class TestConnectorOwner
         : public core::socket::stream::SocketConnector<TestPhysicalSocket, TestConfigInstance, TestTemplatedSocketConnection> {
@@ -116,7 +189,36 @@ namespace {
             return Super::makeLogScope(instanceName).logger(std::move(sink), threshold);
         }
     };
+
+    class TestAttemptConnector
+        : public core::socket::stream::SocketConnector<TestPhysicalSocket, TestConfigInstance, TestTemplatedSocketConnection> {
+    private:
+        using Super = core::socket::stream::SocketConnector<TestPhysicalSocket, TestConfigInstance, TestTemplatedSocketConnection>;
+
+    public:
+        explicit TestAttemptConnector(const std::shared_ptr<TestConfigInstance>& config)
+            : Super({}, {}, {}, {}, {}, {}, config) {
+        }
+
+    private:
+        void useNextSocketAddress() override {
+        }
+    };
 } // namespace
+
+namespace core::socket::stream {
+    struct SocketConnectorLifecycleTestAccess {
+        template <typename Connector>
+        static void start(Connector& connector) {
+            connector.startAttempt();
+        }
+
+        template <typename Connector>
+        static void finish(Connector& connector, const char* outcome) {
+            connector.finishAttempt(outcome);
+        }
+    };
+} // namespace core::socket::stream
 
 int main() {
     tests::support::TestResult result;
@@ -207,6 +309,45 @@ int main() {
         result.expectEqual(0, evaluations, "suppressed production formatting does not evaluate ExpensiveValue after PR #151");
     }
     result.expectTrue(readFile(suppressedPath).empty(), "suppressed production formatting emits no backend output");
+
+    const auto attemptPath = tempLogPath("snodec-phase2-attempt-timeout.jsonl");
+    {
+        LoggerStateGuard guard(attemptPath.string());
+        logger::LogManager::setGlobalLevel(logger::LogLevel::Debug);
+        logger::LogManager::setFormat(logger::LogManager::Format::Json);
+        logger::LogManager::freeze();
+
+        auto config = std::make_shared<TestConfigInstance>("phase2-timeout-client", TestConfigInstance::Role::CLIENT);
+        TestAttemptConnector connector(config);
+        core::socket::stream::SocketConnectorLifecycleTestAccess::start(connector);
+        core::socket::stream::SocketConnectorLifecycleTestAccess::finish(connector, "connection attempt timed out");
+        core::socket::stream::SocketConnectorLifecycleTestAccess::finish(connector, "connection attempt cancelled");
+    }
+
+    int attemptStarted = 0;
+    int attemptTimedOut = 0;
+    int attemptCancelled = 0;
+    std::ifstream attemptInput(attemptPath);
+    std::string attemptLine;
+    while (std::getline(attemptInput, attemptLine)) {
+        if (attemptLine.empty()) {
+            continue;
+        }
+        const auto record = nlohmann::json::parse(attemptLine);
+        const std::string message = record.at("message").get<std::string>();
+        if (message == "connection attempt started" || message == "connection attempt timed out") {
+            result.expectTrue(record.at("level") == "debug" && record.at("origin") == "framework" && record.at("boundary") == "instance" &&
+                                  record.at("component") == "core.socket.stream" && record.at("instance") == "phase2-timeout-client" &&
+                                  record.at("role") == "client" && !record.contains("connection"),
+                              message + " carries client endpoint identity at Debug");
+        }
+        attemptStarted += message == "connection attempt started" ? 1 : 0;
+        attemptTimedOut += message == "connection attempt timed out" ? 1 : 0;
+        attemptCancelled += message == "connection attempt cancelled" ? 1 : 0;
+    }
+    result.expectEqual(1, attemptStarted, "timeout scenario emits one attempt start");
+    result.expectEqual(1, attemptTimedOut, "timeout scenario emits exactly one terminal timeout");
+    result.expectEqual(0, attemptCancelled, "terminal timeout suppresses later cancellation");
 
     return result.processResult();
 }

--- a/tests/unit/log/SocketContextDetachPolicyTest.cpp
+++ b/tests/unit/log/SocketContextDetachPolicyTest.cpp
@@ -134,8 +134,7 @@ int main() {
 
     ok &= requireNotContains(switchBlock, "onDisconnect", socketConnectionPath);
 
-    const std::string_view closeBlock =
-        requireBlock(socketConnection, "::unobservedEvent() {", "Super::log().debug(\"disconnected\");", socketConnectionPath);
+    const std::string_view closeBlock = requireBlock(socketConnection, "::unobservedEvent() {", "delete this;", socketConnectionPath);
 
     ok &= !closeBlock.empty();
 
@@ -147,7 +146,8 @@ int main() {
                           "socketContext = nullptr;",
                           "delete std::exchange("
                           "newSocketContext, nullptr);",
-                          "onDisconnect();"},
+                          "onDisconnect();",
+                          "Super::log().info(\"transport disconnected\");"},
                          socketConnectionPath);
 
     ok &= requireNotContains(closeBlock, "terminalSocketContextTeardown", socketConnectionPath);

--- a/tests/unit/log/TransportLifecyclePhase2PolicyTest.cpp
+++ b/tests/unit/log/TransportLifecyclePhase2PolicyTest.cpp
@@ -1,0 +1,150 @@
+#include "SourcePolicyTestRoot.h"
+
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+    bool require(std::string_view source, std::string_view fragment, const std::filesystem::path& path) {
+        if (source.find(fragment) != std::string_view::npos) {
+            return true;
+        }
+        std::cerr << "Missing Phase 2 fragment in " << path << ": " << fragment << '\n';
+        return false;
+    }
+
+    bool forbid(std::string_view source, std::string_view fragment, const std::filesystem::path& path) {
+        if (source.find(fragment) == std::string_view::npos) {
+            return true;
+        }
+        std::cerr << "Forbidden Phase 2 fragment in " << path << ": " << fragment << '\n';
+        return false;
+    }
+
+    bool ordered(std::string_view source, const std::vector<std::string_view>& fragments, const std::filesystem::path& path) {
+        std::size_t offset = 0;
+        for (const auto fragment : fragments) {
+            const std::size_t position = source.find(fragment, offset);
+            if (position == std::string_view::npos) {
+                std::cerr << "Missing ordered Phase 2 fragment in " << path << ": " << fragment << '\n';
+                return false;
+            }
+            offset = position + fragment.size();
+        }
+        return true;
+    }
+
+    std::string readSourceTree(const std::filesystem::path& root) {
+        std::string source;
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(root)) {
+            if (entry.is_regular_file()) {
+                const auto extension = entry.path().extension();
+                if (extension == ".cpp" || extension == ".h" || extension == ".hpp") {
+                    source += source_policy::readSourcePolicyFile(entry.path());
+                }
+            }
+        }
+        return source;
+    }
+} // namespace
+
+int main() {
+    const std::filesystem::path root = source_policy::sourcePolicyProjectRoot();
+    if (root.empty()) {
+        return 1;
+    }
+
+    const auto connectionPath = root / "src/core/socket/stream/SocketConnection.hpp";
+    const auto connectorPath = root / "src/core/socket/stream/SocketConnector.hpp";
+    const auto acceptorPath = root / "src/core/socket/stream/SocketAcceptor.hpp";
+    const auto clientPath = root / "src/core/socket/stream/SocketClient.h";
+    const auto serverPath = root / "src/core/socket/stream/SocketServer.h";
+    const auto tlsClientPath = root / "src/core/socket/stream/tls/SocketConnector.hpp";
+    const auto tlsServerPath = root / "src/core/socket/stream/tls/SocketAcceptor.hpp";
+    const auto codexPath = root / "src/ai/openai/codex/stdio/StdioTransport.cpp";
+    const auto contextPath = root / "src/core/socket/stream/SocketContext.cpp";
+    const auto mqttPath = root / "src/iot/mqtt/Mqtt.cpp";
+
+    const std::string connection = source_policy::readSourcePolicyFile(connectionPath);
+    const std::string connector = source_policy::readSourcePolicyFile(connectorPath);
+    const std::string acceptor = source_policy::readSourcePolicyFile(acceptorPath);
+    const std::string client = source_policy::readSourcePolicyFile(clientPath);
+    const std::string server = source_policy::readSourcePolicyFile(serverPath);
+    const std::string tlsClient = source_policy::readSourcePolicyFile(tlsClientPath);
+    const std::string tlsServer = source_policy::readSourcePolicyFile(tlsServerPath);
+    const std::string codex = source_policy::readSourcePolicyFile(codexPath);
+    const std::string context = source_policy::readSourcePolicyFile(contextPath);
+    const std::string coreSocketSources = readSourceTree(root / "src/core/socket");
+    const std::string mqtt = source_policy::readSourcePolicyFile(mqttPath);
+
+    bool ok = true;
+    ok &= require(connector, "socketConnection->log().info(\"transport connected\")", connectorPath);
+    ok &= require(acceptor, "socketConnection->log().info(\"transport connected\")", acceptorPath);
+    ok &= require(connection, "Super::log().info(\"transport disconnected\")", connectionPath);
+    ok &= forbid(connection, "log().debug(\"disconnected\")", connectionPath);
+    ok &= forbid(coreSocketSources, ".debug(\"disconnected\")", root / "src/core/socket");
+    ok &= forbid(coreSocketSources, ".info(\"disconnected\")", root / "src/core/socket");
+    ok &= ordered(connection,
+                  {"socketContext->detach(SocketContext::DetachReason::ConnectionClose)",
+                   "onDisconnect();",
+                   "Super::log().info(\"transport disconnected\")",
+                   "delete this;"},
+                  connectionPath);
+
+    for (const auto outcome : {"connection attempt started",
+                               "connection attempt succeeded",
+                               "connection attempt failed",
+                               "connection attempt timed out",
+                               "connection attempt cancelled"}) {
+        ok &= require(connector, outcome, connectorPath);
+    }
+    ok &= require(connector, "std::exchange(attemptActive, false)", connectorPath);
+    ok &= require(connector, "log().debug(outcome)", connectorPath);
+
+    ok &= require(acceptor, "log().info(\"listener started\")", acceptorPath);
+    ok &= require(acceptor, "log().info(\"listener stopped\")", acceptorPath);
+    ok &= require(acceptor, "log().debug(\"listener start failed\")", acceptorPath);
+    ok &= ordered(acceptor, {"unobservedEvent()", "listener stopped", "destruct();"}, acceptorPath);
+
+    for (const auto continuation : {"retry scheduled", "retry dispatched", "retry cancelled"}) {
+        ok &= require(client, continuation, clientPath);
+        ok &= require(server, continuation, serverPath);
+    }
+    for (const auto continuation : {"reconnect scheduled", "reconnect dispatched", "reconnect cancelled"}) {
+        ok &= require(client, continuation, clientPath);
+    }
+    ok &= forbid(client, "log.info(\"Retry connect", clientPath);
+    ok &= forbid(client, "log.info(\"Reconnect", clientPath);
+    ok &= forbid(server, "log.info(\"Retry listen", serverPath);
+
+    ok &= require(tlsClient, "log.info(\"transport ready\")", tlsClientPath);
+    ok &= require(tlsServer, "log.info(\"transport ready\")", tlsServerPath);
+    ok &= ordered(tlsClient, {"Handshake success", "transport ready", "onConnected(socketConnection)"}, tlsClientPath);
+    ok &= ordered(tlsServer, {"Handshake success", "transport ready", "onConnected(socketConnection)"}, tlsServerPath);
+
+    for (const auto processEvent : {"child process spawned",
+                                    "child process exited",
+                                    "child process terminated",
+                                    "child process spawn failed",
+                                    "stdio transport started",
+                                    "stdio transport stopped",
+                                    "stdio transport start failed"}) {
+        ok &= require(codex, processEvent, codexPath);
+    }
+    ok &= require(codex, "childPid = -1;", codexPath);
+    ok &= ordered(codex, {"child process spawned", "stdio transport started"}, codexPath);
+    ok &= ordered(codex, {"child process exited", "childPid = -1", "stdio transport stopped"}, codexPath);
+
+    ok &= require(context, "Context attached", contextPath);
+    ok &= require(context, "Context detached for context switch", contextPath);
+    ok &= require(context, "Context detached for connection close", contextPath);
+    ok &= forbid(context, "transport connected", contextPath);
+    ok &= forbid(context, "transport disconnected", contextPath);
+
+    ok &= require(mqtt, "MQTT: Connected", mqttPath);
+    ok &= require(mqtt, "MQTT: Disconnected", mqttPath);
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

* Normalizes accepted-server and outgoing-client transport establishment and final teardown as connection-bound, symmetric, exactly-once lifecycle records.
* Gives every dispatched connection attempt one Debug start and one explicit terminal outcome; failed and timed-out attempts never create a transport or emit a fictional disconnect.
* Pairs listener activation and final stop, with explicit startup failure and no stopped record for an inactive listener.
* Separates retry/reconnect scheduling, dispatch, and cancellation while preserving the existing dispatched-attempt counters and policies.
* Distinguishes TLS physical connection from handshake-complete readiness without changing the TLS state machine.
* Normalizes Codex stdio transport and child-process spawn, reap, requested termination, and forced termination records while preserving descriptor/process ownership.
* Uses existing owner state plus narrow private flags only; dual receiver teardown, shutdown reentry, TLS shutdown, pidfd/poll fallback, and destructor cleanup cannot duplicate terminal records.
* Adds deterministic runtime coverage for listener startup failure and strengthens successful listener start/stop identity assertions.

## Canonical vocabulary

Implemented lifecycle vocabulary:

* Listener: `listener started`, `listener stopped`, `listener start failed`
* Connection attempt: `connection attempt started`, `connection attempt succeeded`, `connection attempt failed`, `connection attempt timed out`, `connection attempt cancelled`
* Transport: `transport connected`, `transport ready` (TLS only), `transport disconnected`
* Retry: `retry scheduled`, `retry dispatched`, `retry cancelled`
* Reconnect: `reconnect scheduled`, `reconnect dispatched`, `reconnect cancelled`
* Codex process: `child process spawned`, `child process exited`, `child process terminated`, `child process spawn failed`
* Codex shutdown detail: `child process termination requested`, `child process forced termination requested`
* Codex stdio: `stdio transport started`, `stdio transport stopped`, `stdio transport start failed`

Pipe helpers were reviewed and intentionally not given lifecycle records: they are short-lived descriptor plumbing rather than independently owned long-lived transports.

## Severity policy

Successful, externally meaningful, long-lived boundaries use Info:

* listener start/stop;
* transport connect/readiness/disconnect;
* child-process spawn/reap;
* stdio transport start/stop.

Matching normal starts and ends therefore remain visible at the default lifecycle threshold.

Attempts and continuation mechanics use Debug:

* attempt start and every terminal alternative;
* retry/reconnect scheduling, dispatch, and cancellation;
* listener, process, and stdio startup failure classification;
* requested process termination.

Existing syscall, certificate, resource, and setup failures remain separate Warn/Error diagnostics.

Low-level timer, PID, address, handshake, and descriptor details remain Trace or diagnostic records rather than being promoted into lifecycle events.

An abnormal diagnostic does not change the severity of the canonical lifecycle end record. For example, a read error may be logged at Error while the resulting established-transport end remains the matching Info-level `transport disconnected` record.

## Identity model

* Endpoint attempt, listener, retry, and reconnect records use the existing endpoint `LogScopeOwner` with instance and client/server role.
* Established transport start/end records use the constructed connection logger, carrying matching framework origin, connection boundary, component, instance, role, and semantic connection ID.
* `SocketConnection::getConnectionName()` remains an unchanged display and compatibility value.
* TLS readiness is emitted by the TLS connector/acceptor success wrapper through the same connection logger and only after successful handshake completion.
* Codex process and stdio records use the existing Codex stdio session transport scope; no second process or attempt identity model is introduced.

## Listener lifecycle

A listener emits:

```text
listener started
```

only after its descriptor has been successfully registered and enabled.

A listener that fails during startup emits:

```text
listener start failed
```

exactly once and does not emit either:

```text
listener started
listener stopped
```

A successfully active listener emits:

```text
listener stopped
```

exactly once during final receiver teardown.

Low-level socket operations such as `open`, `bind`, `listen`, and descriptor enablement remain detailed diagnostics and do not become separate long-lived lifecycle objects.

The current listener architecture has no asynchronous listener-start timeout or listener-start cancellation state. Therefore no artificial `listener start timed out` or `listener start cancelled` records are introduced.

## Connection-attempt lifecycle

Every dispatched connection attempt emits:

```text
connection attempt started
```

and exactly one of:

```text
connection attempt succeeded
connection attempt failed
connection attempt timed out
connection attempt cancelled
```

The connector owns the attempt lifecycle and uses one narrow private `attemptActive` state flag to prevent duplicate terminal records.

Immediate connection success, asynchronous connection success, physical-socket setup failure, connect failure, timeout, address fallback, descriptor registration failure, and final connector destruction converge on the same exactly-once attempt outcome mechanism.

A failed, timed-out, or cancelled attempt does not create an established transport and therefore does not emit:

```text
transport disconnected
```

## Established transport lifecycle

Once an accepted or outgoing physical connection has been constructed, its connection-bound logger emits:

```text
transport connected
```

Final connection teardown emits:

```text
transport disconnected
```

Both records use Info and carry matching connection identity.

Accepted server transports and outgoing client transports use the same canonical vocabulary.

The final disconnect record remains late enough that the connection log scope, instance, role, and semantic connection ID are still valid.

Reader/writer dual receiver teardown, coordinated framework shutdown, already-active TLS shutdown, context detach, and destructor cleanup cannot duplicate the final transport record.

## Plain and TLS readiness

Plain streams are usable immediately after physical transport establishment and therefore do not emit a redundant `transport ready` record.

TLS streams distinguish physical connection from encrypted application readiness:

```text
transport connected
TLS handshake
transport ready
```

`transport ready` is emitted through the same connection logger only after a successful TLS handshake.

A failed TLS handshake emits no `transport ready` record.

This PR does not change TLS handshake state, ownership, callback ordering, timeout behavior, shutdown behavior, plaintext continuation, or failure handling.

## Retry and reconnect lifecycle

Retry and reconnect scheduling are distinct from actual dispatch:

```text
retry scheduled
retry dispatched
retry cancelled

reconnect scheduled
reconnect dispatched
reconnect cancelled
```

A timer being armed counts as scheduled, not dispatched.

The existing counters remain unchanged in meaning:

* `retries` counts retry attempts actually dispatched after the initial attempt;
* `reconnects` counts reconnect attempts actually dispatched after an established client transport disconnects.

Cancelling a scheduled timer does not increment either counter.

Retry/reconnect policy, timing, jitter, termination conditions, and callback behavior remain unchanged.

## Codex stdio and child-process lifecycle

Codex stdio transport and child-process lifetime remain separate concepts.

Process lifecycle:

```text
child process spawned
child process exited
child process terminated
child process spawn failed
```

Shutdown/escalation detail:

```text
child process termination requested
child process forced termination requested
```

Stdio transport lifecycle:

```text
stdio transport started
stdio transport stopped
stdio transport start failed
```

The implementation distinguishes:

* failure before process spawn;
* `posix_spawnp()` failure;
* process spawn followed by stdio setup failure;
* normal process exit;
* signal termination;
* requested termination;
* forced termination;
* stdio transport startup failure;
* stdio transport final stop.

Child process terminal records are emitted only from the reaped process status.

Pidfd and polling fallback paths cannot emit duplicate process terminal records.

Descriptor closure is not mislabeled as process exit.

A stdio transport that never reached the started state does not emit `stdio transport stopped`.

## Exactly-once guarantees

The implementation uses existing lifecycle ownership and narrow private bookkeeping rather than a general lifecycle registry.

The following invariants are enforced:

* no duplicate listener start or stop;
* no stop after listener startup failure;
* one connection-attempt start and one terminal outcome;
* no cancellation record after an attempt already succeeded, failed, or timed out;
* no transport disconnect after an unestablished connection attempt;
* one transport connect and one final disconnect per established connection;
* no duplicate disconnect from reader/writer dual receiver teardown;
* no duplicate disconnect during coordinated framework shutdown;
* no duplicate TLS readiness;
* no duplicate retry/reconnect dispatch;
* no duplicate child exit from pidfd and polling paths;
* no stdio stop after startup failure;
* no second terminal record from destructor cleanup.

## Behavior preservation

This PR changes emitted lifecycle wording, levels, placement, and connection-role metadata only.

It does not change:

* EventLoop shutdown behavior;
* coordinated stream shutdown behavior;
* callback signatures or ordering;
* `SocketContext` attach/detach ordering or lifetime;
* retry/reconnect policy or counters;
* timeout values;
* timer or descriptor admission;
* TLS handshake or shutdown behavior;
* connection ownership;
* child-process ownership or reaping behavior;
* public socket APIs;
* semantic logger schema;
* logger backend;
* text or JSON formatting;
* filtering precedence;
* global logging policy;
* SOVERSION.

There is no public or protected source API change and no callback signature change.

The private layout of the public `SocketConnector` template changes because its installed header now contains the attempt lifecycle state. Affected dependent code and template instantiations must be rebuilt; binary compatibility is not claimed.

The internal `SocketClient` and `SocketServer` shared context layouts also change because of private retry/reconnect lifecycle state, but those contexts are not intended public ABI surfaces.

The remaining new state is private Codex session lifecycle bookkeeping.

## Audit report

The reviewed semantic audit and implementation report are in:

```text
docs/logging/phase-2-transport-attempt-lifecycle.md
```

Audit accounting:

* 488 broad production candidates across 93 files reviewed;
* 43 Phase 2 lifecycle decision/emission sites classified;
* 96 owner-scope diagnostics, progress, policy, and summary records retained;
* 237 protocol/application records explicitly deferred to Phase 3;
* 112 matches classified as not log records;
* 0 unresolved or unclassified relevant Phase 2 production lifecycle records.

The common stream implementation owns canonical records for the IPv4, IPv6, Unix-domain, RFCOMM, and L2CAP specializations.

Phase 1 `attached` / `detached` context vocabulary and its policy tests remain unchanged.

## Runtime coverage

Runtime JSON capture tests cover:

* outgoing plain transport connect/disconnect;
* accepted server transport connect/disconnect;
* failed client connection attempts with no fictional transport disconnect;
* connection-attempt exactly-once terminal behavior;
* deterministic listener startup failure;
* successful listener start/stop pairing;
* absence of listener stop after failed startup;
* listener identity and severity symmetry;
* graceful framework shutdown;
* reader/writer dual receiver teardown;
* TLS readiness placement;
* established TLS teardown;
* retry/reconnect schedule, dispatch, cancellation, and counter behavior;
* Codex process spawn;
* process spawn/setup failure;
* normal process exit;
* requested and forced termination;
* pidfd and polling fallback;
* stdio transport start/stop and startup failure.

`ListenerLifecyclePhase2Test` deterministically simulates physical listener open failure and asserts:

```text
listener start failed: exactly 1
listener started:      exactly 0
listener stopped:      exactly 0
```

It also asserts:

* Debug severity;
* framework origin;
* instance boundary;
* `core.socket.stream` component;
* expected instance name;
* server role;
* no connection field;
* one status callback;
* one final initialization-state callback.

`InetLegacyServerClientDisconnectLifecycleTest` verifies the successful listener pair:

```text
listener started:      exactly 1
listener stopped:      exactly 1
listener start failed: exactly 0
```

with matching Info-level server endpoint identity.

## Validation

GCC 15.3.0 Debug build:

```sh
cmake --build build -j4
```

Result: the complete build passed.

Broad focused GCC runtime/source-policy suite:

```sh
ctest --test-dir build --output-on-failure -j2 \
  -R '^(TLS(ResultClassificationTest|IoFatalPathTest|LifecycleHelperOwnershipTest|TransportStateMachineTest|LifecycleAbiSourceCompatibilityTest)|StreamFrameworkShutdown_|TLSFrameworkShutdown_|SocketConnectorAcceptorMigration02Test|ListenerLifecyclePhase2Test|EndpointLifetimeCountersTest|ContextLifecyclePhase1Test|SocketContextDetachPolicyTest|TransportLifecyclePhase2PolicyTest|InetLegacyServerClientDisconnectLifecycleTest|InetLegacyClientConnectFailureTest|CodexStdioLifecycleTest|CodexStdioProtocolFlow_|CodexStdioScenario_)'
```

Result: 59/59 passed.

The new `ListenerLifecyclePhase2Test` uses a fake physical server whose `open()` deterministically returns `EACCES` while executing the real production `SocketAcceptor::init()` lifecycle path. Structured JSON assertions require exactly one Debug/framework/instance/`core.socket.stream`/`phase2-failing-listener`/server `listener start failed` record with no connection field, and zero `listener started` and `listener stopped` records. `InetLegacyServerClientDisconnectLifecycleTest` separately proves the successful listener emits exactly one matching Info start and stop and zero startup failures.

Required review-focused GCC matrix:

```sh
ctest --test-dir build --output-on-failure -j2 \
  -R '^(ListenerLifecyclePhase2Test|TransportLifecyclePhase2PolicyTest|SocketConnectorAcceptorMigration02Test|EndpointLifetimeCountersTest|InetLegacyServerClientDisconnectLifecycleTest|InetLegacyClientConnectFailureTest|StreamFrameworkShutdown_.*|TLSFrameworkShutdown_.*)$'
```

Result: 23/23 passed.

Complete GCC suite:

```sh
ctest --test-dir build --output-on-failure -j2
```

Result: 246 tests discovered; 245 passed, 0 failed, and the existing optional `CodexTypedAppServerIntegrationTest` was skipped by its availability/environment gate.

Clang 21.1.8 review-focused build and tests:

```sh
cmake -S . -B /tmp/snodec-phase2-clang \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_CXX_COMPILER=clang++ \
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_CXX_FLAGS=-Wno-error=nrvo

cmake --build /tmp/snodec-phase2-clang \
  --target ListenerLifecyclePhase2Test \
           InetLegacyServerClientDisconnectLifecycleTest \
           TransportLifecyclePhase2PolicyTest \
           SocketConnectorAcceptorMigration02Test \
           EndpointLifetimeCountersTest \
           StreamFrameworkShutdownTest \
           TLSFrameworkShutdownTest \
  -j4

cmake --build /tmp/snodec-phase2-clang \
  --target InetLegacyClientConnectFailureTest -j4

ctest --test-dir /tmp/snodec-phase2-clang --output-on-failure -j2 \
  -R '^(ListenerLifecyclePhase2Test|TransportLifecyclePhase2PolicyTest|SocketConnectorAcceptorMigration02Test|EndpointLifetimeCountersTest|InetLegacyServerClientDisconnectLifecycleTest|InetLegacyClientConnectFailureTest|StreamFrameworkShutdown_.*|TLSFrameworkShutdown_.*)$'
```

Result: changed targets built and 23/23 tests passed. Clang 21 diagnoses an unchanged return in `detail/ItemDecoder.cpp` with `-Wnrvo`; only that unrelated warning was demoted from error for the focused validation. No source change was made for that diagnostic.

The Phase 2 production revision's AddressSanitizer/LeakSanitizer subset previously passed 19/19 with leak detection enabled. It was not rerun for this review follow-up because commit `ae97962c5` changes only tests and documentation; no production source changed.

GitHub Actions run [CI #297](https://github.com/SNodeC/snode.c/actions/runs/29948237541) on commit `ae97962c50f3de79c275080e90e1b6e0bd5f764b` completed successfully. The `gcc-debug` job passed checkout, dependency installation, configure, clean full build, and Tests.

## Deliberate Phase 3 deferrals

The following reviewed areas remain intentionally unchanged unless they merely duplicated transport lifecycle records:

* MQTT protocol engine lifecycle;
* MQTT session `Connected` / `Disconnected` records;
* HTTP request/response lifecycle;
* HTTP protocol-engine lifecycle;
* EventSource protocol lifecycle;
* WebSocket protocol and subprotocol lifecycle;
* database protocol, command, and session lifecycle;
* Codex app-server protocol/session lifecycle;
* Codex JSON-RPC requests and notifications;
* Codex threads and turns;
* model/session/user-message state;
* protocol-level cancellation;
* application-domain sessions.

Reference applications may still say that they are listening or connected as user-facing status. Those messages neither own nor replace the canonical framework lifecycle records and are classified as application-facing output.

## Known limitations

* The optional `CodexTypedAppServerIntegrationTest` remains governed by its existing environment/availability gate and is not reported as passing when skipped.
* Clang 21 Codex validation requires `-Wno-error=nrvo` because of an unrelated existing codec diagnostic.
* Binary compatibility is not claimed because the private layout of affected public template instantiations changes.
* Phase 3 protocol/session/request lifecycle normalization remains deliberately deferred.
