### PR TITLE
Audit and freeze the Codex A1.4 stable residue

### DIFF
--- a/docs/ai/openai/codex/a1-4-integrations-and-long-tail-plan.md
+++ b/docs/ai/openai/codex/a1-4-integrations-and-long-tail-plan.md
@@ -1,0 +1,556 @@
+# Codex A1.4 integrations, long tail, and final-A1 plan
+
+## Scope and authority
+
+This document freezes the audit and implementation plan for A1.4. It does not
+mark A1.4 implemented or complete. The audit branch contains no production
+implementation, public API, registry promotion, SOVERSION change, backend or
+frontend expansion, application behavior change, descriptor regeneration, or
+fixture change.
+
+The verified base is commit
+`bed5ee05184739d54cddc6518bd43b264e2b496d`, tree
+`8bf44f0eed6bd8c9d5309176db07a7d6a6240ef3`, the merge of PR #222. The
+pinned authority remains Codex CLI 0.144.6, upstream tag `rust-v0.144.6`,
+source commit `5d1fbf26c43abc65a203928b2e31561cb039e06d`. Provenance and aggregate
+hashes are frozen in `a1-4-start-state.json`.
+
+Authority order is:
+
+1. pinned stable schema and provenance;
+2. vendored protocol source and operation contracts;
+3. the unchanged module/slice assignment;
+4. `ProtocolSurfaceRegistryData.inc`, the sole local production authority;
+5. generated A1.4 reports, which are guards and plans rather than another
+   runtime registry.
+
+Experimental schemas are used only to prove the boundary. They are not
+implementation authority for A1.
+
+## Total partition and start state
+
+The inventory, assignment, and registry key sets are an exact 387-key
+bijection:
+
+| Bucket | Identities |
+|---|---:|
+| A1.0 | 19 |
+| A1.1 | 151 |
+| A1.2 | 45 |
+| A1.3 | 68 |
+| A1.4 | 56 |
+| InventoryOnly | 48 |
+| **Total** | **387** |
+
+The equivalent stability accounting is:
+
+| Classification | Identities |
+|---|---:|
+| Stable identities assigned to A1.0–A1.4 | 339 |
+| Stable-unreachable InventoryOnly | 12 |
+| Experimental-only InventoryOnly | 36 |
+| **Total stable inventory** | **351** |
+| **Total inventory** | **387** |
+
+InventoryOnly is not an experimental synonym. It contains 36
+`ExperimentalInventoryOnly` rows and 12
+`StableUnreachableInventory` rows.
+
+The current global status is:
+
+| Status | Count |
+|---|---:|
+| Complete | 280 |
+| Partial | 4 |
+| NotImplemented | 55 |
+| NotApplicable | 48 |
+
+The native A1.4 status is `0 Complete / 1 Partial / 55 NotImplemented`.
+`item/tool/requestUserInput` is the one native Partial. The other three
+Partials—`initialize`, `initialized`, and `error`—remain Common/A1.0-owned
+and are scheduled as inherited final-A1 closure obligations.
+
+Native A1.4 completion projects the global state to
+`336 Complete / 3 Partial / 0 NotImplemented / 48 NotApplicable`. Completing
+the inherited A1.0 rows then projects final A1 to
+`339 Complete / 0 Partial / 0 NotImplemented / 48 NotApplicable`.
+
+## Exact native A1.4 surface
+
+Every native row is stable, assigned to module
+`IntegrationsAndLongTail`, and assigned to slice A1.4. Its taxonomy is
+29 client requests, 16 server notifications, four server requests, and seven
+tagged-union alternatives.
+
+### Client requests and result contracts
+
+| Method | Parameters | Result | Result kind |
+|---|---|---|---|
+| `app/list` | `AppsListParams` | `AppsListResponse` | Concrete |
+| `externalAgentConfig/detect` | `ExternalAgentConfigDetectParams` | `ExternalAgentConfigDetectResponse` | Concrete |
+| `externalAgentConfig/import` | `ExternalAgentConfigImportParams` | `ExternalAgentConfigImportResponse` | Concrete |
+| `externalAgentConfig/import/readHistories` | `Unit` | `ExternalAgentConfigImportHistoriesReadResponse` | Concrete |
+| `feedback/upload` | `FeedbackUploadParams` | `FeedbackUploadResponse` | Concrete |
+| `hooks/list` | `HooksListParams` | `HooksListResponse` | Concrete |
+| `marketplace/add` | `MarketplaceAddParams` | `MarketplaceAddResponse` | Concrete |
+| `marketplace/remove` | `MarketplaceRemoveParams` | `MarketplaceRemoveResponse` | Concrete |
+| `marketplace/upgrade` | `MarketplaceUpgradeParams` | `MarketplaceUpgradeResponse` | Concrete |
+| `mcpServer/oauth/login` | `McpServerOauthLoginParams` | `McpServerOauthLoginResponse` | Concrete |
+| `mcpServer/resource/read` | `McpResourceReadParams` | `McpResourceReadResponse` | Concrete |
+| `mcpServer/tool/call` | `McpServerToolCallParams` | `McpServerToolCallResponse` | Concrete |
+| `mcpServerStatus/list` | `ListMcpServerStatusParams` | `ListMcpServerStatusResponse` | Concrete |
+| `plugin/install` | `PluginInstallParams` | `PluginInstallResponse` | Concrete |
+| `plugin/installed` | `PluginInstalledParams` | `PluginInstalledResponse` | Concrete |
+| `plugin/list` | `PluginListParams` | `PluginListResponse` | Concrete |
+| `plugin/read` | `PluginReadParams` | `PluginReadResponse` | Concrete |
+| `plugin/share/checkout` | `PluginShareCheckoutParams` | `PluginShareCheckoutResponse` | Concrete |
+| `plugin/share/delete` | `PluginShareDeleteParams` | `Unit` | Unit |
+| `plugin/share/list` | `PluginShareListParams` | `PluginShareListResponse` | Concrete |
+| `plugin/share/save` | `PluginShareSaveParams` | `PluginShareSaveResponse` | Concrete |
+| `plugin/share/updateTargets` | `PluginShareUpdateTargetsParams` | `PluginShareUpdateTargetsResponse` | Concrete |
+| `plugin/skill/read` | `PluginSkillReadParams` | `PluginSkillReadResponse` | Concrete |
+| `plugin/uninstall` | `PluginUninstallParams` | `Unit` | Unit |
+| `skills/config/write` | `SkillsConfigWriteParams` | `SkillsConfigWriteResponse` | Concrete |
+| `skills/extraRoots/set` | `SkillsExtraRootsSetParams` | `Unit` | Unit |
+| `skills/list` | `SkillsListParams` | `SkillsListResponse` | Concrete |
+| `windowsSandbox/readiness` | `Unit` | `WindowsSandboxReadinessResponse` | Concrete |
+| `windowsSandbox/setupStart` | `WindowsSandboxSetupStartParams` | `WindowsSandboxSetupStartResponse` | Concrete |
+
+The result split is exactly 26 Concrete and three Unit. The Unit-result
+operations are only `plugin/share/delete`, `plugin/uninstall`, and
+`skills/extraRoots/set`.
+
+### Server notifications
+
+The exact 16 notifications are:
+
+```text
+app/list/updated
+deprecationNotice
+externalAgentConfig/import/completed
+externalAgentConfig/import/progress
+hook/completed
+hook/started
+mcpServer/oauthLogin/completed
+mcpServer/startupStatus/updated
+process/exited
+process/outputDelta
+remoteControl/status/changed
+serverRequest/resolved
+skills/changed
+warning
+windows/worldWritableWarning
+windowsSandbox/setupCompleted
+```
+
+`process/exited` and `process/outputDelta` are stable incoming notifications.
+The outgoing `process/spawn`, `process/kill`, `process/writeStdin`, and
+`process/resizePty` methods remain experimental-only InventoryOnly.
+`remoteControl/status/changed` is stable; all outgoing remote-control methods
+remain experimental-only. Stable observation does not promote experimental
+control.
+
+### Server requests and direct responses
+
+| Method | Parameters | Response |
+|---|---|---|
+| `attestation/generate` | `AttestationGenerateParams` | `AttestationGenerateResponse` |
+| `item/tool/call` | `DynamicToolCallParams` | `DynamicToolCallResponse` |
+| `item/tool/requestUserInput` | `ToolRequestUserInputParams` | `ToolRequestUserInputResponse` |
+| `mcpServer/elicitation/request` | `McpServerElicitationRequestParams` | `McpServerElicitationRequestResponse` |
+
+All four have concrete responses and remain on the existing Requests
+occurrence machinery. The frozen path is:
+
+```text
+incoming server request
+  -> existing occurrence token and transport generation
+  -> typed callback
+  -> typed response validation
+  -> direct JSON-RPC response with the original request ID
+```
+
+### Tagged unions
+
+`McpServerElicitationRequestParams` is a Draft-07 object plus `oneOf`,
+discriminated by `mode`. Outer `serverName` and `threadId` are required;
+outer `turnId` is optional and nullable. All outer and branch objects allow
+future properties.
+
+| Alternative | Required branch fields | Optional/nullable fields |
+|---|---|---|
+| `form` | `mode`, `message`, `requestedSchema` | `_meta` optional/nullable/opaque |
+| `openai/form` | `mode`, `message`, `requestedSchema` | `_meta` optional/nullable/opaque; `requestedSchema` nullable/opaque |
+| `url` | `mode`, `message`, `elicitationId`, `url` | `_meta` optional/nullable/opaque |
+
+Its only reaching root is `mcpServer/elicitation/request`, and the MCP/reverse
+request batch owns it.
+
+`PluginSource` is a Draft-07 object plus `oneOf`, discriminated by `type`.
+All branches allow future properties.
+
+| Alternative | Required fields | Optional nullable fields |
+|---|---|---|
+| `local` | `type`, `path` | none |
+| `git` | `type`, `url` | `path`, `refName`, `sha` |
+| `npm` | `type`, `package` | `registry`, `version` |
+| `remote` | `type` | none |
+
+It is reached only by `plugin/installed`, `plugin/list`, `plugin/read`, and
+`plugin/share/list`; the user-integrations batch owns it.
+
+Both union families preserve a raw future-unknown alternative plus a
+diagnostic. A known discriminator with missing or wrong-typed required fields
+is malformed-known and must not be coerced to unknown.
+
+## Stable type closure
+
+The shared schema catalog, definition graph, Draft-07 handling, and schema
+walker derive 81 seed definitions and 189 reachable definitions (34 legacy,
+155 v2). The frozen closure contains:
+
+- 646 value paths: 548 properties, 91 array elements, seven map values;
+- 288 required and 260 optional property paths;
+- 243 nullable and 22 default-bearing paths;
+- 24 intentionally opaque JSON paths;
+- 162 object-policy nodes: 143 open, 12 closed, seven schema-valued maps;
+- 11 minimum-bearing paths and no maximum-bearing path;
+- integer/number formats: three `double`, one `int32`, eight `int64`, one
+  `uint`, four `uint32`, and six `uint64`;
+- 127 mechanically flagged sensitive paths.
+
+`a1-4-type-closure.json` records every definition, edge, field state, array
+element, map value, numeric constraint, object policy, union branch, and
+reaching root. The 127 sensitive-path heuristic is a minimum rather than an
+allowlist.
+
+## Cross-slice completion ledger
+
+| Identity | Owner | Current status | Completion stage |
+|---|---|---|---|
+| `initialize` | Common / A1.0 | Partial | final A1 closure in A1.4 |
+| `initialized` | Common / A1.0 | Partial | final A1 closure in A1.4 |
+| `error` | Common / A1.0 | Partial | final A1 closure in A1.4 |
+| `item/tool/requestUserInput` | IntegrationsAndLongTail / A1.4 | Partial | native A1.4 implementation |
+
+All four rows currently lack the same seven schema-completeness predicates:
+schema-property coverage, nullable semantics, reachable-union coverage,
+direction assertions, registry/decoder agreement, opaque-field declaration,
+and proof that no known field is dropped.
+
+`initialize` must preserve automatic initialization and existing constructors
+while representing optional-null `clientInfo.title`, optional-null
+capabilities, capability defaults, form elicitation support, optional-null
+notification opt-outs, and attestation request support. `initialized` has no
+payload and needs exact internal direction/encoder evidence, not a facade.
+`error` preserves `TurnErrorEvent` at Event index 44 while adding a complete
+canonical error view without changing backend/frontend behavior.
+
+`item/tool/requestUserInput` preserves its existing public compatibility types,
+response overload, direct response path, and `TypedServerRequest` index 2.
+Completion adds canonical parameters/response and diagnostics, distinguishes
+omitted/null/value `autoResolutionMs` and options, and exercises all response
+fields and one-shot lifecycle behavior.
+
+The assignment file remains unchanged. The three inherited rows are never
+counted inside the native 56 denominator.
+
+## `serverRequest/resolved` semantics
+
+The stable payload is
+`ServerRequestResolvedNotification{threadId: string, requestId: string|int64}`.
+Both fields are required and non-nullable; future properties are allowed.
+There is no outcome, method, item ID, result, error, generation, or completion
+status. `requestId` is the original server-generated JSON-RPC request ID, not
+an item ID or local occurrence token. String IDs must still be preserved.
+
+The pinned production method matrix is:
+
+| Slice | Server request | Emits resolved |
+|---|---|---:|
+| A1.3 | `item/commandExecution/requestApproval` | yes |
+| A1.3 | `item/fileChange/requestApproval` | yes |
+| A1.3 | `item/permissions/requestApproval` | yes |
+| A1.3 | `applyPatchApproval` | no |
+| A1.3 | `execCommandApproval` | no |
+| A1.4 | `item/tool/requestUserInput` | yes |
+| A1.4 | `mcpServer/elicitation/request` | yes |
+| A1.4 | `item/tool/call` | no |
+| A1.4 | `attestation/generate` | no |
+
+For the five positive methods, normal results, domain decline/cancel results,
+JSON-RPC errors, malformed successful results, and turn-transition cleanup can
+emit it. There is no generic timeout or server-owned `autoResolutionMs` timer,
+and disconnect alone does not emit it.
+
+The direct JSON-RPC response is causally earlier: App Server removes the
+callback and wakes the handler before that handler queues the lifecycle
+notification. The notification is informational and lifecycle-significant for
+shared pending UI, but it does not report the operation outcome. A responding
+SNode.C client normally has already removed its local occurrence when the
+notification arrives; another subscriber can still have the shared upstream
+ID pending.
+
+The payload itself is not generation-tagged. SNode.C must scope it to the
+transport generation that delivered it. A matching current ID/thread may
+retire an occurrence idempotently as externally resolved. Unknown,
+already-consumed, duplicate, stale-generation, or thread-mismatched IDs are
+nonfatal no-ops for registry state, while the typed event is still delivered.
+They never reopen a request or cause wire output.
+
+Typing this event never makes it a response transport, response prerequisite,
+acknowledgement prerequisite, second terminal completion, or retroactive
+change to the A1.3 contract. Future lifecycle tests cover both ID forms, the
+method matrix, all terminal paths, response-before-event ordering, absence of
+the event, already-consumed and external-resolution cases, duplicates,
+thread/generation mismatch, reconnect ID reuse, and multi-subscriber behavior.
+Exact pinned source links and line anchors are recorded in
+`a1-4-implementation-plan.json`.
+
+## InventoryOnly hard boundary
+
+The 36 experimental-only identities are:
+
+```text
+collaborationMode/list
+environment/add
+environment/info
+fuzzyFileSearch/sessionStart
+fuzzyFileSearch/sessionStop
+fuzzyFileSearch/sessionUpdate
+memory/reset
+mock/experimentalMethod
+process/kill
+process/resizePty
+process/spawn
+process/writeStdin
+remoteControl/client/list
+remoteControl/client/revoke
+remoteControl/disable
+remoteControl/enable
+remoteControl/pairing/start
+remoteControl/pairing/status
+remoteControl/status/read
+thread/backgroundTerminals/clean
+thread/backgroundTerminals/list
+thread/backgroundTerminals/terminate
+thread/decrement_elicitation
+thread/increment_elicitation
+thread/items/list
+thread/memoryMode/set
+thread/realtime/appendAudio
+thread/realtime/appendSpeech
+thread/realtime/appendText
+thread/realtime/listVoices
+thread/realtime/start
+thread/realtime/stop
+thread/search
+thread/settings/update
+thread/turns/list
+currentTime/read
+```
+
+The 12 stable-but-unreachable union alternatives are:
+
+```text
+CapabilityRootLocation:type:environment
+ConfiguredHookHandler:type:agent
+ConfiguredHookHandler:type:command
+ConfiguredHookHandler:type:prompt
+DynamicToolNamespaceTool:type:function
+DynamicToolSpec:type:function
+DynamicToolSpec:type:namespace
+MultiAgentMode:$variant:custom
+MultiAgentMode:$variant:explicitRequestOnly
+MultiAgentMode:$variant:proactive
+ThreadRealtimeStartTransport:type:webrtc
+ThreadRealtimeStartTransport:type:websocket
+```
+
+All 48 remain NotApplicable for A1. They receive no public API, production
+target, implementation batch, registry promotion, or status change.
+
+## Recommended implementation sequence
+
+Three native implementation PRs are the smallest reviewable split. One PR
+mixes nine facade domains, reverse-request lifecycle, high-volume process
+events, platform behavior, and both union families. Two PRs still leave one
+review spanning unrelated API and lifecycle risks. More than three fragments
+cohesive schemas without another honest closure boundary.
+
+### PR A: user-facing integrations
+
+- Branch: `codex/a1-4-user-integrations`
+- Title: `Type the Codex A1.4 user-facing integrations`
+- 33 identities: 23 client requests, six notifications, four `PluginSource`
+  alternatives
+- Result split: 20 Concrete, three Unit
+- Native arithmetic: `0/1/55 -> 33/1/22`
+- Global arithmetic: `280/4/55/48 -> 313/4/22/48`
+- Closure: 52 seeds, 118 v2 definitions, 411 paths
+
+It owns the app, external-agent, feedback, hooks, marketplace, plugins, and
+skills requests; their six matching notifications; and `PluginSource`.
+Proposed headers are `Apps.h`, `ExternalAgents.h`, `Feedback.h`, `Hooks.h`,
+`Marketplace.h`, `Plugins.h`, and `Skills.h`.
+
+### PR B: MCP and reverse requests
+
+- Branch: `codex/a1-4-mcp-reverse-requests`
+- Title: `Type the Codex A1.4 MCP and reverse requests`
+- 13 identities: four client requests, two notifications, four server
+  requests, three elicitation alternatives
+- Native arithmetic: `33/1/22 -> 46/0/10`
+- Global arithmetic: `313/4/22/48 -> 326/3/10/48`
+- Closure: 18 seeds, 55 definitions (34 legacy, 21 v2), 204 paths
+
+It owns all `mcpServer/*` and status operations in A1.4, all four incoming
+requests, and the elicitation union. `UserInputRequest` stays request-variant
+index 2; append Attestation at 8, DynamicTool at 9, and MCP Elicitation at 10.
+This PR adds `Mcp.h` and extends existing Events/Requests without replacing the
+occurrence lifecycle.
+
+### PR C: runtime and platform long tail
+
+- Branch: `codex/a1-4-runtime-platform`
+- Title: `Type the Codex A1.4 runtime and platform long tail`
+- 10 identities: two client requests and eight notifications
+- Native arithmetic: `46/0/10 -> 56/0/0`
+- Global arithmetic: `326/3/10/48 -> 336/3/0/48`
+- Closure: 11 seeds, 17 v2 definitions, 31 paths
+
+It owns both Windows sandbox requests plus deprecation, warning, process,
+remote status, resolved-request, and Windows notifications. It follows PR B
+because resolved-request lifecycle tests need every A1.3/A1.4 request kind.
+It adds `WindowsSandbox.h`; it does not add process or remote-control outgoing
+facades.
+
+The only cross-batch schema dependency is existing
+`v2::AbsolutePathBuf`, primarily accounted for in PR A and reused in PR C.
+The union families are each owned once.
+
+### Final A1 closure
+
+A distinct `codex/a1-final-closure` PR, titled
+`Close the Codex A1 typed surface and bump its SOVERSION`, completes
+`initialize`, `initialized`, and `error` in Common/A1.0. Its arithmetic is
+`336/3/0/48 -> 339/0/0/48`; native A1.4 remains 56 Complete.
+
+Production completion commits precede a pure final closure commit. The pure
+closure commit contains no deferred production implementation.
+
+## Public API, ABI, and SOVERSION
+
+The proposed facade ownership is:
+
+- `client.typed().apps().list()`;
+- external agents: detect, import, and read import histories;
+- feedback: upload;
+- hooks: list;
+- marketplace: add, remove, and upgrade;
+- MCP: OAuth login, resource read, tool call, and server-status list;
+- plugins: install, installed, list, read, checkout/delete/list/save/update
+  shares, read skill, and uninstall;
+- skills: write config, set extra roots, and list;
+- Windows sandbox: readiness and setup start.
+
+Every facade remains behind `typed::Client`'s one-pointer PIMPL. No member is
+added to `AppServerClient`; no public virtual interface or generic
+invoke-by-method API is introduced. Events remain on `Events`, and incoming
+requests remain on `Requests`.
+
+Exact existing reuse is limited to `AbsolutePathBuf`,
+`DynamicToolCallOutputContentItem`, and `WindowsSandboxSetupMode`, plus shared
+infrastructure vocabulary such as `Unit`, `OperationResult`, IDs, JSON,
+nullable state, diagnostics, and request tokens. Similar command-process,
+warning, conversation-input, MCP thread-item, account-authentication,
+configuration-source, hook-source, and sandbox-policy types are not schema
+substitutes.
+
+Current ABI-sensitive variants have 51 canonical notification alternatives,
+53 Event alternatives, and eight typed server-request alternatives. Existing
+indices remain fixed. PR A appends canonical indices 51–56 and Event indices
+53–58; PR B appends 57–58 and 59–60; PR C appends 59–66 and 61–68.
+Final `ErrorNotification` is canonical index 67 while `TurnErrorEvent` remains
+Event index 44.
+
+The root project is version 1.0.1 and
+`SNODEC_SOVERSION = SNode.C_VERSION_MAJOR`, currently 1. There are 68 uses of
+the global authority: three Codex shared libraries and 65 unrelated targets.
+Existing A1 policy commits to one final bump, and A1.3 ABI evidence already
+proved incompatibility (`TypedServerRequest` grew from 312 to 960 bytes).
+
+The frozen action is a scoped Codex SOVERSION `1 -> 2` at final A1 closure,
+after the 339/0/0/48 proof and before final ABI/package capture. A
+Codex-specific authority should switch `ai-openai-codex`,
+`ai-openai-codex-backend`, and `ai-openai-codex-frontend`; unrelated targets
+must not be bumped. Binary packages move from `.so.1` to `.so.2`, and installed
+consumers rebuild and relink.
+
+Layout probes cover `AppServerClient`, `typed::Client`, all three public
+variants, `UserInputRequest`, `TurnErrorEvent`, `ClientInfo`,
+`InitializeResult`, every introduced aggregate/variant, and all facades.
+Symbol and package evidence is recaptured. No earlier implementation PR may
+claim binary compatibility merely because SONAME 1 remains unchanged.
+
+## Security and sensitive data
+
+Treat every raw envelope, opaque JSON field, and flagged field path as
+sensitive. Redaction covers:
+
+- app metadata, configuration, branding, screenshots, and reviews;
+- external-agent configuration, cwd/home detection, histories, progress, and
+  failures;
+- feedback content, reasons, tags, attachments/logs, and thread IDs;
+- hook definitions, handlers, sources, paths, inputs, outputs, and failures;
+- marketplace/plugin sources, URLs, paths, refs, SHAs, packages, registries,
+  checkouts, principals, shares, targets, roles, and errors;
+- skill names, paths, roots, dependencies, configuration, and errors;
+- MCP server identity, OAuth state/scopes/URLs, resource identity/content,
+  tool schemas/arguments/results, metadata, and elicitation content;
+- all user questions, options, and answers, regardless of `isSecret`;
+- all attestation inputs and outputs;
+- process handles/output, remote status/identity, warning/deprecation text,
+  IDs, paths, and Windows diagnostics.
+
+Diagnostics may contain method, structural path, expected type, and safe
+counts, never values. Audit evidence and future fixtures use synthetic IDs,
+`/synthetic/...` paths, `example.invalid` URLs, and fake tokens. They never
+capture credentials, OAuth tokens, environment variables, private
+repositories or paths, MCP configuration, feedback content, process output,
+user answers, or attestation material.
+
+## Packaging, validation, and non-goals
+
+Source packaging retains the audit tool, focused test, five evidence files,
+and this document. The pinned counts move from 22 to 27 evidence files, 18 to
+19 Codex documents, and 13 to 14 top-level Codex tools. The extracted archive
+runs `app_server_a1_4.py check`. Audit tools, tests, documentation, evidence,
+JSON, and Python remain excluded from installed and binary packages; the
+public-header count remains 34 in this audit.
+
+The focused test is registered in `tests/CMakeLists.txt` rather than
+`tests/component/codex/CMakeLists.txt`. The latter is hashed by the immutable
+A1.3 closure report, so root registration proves discovery without rewriting
+existing A1.3 evidence.
+
+The A1.3 closure checker also treats its own captured source record and the
+source-package guard record as historical A1.3 evidence. It retains those two
+frozen records while live successor-aware token checks require every A1.4
+package entry and extracted check. This lets the required predecessor closure
+check remain byte-stable without hiding or rewriting the A1.4 source-package
+expansion.
+
+Audit validation runs the A1.3 audit and closure checks, the A1.4 checker and
+mutation test, test-enabled CMake configuration, focused Codex CTest, source
+package retention, deterministic regeneration, syntax/import checks,
+`git diff --check`, and the synthetic-secret guard. It does not run
+unfiltered CTest, stress/soak/fuzz/benchmark/sanitizer matrices, or the
+credential-bearing live integration. Those targets add no audit-specific
+signal; runtime integration risk remains scheduled for the three
+implementation PRs.
+
+Explicit A2 non-goals include every InventoryOnly identity, experimental
+process/remote/fuzzy-search/collaboration/environment/memory/realtime/search
+and settings control, stable-unreachable union alternatives, and any backend,
+frontend, or application expansion outside the typed A1 boundary.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,10 @@ add_test(
         ${CODEX_PHASE_A1_4_EVIDENCE_ROOT}/a1-4-total-partition.json
         --closure
         ${CODEX_PHASE_A1_4_EVIDENCE_ROOT}/a1-4-type-closure.json
+        --plan
+        ${CODEX_PHASE_A1_4_EVIDENCE_ROOT}/a1-4-implementation-plan.json
+        --ledger
+        ${CODEX_PHASE_A1_4_EVIDENCE_ROOT}/a1-final-cross-slice-ledger.json
 )
 set_tests_properties(
     CodexA14AuditToolTest

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,35 @@ add_subdirectory(unit)
 add_subdirectory(component)
 add_subdirectory(policy)
 
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+set(CODEX_PHASE_A1_4_EVIDENCE_ROOT
+    ${PROJECT_SOURCE_DIR}/tools/codex/app-server-evidence/0.144.6
+)
+add_test(
+    NAME CodexA14AuditToolTest
+    COMMAND
+        ${Python3_EXECUTABLE}
+        ${PROJECT_SOURCE_DIR}/tests/component/codex/CodexA14AuditToolTest.py
+        --tool
+        ${PROJECT_SOURCE_DIR}/tools/codex/app_server_a1_4.py
+        --repo-root
+        ${PROJECT_SOURCE_DIR}
+        --start-state
+        ${CODEX_PHASE_A1_4_EVIDENCE_ROOT}/a1-4-start-state.json
+        --partition
+        ${CODEX_PHASE_A1_4_EVIDENCE_ROOT}/a1-4-total-partition.json
+        --closure
+        ${CODEX_PHASE_A1_4_EVIDENCE_ROOT}/a1-4-type-closure.json
+)
+set_tests_properties(
+    CodexA14AuditToolTest
+    PROPERTIES
+        DEPENDS CodexA13ClosureEvidenceTest
+        LABELS "component;ai;openai;codex;phase-a1-4;schema;audit;generated"
+        TIMEOUT 60
+)
+
 add_test(NAME StagedInstalledConsumerTest
          COMMAND ${CMAKE_COMMAND}
                  -DSNODEC_BUILD_DIR=${CMAKE_BINARY_DIR}

--- a/tests/CodexSourcePackageTest.cmake
+++ b/tests/CodexSourcePackageTest.cmake
@@ -154,9 +154,9 @@ assert_retained_prefix("tools/codex/app-server-fixtures/0.144.6" 5884)
 assert_retained_prefix(
     "tools/codex/app-server-protocol-source/0.144.6" 4
 )
-assert_retained_prefix("tools/codex/app-server-evidence/0.144.6" 22)
+assert_retained_prefix("tools/codex/app-server-evidence/0.144.6" 27)
 assert_retained_prefix("tools/codex/app-server-surface" 1)
-assert_retained_prefix("docs/ai/openai/codex" 18)
+assert_retained_prefix("docs/ai/openai/codex" 19)
 assert_retained_prefix(
     "tests/component/codex/fixtures/app-server-0.144.6" 7
 )
@@ -169,10 +169,10 @@ file(
 )
 list(SORT top_level_codex_tools)
 list(LENGTH top_level_codex_tools top_level_codex_tool_count)
-if(NOT top_level_codex_tool_count EQUAL 13)
+if(NOT top_level_codex_tool_count EQUAL 14)
     message(
         FATAL_ERROR
-            "pinned top-level Codex tool count changed: expected 13, found ${top_level_codex_tool_count}"
+            "pinned top-level Codex tool count changed: expected 14, found ${top_level_codex_tool_count}"
     )
 endif()
 set(observed_top_level_codex_tools)
@@ -228,6 +228,11 @@ set(
     "tools/codex/app-server-evidence/0.144.6/a1-3-type-closure.json"
     "tools/codex/app-server-evidence/0.144.6/a1-3-api-abi-evidence.json"
     "tools/codex/app-server-evidence/0.144.6/a1-3-closure-report.json"
+    "tools/codex/app-server-evidence/0.144.6/a1-4-start-state.json"
+    "tools/codex/app-server-evidence/0.144.6/a1-4-total-partition.json"
+    "tools/codex/app-server-evidence/0.144.6/a1-4-type-closure.json"
+    "tools/codex/app-server-evidence/0.144.6/a1-4-implementation-plan.json"
+    "tools/codex/app-server-evidence/0.144.6/a1-final-cross-slice-ledger.json"
     "tools/codex/app-server-fixtures/0.144.6/index.json"
     "tools/codex/app_server_a1_1.py"
     "tools/codex/app_server_a1_1_closure.py"
@@ -235,6 +240,7 @@ set(
     "tools/codex/app_server_a1_2_closure.py"
     "tools/codex/app_server_a1_3.py"
     "tools/codex/app_server_a1_3_closure.py"
+    "tools/codex/app_server_a1_4.py"
     "tools/codex/app_server_a1_shared.py"
     "tools/codex/app_server_schema_paths.py"
     "tools/codex/app_server_surface.py"
@@ -289,6 +295,7 @@ set(
     "tests/component/codex/CodexA12DocumentationConsistencyTest.py"
     "tests/component/codex/CodexA13AuditToolTest.py"
     "tests/component/codex/CodexA13ClosureEvidenceTest.py"
+    "tests/component/codex/CodexA14AuditToolTest.py"
     "tests/installed/codex/CodexA13AbiLayoutProbe.cpp"
     "tests/component/codex/CodexAppServerContractsToolTest.py"
     "tests/component/codex/CodexAppServerFixtureToolTest.py"
@@ -342,6 +349,7 @@ set(
     "docs/ai/openai/codex/a1-2-test-integrity.md"
     "docs/ai/openai/codex/a1-3-commands-filesystem-reviews-approvals.md"
     "docs/ai/openai/codex/a1-3-test-integrity.md"
+    "docs/ai/openai/codex/a1-4-integrations-and-long-tail-plan.md"
     "docs/ai/openai/codex/a1-typed-foundation.md"
 )
 foreach(required_entry IN LISTS required_source_entries)
@@ -426,9 +434,9 @@ set(extracted_fixture_root
 
 # Run the guards from the extracted archive, not the checkout. This validates
 # every schema/provenance hash, all provenance-listed Rust files, the exact
-# operation contracts/reports, A1.2 audit regeneration, the full indexed
-# fixture corpus, deterministic regeneration, and all required-field/wrong-type
-# mutations using only packaged inputs.
+# operation contracts/reports, A1.1-A1.4 audit and closure regeneration, the
+# full indexed fixture corpus, deterministic regeneration, and all
+# required-field/wrong-type mutations using only packaged inputs.
 run_extracted_check(
     "schema provenance/integrity"
     "${CODEX_PYTHON_EXECUTABLE}"
@@ -603,6 +611,14 @@ run_extracted_check(
     "A1.3 final closure report"
     "${CODEX_PYTHON_EXECUTABLE}"
     "${extracted_root}/tools/codex/app_server_a1_3_closure.py"
+    check
+    --repo-root
+    "${extracted_root}"
+)
+run_extracted_check(
+    "A1.4 partition and implementation-plan audit"
+    "${CODEX_PYTHON_EXECUTABLE}"
+    "${extracted_root}/tools/codex/app_server_a1_4.py"
     check
     --repo-root
     "${extracted_root}"

--- a/tests/component/codex/CodexA14AuditToolTest.py
+++ b/tests/component/codex/CodexA14AuditToolTest.py
@@ -46,13 +46,22 @@ class CodexA14AuditToolTest(unittest.TestCase):
                 str(OPTIONS.partition),
                 "--closure-output",
                 str(OPTIONS.closure),
+                "--plan-output",
+                str(OPTIONS.plan),
+                "--ledger-output",
+                str(OPTIONS.ledger),
             ]
         )
         for name, value in vars(cls.arguments).items():
             if isinstance(value, Path):
                 setattr(cls.arguments, name, value.resolve())
         cls.inputs = cls.tool.load_inputs(cls.arguments)
-        cls.partition, cls.closure = cls.tool.build_foundation(
+        (
+            cls.partition,
+            cls.closure,
+            cls.plan,
+            cls.ledger,
+        ) = cls.tool.build_reports(
             cls.arguments
         )
 
@@ -92,12 +101,35 @@ class CodexA14AuditToolTest(unittest.TestCase):
                 self.tool._operation_rows(inputs, keys)
         self.assertIn(expected_code, raised.exception.codes)
 
+    def assert_plan_mutation(
+        self,
+        mutate: Callable[[dict[str, object], dict[str, object]], None],
+        expected_code: str,
+    ) -> None:
+        plan = copy.deepcopy(self.plan)
+        ledger = copy.deepcopy(self.ledger)
+        mutate(plan, ledger)
+        diagnostics = self.tool.planning_diagnostics(plan, ledger)
+        self.assertIn(
+            expected_code,
+            {row.code for row in diagnostics},
+        )
+        with self.assertRaises(self.tool.AuditError):
+            self.tool.validate_planning_reports(plan, ledger)
+
     def test_checked_reports_are_current_and_deterministic(self) -> None:
-        second_partition, second_closure = (
-            self.tool.build_foundation(self.arguments)
+        (
+            second_partition,
+            second_closure,
+            second_plan,
+            second_ledger,
+        ) = (
+            self.tool.build_reports(self.arguments)
         )
         self.assertEqual(self.partition, second_partition)
         self.assertEqual(self.closure, second_closure)
+        self.assertEqual(self.plan, second_plan)
+        self.assertEqual(self.ledger, second_ledger)
         self.assertEqual(
             self.partition,
             json.loads(OPTIONS.partition.read_text(encoding="utf-8")),
@@ -106,8 +138,19 @@ class CodexA14AuditToolTest(unittest.TestCase):
             self.closure,
             json.loads(OPTIONS.closure.read_text(encoding="utf-8")),
         )
+        self.assertEqual(
+            self.plan,
+            json.loads(OPTIONS.plan.read_text(encoding="utf-8")),
+        )
+        self.assertEqual(
+            self.ledger,
+            json.loads(OPTIONS.ledger.read_text(encoding="utf-8")),
+        )
         self.tool.validate_foundation_reports(
             self.partition, self.closure
+        )
+        self.tool.validate_planning_reports(
+            self.plan, self.ledger
         )
 
     def test_total_partition_and_stability_are_exact(self) -> None:
@@ -928,6 +971,266 @@ class CodexA14AuditToolTest(unittest.TestCase):
                     include, "A14IdentitySetMismatch"
                 )
 
+    def test_implementation_batches_cover_native_slice_once(self) -> None:
+        batches = {
+            row["batch"]: row
+            for row in self.plan["implementation_batches"]
+        }
+        self.assertEqual(
+            {
+                "A14-UserIntegrations",
+                "A14-McpReverse",
+                "A14-RuntimePlatform",
+            },
+            set(batches),
+        )
+        self.assertEqual(
+            {
+                "A14-UserIntegrations": 33,
+                "A14-McpReverse": 13,
+                "A14-RuntimePlatform": 10,
+            },
+            {
+                name: row["identity_count"]
+                for name, row in batches.items()
+            },
+        )
+        keys = [
+            self.tool.Key.from_row(
+                row["protocol_surface_key"]
+            )
+            for batch in batches.values()
+            for row in batch["identities"]
+        ]
+        self.assertEqual(56, len(keys))
+        self.assertEqual(56, len(set(keys)))
+        self.assertEqual(
+            self.tool.expected_a1_4_keys(), set(keys)
+        )
+        self.assertEqual(
+            {
+                "Complete": 336,
+                "NotApplicable": 48,
+                "NotImplemented": 0,
+                "Partial": 3,
+            },
+            batches["A14-RuntimePlatform"]["global_metrics"]["end"],
+        )
+
+    def test_cross_slice_ledger_freezes_ownership(self) -> None:
+        inherited = self.ledger[
+            "inherited_final_a1_obligations"
+        ]
+        self.assertEqual(
+            {"initialize", "initialized", "error"},
+            {
+                row["protocol_surface_key"]["name"]
+                for row in inherited
+            },
+        )
+        self.assertTrue(
+            all(
+                row["current_module"] == "Common"
+                and row["current_slice"] == "A1.0"
+                and row["current_status"] == "Partial"
+                and row["completion_stage"]
+                == "final A1 closure in A1.4"
+                and row["assignment_unchanged_proof"][
+                    "registry_matches_assignment"
+                ]
+                for row in inherited
+            )
+        )
+        native = self.ledger["native_a1_4_obligation"]
+        self.assertEqual(
+            "item/tool/requestUserInput",
+            native["protocol_surface_key"]["name"],
+        )
+        self.assertEqual("A1.4", native["current_slice"])
+        self.assertEqual(
+            "native A1.4 implementation",
+            native["completion_stage"],
+        )
+        self.assertTrue(
+            all(
+                len(row["missing_schema_completeness_facts"]) == 7
+                for row in [*inherited, native]
+            )
+        )
+
+    def test_server_request_resolved_semantics_are_frozen(self) -> None:
+        resolved = self.plan[
+            "server_request_resolved_semantics"
+        ]
+        self.assertEqual(
+            {
+                "requestId": "string | int64",
+                "threadId": "string",
+            },
+            resolved["payload"]["required_fields"],
+        )
+        self.assertEqual(
+            "original server-generated JSON-RPC request ID",
+            resolved["identifier_semantics"]["kind"],
+        )
+        emitting = {
+            row["method"]
+            for row in resolved["emission_method_matrix"]
+            if row["emits_notification"]
+        }
+        self.assertEqual(
+            {
+                "item/commandExecution/requestApproval",
+                "item/fileChange/requestApproval",
+                "item/permissions/requestApproval",
+                "item/tool/requestUserInput",
+                "mcpServer/elicitation/request",
+            },
+            emitting,
+        )
+        direct = resolved["direct_response_non_regression"]
+        self.assertTrue(
+            all(
+                direct[field] is False
+                for field in (
+                    "is_response_transport",
+                    "is_response_prerequisite",
+                    "is_acknowledgement_prerequisite",
+                    "is_second_terminal_completion",
+                    "can_reopen_completed_occurrence",
+                    "changes_a1_3_response_contract",
+                )
+            )
+        )
+        self.assertTrue(resolved["ordering"]["direct_response_is_earlier"])
+        self.assertTrue(
+            resolved["recipient_behavior"][
+                "already_consumed_possible"
+            ]
+        )
+
+    def test_public_api_abi_security_and_package_plans_are_exact(
+        self,
+    ) -> None:
+        api = self.plan["public_api_plan"]
+        self.assertEqual(29, len(api["facade_operations"]))
+        self.assertEqual(16, len(api["notification_ownership"]))
+        self.assertEqual(4, len(api["server_request_ownership"]))
+        variants = api["variant_and_layout_plan"]["current"]
+        self.assertEqual(
+            51, len(variants["CanonicalServerNotification"])
+        )
+        self.assertEqual(53, len(variants["Event"]))
+        self.assertEqual(8, len(variants["TypedServerRequest"]))
+        soversion = self.plan["api_abi_and_soversion"]
+        self.assertEqual(
+            "bump Codex SOVERSION 1 -> 2",
+            soversion["final_action"]["decision"],
+        )
+        self.assertEqual(
+            68,
+            soversion["current_authority"][
+                "declarations_using_global_authority"
+            ],
+        )
+        self.assertEqual(
+            127,
+            self.plan["security_and_sensitive_data"][
+                "heuristic_schema_paths"
+            ]["count"],
+        )
+        source_counts = self.plan[
+            "source_and_binary_package_plan"
+        ]["source_counts"]
+        self.assertEqual(
+            {"before": 22, "after": 27},
+            source_counts["evidence_files"],
+        )
+        self.assertEqual(
+            {"before": 18, "after": 19},
+            source_counts["codex_docs"],
+        )
+
+    def test_plan_and_ledger_mutation_guards(self) -> None:
+        cases = (
+            (
+                "native denominator includes inherited partials",
+                lambda plan, ledger: plan["native_start"].__setitem__(
+                    "identity_count", 59
+                ),
+                "NativeDenominatorMismatch",
+            ),
+            (
+                "missing implementation identity",
+                lambda plan, ledger: plan[
+                    "implementation_batches"
+                ][0]["identities"].pop(),
+                "ImplementationPlanIdentityMissing",
+            ),
+            (
+                "duplicate implementation ownership",
+                lambda plan, ledger: plan[
+                    "implementation_batches"
+                ][1]["identities"].append(
+                    copy.deepcopy(
+                        plan["implementation_batches"][0][
+                            "identities"
+                        ][0]
+                    )
+                ),
+                "ImplementationPlanIdentityOverlap",
+            ),
+            (
+                "wrong per-PR arithmetic",
+                lambda plan, ledger: plan[
+                    "implementation_batches"
+                ][1]["global_metrics"]["end"].__setitem__(
+                    "Complete", 325
+                ),
+                "NativeCompletionArithmeticMismatch",
+            ),
+            (
+                "resolved becomes response transport",
+                lambda plan, ledger: plan[
+                    "server_request_resolved_semantics"
+                ]["direct_response_non_regression"].__setitem__(
+                    "is_response_transport", True
+                ),
+                "ResponsePathMismatch",
+            ),
+            (
+                "missing ledger entry",
+                lambda plan, ledger: ledger[
+                    "inherited_final_a1_obligations"
+                ].pop(),
+                "CrossSliceLedgerMismatch",
+            ),
+            (
+                "reassign inherited identity",
+                lambda plan, ledger: ledger[
+                    "inherited_final_a1_obligations"
+                ][0].__setitem__("current_slice", "A1.4"),
+                "CrossSliceOwnershipMismatch",
+            ),
+            (
+                "wrong final A1 arithmetic",
+                lambda plan, ledger: plan[
+                    "final_a1_closure"
+                ]["global_end"].__setitem__("Partial", 1),
+                "FinalA1ArithmeticMismatch",
+            ),
+            (
+                "missing SOVERSION closure decision",
+                lambda plan, ledger: plan[
+                    "api_abi_and_soversion"
+                ].pop("final_action"),
+                "SOVERSIONDecisionMissing",
+            ),
+        )
+        for name, mutate, code in cases:
+            with self.subTest(case=name):
+                self.assert_plan_mutation(mutate, code)
+
     def test_stale_generated_report_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory(
             prefix="codex-a1-4-stale-"
@@ -969,6 +1272,16 @@ def parse_options() -> argparse.Namespace:
         "--closure",
         type=Path,
         default=evidence / "a1-4-type-closure.json",
+    )
+    parser.add_argument(
+        "--plan",
+        type=Path,
+        default=evidence / "a1-4-implementation-plan.json",
+    )
+    parser.add_argument(
+        "--ledger",
+        type=Path,
+        default=evidence / "a1-final-cross-slice-ledger.json",
     )
     return parser.parse_args()
 

--- a/tests/component/codex/CodexA14AuditToolTest.py
+++ b/tests/component/codex/CodexA14AuditToolTest.py
@@ -1,0 +1,979 @@
+#!/usr/bin/env python3
+
+"""Determinism and mutation guards for the frozen A1.4 audit."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import ModuleType
+from typing import Callable
+
+sys.dont_write_bytecode = True
+
+
+def load_tool(path: Path) -> ModuleType:
+    sys.path.insert(0, str(path.resolve().parent))
+    specification = importlib.util.spec_from_file_location(
+        "snodec_codex_a1_4_audit", path
+    )
+    if specification is None or specification.loader is None:
+        raise AssertionError(f"unable to import A1.4 audit tool: {path}")
+    module = importlib.util.module_from_spec(specification)
+    sys.modules[specification.name] = module
+    specification.loader.exec_module(module)
+    return module
+
+
+class CodexA14AuditToolTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tool = load_tool(OPTIONS.tool)
+        cls.arguments = cls.tool.parser().parse_args(
+            [
+                "check",
+                "--repo-root",
+                str(OPTIONS.repo_root),
+                "--start-state",
+                str(OPTIONS.start_state),
+                "--partition-output",
+                str(OPTIONS.partition),
+                "--closure-output",
+                str(OPTIONS.closure),
+            ]
+        )
+        for name, value in vars(cls.arguments).items():
+            if isinstance(value, Path):
+                setattr(cls.arguments, name, value.resolve())
+        cls.inputs = cls.tool.load_inputs(cls.arguments)
+        cls.partition, cls.closure = cls.tool.build_foundation(
+            cls.arguments
+        )
+
+    def assert_report_mutation(
+        self,
+        mutate: Callable[[dict[str, object], dict[str, object]], None],
+        expected_code: str,
+    ) -> None:
+        partition = copy.deepcopy(self.partition)
+        closure = copy.deepcopy(self.closure)
+        mutate(partition, closure)
+        diagnostics = self.tool.foundation_diagnostics(
+            partition, closure
+        )
+        self.assertIn(
+            expected_code,
+            {row.code for row in diagnostics},
+        )
+        with self.assertRaises(self.tool.AuditError):
+            self.tool.validate_foundation_reports(partition, closure)
+
+    def assert_input_mutation(
+        self,
+        mutate: Callable[[object], None],
+        expected_code: str,
+        *,
+        arithmetic: bool = False,
+        contracts: bool = False,
+    ) -> None:
+        inputs = copy.deepcopy(self.inputs)
+        mutate(inputs)
+        with self.assertRaises(self.tool.AuditError) as raised:
+            keys = self.tool.validate_partition_inputs(inputs)
+            if arithmetic:
+                self.tool.validate_start_arithmetic(inputs, keys)
+            if contracts:
+                self.tool._operation_rows(inputs, keys)
+        self.assertIn(expected_code, raised.exception.codes)
+
+    def test_checked_reports_are_current_and_deterministic(self) -> None:
+        second_partition, second_closure = (
+            self.tool.build_foundation(self.arguments)
+        )
+        self.assertEqual(self.partition, second_partition)
+        self.assertEqual(self.closure, second_closure)
+        self.assertEqual(
+            self.partition,
+            json.loads(OPTIONS.partition.read_text(encoding="utf-8")),
+        )
+        self.assertEqual(
+            self.closure,
+            json.loads(OPTIONS.closure.read_text(encoding="utf-8")),
+        )
+        self.tool.validate_foundation_reports(
+            self.partition, self.closure
+        )
+
+    def test_total_partition_and_stability_are_exact(self) -> None:
+        counts = self.partition["counts"]
+        self.assertEqual(387, counts["total_inventory"])
+        self.assertEqual(
+            {
+                "A1.0": 19,
+                "A1.1": 151,
+                "A1.2": 45,
+                "A1.3": 68,
+                "A1.4": 56,
+                "InventoryOnly": 48,
+            },
+            counts["partition"],
+        )
+        self.assertEqual(
+            {
+                "experimental_only_inventory": 36,
+                "stable_a1": 339,
+                "stable_inventory": 351,
+                "stable_unreachable_inventory": 12,
+                "total_inventory": 387,
+            },
+            counts["stability_accounting"],
+        )
+        self.assertEqual(
+            {
+                "ExperimentalInventoryOnly": 36,
+                "StableUnreachableInventory": 12,
+            },
+            counts["inventory_only_classifications"],
+        )
+        all_rows = [
+            row
+            for rows in self.partition["buckets"].values()
+            for row in rows
+        ]
+        all_keys = [
+            self.tool.Key.from_row(row["protocol_surface_key"])
+            for row in all_rows
+        ]
+        self.assertEqual(387, len(all_keys))
+        self.assertEqual(387, len(set(all_keys)))
+        self.assertTrue(
+            all(
+                row["typed_schema_status"] == "NotApplicable"
+                for row in self.partition["buckets"][
+                    "InventoryOnly"
+                ]
+            )
+        )
+
+    def test_native_inventory_contracts_and_status_are_exact(self) -> None:
+        counts = self.partition["counts"]
+        self.assertEqual(
+            {
+                "client_request": 29,
+                "server_notification": 16,
+                "server_request": 4,
+                "tagged_union_discriminator": 7,
+            },
+            counts["native_a1_4_taxonomy"],
+        )
+        self.assertEqual(
+            {"Concrete": 26, "Unit": 3},
+            counts["native_a1_4_result_kinds"],
+        )
+        self.assertEqual(
+            {
+                "Complete": 0,
+                "NotApplicable": 0,
+                "NotImplemented": 55,
+                "Partial": 1,
+            },
+            counts["native_a1_4_start_status"],
+        )
+        rows = self.partition["buckets"]["A1.4"]
+        self.assertEqual(56, len(rows))
+        self.assertTrue(
+            all(
+                row["stability"] == "stable"
+                and row["module"] == "IntegrationsAndLongTail"
+                and row["a1_slice"] == "A1.4"
+                for row in rows
+            )
+        )
+        operations = self.partition["native_a1_4_operations"]
+        self.assertEqual(33, len(operations))
+        units = {
+            row["protocol_surface_key"]["name"]
+            for row in operations
+            if row["protocol_surface_key"]["category"]
+            == "client_request"
+            and row["result_kind"] == "Unit"
+        }
+        self.assertEqual(
+            {
+                "plugin/share/delete",
+                "plugin/uninstall",
+                "skills/extraRoots/set",
+            },
+            units,
+        )
+        server = [
+            row
+            for row in operations
+            if row["protocol_surface_key"]["category"]
+            == "server_request"
+        ]
+        self.assertEqual(4, len(server))
+        self.assertTrue(
+            all(
+                row["result_kind"] == "Concrete"
+                and row["direct_raw_protocol_response"]
+                and not row["depends_on_server_request_resolved"]
+                for row in server
+            )
+        )
+
+    def test_current_and_projected_arithmetic_is_exact(self) -> None:
+        counts = self.partition["counts"]
+        self.assertEqual(
+            {
+                "Complete": 280,
+                "NotApplicable": 48,
+                "NotImplemented": 55,
+                "Partial": 4,
+            },
+            counts["global_start_status"],
+        )
+        self.assertEqual(
+            {
+                "Complete": 336,
+                "NotApplicable": 48,
+                "NotImplemented": 0,
+                "Partial": 3,
+            },
+            counts["native_completion_projection"],
+        )
+        self.assertEqual(
+            {
+                "Complete": 339,
+                "NotApplicable": 48,
+                "NotImplemented": 0,
+                "Partial": 0,
+            },
+            counts["final_a1_projection"],
+        )
+        self.assertEqual(
+            "item/tool/requestUserInput",
+            self.partition["native_partial_identity"]["name"],
+        )
+        self.assertEqual(
+            {"error", "initialize", "initialized"},
+            {
+                row["name"]
+                for row in self.partition[
+                    "inherited_a1_0_partial_identities"
+                ]
+            },
+        )
+
+    def test_inventory_only_and_asymmetries_are_hard_boundaries(
+        self,
+    ) -> None:
+        inventory = self.partition["inventory_only"]
+        self.assertEqual(
+            36, len(inventory["ExperimentalInventoryOnly"])
+        )
+        self.assertEqual(
+            12, len(inventory["StableUnreachableInventory"])
+        )
+        self.assertTrue(
+            all(
+                row["stability"] == "experimental_only"
+                for row in inventory["ExperimentalInventoryOnly"]
+            )
+        )
+        self.assertTrue(
+            all(
+                row["stability"] == "stable"
+                for row in inventory["StableUnreachableInventory"]
+            )
+        )
+        asymmetry = self.partition[
+            "stable_experimental_asymmetries"
+        ]
+        self.assertEqual(
+            ["process/exited", "process/outputDelta"],
+            asymmetry["stable_process_notifications"],
+        )
+        self.assertEqual(
+            [
+                "process/kill",
+                "process/resizePty",
+                "process/spawn",
+                "process/writeStdin",
+            ],
+            asymmetry["experimental_process_controls"],
+        )
+        self.assertEqual(
+            "remoteControl/status/changed",
+            asymmetry["stable_remote_control_notification"],
+        )
+        self.assertEqual(
+            sorted(self.tool.EXPERIMENTAL_REMOTE_CONTROLS),
+            asymmetry["experimental_remote_control_controls"],
+        )
+
+    def test_full_transitive_schema_closure_is_frozen(self) -> None:
+        self.assertEqual(
+            {
+                "default_bearing_paths": 22,
+                "definition_namespaces": {
+                    "legacy": 34,
+                    "v2": 155,
+                },
+                "integer_formats": {
+                    "double": 3,
+                    "int32": 1,
+                    "int64": 8,
+                    "uint": 1,
+                    "uint32": 4,
+                    "uint64": 6,
+                },
+                "maximum_bearing_paths": 0,
+                "minimum_bearing_paths": 11,
+                "nullable_paths": 243,
+                "object_nodes": 162,
+                "opaque_json_paths": 24,
+                "optional_paths": 260,
+                "reachable_named_definitions": 189,
+                "required_paths": 288,
+                "schema_path_kinds": {
+                    "array_element": 91,
+                    "map_value": 7,
+                    "property": 548,
+                },
+                "schema_paths": 646,
+                "seed_definitions": 81,
+                "sensitive_paths": 127,
+            },
+            self.closure["counts"],
+        )
+        paths = self.closure["schema_paths"]
+        self.assertEqual(646, len(paths))
+        self.assertTrue(
+            all(
+                {
+                    "required",
+                    "optional",
+                    "nullable",
+                    "default_present",
+                    "value_kind",
+                    "integer_format",
+                    "minimum",
+                    "maximum",
+                    "array_element_type",
+                    "map_value_type",
+                    "additional_properties",
+                    "intentionally_opaque_json",
+                }.issubset(row)
+                for row in paths
+            )
+        )
+
+    def test_union_representation_and_reachability_are_exact(self) -> None:
+        unions = {
+            row["domain"]: row
+            for row in self.closure["union_families"]
+        }
+        self.assertEqual(
+            {"McpServerElicitationRequestParams", "PluginSource"},
+            set(unions),
+        )
+        self.assertEqual(
+            {"form", "openai/form", "url"},
+            {
+                row["alternative"]
+                for row in unions[
+                    "McpServerElicitationRequestParams"
+                ]["alternatives"]
+            },
+        )
+        self.assertEqual(
+            {"git", "local", "npm", "remote"},
+            {
+                row["alternative"]
+                for row in unions["PluginSource"]["alternatives"]
+            },
+        )
+        self.assertEqual(
+            {"mcpServer/elicitation/request"},
+            {
+                row["name"]
+                for row in unions[
+                    "McpServerElicitationRequestParams"
+                ]["reaching_roots"]
+            },
+        )
+        self.assertEqual(
+            {
+                "plugin/installed",
+                "plugin/list",
+                "plugin/read",
+                "plugin/share/list",
+            },
+            {
+                row["name"]
+                for row in unions["PluginSource"]["reaching_roots"]
+            },
+        )
+        self.assertTrue(
+            all(
+                row["future_unknown_handling"]
+                and row["malformed_known_handling"]
+                for row in unions.values()
+            )
+        )
+
+    def test_provenance_and_audit_scope_are_frozen(self) -> None:
+        start = json.loads(
+            OPTIONS.start_state.read_text(encoding="utf-8")
+        )
+        provenance = start["provenance"]
+        self.assertEqual(
+            "5d1fbf26c43abc65a203928b2e31561cb039e06d",
+            provenance["source_commit_sha"],
+        )
+        self.assertEqual(
+            "cee1ac3bcaf95e5fcdcf07499c7e6b00fc423b90c670ea3380f1799434b72add",
+            provenance["schema_trees"]["stable"][
+                "aggregate_sha256"
+            ],
+        )
+        boundaries = self.partition["audit_boundaries"]
+        self.assertEqual([], boundaries["production_paths_changed"])
+        self.assertFalse(boundaries["registry_status_promoted"])
+        self.assertFalse(boundaries["soversion_changed"])
+        self.assertTrue(
+            all(
+                not path.startswith("src/")
+                for path in boundaries["changed_paths"]
+            )
+        )
+
+    def test_duplicate_unassigned_and_overlap_input_guards(self) -> None:
+        rows = copy.deepcopy(
+            self.inputs.assignments_document["assignments"]
+        )
+        duplicate = copy.deepcopy(rows[0])
+        with self.assertRaises(self.tool.AuditError) as raised:
+            self.tool._keys_from_rows(
+                [*rows, duplicate], "assignment"
+            )
+        self.assertEqual("DuplicateAssignment", raised.exception.code)
+
+        overlap = copy.deepcopy(rows[0])
+        overlap["slice"] = "A1.4"
+        with self.assertRaises(self.tool.AuditError) as raised:
+            self.tool._keys_from_rows(
+                [*rows, overlap], "assignment"
+            )
+        self.assertEqual("CrossSliceOverlap", raised.exception.code)
+
+        def unassign(inputs: object) -> None:
+            inputs.assignments_document["assignments"][0][
+                "slice"
+            ] = "Unassigned"
+            key = self.tool.Key.from_row(
+                inputs.assignments_document["assignments"][0]
+            )
+            inputs.assignments[key]["slice"] = "Unassigned"
+
+        self.assert_input_mutation(
+            unassign, "UnassignedIdentity"
+        )
+
+    def test_missing_and_extra_inventory_authority_are_rejected(
+        self,
+    ) -> None:
+        manifest = json.loads(
+            self.arguments.manifest.read_text(encoding="utf-8")
+        )
+        mutations = (
+            ("missing", lambda rows: rows.pop()),
+            (
+                "extra",
+                lambda rows: rows.append(
+                    {
+                        **copy.deepcopy(rows[-1]),
+                        "id": "client_request:synthetic/extra",
+                        "name": "synthetic/extra",
+                        "category": "client_request",
+                        "domain": "ClientRequest",
+                        "discriminator_field": "method",
+                    }
+                ),
+            ),
+        )
+        for name, mutate in mutations:
+            with self.subTest(case=name), tempfile.TemporaryDirectory(
+                prefix=f"codex-a1-4-{name}-"
+            ) as directory:
+                changed = copy.deepcopy(manifest)
+                mutate(changed["entries"])
+                path = Path(directory) / "manifest.json"
+                path.write_text(
+                    json.dumps(changed, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+                arguments = copy.copy(self.arguments)
+                arguments.manifest = path
+                with self.assertRaises(
+                    self.tool.AuditError
+                ) as raised:
+                    self.tool.load_inputs(arguments)
+                self.assertEqual(
+                    "TotalDenominatorMismatch",
+                    raised.exception.code,
+                )
+
+    def test_assignment_and_boundary_input_guards(self) -> None:
+        a1_4_key = next(
+            key
+            for key in self.inputs.assignments
+            if key.name == "app/list"
+        )
+        experimental_key = next(
+            key
+            for key, row in self.inputs.assignments.items()
+            if row["classification"]
+            == "ExperimentalInventoryOnly"
+        )
+        unreachable_key = next(
+            key
+            for key, row in self.inputs.assignments.items()
+            if row["classification"]
+            == "StableUnreachableInventory"
+        )
+
+        def wrong_module(inputs: object) -> None:
+            inputs.assignments[a1_4_key]["module"] = "Common"
+            inputs.registry[a1_4_key]["typed_module"] = "Common"
+
+        self.assert_input_mutation(
+            wrong_module, "A14ModuleMismatch"
+        )
+
+        def wrong_stability(inputs: object) -> None:
+            inputs.assignments[a1_4_key][
+                "stability"
+            ] = "experimental_only"
+
+        self.assert_input_mutation(
+            wrong_stability, "StabilityMismatch"
+        )
+
+        def promote_experimental(inputs: object) -> None:
+            inputs.assignments[experimental_key]["slice"] = "A1.4"
+            inputs.assignments[experimental_key][
+                "module"
+            ] = "IntegrationsAndLongTail"
+            inputs.registry[experimental_key]["a1_slice"] = "A1.4"
+            inputs.registry[experimental_key][
+                "typed_module"
+            ] = "IntegrationsAndLongTail"
+
+        self.assert_input_mutation(
+            promote_experimental, "ExperimentalLeakage"
+        )
+
+        def promote_unreachable(inputs: object) -> None:
+            inputs.assignments[unreachable_key]["slice"] = "A1.4"
+            inputs.assignments[unreachable_key][
+                "module"
+            ] = "IntegrationsAndLongTail"
+            inputs.registry[unreachable_key]["a1_slice"] = "A1.4"
+            inputs.registry[unreachable_key][
+                "typed_module"
+            ] = "IntegrationsAndLongTail"
+
+        self.assert_input_mutation(
+            promote_unreachable,
+            "StableUnreachableBoundaryMismatch",
+        )
+
+        def move_native_to_inventory(inputs: object) -> None:
+            inputs.assignments[a1_4_key]["slice"] = "InventoryOnly"
+            inputs.registry[a1_4_key][
+                "a1_slice"
+            ] = "InventoryOnly"
+
+        self.assert_input_mutation(
+            move_native_to_inventory, "PartitionCountMismatch"
+        )
+
+        for inherited_name in ("initialize", "initialized", "error"):
+            inherited_key = next(
+                key
+                for key in self.inputs.assignments
+                if key.name == inherited_name
+            )
+
+            def reassign(inputs: object, key=inherited_key) -> None:
+                inputs.assignments[key]["slice"] = "A1.4"
+                inputs.assignments[key][
+                    "module"
+                ] = "IntegrationsAndLongTail"
+                inputs.registry[key]["a1_slice"] = "A1.4"
+                inputs.registry[key][
+                    "typed_module"
+                ] = "IntegrationsAndLongTail"
+
+            with self.subTest(inherited=inherited_name):
+                self.assert_input_mutation(
+                    reassign, "CrossSliceOwnershipMismatch"
+                )
+
+    def test_contract_and_status_input_guards(self) -> None:
+        client_key = next(
+            key
+            for key in self.inputs.contracts
+            if key.name == "app/list"
+        )
+        server_key = next(
+            key
+            for key in self.inputs.contracts
+            if key.name == "attestation/generate"
+        )
+
+        def wrong_client_result(inputs: object) -> None:
+            inputs.contracts[client_key][
+                "result_type_identity"
+            ] = "Unit"
+            inputs.registry[client_key][
+                "result_type_identity"
+            ] = "Unit"
+
+        self.assert_input_mutation(
+            wrong_client_result,
+            "ClientResultAssociationMismatch",
+            contracts=True,
+        )
+
+        def wrong_server_response(inputs: object) -> None:
+            inputs.contracts[server_key][
+                "result_type_identity"
+            ] = "Unit"
+            inputs.registry[server_key][
+                "result_type_identity"
+            ] = "Unit"
+
+        self.assert_input_mutation(
+            wrong_server_response,
+            "ServerResponseContractMismatch",
+            contracts=True,
+        )
+
+        def promote_registry(inputs: object) -> None:
+            key = next(
+                value
+                for value in inputs.registry
+                if value.name == "app/list"
+            )
+            inputs.registry[key]["typed_schema_status"] = "Complete"
+
+        self.assert_input_mutation(
+            promote_registry,
+            "NativeStartStatusMismatch",
+            arithmetic=True,
+        )
+
+    def test_logical_report_mutation_guards(self) -> None:
+        cases = (
+            (
+                "total denominator",
+                lambda partition, closure: partition["counts"].__setitem__(
+                    "total_inventory", 386
+                ),
+                "TotalDenominatorMismatch",
+            ),
+            (
+                "partition denominator",
+                lambda partition, closure: partition["counts"][
+                    "partition"
+                ].__setitem__("A1.4", 55),
+                "PartitionCountMismatch",
+            ),
+            (
+                "missing identity",
+                lambda partition, closure: partition["buckets"][
+                    "A1.4"
+                ].pop(),
+                "PartitionSetMismatch",
+            ),
+            (
+                "cross-slice overlap",
+                lambda partition, closure: partition["buckets"][
+                    "A1.4"
+                ].append(
+                    copy.deepcopy(partition["buckets"]["A1.0"][0])
+                ),
+                "PartitionSetMismatch",
+            ),
+            (
+                "taxonomy",
+                lambda partition, closure: partition["counts"].__setitem__(
+                    "native_a1_4_taxonomy", {}
+                ),
+                "TaxonomyMismatch",
+            ),
+            (
+                "module",
+                lambda partition, closure: partition["buckets"]["A1.4"][
+                    0
+                ].__setitem__("module", "Common"),
+                "A14ModuleMismatch",
+            ),
+            (
+                "stability",
+                lambda partition, closure: partition["buckets"]["A1.4"][
+                    0
+                ].__setitem__("stability", "experimental_only"),
+                "StabilityMismatch",
+            ),
+            (
+                "result kind",
+                lambda partition, closure: partition["counts"].__setitem__(
+                    "native_a1_4_result_kinds",
+                    {"Concrete": 29},
+                ),
+                "ResultKindMismatch",
+            ),
+            (
+                "client result association",
+                lambda partition, closure: next(
+                    row
+                    for row in partition[
+                        "native_a1_4_operations"
+                    ]
+                    if row["protocol_surface_key"]["name"]
+                    == "app/list"
+                ).__setitem__("result_type", "Unit"),
+                "ClientResultAssociationMismatch",
+            ),
+            (
+                "server response association",
+                lambda partition, closure: next(
+                    row
+                    for row in partition[
+                        "native_a1_4_operations"
+                    ]
+                    if row["protocol_surface_key"]["name"]
+                    == "attestation/generate"
+                ).__setitem__("result_type", "Unit"),
+                "ServerResponseContractMismatch",
+            ),
+            (
+                "resolved response transport",
+                lambda partition, closure: next(
+                    row
+                    for row in partition[
+                        "native_a1_4_operations"
+                    ]
+                    if row["protocol_surface_key"]["name"]
+                    == "item/tool/requestUserInput"
+                ).__setitem__(
+                    "depends_on_server_request_resolved", True
+                ),
+                "ResponsePathMismatch",
+            ),
+            (
+                "native partial",
+                lambda partition, closure: partition[
+                    "native_partial_identity"
+                ].__setitem__("name", "initialize"),
+                "NativePartialMismatch",
+            ),
+            (
+                "missing inherited partial",
+                lambda partition, closure: partition[
+                    "inherited_a1_0_partial_identities"
+                ].pop(),
+                "CrossSliceLedgerMismatch",
+            ),
+            (
+                "all InventoryOnly experimental",
+                lambda partition, closure: partition["counts"].__setitem__(
+                    "inventory_only_classifications",
+                    {"ExperimentalInventoryOnly": 48},
+                ),
+                "InventoryClassificationMismatch",
+            ),
+            (
+                "missing stable unreachable",
+                lambda partition, closure: partition["inventory_only"][
+                    "StableUnreachableInventory"
+                ].pop(),
+                "InventoryClassificationMismatch",
+            ),
+            (
+                "native arithmetic",
+                lambda partition, closure: partition["counts"].__setitem__(
+                    "native_completion_projection", {}
+                ),
+                "NativeCompletionArithmeticMismatch",
+            ),
+            (
+                "final arithmetic",
+                lambda partition, closure: partition["counts"].__setitem__(
+                    "final_a1_projection", {}
+                ),
+                "FinalA1ArithmeticMismatch",
+            ),
+            (
+                "union alternative",
+                lambda partition, closure: closure["union_families"][0][
+                    "alternatives"
+                ].pop(),
+                "UnionSchemaMismatch",
+            ),
+            (
+                "schema closure",
+                lambda partition, closure: closure["counts"].__setitem__(
+                    "schema_paths", 645
+                ),
+                "SchemaClosureMismatch",
+            ),
+            (
+                "schema path",
+                lambda partition, closure: closure[
+                    "schema_paths"
+                ].pop(),
+                "SchemaPathMismatch",
+            ),
+            (
+                "production scope",
+                lambda partition, closure: partition[
+                    "audit_boundaries"
+                ].__setitem__(
+                    "production_paths_changed",
+                    ["src/ai/openai/codex/AppServerClient.cpp"],
+                ),
+                "ProductionScopeViolation",
+            ),
+            (
+                "registry promotion",
+                lambda partition, closure: partition[
+                    "audit_boundaries"
+                ].__setitem__("registry_status_promoted", True),
+                "RegistryPromotionViolation",
+            ),
+            (
+                "SOVERSION decision",
+                lambda partition, closure: partition[
+                    "audit_boundaries"
+                ].__setitem__("soversion_changed", True),
+                "BoundaryMismatch",
+            ),
+        )
+        for name, mutate, code in cases:
+            with self.subTest(case=name):
+                self.assert_report_mutation(mutate, code)
+
+    def test_named_stable_experimental_mutation_guards(self) -> None:
+        names_and_codes = (
+            ("process/exited", "A14IdentitySetMismatch"),
+            ("process/outputDelta", "A14IdentitySetMismatch"),
+            (
+                "remoteControl/status/changed",
+                "A14IdentitySetMismatch",
+            ),
+            ("serverRequest/resolved", "A14IdentitySetMismatch"),
+            (
+                "item/tool/requestUserInput",
+                "A14IdentitySetMismatch",
+            ),
+        )
+        for name, code in names_and_codes:
+            def remove(
+                partition: dict[str, object],
+                _closure: dict[str, object],
+                identity=name,
+            ) -> None:
+                rows = partition["buckets"]["A1.4"]
+                rows[:] = [
+                    row
+                    for row in rows
+                    if row["protocol_surface_key"]["name"] != identity
+                ]
+
+            with self.subTest(identity=name):
+                self.assert_report_mutation(remove, code)
+
+        inventory_by_name = {
+            row["protocol_surface_key"]["name"]: row
+            for row in self.partition["buckets"]["InventoryOnly"]
+        }
+        for name in (
+            *sorted(self.tool.EXPERIMENTAL_PROCESS_CONTROLS),
+            *sorted(self.tool.EXPERIMENTAL_REMOTE_CONTROLS),
+        ):
+            self.assertIn(name, inventory_by_name)
+
+            def include(
+                partition: dict[str, object],
+                _closure: dict[str, object],
+                identity=name,
+            ) -> None:
+                partition["buckets"]["A1.4"][0] = copy.deepcopy(
+                    inventory_by_name[identity]
+                )
+
+            with self.subTest(experimental_identity=name):
+                self.assert_report_mutation(
+                    include, "A14IdentitySetMismatch"
+                )
+
+    def test_stale_generated_report_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory(
+            prefix="codex-a1-4-stale-"
+        ) as directory:
+            path = Path(directory) / "partition.json"
+            stale = copy.deepcopy(self.partition)
+            stale["counts"]["total_inventory"] = 386
+            path.write_text(
+                json.dumps(stale, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(self.tool.AuditError):
+                self.tool.write_or_check(
+                    path, self.partition, True
+                )
+
+
+def parse_options() -> argparse.Namespace:
+    root = Path(__file__).resolve().parents[3]
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tool",
+        type=Path,
+        default=root / "tools/codex/app_server_a1_4.py",
+    )
+    parser.add_argument("--repo-root", type=Path, default=root)
+    evidence = root / "tools/codex/app-server-evidence/0.144.6"
+    parser.add_argument(
+        "--start-state",
+        type=Path,
+        default=evidence / "a1-4-start-state.json",
+    )
+    parser.add_argument(
+        "--partition",
+        type=Path,
+        default=evidence / "a1-4-total-partition.json",
+    )
+    parser.add_argument(
+        "--closure",
+        type=Path,
+        default=evidence / "a1-4-type-closure.json",
+    )
+    return parser.parse_args()
+
+
+OPTIONS = parse_options()
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]])

--- a/tools/codex/README.md
+++ b/tools/codex/README.md
@@ -372,6 +372,40 @@ evidence. `serverRequest/resolved` and experimental controls remain excluded.
 BackendCommand, BackendState, Frontend Protocol v1, and reference applications
 remain outside A1.3 semantics.
 
+## A1.4 integrations, long tail, and final-A1 planning audit
+
+The A1.4 audit reuses the shared schema catalog, definition graph, Draft-07
+walker, registry/assignment/contract parsers, deterministic JSON writer, and
+mutation-diagnostic conventions:
+
+```sh
+python3 tools/codex/app_server_a1_4.py generate
+python3 tools/codex/app_server_a1_4.py check
+```
+
+The checked artifacts are:
+
+- `app-server-evidence/0.144.6/a1-4-start-state.json`;
+- `app-server-evidence/0.144.6/a1-4-total-partition.json`;
+- `app-server-evidence/0.144.6/a1-4-type-closure.json`;
+- `app-server-evidence/0.144.6/a1-4-implementation-plan.json`; and
+- `app-server-evidence/0.144.6/a1-final-cross-slice-ledger.json`.
+
+The audit proves the exact 387-key partition
+`19/151/45/68/56/48`, including the corrected InventoryOnly split of
+36 experimental-only plus 12 stable-unreachable identities. It freezes the
+native 29/16/4/7 A1.4 taxonomy, 26 Concrete/3 Unit client-result split,
+0/1/55 native start state, three implementation batches, inherited A1.0
+closure ledger, `serverRequest/resolved` lifecycle semantics, and the final
+Codex SOVERSION `1 -> 2` plan.
+
+The reviewed plan is documented in
+`docs/ai/openai/codex/a1-4-integrations-and-long-tail-plan.md`. This is an
+audit-only boundary: it does not implement the 56 identities, promote the
+production registry, rewrite assignment, change SOVERSION, or expand backend,
+frontend, and application behavior. The focused test is registered from the
+root test CMake file so immutable A1.3 closure evidence remains unchanged.
+
 ## Re-running the pinned upstream generation
 
 The TypeScript trees are an independent method and discriminator cross-check;
@@ -471,6 +505,12 @@ Do not hand-edit these generated artifacts:
 - `app-server-evidence/0.144.6/a1-3-type-closure.json`;
 - `app-server-evidence/0.144.6/a1-3-api-abi-evidence.json`;
 - `app-server-evidence/0.144.6/a1-3-closure-report.json`;
+- `app-server-evidence/0.144.6/a1-4-start-state.json` (one-time immutable
+  Commit 1 freeze; never ordinary regeneration);
+- `app-server-evidence/0.144.6/a1-4-total-partition.json`;
+- `app-server-evidence/0.144.6/a1-4-type-closure.json`;
+- `app-server-evidence/0.144.6/a1-4-implementation-plan.json`;
+- `app-server-evidence/0.144.6/a1-final-cross-slice-ledger.json`;
 - `app-server-fixtures/0.144.6/`;
 - `ClientOperationCodecDescriptors.inc`;
 - `ConversationUnionCodecDescriptors.inc`;

--- a/tools/codex/app-server-evidence/0.144.6/a1-4-implementation-plan.json
+++ b/tools/codex/app-server-evidence/0.144.6/a1-4-implementation-plan.json
@@ -1,0 +1,7220 @@
+{
+  "a2_non_goals": [
+    "all 36 experimental-only InventoryOnly identities",
+    "all 12 stable-unreachable InventoryOnly identities",
+    "process control requests",
+    "remote-control outgoing requests",
+    "fuzzy-search session controls",
+    "collaboration, environment, and memory operations",
+    "background-terminal, realtime, search, and settings controls",
+    "frontend/backend/application expansion outside typed A1"
+  ],
+  "api_abi_and_soversion": {
+    "actual_abi_evidence": {
+      "added_symbols_at_a1_3_boundary": 15733,
+      "base_typed_server_request_size": 312,
+      "binary_compatible": false,
+      "current_app_server_client_size": 16,
+      "current_typed_client_size": 8,
+      "current_typed_server_request_size": 960,
+      "installed_consumers_must_rebuild": true,
+      "removed_symbols_at_a1_3_boundary": 6286,
+      "source": {
+        "path": "tools/codex/app-server-evidence/0.144.6/a1-3-api-abi-evidence.json",
+        "sha256": "b6d05bd993ec421aa7d2ff3e720a399fc54d801305c906f3a8c9c7557be9b611"
+      }
+    },
+    "current_authority": {
+      "SNODEC_SOVERSION": 1,
+      "codex_declarations": [
+        "src/ai/openai/codex/CMakeLists.txt",
+        "src/ai/openai/codex/backend/CMakeLists.txt",
+        "src/ai/openai/codex/frontend/CMakeLists.txt"
+      ],
+      "declarations_using_global_authority": 68,
+      "definition": "SNODEC_SOVERSION = SNode.C_VERSION_MAJOR",
+      "project_version": "1.0.1",
+      "root_source": {
+        "path": "CMakeLists.txt",
+        "sha256": "2f96eb43d668348121fcad099714eaef13de5fab919a40984ec6abd021d2bfa3"
+      },
+      "unrelated_declarations": 65
+    },
+    "existing_a1_policy": {
+      "decision": "remain at 1 through native A1.4 implementation, then bump once at final A1 closure",
+      "source": "docs/ai/openai/codex/a1-typed-foundation.md#final-closure-policy"
+    },
+    "expected_api_abi_changes": {
+      "aggregates_may_grow": [
+        "ClientInfo",
+        "TurnErrorEvent",
+        "UserInputRequest",
+        "notification and operation result aggregates"
+      ],
+      "intentional_symbols_removed": [],
+      "symbols_added": [
+        "typed::Client facade accessors",
+        "typed operation methods",
+        "typed reverse-request response overloads",
+        "new aggregate and variant support symbols"
+      ],
+      "variants_gain_alternatives": [
+        "CanonicalServerNotification",
+        "Event",
+        "TypedServerRequest",
+        "PluginSource",
+        "McpServerElicitationRequestParams"
+      ]
+    },
+    "final_action": {
+      "binary_package_change": ".so.1 -> .so.2",
+      "decision": "bump Codex SOVERSION 1 -> 2",
+      "earlier_pr_rule": "an unchanged SONAME 1 is not a binary-compatibility claim during native A1.4 implementation",
+      "installed_consumer_action": "rebuild and relink every installed consumer",
+      "mechanism": "introduce a Codex-specific SOVERSION authority at final closure; do not bump 65 unrelated targets",
+      "scope": [
+        "ai-openai-codex",
+        "ai-openai-codex-backend",
+        "ai-openai-codex-frontend"
+      ],
+      "sequence_point": "after the 339 Complete / 0 Partial / 0 NotImplemented / 48 NotApplicable proof, before final ABI and package capture"
+    },
+    "required_layout_probes": [
+      "AppServerClient",
+      "typed::Client",
+      "Event",
+      "CanonicalServerNotification",
+      "TypedServerRequest",
+      "UserInputRequest",
+      "TurnErrorEvent",
+      "ClientInfo",
+      "InitializeResult",
+      "every introduced public aggregate and variant",
+      "every new typed facade object"
+    ]
+  },
+  "authority": {
+    "base_sha": "bed5ee05184739d54cddc6518bd43b264e2b496d",
+    "base_tree": "8bf44f0eed6bd8c9d5309176db07a7d6a6240ef3",
+    "codex_version": "codex-cli 0.144.6",
+    "cross_slice_ledger": "tools/codex/app-server-evidence/0.144.6/a1-final-cross-slice-ledger.json",
+    "partition_report": {
+      "path": "tools/codex/app-server-evidence/0.144.6/a1-4-total-partition.json",
+      "sha256": "81e0ed3e4b1a9d089a2d39291bafe66d14ea44f4346ab8614b98605117f502ac"
+    },
+    "type_closure_report": {
+      "path": "tools/codex/app-server-evidence/0.144.6/a1-4-type-closure.json",
+      "sha256": "f2967c958d405a9658a9940f0bdc6b0570c956a0f0849f9764b4b8bbc3574631"
+    },
+    "upstream_source_commit": "5d1fbf26c43abc65a203928b2e31561cb039e06d",
+    "upstream_tag": "rust-v0.144.6"
+  },
+  "decision": {
+    "candidate_evaluation": [
+      {
+        "candidate": "one native implementation PR",
+        "decision": "rejected",
+        "reason": "mixes nine facade domains, reverse-request lifecycle, high-volume runtime events, platform behavior, and two union families"
+      },
+      {
+        "candidate": "two native implementation PRs",
+        "decision": "rejected",
+        "reason": "still forces either reverse-request lifecycle or runtime/platform behavior into the large user-facing integration review"
+      },
+      {
+        "candidate": "three native implementation PRs",
+        "decision": "selected",
+        "reason": "creates coherent schema/API/lifecycle review boundaries and every PR ends in an honest registry state"
+      },
+      {
+        "candidate": "more than three native PRs",
+        "decision": "rejected",
+        "reason": "fragments cohesive app/plugin/hook/skill or MCP schema families without another independent closure boundary"
+      }
+    ],
+    "selected_batches": [
+      "A14-UserIntegrations",
+      "A14-McpReverse",
+      "A14-RuntimePlatform"
+    ],
+    "selected_native_implementation_pr_count": 3,
+    "selection_factors": [
+      "domain cohesion",
+      "transitive schema and codec sharing",
+      "public facade ownership",
+      "server-request and notification lifecycle risk",
+      "API/ABI impact",
+      "test-corpus reviewability",
+      "honest independent registry closure"
+    ]
+  },
+  "final_a1_closure": {
+    "branch": "codex/a1-final-closure",
+    "commit_rule": "the pure closure commit follows the three production completion commits and contains no deferred runtime implementation",
+    "completion_stage": "final A1 closure in A1.4",
+    "draft_pr_title": "Close the Codex A1 typed surface and bump its SOVERSION",
+    "global_end": {
+      "Complete": 339,
+      "NotApplicable": 48,
+      "NotImplemented": 0,
+      "Partial": 0
+    },
+    "global_start": {
+      "Complete": 336,
+      "NotApplicable": 48,
+      "NotImplemented": 0,
+      "Partial": 3
+    },
+    "identities": [
+      {
+        "category": "client_notification",
+        "discriminator_field": "method",
+        "domain": "ClientNotification",
+        "name": "initialized"
+      },
+      {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "initialize"
+      },
+      {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "error"
+      }
+    ],
+    "identity_count": 3,
+    "native_a1_4_status": {
+      "Complete": 56,
+      "NotImplemented": 0,
+      "Partial": 0
+    },
+    "ordered_sequence": [
+      "implement initialize schema-complete lifecycle in place",
+      "implement initialized exact direction evidence in place",
+      "implement error canonical completeness in place",
+      "prove all 339 stable A1 identities Complete",
+      "capture final public API/ABI layout and symbol evidence",
+      "perform the scoped Codex SOVERSION 1 -> 2 action",
+      "rebuild installed consumers and source/binary packages",
+      "run the final A1 closure checker"
+    ],
+    "owner": "A1.0 / Common, unchanged"
+  },
+  "format_version": 1,
+  "generated_notice": "Generated implementation and final-A1 closure plan. Nothing in this report promotes production status.",
+  "identity_bijection": [
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "app/list"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/detect"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/import"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/import/readHistories"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "feedback/upload"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "hooks/list"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/add"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/remove"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/upgrade"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/oauth/login"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/resource/read"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/tool/call"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServerStatus/list"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/install"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/installed"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/list"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/read"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/checkout"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/delete"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/list"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/save"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/updateTargets"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/skill/read"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/uninstall"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/config/write"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/extraRoots/set"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/list"
+      }
+    },
+    {
+      "implementation_batch": "A14-RuntimePlatform",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "windowsSandbox/readiness"
+      }
+    },
+    {
+      "implementation_batch": "A14-RuntimePlatform",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "windowsSandbox/setupStart"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "app/list/updated"
+      }
+    },
+    {
+      "implementation_batch": "A14-RuntimePlatform",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "deprecationNotice"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "externalAgentConfig/import/completed"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "externalAgentConfig/import/progress"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "hook/completed"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "hook/started"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "mcpServer/oauthLogin/completed"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "mcpServer/startupStatus/updated"
+      }
+    },
+    {
+      "implementation_batch": "A14-RuntimePlatform",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "process/exited"
+      }
+    },
+    {
+      "implementation_batch": "A14-RuntimePlatform",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "process/outputDelta"
+      }
+    },
+    {
+      "implementation_batch": "A14-RuntimePlatform",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "remoteControl/status/changed"
+      }
+    },
+    {
+      "implementation_batch": "A14-RuntimePlatform",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "serverRequest/resolved"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "skills/changed"
+      }
+    },
+    {
+      "implementation_batch": "A14-RuntimePlatform",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "warning"
+      }
+    },
+    {
+      "implementation_batch": "A14-RuntimePlatform",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "windows/worldWritableWarning"
+      }
+    },
+    {
+      "implementation_batch": "A14-RuntimePlatform",
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "windowsSandbox/setupCompleted"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "attestation/generate"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "item/tool/call"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "item/tool/requestUserInput"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "mcpServer/elicitation/request"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "name": "form"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "name": "openai/form"
+      }
+    },
+    {
+      "implementation_batch": "A14-McpReverse",
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "name": "url"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "git"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "local"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "npm"
+      }
+    },
+    {
+      "implementation_batch": "A14-UserIntegrations",
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "remote"
+      }
+    }
+  ],
+  "implementation_batches": [
+    {
+      "api_abi_impact": "public headers, aggregates, facade symbols, and variants may grow; unchanged SONAME 1 is not a binary-compatibility claim",
+      "batch": "A14-UserIntegrations",
+      "branch": "codex/a1-4-user-integrations",
+      "client_result_kinds": {
+        "Concrete": 20,
+        "Unit": 3
+      },
+      "codec_units": [
+        "detail/AppCodec.{h,cpp}",
+        "detail/ExternalAgentCodec.{h,cpp}",
+        "detail/FeedbackCodec.{h,cpp}",
+        "detail/HookCodec.{h,cpp}",
+        "detail/MarketplaceCodec.{h,cpp}",
+        "detail/PluginCodec.{h,cpp}",
+        "detail/SkillCodec.{h,cpp}"
+      ],
+      "dependencies": [],
+      "descriptor_changes": [
+        "ClientOperationCodecDescriptors.inc",
+        "ServerNotificationCodecDescriptors.inc",
+        "IntegrationsAndLongTailUnionCodecDescriptors.inc"
+      ],
+      "draft_pr_title": "Type the Codex A1.4 user-facing integrations",
+      "global_metrics": {
+        "end": {
+          "Complete": 313,
+          "NotApplicable": 48,
+          "NotImplemented": 22,
+          "Partial": 4
+        },
+        "start": {
+          "Complete": 280,
+          "NotApplicable": 48,
+          "NotImplemented": 55,
+          "Partial": 4
+        }
+      },
+      "honest_closure_rule": "promote an identity only after its complete transitive types, codecs, descriptors, API, and tests are present in this PR",
+      "identities": [
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/AppsList",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "AppsListParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "app/list"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "AppsListResponse",
+            "result_type": "AppsListResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "app/list"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/ExternalAgentConfigDetect",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "ExternalAgentConfigDetectParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "externalAgentConfig/detect"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "ExternalAgentConfigDetectResponse",
+            "result_type": "ExternalAgentConfigDetectResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "externalAgentConfig/detect"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/ExternalAgentConfigImport",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "ExternalAgentConfigImportParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "externalAgentConfig/import"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "ExternalAgentConfigImportResponse",
+            "result_type": "ExternalAgentConfigImportResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "externalAgentConfig/import"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/ExternalAgentConfigImportHistoriesRead",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "Unit",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "externalAgentConfig/import/readHistories"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "ExternalAgentConfigImportHistoriesReadResponse",
+            "result_type": "ExternalAgentConfigImportHistoriesReadResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "externalAgentConfig/import/readHistories"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/FeedbackUpload",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "FeedbackUploadParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "feedback/upload"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "FeedbackUploadResponse",
+            "result_type": "FeedbackUploadResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "feedback/upload"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/HooksList",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "HooksListParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "hooks/list"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "HooksListResponse",
+            "result_type": "HooksListResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "hooks/list"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/MarketplaceAdd",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "MarketplaceAddParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "marketplace/add"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "MarketplaceAddResponse",
+            "result_type": "MarketplaceAddResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "marketplace/add"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/MarketplaceRemove",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "MarketplaceRemoveParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "marketplace/remove"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "MarketplaceRemoveResponse",
+            "result_type": "MarketplaceRemoveResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "marketplace/remove"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/MarketplaceUpgrade",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "MarketplaceUpgradeParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "marketplace/upgrade"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "MarketplaceUpgradeResponse",
+            "result_type": "MarketplaceUpgradeResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "marketplace/upgrade"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginInstall",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "PluginInstallParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "plugin/install"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "PluginInstallResponse",
+            "result_type": "PluginInstallResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/install"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginInstalled",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "PluginInstalledParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "plugin/installed"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "PluginInstalledResponse",
+            "result_type": "PluginInstalledResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/installed"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginList",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "PluginListParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "plugin/list"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "PluginListResponse",
+            "result_type": "PluginListResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/list"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginRead",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "PluginReadParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "plugin/read"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "PluginReadResponse",
+            "result_type": "PluginReadResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/read"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareCheckout",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "PluginShareCheckoutParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "plugin/share/checkout"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "PluginShareCheckoutResponse",
+            "result_type": "PluginShareCheckoutResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/checkout"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareDelete",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "PluginShareDeleteParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "plugin/share/delete"
+            },
+            "result_kind": "Unit",
+            "result_schema_type": "PluginShareDeleteResponse",
+            "result_type": "Unit"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/delete"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareList",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "PluginShareListParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "plugin/share/list"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "PluginShareListResponse",
+            "result_type": "PluginShareListResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/list"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareSave",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "PluginShareSaveParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "plugin/share/save"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "PluginShareSaveResponse",
+            "result_type": "PluginShareSaveResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/save"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareUpdateTargets",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "PluginShareUpdateTargetsParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "plugin/share/updateTargets"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "PluginShareUpdateTargetsResponse",
+            "result_type": "PluginShareUpdateTargetsResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/updateTargets"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginSkillRead",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "PluginSkillReadParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "plugin/skill/read"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "PluginSkillReadResponse",
+            "result_type": "PluginSkillReadResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/skill/read"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginUninstall",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "PluginUninstallParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "plugin/uninstall"
+            },
+            "result_kind": "Unit",
+            "result_schema_type": "PluginUninstallResponse",
+            "result_type": "Unit"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/uninstall"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/SkillsConfigWrite",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "SkillsConfigWriteParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "skills/config/write"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "SkillsConfigWriteResponse",
+            "result_type": "SkillsConfigWriteResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "skills/config/write"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/SkillsExtraRootsSet",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "SkillsExtraRootsSetParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "skills/extraRoots/set"
+            },
+            "result_kind": "Unit",
+            "result_schema_type": "SkillsExtraRootsSetResponse",
+            "result_type": "Unit"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "skills/extraRoots/set"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/SkillsList",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "SkillsListParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "skills/list"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "SkillsListResponse",
+            "result_type": "SkillsListResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "skills/list"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "app/list/updated"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "externalAgentConfig/import/completed"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "externalAgentConfig/import/progress"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "hook/completed"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "hook/started"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "skills/changed"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "OpaquePreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "type",
+            "domain": "PluginSource",
+            "name": "git"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "OpaquePreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "type",
+            "domain": "PluginSource",
+            "name": "local"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "OpaquePreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "type",
+            "domain": "PluginSource",
+            "name": "npm"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "OpaquePreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "type",
+            "domain": "PluginSource",
+            "name": "remote"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        }
+      ],
+      "identity_count": 33,
+      "lifecycle_tests": [],
+      "logical_commit_subjects": [
+        "Add Codex A1.4 integration public types",
+        "Implement Codex A1.4 integration codecs and facades",
+        "Close Codex A1.4 integration registry evidence"
+      ],
+      "native_metrics": {
+        "end": {
+          "Complete": 33,
+          "NotImplemented": 22,
+          "Partial": 1
+        },
+        "start": {
+          "Complete": 0,
+          "NotImplemented": 55,
+          "Partial": 1
+        }
+      },
+      "owned_public_headers": [
+        "ai/openai/codex/typed/Apps.h",
+        "ai/openai/codex/typed/ExternalAgents.h",
+        "ai/openai/codex/typed/Feedback.h",
+        "ai/openai/codex/typed/Hooks.h",
+        "ai/openai/codex/typed/Marketplace.h",
+        "ai/openai/codex/typed/Plugins.h",
+        "ai/openai/codex/typed/Skills.h"
+      ],
+      "owned_start_status": {
+        "NotImplemented": 33
+      },
+      "package_tests": [
+        "public headers are self-contained",
+        "installed consumer compiles and links",
+        "source archive retains implementation evidence",
+        "binary archive excludes private evidence"
+      ],
+      "primary_owned_schema_definitions": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppBranding",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppInfo",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppListUpdatedNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppMetadata",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppReview",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppScreenshot",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppSummary",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppTemplateSummary",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppTemplateUnavailableReason",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppsListParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppsListResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "CommandMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigDetectParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigDetectResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigImportCompletedNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigImportHistoriesReadResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigImportHistory",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigImportItemTypeFailure",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigImportItemTypeSuccess",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigImportParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigImportProgressNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigImportResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigImportTypeResult",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigMigrationItem",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigMigrationItemType",
+          "namespace": "v2"
+        },
+        {
+          "name": "FeedbackUploadParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "FeedbackUploadResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookCompletedNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookErrorInfo",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookEventName",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookExecutionMode",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookHandlerType",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookMetadata",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookOutputEntry",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookOutputEntryKind",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookRunStatus",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookRunSummary",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookScope",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookSource",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookStartedNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookTrustStatus",
+          "namespace": "v2"
+        },
+        {
+          "name": "HooksListEntry",
+          "namespace": "v2"
+        },
+        {
+          "name": "HooksListParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "HooksListResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "MarketplaceAddParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "MarketplaceAddResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "MarketplaceInterface",
+          "namespace": "v2"
+        },
+        {
+          "name": "MarketplaceLoadErrorInfo",
+          "namespace": "v2"
+        },
+        {
+          "name": "MarketplaceRemoveParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "MarketplaceRemoveResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "MarketplaceUpgradeErrorInfo",
+          "namespace": "v2"
+        },
+        {
+          "name": "MarketplaceUpgradeParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "MarketplaceUpgradeResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "MigrationDetails",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginAuthPolicy",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginAvailability",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginDetail",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginHookSummary",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginInstallParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginInstallPolicy",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginInstallPolicySource",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginInstallResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginInstalledParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginInstalledResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginInterface",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginListMarketplaceKind",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginListParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginListResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginMarketplaceEntry",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginReadParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginReadResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareCheckoutParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareCheckoutResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareContext",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareDeleteParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareDeleteResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareDiscoverability",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareListItem",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareListParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareListResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSharePrincipal",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSharePrincipalRole",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSharePrincipalType",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareSaveParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareSaveResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareTarget",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareTargetRole",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareUpdateDiscoverability",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareUpdateTargetsParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareUpdateTargetsResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSkillReadParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSkillReadResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSource",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSummary",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginUninstallParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginUninstallResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginsMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "SessionMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillDependencies",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillErrorInfo",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillInterface",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillMetadata",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillScope",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillSummary",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillToolDependency",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillsChangedNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillsConfigWriteParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillsConfigWriteResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillsExtraRootsSetParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillsExtraRootsSetResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillsListEntry",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillsListParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillsListResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "SubagentMigration",
+          "namespace": "v2"
+        }
+      ],
+      "primary_tests": [
+        "CodexA14UserIntegrationsCodecTest",
+        "CodexA14UserIntegrationsWireTest",
+        "CodexA14UserIntegrationsFacadeTest",
+        "CodexA14PluginSourceUnionTest"
+      ],
+      "proposed_facades_and_channels": [
+        "Apps",
+        "ExternalAgents",
+        "Feedback",
+        "Hooks",
+        "Marketplace",
+        "Plugins",
+        "Skills"
+      ],
+      "registry_promotions": [
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "app/list"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "externalAgentConfig/detect"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "externalAgentConfig/import"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "externalAgentConfig/import/readHistories"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "feedback/upload"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "hooks/list"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "marketplace/add"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "marketplace/remove"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "marketplace/upgrade"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/install"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/installed"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/list"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/read"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/checkout"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/delete"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/list"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/save"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/updateTargets"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/skill/read"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/uninstall"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "skills/config/write"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "skills/extraRoots/set"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "skills/list"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "app/list/updated"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "externalAgentConfig/import/completed"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "externalAgentConfig/import/progress"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "hook/completed"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "hook/started"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "skills/changed"
+        },
+        {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "git"
+        },
+        {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "local"
+        },
+        {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "npm"
+        },
+        {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "remote"
+        }
+      ],
+      "reused_schema_dependencies": [],
+      "schema_closure": {
+        "counts": {
+          "default_bearing_paths": 19,
+          "definition_namespaces": {
+            "v2": 118
+          },
+          "nullable_paths": 141,
+          "object_nodes": 103,
+          "opaque_json_paths": 0,
+          "optional_paths": 163,
+          "reachable_named_definitions": 118,
+          "required_paths": 176,
+          "schema_path_kinds": {
+            "array_element": 68,
+            "map_value": 4,
+            "property": 339
+          },
+          "schema_paths": 411,
+          "seed_definitions": 52,
+          "sensitive_paths": 66
+        },
+        "reachable_definitions": [
+          {
+            "name": "AbsolutePathBuf",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppBranding",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppInfo",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppListUpdatedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppMetadata",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppReview",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppScreenshot",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppSummary",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppTemplateSummary",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppTemplateUnavailableReason",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppsListParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppsListResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "CommandMigration",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigDetectParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigDetectResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportCompletedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportHistoriesReadResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportHistory",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportItemTypeFailure",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportItemTypeSuccess",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportProgressNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportTypeResult",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigMigrationItem",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigMigrationItemType",
+            "namespace": "v2"
+          },
+          {
+            "name": "FeedbackUploadParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "FeedbackUploadResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookCompletedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookErrorInfo",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookEventName",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookExecutionMode",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookHandlerType",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookMetadata",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookMigration",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookOutputEntry",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookOutputEntryKind",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookRunStatus",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookRunSummary",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookScope",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookSource",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookStartedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookTrustStatus",
+            "namespace": "v2"
+          },
+          {
+            "name": "HooksListEntry",
+            "namespace": "v2"
+          },
+          {
+            "name": "HooksListParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "HooksListResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceAddParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceAddResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceInterface",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceLoadErrorInfo",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceRemoveParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceRemoveResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceUpgradeErrorInfo",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceUpgradeParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceUpgradeResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerMigration",
+            "namespace": "v2"
+          },
+          {
+            "name": "MigrationDetails",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginAuthPolicy",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginAvailability",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginDetail",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginHookSummary",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginInstallParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginInstallPolicy",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginInstallPolicySource",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginInstallResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginInstalledParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginInstalledResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginInterface",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginListMarketplaceKind",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginListParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginListResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginMarketplaceEntry",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginReadParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginReadResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareCheckoutParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareCheckoutResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareContext",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareDeleteParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareDeleteResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareDiscoverability",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareListItem",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareListParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareListResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginSharePrincipal",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginSharePrincipalRole",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginSharePrincipalType",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareSaveParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareSaveResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareTarget",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareTargetRole",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareUpdateDiscoverability",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareUpdateTargetsParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareUpdateTargetsResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginSkillReadParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginSkillReadResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginSource",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginSummary",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginUninstallParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginUninstallResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginsMigration",
+            "namespace": "v2"
+          },
+          {
+            "name": "SessionMigration",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillDependencies",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillErrorInfo",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillInterface",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillMetadata",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillMigration",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillScope",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillSummary",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillToolDependency",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsChangedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsConfigWriteParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsConfigWriteResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsExtraRootsSetParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsExtraRootsSetResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsListEntry",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsListParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsListResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "SubagentMigration",
+            "namespace": "v2"
+          }
+        ],
+        "seed_definitions": [
+          {
+            "name": "AppListUpdatedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppsListParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "AppsListResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigDetectParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigDetectResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportCompletedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportHistoriesReadResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportProgressNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "ExternalAgentConfigImportResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "FeedbackUploadParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "FeedbackUploadResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookCompletedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "HookStartedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "HooksListParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "HooksListResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceAddParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceAddResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceRemoveParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceRemoveResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceUpgradeParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "MarketplaceUpgradeResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginInstallParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginInstallResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginInstalledParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginInstalledResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginListParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginListResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginReadParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginReadResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareCheckoutParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareCheckoutResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareDeleteParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareDeleteResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareListParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareListResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareSaveParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareSaveResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareUpdateTargetsParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginShareUpdateTargetsResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginSkillReadParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginSkillReadResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginSource",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginUninstallParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "PluginUninstallResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsChangedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsConfigWriteParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsConfigWriteResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsExtraRootsSetParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsExtraRootsSetResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsListParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "SkillsListResponse",
+            "namespace": "v2"
+          }
+        ],
+        "sensitive_schema_paths": [
+          {
+            "definition": {
+              "name": "AppInfo",
+              "namespace": "v2"
+            },
+            "field": "id",
+            "schema_path": "#/definitions/v2/AppInfo/properties/id",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "AppInfo",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/AppInfo/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "AppListUpdatedNotification",
+              "namespace": "v2"
+            },
+            "field": "data",
+            "schema_path": "#/definitions/v2/AppListUpdatedNotification/properties/data",
+            "value_kind": "array"
+          },
+          {
+            "definition": {
+              "name": "AppScreenshot",
+              "namespace": "v2"
+            },
+            "field": "url",
+            "schema_path": "#/definitions/v2/AppScreenshot/properties/url",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "AppSummary",
+              "namespace": "v2"
+            },
+            "field": "id",
+            "schema_path": "#/definitions/v2/AppSummary/properties/id",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "AppSummary",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/AppSummary/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "AppTemplateSummary",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/AppTemplateSummary/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "AppTemplateSummary",
+              "namespace": "v2"
+            },
+            "field": "reason",
+            "schema_path": "#/definitions/v2/AppTemplateSummary/properties/reason",
+            "value_kind": "union"
+          },
+          {
+            "definition": {
+              "name": "AppsListParams",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/AppsListParams/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "AppsListResponse",
+              "namespace": "v2"
+            },
+            "field": "data",
+            "schema_path": "#/definitions/v2/AppsListResponse/properties/data",
+            "value_kind": "array"
+          },
+          {
+            "definition": {
+              "name": "CommandMigration",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/CommandMigration/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ExternalAgentConfigImportHistoriesReadResponse",
+              "namespace": "v2"
+            },
+            "field": "data",
+            "schema_path": "#/definitions/v2/ExternalAgentConfigImportHistoriesReadResponse/properties/data",
+            "value_kind": "array"
+          },
+          {
+            "definition": {
+              "name": "ExternalAgentConfigImportItemTypeFailure",
+              "namespace": "v2"
+            },
+            "field": "cwd",
+            "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeFailure/properties/cwd",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ExternalAgentConfigImportItemTypeFailure",
+              "namespace": "v2"
+            },
+            "field": "message",
+            "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeFailure/properties/message",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ExternalAgentConfigImportItemTypeFailure",
+              "namespace": "v2"
+            },
+            "field": "source",
+            "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeFailure/properties/source",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ExternalAgentConfigImportItemTypeSuccess",
+              "namespace": "v2"
+            },
+            "field": "cwd",
+            "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeSuccess/properties/cwd",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ExternalAgentConfigImportItemTypeSuccess",
+              "namespace": "v2"
+            },
+            "field": "source",
+            "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeSuccess/properties/source",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ExternalAgentConfigImportItemTypeSuccess",
+              "namespace": "v2"
+            },
+            "field": "target",
+            "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeSuccess/properties/target",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ExternalAgentConfigImportParams",
+              "namespace": "v2"
+            },
+            "field": "source",
+            "schema_path": "#/definitions/v2/ExternalAgentConfigImportParams/properties/source",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ExternalAgentConfigMigrationItem",
+              "namespace": "v2"
+            },
+            "field": "cwd",
+            "schema_path": "#/definitions/v2/ExternalAgentConfigMigrationItem/properties/cwd",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "FeedbackUploadParams",
+              "namespace": "v2"
+            },
+            "field": "reason",
+            "schema_path": "#/definitions/v2/FeedbackUploadParams/properties/reason",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "FeedbackUploadParams",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/FeedbackUploadParams/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "FeedbackUploadResponse",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/FeedbackUploadResponse/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "HookCompletedNotification",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/HookCompletedNotification/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "HookCompletedNotification",
+              "namespace": "v2"
+            },
+            "field": "turnId",
+            "schema_path": "#/definitions/v2/HookCompletedNotification/properties/turnId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "HookErrorInfo",
+              "namespace": "v2"
+            },
+            "field": "message",
+            "schema_path": "#/definitions/v2/HookErrorInfo/properties/message",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "HookErrorInfo",
+              "namespace": "v2"
+            },
+            "field": "path",
+            "schema_path": "#/definitions/v2/HookErrorInfo/properties/path",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "HookMetadata",
+              "namespace": "v2"
+            },
+            "field": "source",
+            "schema_path": "#/definitions/v2/HookMetadata/properties/source",
+            "value_kind": "reference"
+          },
+          {
+            "definition": {
+              "name": "HookMigration",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/HookMigration/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "HookRunSummary",
+              "namespace": "v2"
+            },
+            "field": "id",
+            "schema_path": "#/definitions/v2/HookRunSummary/properties/id",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "HookRunSummary",
+              "namespace": "v2"
+            },
+            "field": "source",
+            "schema_path": "#/definitions/v2/HookRunSummary/properties/source",
+            "value_kind": "reference"
+          },
+          {
+            "definition": {
+              "name": "HookStartedNotification",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/HookStartedNotification/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "HookStartedNotification",
+              "namespace": "v2"
+            },
+            "field": "turnId",
+            "schema_path": "#/definitions/v2/HookStartedNotification/properties/turnId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "HooksListEntry",
+              "namespace": "v2"
+            },
+            "field": "cwd",
+            "schema_path": "#/definitions/v2/HooksListEntry/properties/cwd",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "HooksListResponse",
+              "namespace": "v2"
+            },
+            "field": "data",
+            "schema_path": "#/definitions/v2/HooksListResponse/properties/data",
+            "value_kind": "array"
+          },
+          {
+            "definition": {
+              "name": "MarketplaceAddParams",
+              "namespace": "v2"
+            },
+            "field": "source",
+            "schema_path": "#/definitions/v2/MarketplaceAddParams/properties/source",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "MarketplaceLoadErrorInfo",
+              "namespace": "v2"
+            },
+            "field": "message",
+            "schema_path": "#/definitions/v2/MarketplaceLoadErrorInfo/properties/message",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "MarketplaceUpgradeErrorInfo",
+              "namespace": "v2"
+            },
+            "field": "message",
+            "schema_path": "#/definitions/v2/MarketplaceUpgradeErrorInfo/properties/message",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerMigration",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/McpServerMigration/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "PluginDetail",
+              "namespace": "v2"
+            },
+            "field": "apps",
+            "schema_path": "#/definitions/v2/PluginDetail/properties/apps",
+            "value_kind": "array"
+          },
+          {
+            "definition": {
+              "name": "PluginMarketplaceEntry",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/PluginMarketplaceEntry/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "PluginMarketplaceEntry",
+              "namespace": "v2"
+            },
+            "field": "path",
+            "schema_path": "#/definitions/v2/PluginMarketplaceEntry/properties/path",
+            "value_kind": "union"
+          },
+          {
+            "definition": {
+              "name": "PluginShareListResponse",
+              "namespace": "v2"
+            },
+            "field": "data",
+            "schema_path": "#/definitions/v2/PluginShareListResponse/properties/data",
+            "value_kind": "array"
+          },
+          {
+            "definition": {
+              "name": "PluginSharePrincipal",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/PluginSharePrincipal/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "PluginSource",
+              "namespace": "v2"
+            },
+            "field": "path",
+            "schema_path": "#/definitions/v2/PluginSource/oneOf/0/properties/path",
+            "value_kind": "reference"
+          },
+          {
+            "definition": {
+              "name": "PluginSource",
+              "namespace": "v2"
+            },
+            "field": "path",
+            "schema_path": "#/definitions/v2/PluginSource/oneOf/1/properties/path",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "PluginSource",
+              "namespace": "v2"
+            },
+            "field": "url",
+            "schema_path": "#/definitions/v2/PluginSource/oneOf/1/properties/url",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "PluginSummary",
+              "namespace": "v2"
+            },
+            "field": "id",
+            "schema_path": "#/definitions/v2/PluginSummary/properties/id",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "PluginSummary",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/PluginSummary/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "PluginSummary",
+              "namespace": "v2"
+            },
+            "field": "source",
+            "schema_path": "#/definitions/v2/PluginSummary/properties/source",
+            "value_kind": "reference"
+          },
+          {
+            "definition": {
+              "name": "SessionMigration",
+              "namespace": "v2"
+            },
+            "field": "cwd",
+            "schema_path": "#/definitions/v2/SessionMigration/properties/cwd",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "SessionMigration",
+              "namespace": "v2"
+            },
+            "field": "path",
+            "schema_path": "#/definitions/v2/SessionMigration/properties/path",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "SkillErrorInfo",
+              "namespace": "v2"
+            },
+            "field": "message",
+            "schema_path": "#/definitions/v2/SkillErrorInfo/properties/message",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "SkillErrorInfo",
+              "namespace": "v2"
+            },
+            "field": "path",
+            "schema_path": "#/definitions/v2/SkillErrorInfo/properties/path",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "SkillMetadata",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/SkillMetadata/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "SkillMetadata",
+              "namespace": "v2"
+            },
+            "field": "path",
+            "schema_path": "#/definitions/v2/SkillMetadata/properties/path",
+            "value_kind": "reference"
+          },
+          {
+            "definition": {
+              "name": "SkillMigration",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/SkillMigration/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "SkillSummary",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/SkillSummary/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "SkillSummary",
+              "namespace": "v2"
+            },
+            "field": "path",
+            "schema_path": "#/definitions/v2/SkillSummary/properties/path",
+            "value_kind": "union"
+          },
+          {
+            "definition": {
+              "name": "SkillToolDependency",
+              "namespace": "v2"
+            },
+            "field": "url",
+            "schema_path": "#/definitions/v2/SkillToolDependency/properties/url",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "SkillToolDependency",
+              "namespace": "v2"
+            },
+            "field": "value",
+            "schema_path": "#/definitions/v2/SkillToolDependency/properties/value",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "SkillsConfigWriteParams",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/SkillsConfigWriteParams/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "SkillsConfigWriteParams",
+              "namespace": "v2"
+            },
+            "field": "path",
+            "schema_path": "#/definitions/v2/SkillsConfigWriteParams/properties/path",
+            "value_kind": "union"
+          },
+          {
+            "definition": {
+              "name": "SkillsListEntry",
+              "namespace": "v2"
+            },
+            "field": "cwd",
+            "schema_path": "#/definitions/v2/SkillsListEntry/properties/cwd",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "SkillsListResponse",
+              "namespace": "v2"
+            },
+            "field": "data",
+            "schema_path": "#/definitions/v2/SkillsListResponse/properties/data",
+            "value_kind": "array"
+          },
+          {
+            "definition": {
+              "name": "SubagentMigration",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/SubagentMigration/properties/name",
+            "value_kind": "string"
+          }
+        ]
+      },
+      "security_obligations": [
+        "redact every listed sensitive schema path and every raw/opaque JSON value",
+        "diagnostics may contain only method, schema path, expected type, and safe counts",
+        "fixtures use synthetic IDs, /synthetic paths, example.invalid URLs, and fake tokens"
+      ],
+      "taxonomy": {
+        "client_request": 23,
+        "server_notification": 6,
+        "server_request": 0,
+        "tagged_union_discriminator": 4
+      }
+    },
+    {
+      "api_abi_impact": "public headers, aggregates, facade symbols, and variants may grow; unchanged SONAME 1 is not a binary-compatibility claim",
+      "batch": "A14-McpReverse",
+      "branch": "codex/a1-4-mcp-reverse-requests",
+      "client_result_kinds": {
+        "Concrete": 4,
+        "Unit": 0
+      },
+      "codec_units": [
+        "detail/McpCodec.{h,cpp}",
+        "detail/AttestationCodec.{h,cpp}",
+        "detail/DynamicToolCodec.{h,cpp}",
+        "detail/UserInputRequestCodec.{h,cpp}",
+        "detail/McpElicitationCodec.{h,cpp}",
+        "detail/ServerRequestDecoder.cpp"
+      ],
+      "dependencies": [
+        "A14-UserIntegrations"
+      ],
+      "descriptor_changes": [
+        "ClientOperationCodecDescriptors.inc",
+        "ServerNotificationCodecDescriptors.inc",
+        "ServerRequestCodecDescriptors.inc",
+        "IntegrationsAndLongTailUnionCodecDescriptors.inc"
+      ],
+      "draft_pr_title": "Type the Codex A1.4 MCP and reverse requests",
+      "global_metrics": {
+        "end": {
+          "Complete": 326,
+          "NotApplicable": 48,
+          "NotImplemented": 10,
+          "Partial": 3
+        },
+        "start": {
+          "Complete": 313,
+          "NotApplicable": 48,
+          "NotImplemented": 22,
+          "Partial": 4
+        }
+      },
+      "honest_closure_rule": "promote an identity only after its complete transitive types, codecs, descriptors, API, and tests are present in this PR",
+      "identities": [
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpServerOauthLogin",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "McpServerOauthLoginParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "mcpServer/oauth/login"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "McpServerOauthLoginResponse",
+            "result_type": "McpServerOauthLoginResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServer/oauth/login"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpResourceRead",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "McpResourceReadParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "mcpServer/resource/read"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "McpResourceReadResponse",
+            "result_type": "McpResourceReadResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServer/resource/read"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpServerToolCall",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "McpServerToolCallParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "mcpServer/tool/call"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "McpServerToolCallResponse",
+            "result_type": "McpServerToolCallResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServer/tool/call"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpServerStatusList",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "ListMcpServerStatusParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "mcpServerStatus/list"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "ListMcpServerStatusResponse",
+            "result_type": "ListMcpServerStatusResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServerStatus/list"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "mcpServer/oauthLogin/completed"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "mcpServer/startupStatus/updated"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "stable/ServerRequest.json#/oneOf/7+stable/AttestationGenerateResponse.json",
+            "association_evidence_kind": "VendoredSchemaPair",
+            "cross_check_evidence": [
+              {
+                "agrees": true,
+                "key": "codex-rs/app-server-protocol/src/protocol/common.rs#server_request_definitions!/AttestationGenerate",
+                "kind": "VendoredRust",
+                "parameter_type_identity": "AttestationGenerateParams",
+                "result_contract_kind": "Concrete",
+                "result_schema_type_identity": "AttestationGenerateResponse",
+                "result_type_identity": "AttestationGenerateResponse"
+              }
+            ],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": true,
+            "parameter_type": "AttestationGenerateParams",
+            "protocol_surface_key": {
+              "category": "server_request",
+              "discriminator_field": "method",
+              "domain": "ServerRequest",
+              "name": "attestation/generate"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "AttestationGenerateResponse",
+            "result_type": "AttestationGenerateResponse"
+          },
+          "protocol_surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "attestation/generate"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "stable/ServerRequest.json#/oneOf/5+stable/DynamicToolCallResponse.json",
+            "association_evidence_kind": "VendoredSchemaPair",
+            "cross_check_evidence": [
+              {
+                "agrees": true,
+                "key": "codex-rs/app-server-protocol/src/protocol/common.rs#server_request_definitions!/DynamicToolCall",
+                "kind": "VendoredRust",
+                "parameter_type_identity": "DynamicToolCallParams",
+                "result_contract_kind": "Concrete",
+                "result_schema_type_identity": "DynamicToolCallResponse",
+                "result_type_identity": "DynamicToolCallResponse"
+              }
+            ],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": true,
+            "parameter_type": "DynamicToolCallParams",
+            "protocol_surface_key": {
+              "category": "server_request",
+              "discriminator_field": "method",
+              "domain": "ServerRequest",
+              "name": "item/tool/call"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "DynamicToolCallResponse",
+            "result_type": "DynamicToolCallResponse"
+          },
+          "protocol_surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "item/tool/call"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Typed",
+          "current_status": "Partial",
+          "operation_contract": {
+            "association_evidence_key": "stable/ServerRequest.json#/oneOf/2+stable/ToolRequestUserInputResponse.json",
+            "association_evidence_kind": "VendoredSchemaPair",
+            "cross_check_evidence": [
+              {
+                "agrees": true,
+                "key": "codex-rs/app-server-protocol/src/protocol/common.rs#server_request_definitions!/ToolRequestUserInput",
+                "kind": "VendoredRust",
+                "parameter_type_identity": "ToolRequestUserInputParams",
+                "result_contract_kind": "Concrete",
+                "result_schema_type_identity": "ToolRequestUserInputResponse",
+                "result_type_identity": "ToolRequestUserInputResponse"
+              }
+            ],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": true,
+            "parameter_type": "ToolRequestUserInputParams",
+            "protocol_surface_key": {
+              "category": "server_request",
+              "discriminator_field": "method",
+              "domain": "ServerRequest",
+              "name": "item/tool/requestUserInput"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "ToolRequestUserInputResponse",
+            "result_type": "ToolRequestUserInputResponse"
+          },
+          "protocol_surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "item/tool/requestUserInput"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "stable/ServerRequest.json#/oneOf/3+stable/McpServerElicitationRequestResponse.json",
+            "association_evidence_kind": "VendoredSchemaPair",
+            "cross_check_evidence": [
+              {
+                "agrees": true,
+                "key": "codex-rs/app-server-protocol/src/protocol/common.rs#server_request_definitions!/McpServerElicitationRequest",
+                "kind": "VendoredRust",
+                "parameter_type_identity": "McpServerElicitationRequestParams",
+                "result_contract_kind": "Concrete",
+                "result_schema_type_identity": "McpServerElicitationRequestResponse",
+                "result_type_identity": "McpServerElicitationRequestResponse"
+              }
+            ],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": true,
+            "parameter_type": "McpServerElicitationRequestParams",
+            "protocol_surface_key": {
+              "category": "server_request",
+              "discriminator_field": "method",
+              "domain": "ServerRequest",
+              "name": "mcpServer/elicitation/request"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "McpServerElicitationRequestResponse",
+            "result_type": "McpServerElicitationRequestResponse"
+          },
+          "protocol_surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "mcpServer/elicitation/request"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "OpaquePreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "mode",
+            "domain": "McpServerElicitationRequestParams",
+            "name": "form"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "OpaquePreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "mode",
+            "domain": "McpServerElicitationRequestParams",
+            "name": "openai/form"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "OpaquePreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "mode",
+            "domain": "McpServerElicitationRequestParams",
+            "name": "url"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        }
+      ],
+      "identity_count": 13,
+      "lifecycle_tests": [
+        "all nine A1.3/A1.4 typed requests concurrent and out of order",
+        "original request ID, one-shot token, generation and reconnect isolation"
+      ],
+      "logical_commit_subjects": [
+        "Add Codex A1.4 MCP and reverse-request public types",
+        "Implement Codex A1.4 MCP and reverse-request codecs",
+        "Close Codex A1.4 MCP and reverse-request registry evidence"
+      ],
+      "native_metrics": {
+        "end": {
+          "Complete": 46,
+          "NotImplemented": 10,
+          "Partial": 0
+        },
+        "start": {
+          "Complete": 33,
+          "NotImplemented": 22,
+          "Partial": 1
+        }
+      },
+      "owned_public_headers": [
+        "ai/openai/codex/typed/Mcp.h",
+        "ai/openai/codex/typed/ServerRequests.h"
+      ],
+      "owned_start_status": {
+        "NotImplemented": 12,
+        "Partial": 1
+      },
+      "package_tests": [
+        "public headers are self-contained",
+        "installed consumer compiles and links",
+        "source archive retains implementation evidence",
+        "binary archive excludes private evidence"
+      ],
+      "primary_owned_schema_definitions": [
+        {
+          "name": "AttestationGenerateParams",
+          "namespace": "legacy"
+        },
+        {
+          "name": "AttestationGenerateResponse",
+          "namespace": "legacy"
+        },
+        {
+          "name": "DynamicToolCallParams",
+          "namespace": "legacy"
+        },
+        {
+          "name": "DynamicToolCallResponse",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationArrayType",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationBooleanSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationBooleanType",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationConstOption",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationLegacyTitledEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationMultiSelectEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationNumberSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationNumberType",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationObjectType",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationPrimitiveSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationSingleSelectEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationStringFormat",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationStringSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationStringType",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationTitledEnumItems",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationTitledMultiSelectEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationTitledSingleSelectEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationUntitledEnumItems",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationUntitledMultiSelectEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationUntitledSingleSelectEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpServerElicitationAction",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpServerElicitationRequestParams",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpServerElicitationRequestResponse",
+          "namespace": "legacy"
+        },
+        {
+          "name": "ToolRequestUserInputAnswer",
+          "namespace": "legacy"
+        },
+        {
+          "name": "ToolRequestUserInputOption",
+          "namespace": "legacy"
+        },
+        {
+          "name": "ToolRequestUserInputParams",
+          "namespace": "legacy"
+        },
+        {
+          "name": "ToolRequestUserInputQuestion",
+          "namespace": "legacy"
+        },
+        {
+          "name": "ToolRequestUserInputResponse",
+          "namespace": "legacy"
+        },
+        {
+          "name": "DynamicToolCallOutputContentItem",
+          "namespace": "v2"
+        },
+        {
+          "name": "ListMcpServerStatusParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "ListMcpServerStatusResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpAuthStatus",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpResourceReadParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpResourceReadResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerInfo",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerOauthLoginCompletedNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerOauthLoginParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerOauthLoginResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerStartupFailureReason",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerStartupState",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerStatus",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerStatusDetail",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerStatusUpdatedNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerToolCallParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerToolCallResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "Resource",
+          "namespace": "v2"
+        },
+        {
+          "name": "ResourceContent",
+          "namespace": "v2"
+        },
+        {
+          "name": "ResourceTemplate",
+          "namespace": "v2"
+        },
+        {
+          "name": "Tool",
+          "namespace": "v2"
+        }
+      ],
+      "primary_tests": [
+        "CodexA14McpCodecTest",
+        "CodexA14McpWireTest",
+        "CodexA14ReverseRequestCodecTest",
+        "CodexA14ReverseRequestWireTest",
+        "CodexA14UserInputCompatibilityTest",
+        "CodexA14McpElicitationUnionTest"
+      ],
+      "proposed_facades_and_channels": [
+        "Mcp",
+        "Requests",
+        "Events"
+      ],
+      "registry_promotions": [
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServer/oauth/login"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServer/resource/read"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServer/tool/call"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServerStatus/list"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "mcpServer/oauthLogin/completed"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "mcpServer/startupStatus/updated"
+        },
+        {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "attestation/generate"
+        },
+        {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "item/tool/call"
+        },
+        {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "item/tool/requestUserInput"
+        },
+        {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "mcpServer/elicitation/request"
+        },
+        {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "mode",
+          "domain": "McpServerElicitationRequestParams",
+          "name": "form"
+        },
+        {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "mode",
+          "domain": "McpServerElicitationRequestParams",
+          "name": "openai/form"
+        },
+        {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "mode",
+          "domain": "McpServerElicitationRequestParams",
+          "name": "url"
+        }
+      ],
+      "reused_schema_dependencies": [],
+      "schema_closure": {
+        "counts": {
+          "default_bearing_paths": 3,
+          "definition_namespaces": {
+            "legacy": 34,
+            "v2": 21
+          },
+          "nullable_paths": 97,
+          "object_nodes": 48,
+          "opaque_json_paths": 24,
+          "optional_paths": 92,
+          "reachable_named_definitions": 55,
+          "required_paths": 87,
+          "schema_path_kinds": {
+            "array_element": 22,
+            "map_value": 3,
+            "property": 179
+          },
+          "schema_paths": 204,
+          "seed_definitions": 18,
+          "sensitive_paths": 53
+        },
+        "reachable_definitions": [
+          {
+            "name": "AttestationGenerateParams",
+            "namespace": "legacy"
+          },
+          {
+            "name": "AttestationGenerateResponse",
+            "namespace": "legacy"
+          },
+          {
+            "name": "DynamicToolCallParams",
+            "namespace": "legacy"
+          },
+          {
+            "name": "DynamicToolCallResponse",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationArrayType",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationBooleanSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationBooleanType",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationConstOption",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationEnumSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationLegacyTitledEnumSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationMultiSelectEnumSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationNumberSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationNumberType",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationObjectType",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationPrimitiveSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationSingleSelectEnumSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationStringFormat",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationStringSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationStringType",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationTitledEnumItems",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationTitledMultiSelectEnumSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationTitledSingleSelectEnumSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationUntitledEnumItems",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationUntitledMultiSelectEnumSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpElicitationUntitledSingleSelectEnumSchema",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpServerElicitationAction",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpServerElicitationRequestParams",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpServerElicitationRequestResponse",
+            "namespace": "legacy"
+          },
+          {
+            "name": "ToolRequestUserInputAnswer",
+            "namespace": "legacy"
+          },
+          {
+            "name": "ToolRequestUserInputOption",
+            "namespace": "legacy"
+          },
+          {
+            "name": "ToolRequestUserInputParams",
+            "namespace": "legacy"
+          },
+          {
+            "name": "ToolRequestUserInputQuestion",
+            "namespace": "legacy"
+          },
+          {
+            "name": "ToolRequestUserInputResponse",
+            "namespace": "legacy"
+          },
+          {
+            "name": "DynamicToolCallOutputContentItem",
+            "namespace": "v2"
+          },
+          {
+            "name": "ListMcpServerStatusParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "ListMcpServerStatusResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpAuthStatus",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpResourceReadParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpResourceReadResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerInfo",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerOauthLoginCompletedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerOauthLoginParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerOauthLoginResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerStartupFailureReason",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerStartupState",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerStatus",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerStatusDetail",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerStatusUpdatedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerToolCallParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerToolCallResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "Resource",
+            "namespace": "v2"
+          },
+          {
+            "name": "ResourceContent",
+            "namespace": "v2"
+          },
+          {
+            "name": "ResourceTemplate",
+            "namespace": "v2"
+          },
+          {
+            "name": "Tool",
+            "namespace": "v2"
+          }
+        ],
+        "seed_definitions": [
+          {
+            "name": "AttestationGenerateParams",
+            "namespace": "legacy"
+          },
+          {
+            "name": "AttestationGenerateResponse",
+            "namespace": "legacy"
+          },
+          {
+            "name": "DynamicToolCallParams",
+            "namespace": "legacy"
+          },
+          {
+            "name": "DynamicToolCallResponse",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpServerElicitationRequestParams",
+            "namespace": "legacy"
+          },
+          {
+            "name": "McpServerElicitationRequestResponse",
+            "namespace": "legacy"
+          },
+          {
+            "name": "ToolRequestUserInputParams",
+            "namespace": "legacy"
+          },
+          {
+            "name": "ToolRequestUserInputResponse",
+            "namespace": "legacy"
+          },
+          {
+            "name": "ListMcpServerStatusParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "ListMcpServerStatusResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpResourceReadParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpResourceReadResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerOauthLoginCompletedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerOauthLoginParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerOauthLoginResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerStatusUpdatedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerToolCallParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "McpServerToolCallResponse",
+            "namespace": "v2"
+          }
+        ],
+        "sensitive_schema_paths": [
+          {
+            "definition": {
+              "name": "AttestationGenerateResponse",
+              "namespace": "legacy"
+            },
+            "field": "token",
+            "schema_path": "#/definitions/AttestationGenerateResponse/properties/token",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "DynamicToolCallParams",
+              "namespace": "legacy"
+            },
+            "field": "arguments",
+            "schema_path": "#/definitions/DynamicToolCallParams/properties/arguments",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "DynamicToolCallParams",
+              "namespace": "legacy"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/DynamicToolCallParams/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "DynamicToolCallParams",
+              "namespace": "legacy"
+            },
+            "field": "tool",
+            "schema_path": "#/definitions/DynamicToolCallParams/properties/tool",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "DynamicToolCallParams",
+              "namespace": "legacy"
+            },
+            "field": "turnId",
+            "schema_path": "#/definitions/DynamicToolCallParams/properties/turnId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "serverName",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/properties/serverName",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "turnId",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/properties/turnId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "_meta",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/0/properties/_meta",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "message",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/0/properties/message",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "requestedSchema",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/0/properties/requestedSchema",
+            "value_kind": "reference"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "_meta",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/1/properties/_meta",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "message",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/1/properties/message",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "requestedSchema",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/1/properties/requestedSchema",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "_meta",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/2/properties/_meta",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "message",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/2/properties/message",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestParams",
+              "namespace": "legacy"
+            },
+            "field": "url",
+            "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/2/properties/url",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestResponse",
+              "namespace": "legacy"
+            },
+            "field": "_meta",
+            "schema_path": "#/definitions/McpServerElicitationRequestResponse/properties/_meta",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "McpServerElicitationRequestResponse",
+              "namespace": "legacy"
+            },
+            "field": "content",
+            "schema_path": "#/definitions/McpServerElicitationRequestResponse/properties/content",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "ToolRequestUserInputAnswer",
+              "namespace": "legacy"
+            },
+            "field": "answers",
+            "schema_path": "#/definitions/ToolRequestUserInputAnswer/properties/answers",
+            "value_kind": "array"
+          },
+          {
+            "definition": {
+              "name": "ToolRequestUserInputParams",
+              "namespace": "legacy"
+            },
+            "field": "itemId",
+            "schema_path": "#/definitions/ToolRequestUserInputParams/properties/itemId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ToolRequestUserInputParams",
+              "namespace": "legacy"
+            },
+            "field": "questions",
+            "schema_path": "#/definitions/ToolRequestUserInputParams/properties/questions",
+            "value_kind": "array"
+          },
+          {
+            "definition": {
+              "name": "ToolRequestUserInputParams",
+              "namespace": "legacy"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/ToolRequestUserInputParams/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ToolRequestUserInputParams",
+              "namespace": "legacy"
+            },
+            "field": "turnId",
+            "schema_path": "#/definitions/ToolRequestUserInputParams/properties/turnId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ToolRequestUserInputQuestion",
+              "namespace": "legacy"
+            },
+            "field": "id",
+            "schema_path": "#/definitions/ToolRequestUserInputQuestion/properties/id",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ToolRequestUserInputQuestion",
+              "namespace": "legacy"
+            },
+            "field": "question",
+            "schema_path": "#/definitions/ToolRequestUserInputQuestion/properties/question",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ToolRequestUserInputResponse",
+              "namespace": "legacy"
+            },
+            "field": "answers",
+            "schema_path": "#/definitions/ToolRequestUserInputResponse/properties/answers",
+            "value_kind": "object"
+          },
+          {
+            "definition": {
+              "name": "ListMcpServerStatusParams",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/ListMcpServerStatusParams/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ListMcpServerStatusResponse",
+              "namespace": "v2"
+            },
+            "field": "data",
+            "schema_path": "#/definitions/v2/ListMcpServerStatusResponse/properties/data",
+            "value_kind": "array"
+          },
+          {
+            "definition": {
+              "name": "McpResourceReadParams",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/McpResourceReadParams/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerInfo",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/McpServerInfo/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerOauthLoginCompletedNotification",
+              "namespace": "v2"
+            },
+            "field": "error",
+            "schema_path": "#/definitions/v2/McpServerOauthLoginCompletedNotification/properties/error",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerOauthLoginCompletedNotification",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/McpServerOauthLoginCompletedNotification/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerOauthLoginCompletedNotification",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/McpServerOauthLoginCompletedNotification/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerOauthLoginParams",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/McpServerOauthLoginParams/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerOauthLoginParams",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/McpServerOauthLoginParams/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerStatus",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/McpServerStatus/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerStatusUpdatedNotification",
+              "namespace": "v2"
+            },
+            "field": "error",
+            "schema_path": "#/definitions/v2/McpServerStatusUpdatedNotification/properties/error",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerStatusUpdatedNotification",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/McpServerStatusUpdatedNotification/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerStatusUpdatedNotification",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/McpServerStatusUpdatedNotification/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerToolCallParams",
+              "namespace": "v2"
+            },
+            "field": "_meta",
+            "schema_path": "#/definitions/v2/McpServerToolCallParams/properties/_meta",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "McpServerToolCallParams",
+              "namespace": "v2"
+            },
+            "field": "arguments",
+            "schema_path": "#/definitions/v2/McpServerToolCallParams/properties/arguments",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "McpServerToolCallParams",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/McpServerToolCallParams/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerToolCallParams",
+              "namespace": "v2"
+            },
+            "field": "tool",
+            "schema_path": "#/definitions/v2/McpServerToolCallParams/properties/tool",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "McpServerToolCallResponse",
+              "namespace": "v2"
+            },
+            "field": "_meta",
+            "schema_path": "#/definitions/v2/McpServerToolCallResponse/properties/_meta",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "McpServerToolCallResponse",
+              "namespace": "v2"
+            },
+            "field": "content",
+            "schema_path": "#/definitions/v2/McpServerToolCallResponse/properties/content",
+            "value_kind": "array"
+          },
+          {
+            "definition": {
+              "name": "Resource",
+              "namespace": "v2"
+            },
+            "field": "_meta",
+            "schema_path": "#/definitions/v2/Resource/properties/_meta",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "Resource",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/Resource/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ResourceContent",
+              "namespace": "v2"
+            },
+            "field": "_meta",
+            "schema_path": "#/definitions/v2/ResourceContent/anyOf/0/properties/_meta",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "ResourceContent",
+              "namespace": "v2"
+            },
+            "field": "_meta",
+            "schema_path": "#/definitions/v2/ResourceContent/anyOf/1/properties/_meta",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "ResourceTemplate",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/ResourceTemplate/properties/name",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "Tool",
+              "namespace": "v2"
+            },
+            "field": "_meta",
+            "schema_path": "#/definitions/v2/Tool/properties/_meta",
+            "value_kind": "opaque_json"
+          },
+          {
+            "definition": {
+              "name": "Tool",
+              "namespace": "v2"
+            },
+            "field": "name",
+            "schema_path": "#/definitions/v2/Tool/properties/name",
+            "value_kind": "string"
+          }
+        ]
+      },
+      "security_obligations": [
+        "redact every listed sensitive schema path and every raw/opaque JSON value",
+        "diagnostics may contain only method, schema path, expected type, and safe counts",
+        "fixtures use synthetic IDs, /synthetic paths, example.invalid URLs, and fake tokens"
+      ],
+      "taxonomy": {
+        "client_request": 4,
+        "server_notification": 2,
+        "server_request": 4,
+        "tagged_union_discriminator": 3
+      }
+    },
+    {
+      "api_abi_impact": "public headers, aggregates, facade symbols, and variants may grow; unchanged SONAME 1 is not a binary-compatibility claim",
+      "batch": "A14-RuntimePlatform",
+      "branch": "codex/a1-4-runtime-platform",
+      "client_result_kinds": {
+        "Concrete": 2,
+        "Unit": 0
+      },
+      "codec_units": [
+        "detail/RuntimePlatformCodec.{h,cpp}",
+        "detail/WindowsSandboxCodec.{h,cpp}",
+        "detail/EventDecoder.cpp"
+      ],
+      "dependencies": [
+        "A14-McpReverse"
+      ],
+      "descriptor_changes": [
+        "ClientOperationCodecDescriptors.inc",
+        "ServerNotificationCodecDescriptors.inc"
+      ],
+      "draft_pr_title": "Type the Codex A1.4 runtime and platform long tail",
+      "global_metrics": {
+        "end": {
+          "Complete": 336,
+          "NotApplicable": 48,
+          "NotImplemented": 0,
+          "Partial": 3
+        },
+        "start": {
+          "Complete": 326,
+          "NotApplicable": 48,
+          "NotImplemented": 10,
+          "Partial": 3
+        }
+      },
+      "honest_closure_rule": "promote an identity only after its complete transitive types, codecs, descriptors, API, and tests are present in this PR",
+      "identities": [
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/WindowsSandboxReadiness",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "Unit",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "windowsSandbox/readiness"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "WindowsSandboxReadinessResponse",
+            "result_type": "WindowsSandboxReadinessResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "windowsSandbox/readiness"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "Deferred",
+          "current_status": "NotImplemented",
+          "operation_contract": {
+            "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/WindowsSandboxSetupStart",
+            "association_evidence_kind": "VendoredRust",
+            "cross_check_evidence": [],
+            "depends_on_server_request_resolved": false,
+            "direct_raw_protocol_response": false,
+            "parameter_type": "WindowsSandboxSetupStartParams",
+            "protocol_surface_key": {
+              "category": "client_request",
+              "discriminator_field": "method",
+              "domain": "ClientRequest",
+              "name": "windowsSandbox/setupStart"
+            },
+            "result_kind": "Concrete",
+            "result_schema_type": "WindowsSandboxSetupStartResponse",
+            "result_type": "WindowsSandboxSetupStartResponse"
+          },
+          "protocol_surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "windowsSandbox/setupStart"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "deprecationNotice"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "process/exited"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "process/outputDelta"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "remoteControl/status/changed"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "serverRequest/resolved"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "warning"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "windows/worldWritableWarning"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        },
+        {
+          "current_runtime_disposition": "RawPreserved",
+          "current_status": "NotImplemented",
+          "operation_contract": null,
+          "protocol_surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "windowsSandbox/setupCompleted"
+          },
+          "registry_promotion_at_honest_closure": "Complete"
+        }
+      ],
+      "identity_count": 10,
+      "lifecycle_tests": [
+        "direct response versus serverRequest/resolved ordering",
+        "unknown/stale/duplicate/external resolution handling"
+      ],
+      "logical_commit_subjects": [
+        "Add Codex A1.4 runtime and platform public types",
+        "Implement Codex A1.4 runtime and platform codecs",
+        "Close the native Codex A1.4 registry slice"
+      ],
+      "native_metrics": {
+        "end": {
+          "Complete": 56,
+          "NotImplemented": 0,
+          "Partial": 0
+        },
+        "start": {
+          "Complete": 46,
+          "NotImplemented": 10,
+          "Partial": 0
+        }
+      },
+      "owned_public_headers": [
+        "ai/openai/codex/typed/WindowsSandbox.h",
+        "ai/openai/codex/typed/Events.h"
+      ],
+      "owned_start_status": {
+        "NotImplemented": 10
+      },
+      "package_tests": [
+        "public headers are self-contained",
+        "installed consumer compiles and links",
+        "source archive retains implementation evidence",
+        "binary archive excludes private evidence"
+      ],
+      "primary_owned_schema_definitions": [
+        {
+          "name": "DeprecationNoticeNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "ProcessExitedNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "ProcessOutputDeltaNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "ProcessOutputStream",
+          "namespace": "v2"
+        },
+        {
+          "name": "RemoteControlConnectionStatus",
+          "namespace": "v2"
+        },
+        {
+          "name": "RemoteControlStatusChangedNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "RequestId",
+          "namespace": "v2"
+        },
+        {
+          "name": "ServerRequestResolvedNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "WarningNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "WindowsSandboxReadiness",
+          "namespace": "v2"
+        },
+        {
+          "name": "WindowsSandboxReadinessResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "WindowsSandboxSetupCompletedNotification",
+          "namespace": "v2"
+        },
+        {
+          "name": "WindowsSandboxSetupMode",
+          "namespace": "v2"
+        },
+        {
+          "name": "WindowsSandboxSetupStartParams",
+          "namespace": "v2"
+        },
+        {
+          "name": "WindowsSandboxSetupStartResponse",
+          "namespace": "v2"
+        },
+        {
+          "name": "WindowsWorldWritableWarningNotification",
+          "namespace": "v2"
+        }
+      ],
+      "primary_tests": [
+        "CodexA14RuntimePlatformCodecTest",
+        "CodexA14RuntimePlatformWireTest",
+        "CodexA14ServerRequestResolvedLifecycleTest",
+        "CodexA14WindowsSandboxFacadeTest"
+      ],
+      "proposed_facades_and_channels": [
+        "WindowsSandbox",
+        "Events"
+      ],
+      "registry_promotions": [
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "windowsSandbox/readiness"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "windowsSandbox/setupStart"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "deprecationNotice"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "process/exited"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "process/outputDelta"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "remoteControl/status/changed"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "serverRequest/resolved"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "warning"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "windows/worldWritableWarning"
+        },
+        {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "windowsSandbox/setupCompleted"
+        }
+      ],
+      "reused_schema_dependencies": [
+        {
+          "definition": {
+            "name": "AbsolutePathBuf",
+            "namespace": "v2"
+          },
+          "primary_owner": "A14-UserIntegrations"
+        }
+      ],
+      "schema_closure": {
+        "counts": {
+          "default_bearing_paths": 0,
+          "definition_namespaces": {
+            "v2": 17
+          },
+          "nullable_paths": 5,
+          "object_nodes": 11,
+          "opaque_json_paths": 0,
+          "optional_paths": 5,
+          "reachable_named_definitions": 17,
+          "required_paths": 25,
+          "schema_path_kinds": {
+            "array_element": 1,
+            "map_value": 0,
+            "property": 30
+          },
+          "schema_paths": 31,
+          "seed_definitions": 11,
+          "sensitive_paths": 8
+        },
+        "reachable_definitions": [
+          {
+            "name": "AbsolutePathBuf",
+            "namespace": "v2"
+          },
+          {
+            "name": "DeprecationNoticeNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "ProcessExitedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "ProcessOutputDeltaNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "ProcessOutputStream",
+            "namespace": "v2"
+          },
+          {
+            "name": "RemoteControlConnectionStatus",
+            "namespace": "v2"
+          },
+          {
+            "name": "RemoteControlStatusChangedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "RequestId",
+            "namespace": "v2"
+          },
+          {
+            "name": "ServerRequestResolvedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "WarningNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsSandboxReadiness",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsSandboxReadinessResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsSandboxSetupCompletedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsSandboxSetupMode",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsSandboxSetupStartParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsSandboxSetupStartResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsWorldWritableWarningNotification",
+            "namespace": "v2"
+          }
+        ],
+        "seed_definitions": [
+          {
+            "name": "DeprecationNoticeNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "ProcessExitedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "ProcessOutputDeltaNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "RemoteControlStatusChangedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "ServerRequestResolvedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "WarningNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsSandboxReadinessResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsSandboxSetupCompletedNotification",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsSandboxSetupStartParams",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsSandboxSetupStartResponse",
+            "namespace": "v2"
+          },
+          {
+            "name": "WindowsWorldWritableWarningNotification",
+            "namespace": "v2"
+          }
+        ],
+        "sensitive_schema_paths": [
+          {
+            "definition": {
+              "name": "ProcessExitedNotification",
+              "namespace": "v2"
+            },
+            "field": "stderr",
+            "schema_path": "#/definitions/v2/ProcessExitedNotification/properties/stderr",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ProcessExitedNotification",
+              "namespace": "v2"
+            },
+            "field": "stdout",
+            "schema_path": "#/definitions/v2/ProcessExitedNotification/properties/stdout",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "RemoteControlStatusChangedNotification",
+              "namespace": "v2"
+            },
+            "field": "serverName",
+            "schema_path": "#/definitions/v2/RemoteControlStatusChangedNotification/properties/serverName",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "ServerRequestResolvedNotification",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/ServerRequestResolvedNotification/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "WarningNotification",
+              "namespace": "v2"
+            },
+            "field": "message",
+            "schema_path": "#/definitions/v2/WarningNotification/properties/message",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "WarningNotification",
+              "namespace": "v2"
+            },
+            "field": "threadId",
+            "schema_path": "#/definitions/v2/WarningNotification/properties/threadId",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "WindowsSandboxSetupCompletedNotification",
+              "namespace": "v2"
+            },
+            "field": "error",
+            "schema_path": "#/definitions/v2/WindowsSandboxSetupCompletedNotification/properties/error",
+            "value_kind": "string"
+          },
+          {
+            "definition": {
+              "name": "WindowsSandboxSetupStartParams",
+              "namespace": "v2"
+            },
+            "field": "cwd",
+            "schema_path": "#/definitions/v2/WindowsSandboxSetupStartParams/properties/cwd",
+            "value_kind": "union"
+          }
+        ]
+      },
+      "security_obligations": [
+        "redact every listed sensitive schema path and every raw/opaque JSON value",
+        "diagnostics may contain only method, schema path, expected type, and safe counts",
+        "fixtures use synthetic IDs, /synthetic paths, example.invalid URLs, and fake tokens"
+      ],
+      "taxonomy": {
+        "client_request": 2,
+        "server_notification": 8,
+        "server_request": 0,
+        "tagged_union_discriminator": 0
+      }
+    }
+  ],
+  "long_run_test_policy": {
+    "reason": "audit-only changes need deterministic Python, focused CTest, configure/registration, and package evidence; these long targets add no A1.4-specific signal",
+    "residual_risk": "runtime integration risk remains intentionally deferred to the three production implementation PRs",
+    "skipped": [
+      "unfiltered full-repository CTest",
+      "stress tests",
+      "soak tests",
+      "fuzzing campaigns",
+      "benchmarks",
+      "sanitizer matrices",
+      "credential-bearing live App Server integration"
+    ]
+  },
+  "native_start": {
+    "client_result_kinds": {
+      "Concrete": 26,
+      "Unit": 3
+    },
+    "global_runtime_status_matrix": [
+      {
+        "count": 29,
+        "runtime_disposition": "Deferred",
+        "typed_schema_status": "NotImplemented"
+      },
+      {
+        "count": 19,
+        "runtime_disposition": "RawPreserved",
+        "typed_schema_status": "NotImplemented"
+      },
+      {
+        "count": 4,
+        "runtime_disposition": "Typed",
+        "typed_schema_status": "Partial"
+      },
+      {
+        "count": 7,
+        "runtime_disposition": "OpaquePreserved",
+        "typed_schema_status": "NotImplemented"
+      },
+      {
+        "count": 35,
+        "runtime_disposition": "Deferred",
+        "typed_schema_status": "NotApplicable"
+      },
+      {
+        "count": 1,
+        "runtime_disposition": "RawPreserved",
+        "typed_schema_status": "NotApplicable"
+      },
+      {
+        "count": 12,
+        "runtime_disposition": "OpaquePreserved",
+        "typed_schema_status": "NotApplicable"
+      }
+    ],
+    "global_status": {
+      "Complete": 280,
+      "NotApplicable": 48,
+      "NotImplemented": 55,
+      "Partial": 4
+    },
+    "identity_count": 56,
+    "native_runtime_status_matrix": [
+      {
+        "count": 29,
+        "runtime_disposition": "Deferred",
+        "typed_schema_status": "NotImplemented"
+      },
+      {
+        "count": 19,
+        "runtime_disposition": "RawPreserved",
+        "typed_schema_status": "NotImplemented"
+      },
+      {
+        "count": 1,
+        "runtime_disposition": "Typed",
+        "typed_schema_status": "Partial"
+      },
+      {
+        "count": 7,
+        "runtime_disposition": "OpaquePreserved",
+        "typed_schema_status": "NotImplemented"
+      }
+    ],
+    "status": {
+      "Complete": 0,
+      "NotImplemented": 55,
+      "Partial": 1
+    },
+    "taxonomy": {
+      "client_request": 29,
+      "server_notification": 16,
+      "server_request": 4,
+      "tagged_union_discriminator": 7
+    }
+  },
+  "no_expansion_boundaries": [
+    "no production implementation in this audit",
+    "no ProtocolSurfaceRegistryData.inc status promotion",
+    "no module-slice-assignment rewrite",
+    "no generated operation/notification/request descriptor change",
+    "no fixture or fixture-index change",
+    "no BackendState or BackendCommand expansion",
+    "no frontend protocol or application behavior change",
+    "no outgoing process or remote-control stable API",
+    "no SOVERSION change in this audit"
+  ],
+  "public_api_plan": {
+    "facade_operations": [
+      {
+        "client_accessor": "typed::Client::apps",
+        "facade": "Apps",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "app/list",
+        "operation": "list"
+      },
+      {
+        "client_accessor": "typed::Client::externalAgents",
+        "facade": "ExternalAgents",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "externalAgentConfig/detect",
+        "operation": "detect"
+      },
+      {
+        "client_accessor": "typed::Client::externalAgents",
+        "facade": "ExternalAgents",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "externalAgentConfig/import",
+        "operation": "importConfig"
+      },
+      {
+        "client_accessor": "typed::Client::externalAgents",
+        "facade": "ExternalAgents",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "externalAgentConfig/import/readHistories",
+        "operation": "readImportHistories"
+      },
+      {
+        "client_accessor": "typed::Client::feedback",
+        "facade": "Feedback",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "feedback/upload",
+        "operation": "upload"
+      },
+      {
+        "client_accessor": "typed::Client::hooks",
+        "facade": "Hooks",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "hooks/list",
+        "operation": "list"
+      },
+      {
+        "client_accessor": "typed::Client::marketplace",
+        "facade": "Marketplace",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "marketplace/add",
+        "operation": "add"
+      },
+      {
+        "client_accessor": "typed::Client::marketplace",
+        "facade": "Marketplace",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "marketplace/remove",
+        "operation": "remove"
+      },
+      {
+        "client_accessor": "typed::Client::marketplace",
+        "facade": "Marketplace",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "marketplace/upgrade",
+        "operation": "upgrade"
+      },
+      {
+        "client_accessor": "typed::Client::mcp",
+        "facade": "Mcp",
+        "implementation_batch": "A14-McpReverse",
+        "method": "mcpServer/oauth/login",
+        "operation": "oauthLogin"
+      },
+      {
+        "client_accessor": "typed::Client::mcp",
+        "facade": "Mcp",
+        "implementation_batch": "A14-McpReverse",
+        "method": "mcpServer/resource/read",
+        "operation": "readResource"
+      },
+      {
+        "client_accessor": "typed::Client::mcp",
+        "facade": "Mcp",
+        "implementation_batch": "A14-McpReverse",
+        "method": "mcpServer/tool/call",
+        "operation": "callTool"
+      },
+      {
+        "client_accessor": "typed::Client::mcp",
+        "facade": "Mcp",
+        "implementation_batch": "A14-McpReverse",
+        "method": "mcpServerStatus/list",
+        "operation": "listServerStatuses"
+      },
+      {
+        "client_accessor": "typed::Client::plugins",
+        "facade": "Plugins",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "plugin/install",
+        "operation": "install"
+      },
+      {
+        "client_accessor": "typed::Client::plugins",
+        "facade": "Plugins",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "plugin/installed",
+        "operation": "installed"
+      },
+      {
+        "client_accessor": "typed::Client::plugins",
+        "facade": "Plugins",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "plugin/list",
+        "operation": "list"
+      },
+      {
+        "client_accessor": "typed::Client::plugins",
+        "facade": "Plugins",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "plugin/read",
+        "operation": "read"
+      },
+      {
+        "client_accessor": "typed::Client::plugins",
+        "facade": "Plugins",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "plugin/share/checkout",
+        "operation": "checkoutShare"
+      },
+      {
+        "client_accessor": "typed::Client::plugins",
+        "facade": "Plugins",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "plugin/share/delete",
+        "operation": "deleteShare"
+      },
+      {
+        "client_accessor": "typed::Client::plugins",
+        "facade": "Plugins",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "plugin/share/list",
+        "operation": "listShares"
+      },
+      {
+        "client_accessor": "typed::Client::plugins",
+        "facade": "Plugins",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "plugin/share/save",
+        "operation": "saveShare"
+      },
+      {
+        "client_accessor": "typed::Client::plugins",
+        "facade": "Plugins",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "plugin/share/updateTargets",
+        "operation": "updateShareTargets"
+      },
+      {
+        "client_accessor": "typed::Client::plugins",
+        "facade": "Plugins",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "plugin/skill/read",
+        "operation": "readSkill"
+      },
+      {
+        "client_accessor": "typed::Client::plugins",
+        "facade": "Plugins",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "plugin/uninstall",
+        "operation": "uninstall"
+      },
+      {
+        "client_accessor": "typed::Client::skills",
+        "facade": "Skills",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "skills/config/write",
+        "operation": "writeConfig"
+      },
+      {
+        "client_accessor": "typed::Client::skills",
+        "facade": "Skills",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "skills/extraRoots/set",
+        "operation": "setExtraRoots"
+      },
+      {
+        "client_accessor": "typed::Client::skills",
+        "facade": "Skills",
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "skills/list",
+        "operation": "list"
+      },
+      {
+        "client_accessor": "typed::Client::windowsSandbox",
+        "facade": "WindowsSandbox",
+        "implementation_batch": "A14-RuntimePlatform",
+        "method": "windowsSandbox/readiness",
+        "operation": "readiness"
+      },
+      {
+        "client_accessor": "typed::Client::windowsSandbox",
+        "facade": "WindowsSandbox",
+        "implementation_batch": "A14-RuntimePlatform",
+        "method": "windowsSandbox/setupStart",
+        "operation": "setupStart"
+      }
+    ],
+    "notification_ownership": [
+      {
+        "canonical_variant_index": 51,
+        "event_variant_index": 53,
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "app/list/updated",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 52,
+        "event_variant_index": 54,
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "externalAgentConfig/import/completed",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 53,
+        "event_variant_index": 55,
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "externalAgentConfig/import/progress",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 54,
+        "event_variant_index": 56,
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "hook/completed",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 55,
+        "event_variant_index": 57,
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "hook/started",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 56,
+        "event_variant_index": 58,
+        "implementation_batch": "A14-UserIntegrations",
+        "method": "skills/changed",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 57,
+        "event_variant_index": 59,
+        "implementation_batch": "A14-McpReverse",
+        "method": "mcpServer/oauthLogin/completed",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 58,
+        "event_variant_index": 60,
+        "implementation_batch": "A14-McpReverse",
+        "method": "mcpServer/startupStatus/updated",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 59,
+        "event_variant_index": 61,
+        "implementation_batch": "A14-RuntimePlatform",
+        "method": "deprecationNotice",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 60,
+        "event_variant_index": 62,
+        "implementation_batch": "A14-RuntimePlatform",
+        "method": "process/exited",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 61,
+        "event_variant_index": 63,
+        "implementation_batch": "A14-RuntimePlatform",
+        "method": "process/outputDelta",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 62,
+        "event_variant_index": 64,
+        "implementation_batch": "A14-RuntimePlatform",
+        "method": "remoteControl/status/changed",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 63,
+        "event_variant_index": 65,
+        "implementation_batch": "A14-RuntimePlatform",
+        "method": "serverRequest/resolved",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 64,
+        "event_variant_index": 66,
+        "implementation_batch": "A14-RuntimePlatform",
+        "method": "warning",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 65,
+        "event_variant_index": 67,
+        "implementation_batch": "A14-RuntimePlatform",
+        "method": "windows/worldWritableWarning",
+        "owner": "typed::Events"
+      },
+      {
+        "canonical_variant_index": 66,
+        "event_variant_index": 68,
+        "implementation_batch": "A14-RuntimePlatform",
+        "method": "windowsSandbox/setupCompleted",
+        "owner": "typed::Events"
+      }
+    ],
+    "request_user_input_compatibility": {
+      "assignment_unchanged_proof": {
+        "assignment": {
+          "classification": "StablePublicRoot",
+          "module": "IntegrationsAndLongTail",
+          "slice": "A1.4",
+          "stability": "stable"
+        },
+        "authority": {
+          "path": "tools/codex/app-server-evidence/0.144.6/module-slice-assignment.json",
+          "sha256": "e9097d1d27acd3915da65f7c955c2e8fb25f7ee0fce9b185e4415a1ba85396cf"
+        },
+        "registry_matches_assignment": true
+      },
+      "category": "server_request",
+      "completion_stage": "native A1.4 implementation",
+      "current_module": "IntegrationsAndLongTail",
+      "current_runtime_disposition": "Typed",
+      "current_runtime_target": "ServerRequestTarget::ToolRequestUserInput",
+      "current_slice": "A1.4",
+      "current_status": "Partial",
+      "deferred_reason": "native A1.4 reverse-request work owns this existing compatibility projection",
+      "expected_status_after_completion": "Complete",
+      "intended_completion_batch": "A14-McpReverse",
+      "missing_codec_obligations": [
+        "exact params decoder with default and uint64 semantics",
+        "exact ToolRequestUserInputResponse encoder",
+        "post-encode schema validation and direct respondOwned path"
+      ],
+      "missing_public_type_obligations": [
+        "preserve UserInputRequest and TypedServerRequest index 2",
+        "preserve UserInputQuestion/UserInputOption/UserInputAnswer",
+        "append canonical ToolRequestUserInputParams and diagnostics",
+        "model autoResolutionMs and options as omitted/null/value",
+        "add canonical response map without removing legacy overload"
+      ],
+      "missing_schema_completeness_facts": [
+        "direction_assertions_exercised",
+        "no_known_schema_fields_dropped",
+        "nullable_semantics_exercised",
+        "opaque_fields_declared",
+        "reachable_union_alternatives_exercised",
+        "runtime_decoder_matches_registry",
+        "schema_properties_exercised"
+      ],
+      "missing_test_obligations": [
+        "all params/response fields and nullable states",
+        "known/duplicate question validation compatibility",
+        "one-shot/retry/original-ID/generation lifecycle"
+      ],
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "item/tool/requestUserInput"
+      }
+    },
+    "reusable_exact_public_types": {
+      "AbsolutePathBuf": "ai/openai/codex/typed/Types.h",
+      "DynamicToolCallOutputContentItem": "ai/openai/codex/typed/Conversation.h",
+      "WindowsSandboxSetupMode": "ai/openai/codex/typed/Configuration.h"
+    },
+    "reusable_shared_vocabulary": [
+      "Unit and OperationResult<T>",
+      "ThreadId, TurnId, and ItemId",
+      "Json, OptionalNullable, and DecodeDiagnostic",
+      "ServerRequestId and ServerRequestToken"
+    ],
+    "rules": [
+      "retain typed::Client's PIMPL",
+      "add no members to AppServerClient",
+      "add no public virtual interface",
+      "add no generic invoke-by-method API",
+      "do not move A1.1-A1.3 operations",
+      "notifications remain on Events",
+      "incoming requests remain on Requests occurrences",
+      "stable process and remote status notifications do not create outgoing control facades"
+    ],
+    "server_request_ownership": [
+      {
+        "implementation_batch": "A14-McpReverse",
+        "method": "attestation/generate",
+        "occurrence_machinery": "existing occurrence token/generation",
+        "owner": "typed::Requests",
+        "public_type": "AttestationGenerateRequest",
+        "response_transport": "existing direct RawProtocol JSON-RPC response",
+        "variant_index": 8
+      },
+      {
+        "implementation_batch": "A14-McpReverse",
+        "method": "item/tool/call",
+        "occurrence_machinery": "existing occurrence token/generation",
+        "owner": "typed::Requests",
+        "public_type": "DynamicToolCallRequest",
+        "response_transport": "existing direct RawProtocol JSON-RPC response",
+        "variant_index": 9
+      },
+      {
+        "completion_in_place": true,
+        "implementation_batch": "A14-McpReverse",
+        "method": "item/tool/requestUserInput",
+        "occurrence_machinery": "existing occurrence token/generation",
+        "owner": "typed::Requests",
+        "public_type": "UserInputRequest",
+        "response_transport": "existing direct RawProtocol JSON-RPC response",
+        "variant_index": 2
+      },
+      {
+        "implementation_batch": "A14-McpReverse",
+        "method": "mcpServer/elicitation/request",
+        "occurrence_machinery": "existing occurrence token/generation",
+        "owner": "typed::Requests",
+        "public_type": "McpServerElicitationRequest",
+        "response_transport": "existing direct RawProtocol JSON-RPC response",
+        "variant_index": 10
+      }
+    ],
+    "similar_types_that_must_not_be_reused": {
+      "Accounts authentication types": "MCP OAuth lifecycle is not account login lifecycle",
+      "CommandExecProcessId/CommandExecOutputStream": "A1.4 process handles and stream vocabulary are distinct",
+      "ConfigLayerSource/HookSource": "PluginSource has its own tagged union and ownership",
+      "ConfigWarningNotification/GuardianWarning": "generic warning and deprecation payloads have distinct schemas",
+      "DynamicToolCallThreadItem": "dynamic server call params/results are distinct; only the exact output-content union is reusable",
+      "McpToolCallThreadItem": "MCP server operation request/response schemas are distinct",
+      "SandboxMode/SandboxPolicy": "Windows setup/readiness is a distinct platform contract",
+      "conversation UserInput": "ToolRequestUserInput is a reverse-request contract"
+    },
+    "variant_and_layout_plan": {
+      "current": {
+        "CanonicalServerNotification": [
+          {
+            "index": 0,
+            "type": "AccountLoginCompletedNotification"
+          },
+          {
+            "index": 1,
+            "type": "AccountRateLimitsUpdatedNotification"
+          },
+          {
+            "index": 2,
+            "type": "AccountUpdatedNotification"
+          },
+          {
+            "index": 3,
+            "type": "ConfigWarningNotification"
+          },
+          {
+            "index": 4,
+            "type": "ModelReroutedNotification"
+          },
+          {
+            "index": 5,
+            "type": "ModelSafetyBufferingUpdatedNotification"
+          },
+          {
+            "index": 6,
+            "type": "ModelVerificationNotification"
+          },
+          {
+            "index": 7,
+            "type": "AgentMessageDeltaNotification"
+          },
+          {
+            "index": 8,
+            "type": "CommandExecutionOutputDeltaNotification"
+          },
+          {
+            "index": 9,
+            "type": "TerminalInteractionNotification"
+          },
+          {
+            "index": 10,
+            "type": "ItemCompletedNotification"
+          },
+          {
+            "index": 11,
+            "type": "FileChangeOutputDeltaNotification"
+          },
+          {
+            "index": 12,
+            "type": "FileChangePatchUpdatedNotification"
+          },
+          {
+            "index": 13,
+            "type": "McpToolCallProgressNotification"
+          },
+          {
+            "index": 14,
+            "type": "PlanDeltaNotification"
+          },
+          {
+            "index": 15,
+            "type": "ReasoningSummaryPartAddedNotification"
+          },
+          {
+            "index": 16,
+            "type": "ReasoningSummaryTextDeltaNotification"
+          },
+          {
+            "index": 17,
+            "type": "ReasoningTextDeltaNotification"
+          },
+          {
+            "index": 18,
+            "type": "ItemStartedNotification"
+          },
+          {
+            "index": 19,
+            "type": "ThreadArchivedNotification"
+          },
+          {
+            "index": 20,
+            "type": "ThreadClosedNotification"
+          },
+          {
+            "index": 21,
+            "type": "ContextCompactedNotification"
+          },
+          {
+            "index": 22,
+            "type": "ThreadDeletedNotification"
+          },
+          {
+            "index": 23,
+            "type": "ThreadGoalClearedNotification"
+          },
+          {
+            "index": 24,
+            "type": "ThreadGoalUpdatedNotification"
+          },
+          {
+            "index": 25,
+            "type": "ThreadNameUpdatedNotification"
+          },
+          {
+            "index": 26,
+            "type": "ThreadRealtimeClosedNotification"
+          },
+          {
+            "index": 27,
+            "type": "ThreadRealtimeErrorNotification"
+          },
+          {
+            "index": 28,
+            "type": "ThreadRealtimeItemAddedNotification"
+          },
+          {
+            "index": 29,
+            "type": "ThreadRealtimeOutputAudioDeltaNotification"
+          },
+          {
+            "index": 30,
+            "type": "ThreadRealtimeSdpNotification"
+          },
+          {
+            "index": 31,
+            "type": "ThreadRealtimeStartedNotification"
+          },
+          {
+            "index": 32,
+            "type": "ThreadRealtimeTranscriptDeltaNotification"
+          },
+          {
+            "index": 33,
+            "type": "ThreadRealtimeTranscriptDoneNotification"
+          },
+          {
+            "index": 34,
+            "type": "ThreadSettingsUpdatedNotification"
+          },
+          {
+            "index": 35,
+            "type": "ThreadStartedNotification"
+          },
+          {
+            "index": 36,
+            "type": "ThreadStatusChangedNotification"
+          },
+          {
+            "index": 37,
+            "type": "ThreadTokenUsageUpdatedNotification"
+          },
+          {
+            "index": 38,
+            "type": "ThreadUnarchivedNotification"
+          },
+          {
+            "index": 39,
+            "type": "TurnCompletedNotification"
+          },
+          {
+            "index": 40,
+            "type": "TurnDiffUpdatedNotification"
+          },
+          {
+            "index": 41,
+            "type": "TurnModerationMetadataNotification"
+          },
+          {
+            "index": 42,
+            "type": "TurnPlanUpdatedNotification"
+          },
+          {
+            "index": 43,
+            "type": "TurnStartedNotification"
+          },
+          {
+            "index": 44,
+            "type": "CommandExecOutputDeltaNotification"
+          },
+          {
+            "index": 45,
+            "type": "FsChangedNotification"
+          },
+          {
+            "index": 46,
+            "type": "FuzzyFileSearchSessionCompletedNotification"
+          },
+          {
+            "index": 47,
+            "type": "FuzzyFileSearchSessionUpdatedNotification"
+          },
+          {
+            "index": 48,
+            "type": "GuardianWarningNotification"
+          },
+          {
+            "index": 49,
+            "type": "ItemGuardianApprovalReviewCompletedNotification"
+          },
+          {
+            "index": 50,
+            "type": "ItemGuardianApprovalReviewStartedNotification"
+          }
+        ],
+        "Event": [
+          {
+            "index": 0,
+            "type": "ThreadStarted"
+          },
+          {
+            "index": 1,
+            "type": "ThreadStatusChanged"
+          },
+          {
+            "index": 2,
+            "type": "TurnStarted"
+          },
+          {
+            "index": 3,
+            "type": "TurnCompleted"
+          },
+          {
+            "index": 4,
+            "type": "TurnFailed"
+          },
+          {
+            "index": 5,
+            "type": "ItemStarted"
+          },
+          {
+            "index": 6,
+            "type": "ItemCompleted"
+          },
+          {
+            "index": 7,
+            "type": "AgentMessageDelta"
+          },
+          {
+            "index": 8,
+            "type": "ReasoningDelta"
+          },
+          {
+            "index": 9,
+            "type": "CommandOutputDelta"
+          },
+          {
+            "index": 10,
+            "type": "FileChangeUpdated"
+          },
+          {
+            "index": 11,
+            "type": "TokenUsageUpdated"
+          },
+          {
+            "index": 12,
+            "type": "TerminalInteractionNotification"
+          },
+          {
+            "index": 13,
+            "type": "FileChangeOutputDeltaNotification"
+          },
+          {
+            "index": 14,
+            "type": "McpToolCallProgressNotification"
+          },
+          {
+            "index": 15,
+            "type": "PlanDeltaNotification"
+          },
+          {
+            "index": 16,
+            "type": "ReasoningSummaryPartAddedNotification"
+          },
+          {
+            "index": 17,
+            "type": "ThreadArchivedNotification"
+          },
+          {
+            "index": 18,
+            "type": "ThreadClosedNotification"
+          },
+          {
+            "index": 19,
+            "type": "ContextCompactedNotification"
+          },
+          {
+            "index": 20,
+            "type": "ThreadDeletedNotification"
+          },
+          {
+            "index": 21,
+            "type": "ThreadGoalClearedNotification"
+          },
+          {
+            "index": 22,
+            "type": "ThreadGoalUpdatedNotification"
+          },
+          {
+            "index": 23,
+            "type": "ThreadNameUpdatedNotification"
+          },
+          {
+            "index": 24,
+            "type": "ThreadRealtimeClosedNotification"
+          },
+          {
+            "index": 25,
+            "type": "ThreadRealtimeErrorNotification"
+          },
+          {
+            "index": 26,
+            "type": "ThreadRealtimeItemAddedNotification"
+          },
+          {
+            "index": 27,
+            "type": "ThreadRealtimeOutputAudioDeltaNotification"
+          },
+          {
+            "index": 28,
+            "type": "ThreadRealtimeSdpNotification"
+          },
+          {
+            "index": 29,
+            "type": "ThreadRealtimeStartedNotification"
+          },
+          {
+            "index": 30,
+            "type": "ThreadRealtimeTranscriptDeltaNotification"
+          },
+          {
+            "index": 31,
+            "type": "ThreadRealtimeTranscriptDoneNotification"
+          },
+          {
+            "index": 32,
+            "type": "ThreadSettingsUpdatedNotification"
+          },
+          {
+            "index": 33,
+            "type": "ThreadUnarchivedNotification"
+          },
+          {
+            "index": 34,
+            "type": "TurnDiffUpdatedNotification"
+          },
+          {
+            "index": 35,
+            "type": "TurnModerationMetadataNotification"
+          },
+          {
+            "index": 36,
+            "type": "TurnPlanUpdatedNotification"
+          },
+          {
+            "index": 37,
+            "type": "AccountLoginCompletedNotification"
+          },
+          {
+            "index": 38,
+            "type": "AccountRateLimitsUpdatedNotification"
+          },
+          {
+            "index": 39,
+            "type": "AccountUpdatedNotification"
+          },
+          {
+            "index": 40,
+            "type": "ConfigWarningNotification"
+          },
+          {
+            "index": 41,
+            "type": "ModelRerouted"
+          },
+          {
+            "index": 42,
+            "type": "ModelSafetyBufferingUpdatedNotification"
+          },
+          {
+            "index": 43,
+            "type": "ModelVerificationNotification"
+          },
+          {
+            "index": 44,
+            "type": "TurnErrorEvent"
+          },
+          {
+            "index": 45,
+            "type": "UnknownEvent"
+          },
+          {
+            "index": 46,
+            "type": "CommandExecOutputDeltaNotification"
+          },
+          {
+            "index": 47,
+            "type": "FsChangedNotification"
+          },
+          {
+            "index": 48,
+            "type": "FuzzyFileSearchSessionCompletedNotification"
+          },
+          {
+            "index": 49,
+            "type": "FuzzyFileSearchSessionUpdatedNotification"
+          },
+          {
+            "index": 50,
+            "type": "GuardianWarningNotification"
+          },
+          {
+            "index": 51,
+            "type": "ItemGuardianApprovalReviewCompletedNotification"
+          },
+          {
+            "index": 52,
+            "type": "ItemGuardianApprovalReviewStartedNotification"
+          }
+        ],
+        "TypedServerRequest": [
+          {
+            "index": 0,
+            "type": "CommandApprovalRequest"
+          },
+          {
+            "index": 1,
+            "type": "FileChangeApprovalRequest"
+          },
+          {
+            "index": 2,
+            "type": "UserInputRequest"
+          },
+          {
+            "index": 3,
+            "type": "AuthenticationRequest"
+          },
+          {
+            "index": 4,
+            "type": "UnknownServerRequest"
+          },
+          {
+            "index": 5,
+            "type": "ApplyPatchApprovalRequest"
+          },
+          {
+            "index": 6,
+            "type": "ExecCommandApprovalRequest"
+          },
+          {
+            "index": 7,
+            "type": "PermissionsApprovalRequest"
+          }
+        ]
+      },
+      "final_a1_error_completion": {
+        "canonical_index": 67,
+        "canonical_type": "ErrorNotification",
+        "event_change": "TurnErrorEvent remains index 44 and gains an optional canonical view; no Event alternative is inserted"
+      },
+      "frozen_indices": {
+        "TurnErrorEvent": 44,
+        "UnknownEvent": 45,
+        "UnknownServerRequest": 4,
+        "UserInputRequest": 2
+      },
+      "planned_notification_appends": [
+        {
+          "canonical_index": 51,
+          "event_index": 53,
+          "method": "app/list/updated"
+        },
+        {
+          "canonical_index": 52,
+          "event_index": 54,
+          "method": "externalAgentConfig/import/completed"
+        },
+        {
+          "canonical_index": 53,
+          "event_index": 55,
+          "method": "externalAgentConfig/import/progress"
+        },
+        {
+          "canonical_index": 54,
+          "event_index": 56,
+          "method": "hook/completed"
+        },
+        {
+          "canonical_index": 55,
+          "event_index": 57,
+          "method": "hook/started"
+        },
+        {
+          "canonical_index": 56,
+          "event_index": 58,
+          "method": "skills/changed"
+        },
+        {
+          "canonical_index": 57,
+          "event_index": 59,
+          "method": "mcpServer/oauthLogin/completed"
+        },
+        {
+          "canonical_index": 58,
+          "event_index": 60,
+          "method": "mcpServer/startupStatus/updated"
+        },
+        {
+          "canonical_index": 59,
+          "event_index": 61,
+          "method": "deprecationNotice"
+        },
+        {
+          "canonical_index": 60,
+          "event_index": 62,
+          "method": "process/exited"
+        },
+        {
+          "canonical_index": 61,
+          "event_index": 63,
+          "method": "process/outputDelta"
+        },
+        {
+          "canonical_index": 62,
+          "event_index": 64,
+          "method": "remoteControl/status/changed"
+        },
+        {
+          "canonical_index": 63,
+          "event_index": 65,
+          "method": "serverRequest/resolved"
+        },
+        {
+          "canonical_index": 64,
+          "event_index": 66,
+          "method": "warning"
+        },
+        {
+          "canonical_index": 65,
+          "event_index": 67,
+          "method": "windows/worldWritableWarning"
+        },
+        {
+          "canonical_index": 66,
+          "event_index": 68,
+          "method": "windowsSandbox/setupCompleted"
+        }
+      ],
+      "planned_server_request_changes": [
+        {
+          "method": "attestation/generate",
+          "public_type": "AttestationGenerateRequest",
+          "variant_index": 8
+        },
+        {
+          "method": "item/tool/call",
+          "public_type": "DynamicToolCallRequest",
+          "variant_index": 9
+        },
+        {
+          "completion_in_place": true,
+          "method": "item/tool/requestUserInput",
+          "public_type": "UserInputRequest",
+          "variant_index": 2
+        },
+        {
+          "method": "mcpServer/elicitation/request",
+          "public_type": "McpServerElicitationRequest",
+          "variant_index": 10
+        }
+      ],
+      "sources": [
+        {
+          "path": "src/ai/openai/codex/typed/Events.h",
+          "sha256": "25c262350b5498e8bb4fca843b770d3d7710318306b668956e2e26faedaabd03"
+        },
+        {
+          "path": "src/ai/openai/codex/typed/ServerRequests.h",
+          "sha256": "07b3a51559ed44d4c97ebc052e8e9837022ecb4afcae583ef610fa828690abdc"
+        }
+      ]
+    }
+  },
+  "schema_dependency_graph": {
+    "definition_overlap": [
+      {
+        "batches": [
+          "A14-UserIntegrations",
+          "A14-RuntimePlatform"
+        ],
+        "definition": {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        "primary_owner": "A14-UserIntegrations"
+      }
+    ],
+    "edges": [
+      {
+        "from": "A14-UserIntegrations",
+        "reason": "review sequence and stable public facade foundation; schema closures are disjoint",
+        "to": "A14-McpReverse"
+      },
+      {
+        "from": "A14-McpReverse",
+        "reason": "serverRequest/resolved lifecycle tests require all four A1.4 reverse-request types",
+        "to": "A14-RuntimePlatform"
+      },
+      {
+        "from": "A14-RuntimePlatform",
+        "reason": "native 56 must be complete before inherited Common closure and SONAME action",
+        "to": "A1-FinalClosure"
+      }
+    ],
+    "overlap_rule": "v2::AbsolutePathBuf is an existing reusable public type, implemented once and referenced by the platform batch; no union family is implemented twice"
+  },
+  "security_and_sensitive_data": {
+    "default_policy": "treat every raw envelope, opaque JSON field, and listed sensitive path as sensitive; redact values",
+    "diagnostic_rule": "emit method, structural path, expected type, and safe counts only; never payload values",
+    "family_inventory": {
+      "apps": [
+        "metadata",
+        "configuration",
+        "branding",
+        "screenshots",
+        "reviews"
+      ],
+      "external_agents": [
+        "configuration",
+        "cwd/home detection",
+        "import histories",
+        "progress",
+        "failures"
+      ],
+      "feedback": [
+        "content",
+        "reason",
+        "tags",
+        "attachments/logs",
+        "thread IDs"
+      ],
+      "hooks": [
+        "definitions",
+        "handlers",
+        "sources and paths",
+        "input/output",
+        "failures"
+      ],
+      "marketplace_plugins_skills": [
+        "source URLs, paths, refs, SHAs, packages",
+        "checkout/share principals and targets",
+        "installation roots and skill roots",
+        "configuration and errors"
+      ],
+      "mcp_and_reverse_requests": [
+        "server IDs and names",
+        "OAuth scopes, state, and URLs",
+        "resource URIs and contents",
+        "tool names, schemas, arguments, and results",
+        "elicitation messages, values, schemas, and URLs",
+        "all user questions, options, and answers",
+        "entire attestation input and output"
+      ],
+      "runtime_and_platform": [
+        "process handles and output",
+        "remote identities and status",
+        "warning/deprecation text",
+        "request/thread IDs",
+        "filesystem paths",
+        "Windows sandbox diagnostics"
+      ]
+    },
+    "forbidden_real_fixture_data": [
+      "credentials and OAuth tokens",
+      "environment variables",
+      "plugin repositories",
+      "private filesystem paths",
+      "MCP server configuration",
+      "feedback content",
+      "process output",
+      "user answers",
+      "attestation material"
+    ],
+    "heuristic_schema_paths": {
+      "count": 127,
+      "coverage_note": "the 127 mechanically flagged paths are a minimum; family/root policy remains default-deny"
+    },
+    "safe_fixture_vocabulary": [
+      "synthetic IDs",
+      "/synthetic/... paths",
+      "example.invalid URLs",
+      "fake tokens and values"
+    ]
+  },
+  "server_request_resolved_semantics": {
+    "direct_response_non_regression": {
+      "can_reopen_completed_occurrence": false,
+      "changes_a1_3_response_contract": false,
+      "frozen_path": [
+        "incoming server request",
+        "existing occurrence token and generation",
+        "typed callback",
+        "typed response validation",
+        "direct JSON-RPC response using the original request ID"
+      ],
+      "is_acknowledgement_prerequisite": false,
+      "is_response_prerequisite": false,
+      "is_response_transport": false,
+      "is_second_terminal_completion": false
+    },
+    "emission_method_matrix": [
+      {
+        "emits_notification": true,
+        "method": "item/commandExecution/requestApproval",
+        "slice": "A1.3"
+      },
+      {
+        "emits_notification": true,
+        "method": "item/fileChange/requestApproval",
+        "slice": "A1.3"
+      },
+      {
+        "emits_notification": true,
+        "method": "item/permissions/requestApproval",
+        "slice": "A1.3"
+      },
+      {
+        "emits_notification": false,
+        "method": "applyPatchApproval",
+        "slice": "A1.3"
+      },
+      {
+        "emits_notification": false,
+        "method": "execCommandApproval",
+        "slice": "A1.3"
+      },
+      {
+        "emits_notification": true,
+        "method": "item/tool/requestUserInput",
+        "slice": "A1.4"
+      },
+      {
+        "emits_notification": true,
+        "method": "mcpServer/elicitation/request",
+        "slice": "A1.4"
+      },
+      {
+        "emits_notification": false,
+        "method": "item/tool/call",
+        "slice": "A1.4"
+      },
+      {
+        "emits_notification": false,
+        "method": "attestation/generate",
+        "slice": "A1.4"
+      }
+    ],
+    "future_tests": [
+      "integer and string IDs; required/null/wrong-type fields",
+      "future additional properties are accepted and preserved",
+      "positive five-method and negative four-method matrices",
+      "success, decline/cancel, rejection, malformed-result paths",
+      "turn-transition cleanup behavior",
+      "response bytes and local consumption precede reentrant event",
+      "typed responses remain valid if the event never arrives",
+      "already-consumed event causes no second terminal action",
+      "external resolution retires a current matching occurrence",
+      "unknown, duplicate, thread-mismatched IDs are nonfatal",
+      "old-generation event cannot consume a restarted occurrence",
+      "multi-subscriber responder/observer behavior",
+      "resolved precedes downstream completion where promised",
+      "reuse A1.3 original-ID, one-shot, and generation tests"
+    ],
+    "generation_semantics": {
+      "payload_generation_scoped": false,
+      "recipient_rule": "scope the notification to the SNode.C transport generation that delivered it",
+      "restart_risk": "the upstream process counter can restart; an old generation must never consume a new occurrence"
+    },
+    "identifier_semantics": {
+      "kind": "original server-generated JSON-RPC request ID",
+      "not": [
+        "item ID",
+        "call ID",
+        "SNode.C occurrence token"
+      ],
+      "preserve_string_ids": true,
+      "upstream_current_generation": "process-wide monotonically allocated integer"
+    },
+    "local_non_regression_evidence": [
+      {
+        "finding": "answerServerRequest enqueues the original ID and consumes the occurrence before reentrant flush",
+        "path": "src/ai/openai/codex/AppServerClient.cpp"
+      },
+      {
+        "finding": "all A1.3 response operations explicitly exclude serverRequest/resolved as a transport dependency",
+        "path": "tools/codex/app-server-evidence/0.144.6/a1-3-implementation-plan.json"
+      }
+    ],
+    "meaning": {
+      "classification": "informational and lifecycle-significant",
+      "communicates": "a shared pending request was resolved or cleared",
+      "does_not_communicate": "success, decline, cancellation, rejection, or outcome",
+      "outcome_authority": "downstream item/completed or turn/completed"
+    },
+    "method": "serverRequest/resolved",
+    "ordering": {
+      "causal_sequence": [
+        "client enqueues direct JSON-RPC result or error",
+        "App Server removes the matching callback",
+        "the per-method waiter wakes",
+        "the handler queues ResolveServerRequest",
+        "the listener emits serverRequest/resolved",
+        "the handler resumes core processing"
+      ],
+      "direct_response_is_earlier": true,
+      "notification_is_opposite_direction": true,
+      "notification_precedes_downstream_completion": "ordinary positive-handler paths"
+    },
+    "payload": {
+      "absent_semantics": [
+        "method",
+        "item ID",
+        "result",
+        "error",
+        "outcome",
+        "generation",
+        "completion status"
+      ],
+      "additional_properties": "allowed_by_default",
+      "nullable_fields": [],
+      "optional_fields": [],
+      "required_fields": {
+        "requestId": "string | int64",
+        "threadId": "string"
+      },
+      "schema_authority": {
+        "path": "tools/codex/app-server-schema/0.144.6/stable/v2/ServerRequestResolvedNotification.json",
+        "sha256": "7cc32a834be009c7a45dda01b80ae01bb522c642eb0e886c6d4bd7ee89fde643"
+      },
+      "type": "ServerRequestResolvedNotification"
+    },
+    "pinned_upstream_evidence": [
+      {
+        "finding": "payload struct",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server-protocol/src/protocol/v2/notification.rs#L50-L56"
+      },
+      {
+        "finding": "RequestId representation",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server-protocol/src/rpc.rs#L13-L29"
+      },
+      {
+        "finding": "ID generation and callback insertion",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server/src/outgoing_message.rs#L282-L350"
+      },
+      {
+        "finding": "callback removal before waiter wake-up",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server/src/outgoing_message.rs#L373-L410"
+      },
+      {
+        "finding": "single notification emission site",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server/src/request_processors/thread_lifecycle.rs#L748-L771"
+      },
+      {
+        "finding": "five positive response handlers",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server/src/bespoke_event_handling.rs#L1569-L1923"
+      },
+      {
+        "finding": "dynamic tool negative path",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server/src/dynamic_tools.rs#L16-L55"
+      },
+      {
+        "finding": "attestation negative/timeout path",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server/src/attestation.rs#L63-L127"
+      },
+      {
+        "finding": "turn-transition callback cancellation",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server/src/outgoing_message.rs#L176-L190"
+      },
+      {
+        "finding": "disconnect behavior",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server/src/message_processor.rs#L695-L721"
+      },
+      {
+        "finding": "listener serialization",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server/src/thread_state.rs#L164-L193"
+      },
+      {
+        "finding": "documented lifecycle meaning",
+        "url": "https://github.com/openai/codex/blob/5d1fbf26c43abc65a203928b2e31561cb039e06d/codex-rs/app-server/README.md#L1444-L1497"
+      }
+    ],
+    "recipient_behavior": {
+      "already_consumed_possible": true,
+      "current_pending_match": "retire idempotently as externally resolved only when ID, thread, and transport generation all match",
+      "duplicate": "nonfatal idempotent no-op",
+      "later_answer_after_external_resolution": "fail locally without wire output",
+      "multi_subscriber_case": "the responder usually removed its occurrence while another subscriber may still have the shared ID pending",
+      "thread_mismatch": "nonfatal no-op",
+      "unknown_or_stale": "deliver the typed event, perform no registry mutation, and keep the connection healthy"
+    },
+    "terminal_path_matrix": [
+      {
+        "emitted_for_positive_methods": true,
+        "path": "successful JSON-RPC result"
+      },
+      {
+        "emitted_for_positive_methods": true,
+        "path": "domain decline/cancel encoded as valid result"
+      },
+      {
+        "emitted_for_positive_methods": true,
+        "path": "client JSON-RPC rejection/error"
+      },
+      {
+        "emitted_for_positive_methods": true,
+        "note": "emission precedes fallback result decoding",
+        "path": "malformed successful result"
+      },
+      {
+        "emitted_for_positive_methods": true,
+        "path": "turn start/complete/interrupt cleanup"
+      },
+      {
+        "emitted_for_positive_methods": false,
+        "note": "the five positive handlers have no generic timer; autoResolutionMs is only forwarded",
+        "path": "generic timeout"
+      },
+      {
+        "emitted_for_positive_methods": false,
+        "path": "disconnect alone"
+      },
+      {
+        "emitted_for_positive_methods": false,
+        "note": "no such App Server timer exists at this pin",
+        "path": "server-side auto-resolution"
+      }
+    ]
+  },
+  "source_and_binary_package_plan": {
+    "audit_public_header_count": {
+      "after": 34,
+      "before": 34
+    },
+    "binary_and_installed_policy": "tools, tests, docs, evidence, JSON, and Python remain excluded; this audit adds no installed public header",
+    "extracted_check": "python3 -B tools/codex/app_server_a1_4.py check --repo-root <extracted-root>",
+    "future_public_header_counts": [
+      34,
+      41,
+      42,
+      43
+    ],
+    "predecessor_closure_compatibility": "A1.3 retains its historical generator/package source records while live successor-aware tokens require all A1.4 package entries and the extracted A1.4 check",
+    "required_source_entries": [
+      "tools/codex/app_server_a1_4.py",
+      "tests/component/codex/CodexA14AuditToolTest.py",
+      "tools/codex/app-server-evidence/0.144.6/a1-4-start-state.json",
+      "tools/codex/app-server-evidence/0.144.6/a1-4-total-partition.json",
+      "tools/codex/app-server-evidence/0.144.6/a1-4-type-closure.json",
+      "tools/codex/app-server-evidence/0.144.6/a1-4-implementation-plan.json",
+      "tools/codex/app-server-evidence/0.144.6/a1-final-cross-slice-ledger.json",
+      "docs/ai/openai/codex/a1-4-integrations-and-long-tail-plan.md"
+    ],
+    "source_counts": {
+      "codex_docs": {
+        "after": 19,
+        "before": 18
+      },
+      "evidence_files": {
+        "after": 27,
+        "before": 22
+      },
+      "top_level_codex_tools": {
+        "after": 14,
+        "before": 13
+      }
+    }
+  }
+}

--- a/tools/codex/app-server-evidence/0.144.6/a1-4-start-state.json
+++ b/tools/codex/app-server-evidence/0.144.6/a1-4-start-state.json
@@ -1,0 +1,3576 @@
+{
+  "base_sha": "bed5ee05184739d54cddc6518bd43b264e2b496d",
+  "base_tree": "8bf44f0eed6bd8c9d5309176db07a7d6a6240ef3",
+  "capture_sources": {
+    "assignment": {
+      "path": "tools/codex/app-server-evidence/0.144.6/module-slice-assignment.json",
+      "sha256": "e9097d1d27acd3915da65f7c955c2e8fb25f7ee0fce9b185e4415a1ba85396cf"
+    },
+    "contracts": {
+      "path": "tools/codex/app-server-evidence/0.144.6/operation-contracts.json",
+      "sha256": "226c552c5602301966c39539bbf466f345d4aa625e06d6ca603a9dbcd25e3a9e"
+    },
+    "fixture_coverage": {
+      "path": "tools/codex/app-server-evidence/0.144.6/fixture-coverage.json",
+      "sha256": "2fdd569f46b37674127cf230eb0559cfd6a00101d0c7b866936cec7a6ac32870"
+    },
+    "manifest": {
+      "path": "tools/codex/app-server-surface/0.144.6.json",
+      "sha256": "b975aa514fd951161cc68eb26aac2b291b894afb62fd6cc3982bfeacf56a7021"
+    },
+    "nested_reachability": {
+      "path": "tools/codex/app-server-evidence/0.144.6/nested-reachability.json",
+      "sha256": "07c8bfc8096cb565d7ca0cb1e97c1ffffdeda5b50a82a841971035e506f3ce9a"
+    },
+    "protocol_provenance": {
+      "path": "tools/codex/app-server-protocol-source/0.144.6/PROVENANCE.json",
+      "sha256": "6b8af60c405b54363537d9b09d3f19fc25991b517d4e802a1b02c7e5990c38b0"
+    },
+    "registry": {
+      "path": "src/ai/openai/codex/detail/ProtocolSurfaceRegistryData.inc",
+      "sha256": "7de3790505aaa6e63e95b8e5fb811616e9b2d85c1ef7f47e0c2f20906e5cf4de"
+    },
+    "schema_completeness": {
+      "path": "tools/codex/app-server-evidence/0.144.6/schema-completeness-evidence.json",
+      "sha256": "2fb1711bb73012839e004be7d757b641a9777324d889d4730df5102310d7f6f8"
+    },
+    "schema_provenance": {
+      "path": "tools/codex/app-server-schema/0.144.6/PROVENANCE.json",
+      "sha256": "91c5853c85f77dba868425a56d8b8d87c1a17281c8edf10929e5f480b721ace9"
+    },
+    "soversion_authority": {
+      "path": "CMakeLists.txt",
+      "sha256": "2f96eb43d668348121fcad099714eaef13de5fab919a40984ec6abd021d2bfa3"
+    }
+  },
+  "codex_version": "codex-cli 0.144.6",
+  "counts": {
+    "global_schema_status": {
+      "Complete": 280,
+      "NotApplicable": 48,
+      "NotImplemented": 55,
+      "Partial": 4
+    },
+    "identity_count": 56,
+    "native_schema_status": {
+      "Complete": 0,
+      "NotApplicable": 0,
+      "NotImplemented": 55,
+      "Partial": 1
+    },
+    "runtime_dispositions": {
+      "Deferred": 29,
+      "OpaquePreserved": 7,
+      "RawPreserved": 19,
+      "Typed": 1
+    },
+    "taxonomy": {
+      "client_request": 29,
+      "server_notification": 16,
+      "server_request": 4,
+      "tagged_union_discriminator": 7
+    }
+  },
+  "format_version": 1,
+  "generated_notice": "Frozen A1.4 audit start state; review evidence only, never a runtime registry.",
+  "identities": [
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "app/list"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "app/list"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/AppsList",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "app/list",
+        "parameter_type_identity": "AppsListParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "AppsListResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "externalAgentConfig/detect"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/detect"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/ExternalAgentConfigDetect",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "externalAgentConfig/detect",
+        "parameter_type_identity": "ExternalAgentConfigDetectParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "ExternalAgentConfigDetectResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "externalAgentConfig/import"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/import"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/ExternalAgentConfigImport",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "externalAgentConfig/import",
+        "parameter_type_identity": "ExternalAgentConfigImportParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "ExternalAgentConfigImportResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "externalAgentConfig/import/readHistories"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/import/readHistories"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/ExternalAgentConfigImportHistoriesRead",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "externalAgentConfig/import/readHistories",
+        "parameter_type_identity": "Unit",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "ExternalAgentConfigImportHistoriesReadResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "feedback/upload"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "feedback/upload"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/FeedbackUpload",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "feedback/upload",
+        "parameter_type_identity": "FeedbackUploadParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "FeedbackUploadResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "hooks/list"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "hooks/list"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/HooksList",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "hooks/list",
+        "parameter_type_identity": "HooksListParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "HooksListResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "marketplace/add"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/add"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/MarketplaceAdd",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "marketplace/add",
+        "parameter_type_identity": "MarketplaceAddParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "MarketplaceAddResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "marketplace/remove"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/remove"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/MarketplaceRemove",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "marketplace/remove",
+        "parameter_type_identity": "MarketplaceRemoveParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "MarketplaceRemoveResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "marketplace/upgrade"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/upgrade"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/MarketplaceUpgrade",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "marketplace/upgrade",
+        "parameter_type_identity": "MarketplaceUpgradeParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "MarketplaceUpgradeResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServer/oauth/login"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/oauth/login"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpServerOauthLogin",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "mcpServer/oauth/login",
+        "parameter_type_identity": "McpServerOauthLoginParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "McpServerOauthLoginResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServer/resource/read"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/resource/read"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpResourceRead",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "mcpServer/resource/read",
+        "parameter_type_identity": "McpResourceReadParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "McpResourceReadResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServer/tool/call"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/tool/call"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpServerToolCall",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "mcpServer/tool/call",
+        "parameter_type_identity": "McpServerToolCallParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "McpServerToolCallResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServerStatus/list"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServerStatus/list"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpServerStatusList",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "mcpServerStatus/list",
+        "parameter_type_identity": "ListMcpServerStatusParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "ListMcpServerStatusResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/install"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/install"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginInstall",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "plugin/install",
+        "parameter_type_identity": "PluginInstallParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "PluginInstallResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/installed"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/installed"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginInstalled",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "plugin/installed",
+        "parameter_type_identity": "PluginInstalledParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "PluginInstalledResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/list"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/list"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginList",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "plugin/list",
+        "parameter_type_identity": "PluginListParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "PluginListResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/read"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/read"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginRead",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "plugin/read",
+        "parameter_type_identity": "PluginReadParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "PluginReadResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/checkout"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/checkout"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareCheckout",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "plugin/share/checkout",
+        "parameter_type_identity": "PluginShareCheckoutParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "PluginShareCheckoutResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/delete"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/delete"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareDelete",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "plugin/share/delete",
+        "parameter_type_identity": "PluginShareDeleteParams",
+        "result_contract_kind": "Unit",
+        "result_type_identity": "Unit",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/list"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/list"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareList",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "plugin/share/list",
+        "parameter_type_identity": "PluginShareListParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "PluginShareListResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/save"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/save"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareSave",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "plugin/share/save",
+        "parameter_type_identity": "PluginShareSaveParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "PluginShareSaveResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/updateTargets"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/updateTargets"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareUpdateTargets",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "plugin/share/updateTargets",
+        "parameter_type_identity": "PluginShareUpdateTargetsParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "PluginShareUpdateTargetsResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/skill/read"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/skill/read"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginSkillRead",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "plugin/skill/read",
+        "parameter_type_identity": "PluginSkillReadParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "PluginSkillReadResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/uninstall"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/uninstall"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginUninstall",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "plugin/uninstall",
+        "parameter_type_identity": "PluginUninstallParams",
+        "result_contract_kind": "Unit",
+        "result_type_identity": "Unit",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "skills/config/write"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/config/write"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/SkillsConfigWrite",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "skills/config/write",
+        "parameter_type_identity": "SkillsConfigWriteParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "SkillsConfigWriteResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "skills/extraRoots/set"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/extraRoots/set"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/SkillsExtraRootsSet",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "skills/extraRoots/set",
+        "parameter_type_identity": "SkillsExtraRootsSetParams",
+        "result_contract_kind": "Unit",
+        "result_type_identity": "Unit",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "skills/list"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/list"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/SkillsList",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "skills/list",
+        "parameter_type_identity": "SkillsListParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "SkillsListResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "windowsSandbox/readiness"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "windowsSandbox/readiness"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/WindowsSandboxReadiness",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "windowsSandbox/readiness",
+        "parameter_type_identity": "Unit",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "WindowsSandboxReadinessResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "windowsSandbox/setupStart"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "windowsSandbox/setupStart"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/WindowsSandboxSetupStart",
+        "association_evidence_kind": "VendoredRust",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "client_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "frontend_exposure": "NotExposed",
+        "frontend_security": "Unresolved",
+        "name": "windowsSandbox/setupStart",
+        "parameter_type_identity": "WindowsSandboxSetupStartParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "WindowsSandboxSetupStartResponse",
+        "runtime_disposition": "Deferred",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "app/list/updated"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "app/list/updated"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "app/list/updated",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "deprecationNotice"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "deprecationNotice"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "deprecationNotice",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "externalAgentConfig/import/completed"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "externalAgentConfig/import/completed"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "externalAgentConfig/import/completed",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "externalAgentConfig/import/progress"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "externalAgentConfig/import/progress"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "externalAgentConfig/import/progress",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "hook/completed"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "hook/completed"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "hook/completed",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "hook/started"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "hook/started"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "hook/started",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "mcpServer/oauthLogin/completed"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "mcpServer/oauthLogin/completed"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "mcpServer/oauthLogin/completed",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "mcpServer/startupStatus/updated"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "mcpServer/startupStatus/updated"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "mcpServer/startupStatus/updated",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "process/exited"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "process/exited"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "process/exited",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "process/outputDelta"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "process/outputDelta"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "process/outputDelta",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "remoteControl/status/changed"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "remoteControl/status/changed"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "remoteControl/status/changed",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "serverRequest/resolved"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "serverRequest/resolved"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "serverRequest/resolved",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "skills/changed"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "skills/changed"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "skills/changed",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "warning"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "warning"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "warning",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "windows/worldWritableWarning"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "windows/worldWritableWarning"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "windows/worldWritableWarning",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "windowsSandbox/setupCompleted"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "windowsSandbox/setupCompleted"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_notification",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "frontend_exposure": "GenericExtension",
+        "frontend_security": "ExistingRedactedExtensionContract",
+        "name": "windowsSandbox/setupCompleted",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "attestation/generate"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "attestation/generate"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "stable/ServerRequest.json#/oneOf/7+stable/AttestationGenerateResponse.json",
+        "association_evidence_kind": "VendoredSchemaPair",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "frontend_exposure": "GenericUnknownRequest",
+        "frontend_security": "ExistingGenericContractDedicatedUnresolved",
+        "name": "attestation/generate",
+        "parameter_type_identity": "AttestationGenerateParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "AttestationGenerateResponse",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "item/tool/call"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "item/tool/call"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "stable/ServerRequest.json#/oneOf/5+stable/DynamicToolCallResponse.json",
+        "association_evidence_kind": "VendoredSchemaPair",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "frontend_exposure": "GenericUnknownRequest",
+        "frontend_security": "ExistingGenericContractDedicatedUnresolved",
+        "name": "item/tool/call",
+        "parameter_type_identity": "DynamicToolCallParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "DynamicToolCallResponse",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "item/tool/requestUserInput"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "item/tool/requestUserInput"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "stable/ServerRequest.json#/oneOf/2+stable/ToolRequestUserInputResponse.json",
+        "association_evidence_kind": "VendoredSchemaPair",
+        "backend_status": "Implemented",
+        "canonical_state_status": "Implemented",
+        "category": "server_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "frontend_exposure": "ExistingOperationSubset",
+        "frontend_security": "ExistingOperationSubsetExpansionUnresolved",
+        "name": "item/tool/requestUserInput",
+        "parameter_type_identity": "ToolRequestUserInputParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "ToolRequestUserInputResponse",
+        "runtime_disposition": "Typed",
+        "runtime_target": "ServerRequestTarget::ToolRequestUserInput",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "Partial",
+        "typed_status": "Implemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "reason": "fixed A1 domain-root assignment",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "mcpServer/elicitation/request"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "mcpServer/elicitation/request"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "stable/ServerRequest.json#/oneOf/3+stable/McpServerElicitationRequestResponse.json",
+        "association_evidence_kind": "VendoredSchemaPair",
+        "backend_status": "NotImplemented",
+        "canonical_state_status": "NotImplemented",
+        "category": "server_request",
+        "deprecated": false,
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "frontend_exposure": "GenericUnknownRequest",
+        "frontend_security": "ExistingGenericContractDedicatedUnresolved",
+        "name": "mcpServer/elicitation/request",
+        "parameter_type_identity": "McpServerElicitationRequestParams",
+        "result_contract_kind": "Concrete",
+        "result_type_identity": "McpServerElicitationRequestResponse",
+        "runtime_disposition": "RawPreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": true,
+          "direction_assertions_exercised": false,
+          "fixture_current": true,
+          "independently_schema_validated": true,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": true,
+          "optional_present_exercised": true,
+          "positive_fixture_coverage": true,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": true,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "RootOwnedNestedUnion",
+        "module": "IntegrationsAndLongTail",
+        "reason": "assigned to its sole reaching stable root slice",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "mode",
+          "domain": "McpServerElicitationRequestParams",
+          "name": "form"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "name": "form"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotApplicable",
+        "canonical_state_status": "NotApplicable",
+        "category": "tagged_union_discriminator",
+        "deprecated": false,
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "frontend_exposure": "NotApplicable",
+        "frontend_security": "NotApplicable",
+        "name": "form",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "OpaquePreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "RootOwnedNestedUnion",
+        "module": "IntegrationsAndLongTail",
+        "reason": "assigned to its sole reaching stable root slice",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "mode",
+          "domain": "McpServerElicitationRequestParams",
+          "name": "openai/form"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "name": "openai/form"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotApplicable",
+        "canonical_state_status": "NotApplicable",
+        "category": "tagged_union_discriminator",
+        "deprecated": false,
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "frontend_exposure": "NotApplicable",
+        "frontend_security": "NotApplicable",
+        "name": "openai/form",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "OpaquePreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "RootOwnedNestedUnion",
+        "module": "IntegrationsAndLongTail",
+        "reason": "assigned to its sole reaching stable root slice",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "mode",
+          "domain": "McpServerElicitationRequestParams",
+          "name": "url"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "name": "url"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotApplicable",
+        "canonical_state_status": "NotApplicable",
+        "category": "tagged_union_discriminator",
+        "deprecated": false,
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "frontend_exposure": "NotApplicable",
+        "frontend_security": "NotApplicable",
+        "name": "url",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "OpaquePreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "SharedWithinSlice",
+        "module": "IntegrationsAndLongTail",
+        "reason": "shared by multiple stable roots in one fixed slice",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "git"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "git"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotApplicable",
+        "canonical_state_status": "NotApplicable",
+        "category": "tagged_union_discriminator",
+        "deprecated": false,
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "frontend_exposure": "NotApplicable",
+        "frontend_security": "NotApplicable",
+        "name": "git",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "OpaquePreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "SharedWithinSlice",
+        "module": "IntegrationsAndLongTail",
+        "reason": "shared by multiple stable roots in one fixed slice",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "local"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "local"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotApplicable",
+        "canonical_state_status": "NotApplicable",
+        "category": "tagged_union_discriminator",
+        "deprecated": false,
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "frontend_exposure": "NotApplicable",
+        "frontend_security": "NotApplicable",
+        "name": "local",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "OpaquePreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "SharedWithinSlice",
+        "module": "IntegrationsAndLongTail",
+        "reason": "shared by multiple stable roots in one fixed slice",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "npm"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "npm"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotApplicable",
+        "canonical_state_status": "NotApplicable",
+        "category": "tagged_union_discriminator",
+        "deprecated": false,
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "frontend_exposure": "NotApplicable",
+        "frontend_security": "NotApplicable",
+        "name": "npm",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "OpaquePreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    },
+    {
+      "assignment": {
+        "a1_slice": "A1.4",
+        "classification": "SharedWithinSlice",
+        "module": "IntegrationsAndLongTail",
+        "reason": "shared by multiple stable roots in one fixed slice",
+        "slice": "A1.4",
+        "stability": "stable",
+        "surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "remote"
+        }
+      },
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "remote"
+      },
+      "registry": {
+        "a1_slice": "A1.4",
+        "association_evidence_key": "",
+        "association_evidence_kind": "NotApplicable",
+        "backend_status": "NotApplicable",
+        "canonical_state_status": "NotApplicable",
+        "category": "tagged_union_discriminator",
+        "deprecated": false,
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "frontend_exposure": "NotApplicable",
+        "frontend_security": "NotApplicable",
+        "name": "remote",
+        "parameter_type_identity": "",
+        "result_contract_kind": "NotApplicable",
+        "result_type_identity": "",
+        "runtime_disposition": "OpaquePreserved",
+        "runtime_target": "std::monostate{}",
+        "schema_completeness": {
+          "authoritative_root_association": false,
+          "direction_assertions_exercised": false,
+          "fixture_current": false,
+          "independently_schema_validated": false,
+          "no_known_schema_fields_dropped": false,
+          "nullable_semantics_exercised": false,
+          "opaque_fields_declared": false,
+          "optional_omitted_exercised": false,
+          "optional_present_exercised": false,
+          "positive_fixture_coverage": false,
+          "reachable_union_alternatives_exercised": false,
+          "required_fields_exercised": false,
+          "runtime_decoder_matches_registry": false,
+          "schema_properties_exercised": false
+        },
+        "stability": "stable",
+        "typed_module": "IntegrationsAndLongTail",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    }
+  ],
+  "inherited_a1_0_partial_identities": [
+    {
+      "category": "client_notification",
+      "discriminator_field": "method",
+      "domain": "ClientNotification",
+      "name": "initialized"
+    },
+    {
+      "category": "client_request",
+      "discriminator_field": "method",
+      "domain": "ClientRequest",
+      "name": "initialize"
+    },
+    {
+      "category": "server_notification",
+      "discriminator_field": "method",
+      "domain": "ServerNotification",
+      "name": "error"
+    }
+  ],
+  "native_partial_identity": {
+    "category": "server_request",
+    "discriminator_field": "method",
+    "domain": "ServerRequest",
+    "name": "item/tool/requestUserInput"
+  },
+  "protected_predecessor_evidence": {
+    "tools/codex/app-server-evidence/0.144.6/a1-1-closure-report.json": "be9e5f028de164b57519a956a0b2615b15faa238d889b7f1391b07c3b473fb41",
+    "tools/codex/app-server-evidence/0.144.6/a1-1-implementation-plan.json": "59fbbd1e6c1ffcd5e0064e7ff7e2a6a68673ececac5ccb19d3d46cc57eda7661",
+    "tools/codex/app-server-evidence/0.144.6/a1-1-notification-production-coverage.json": "191c9e9152fe6c3a2fd052f542911c510e6643e78bfaf2b293729f9bfe7e62b0",
+    "tools/codex/app-server-evidence/0.144.6/a1-1-operation-production-coverage.json": "9e9cc9a58651d39f2e2b5e9ee9cdb712a6338660029a77814988a7e904ef156e",
+    "tools/codex/app-server-evidence/0.144.6/a1-1-start-state.json": "1614414ea6320f8ac5eb47ef928c4bc8de587c9f429f86d7f94ffeb437b6c705",
+    "tools/codex/app-server-evidence/0.144.6/a1-1-type-closure.json": "187db47c37d094b5f22c27cb0a6c1fc656cd0b3e34c63faf9b81ededce2f8bfc",
+    "tools/codex/app-server-evidence/0.144.6/a1-2-closure-report.json": "6324a85d998fdbf6c3601f7e19b90c61cea472fde63b49c676511ce1654494cc",
+    "tools/codex/app-server-evidence/0.144.6/a1-2-implementation-plan.json": "ff5ab66b79cd53c614a93a8d5cd1a065c54b8a251c706adeb805c900f43f44c4",
+    "tools/codex/app-server-evidence/0.144.6/a1-2-start-state.json": "86dc9319ab212c3bdea0d483a6759dfde7d7eba7d5ab92a440a206d1097ab7b9",
+    "tools/codex/app-server-evidence/0.144.6/a1-2-type-closure.json": "2b8bc5de1c56b1ce7b809939a744ec1027a78574adfc9e5e8c1e966a385047cb",
+    "tools/codex/app-server-evidence/0.144.6/a1-3-api-abi-evidence.json": "b6d05bd993ec421aa7d2ff3e720a399fc54d801305c906f3a8c9c7557be9b611",
+    "tools/codex/app-server-evidence/0.144.6/a1-3-closure-report.json": "3eb5d5c7a0691e59f8a4910334b2661f171d331cd5994d88457a3421c4d3e592",
+    "tools/codex/app-server-evidence/0.144.6/a1-3-implementation-plan.json": "d5905f4f60f1ca2a298c2a910d2effbde13a9bfa6b755d5896dc2d5b6b21034d",
+    "tools/codex/app-server-evidence/0.144.6/a1-3-start-state.json": "ee93456760b366e399f55ba48f3aea343d836dd2544b09a4274bc60850bb16fb",
+    "tools/codex/app-server-evidence/0.144.6/a1-3-type-closure.json": "223e10abd517ac63481276905a19605ed7dd5bd34f806f0adc15a698b8f88e0e"
+  },
+  "provenance": {
+    "codex_version": "codex-cli 0.144.6",
+    "protocol_source_files": [
+      {
+        "bytes": 140314,
+        "path": "codex-rs/app-server-protocol/src/protocol/common.rs",
+        "sha256": "5679cbc5b3e935a2edd69fbe62b82b956eff4d5d050c9969b090ccc9d367fdee"
+      },
+      {
+        "bytes": 10926,
+        "path": "LICENSE.openai-codex",
+        "sha256": "d17f227e4df5da1600391338865ce0f3055211760a36688f816941d58232d8dc"
+      },
+      {
+        "bytes": 242,
+        "path": "NOTICE.openai-codex",
+        "sha256": "9d71575ecfd9a843fc1677b0efb08053c6ba9fd686a0de1a6f5382fd3c220915"
+      }
+    ],
+    "protocol_source_provenance_sha256": "6b8af60c405b54363537d9b09d3f19fc25991b517d4e802a1b02c7e5990c38b0",
+    "schema_provenance_sha256": "91c5853c85f77dba868425a56d8b8d87c1a17281c8edf10929e5f480b721ace9",
+    "schema_trees": {
+      "experimental": {
+        "aggregate_sha256": "4a0ef96787255364d99b15fe40fcfd6227901978d0cddc8b20340bfef98a0d1b",
+        "file_count": 337
+      },
+      "stable": {
+        "aggregate_sha256": "cee1ac3bcaf95e5fcdcf07499c7e6b00fc423b90c670ea3380f1799434b72add",
+        "file_count": 267
+      }
+    },
+    "source_commit_sha": "5d1fbf26c43abc65a203928b2e31561cb039e06d",
+    "typescript_aggregate_sha256": {
+      "experimental": "d561ef0b4ef8a921fff50de4e3c662a0fdff643e82868f2b05a3e71f912aec8c",
+      "stable": "73c95b6a19d5559939519a771e0f7285cc60bbfaa1aac8bd9c52ba308c6e6811"
+    },
+    "upstream_tag": "rust-v0.144.6"
+  },
+  "upstream_tag": "rust-v0.144.6"
+}

--- a/tools/codex/app-server-evidence/0.144.6/a1-4-total-partition.json
+++ b/tools/codex/app-server-evidence/0.144.6/a1-4-total-partition.json
@@ -1,0 +1,7288 @@
+{
+  "audit_boundaries": {
+    "backend_command_changed": false,
+    "backend_state_changed": false,
+    "changed_paths": [
+      "tests/CMakeLists.txt",
+      "tests/component/codex/CodexA14AuditToolTest.py",
+      "tools/codex/app-server-evidence/0.144.6/a1-4-start-state.json",
+      "tools/codex/app-server-evidence/0.144.6/a1-4-total-partition.json",
+      "tools/codex/app-server-evidence/0.144.6/a1-4-type-closure.json",
+      "tools/codex/app_server_a1_4.py"
+    ],
+    "frontend_protocol_changed": false,
+    "module_assignment_changed": false,
+    "production_paths_changed": [],
+    "protected_nonproduction_paths_changed": [],
+    "registry_status_promoted": false,
+    "runtime_implementation_added": false,
+    "soversion_changed": false
+  },
+  "bijection": {
+    "assignment_keys": 387,
+    "cross_slice_overlaps": [],
+    "duplicate_assignments": [],
+    "extra_assignments": [],
+    "extra_registry_rows": [],
+    "inventory_keys": 387,
+    "missing_assignments": [],
+    "missing_registry_rows": [],
+    "registry_keys": 387
+  },
+  "buckets": {
+    "A1.0": [
+      {
+        "a1_slice": "A1.0",
+        "classification": "StablePublicRoot",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "client_notification",
+          "discriminator_field": "method",
+          "domain": "ClientNotification",
+          "name": "initialized"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Partial",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "StablePublicRoot",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "initialize"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Partial",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "StablePublicRoot",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "error"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Partial",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "activeTurnNotSteerable"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "badRequest"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "contextWindowExceeded"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "cyberPolicy"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "httpConnectionFailed"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "internalServerError"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "other"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "responseStreamConnectionFailed"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "responseStreamDisconnected"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "responseTooManyFailedAttempts"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "sandboxError"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "serverOverloaded"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "sessionBudgetExceeded"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "threadRollbackFailed"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "unauthorized"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.0",
+        "classification": "CrossCuttingA1_0Exception",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CodexErrorInfo",
+          "name": "usageLimitExceeded"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      }
+    ],
+    "A1.1": [
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/archive"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/compact/start"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/delete"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/fork"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/goal/clear"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/goal/get"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/goal/set"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/inject_items"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/list"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/loaded/list"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/metadata/update"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/name/set"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/read"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/resume"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/rollback"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/shellCommand"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/start"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/unarchive"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/unsubscribe"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "turn/interrupt"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "turn/start"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "turn/steer"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "agent_message"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "compaction"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "compaction_trigger"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "context_compaction"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "custom_tool_call"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "custom_tool_call_output"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "function_call"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "function_call_output"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "image_generation_call"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "local_shell_call"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "message"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "other"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "reasoning"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "tool_search_call"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "tool_search_output"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponseItem",
+          "name": "web_search_call"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "agentMessage"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "collabAgentToolCall"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "commandExecution"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "contextCompaction"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "dynamicToolCall"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "enteredReviewMode"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "exitedReviewMode"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "fileChange"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "hookPrompt"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "imageGeneration"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "imageView"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "mcpToolCall"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "plan"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "reasoning"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "sleep"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "subAgentActivity"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "userMessage"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StableItemRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "item_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadItem",
+          "name": "webSearch"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/agentMessage/delta"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/commandExecution/outputDelta"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/commandExecution/terminalInteraction"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/completed"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/fileChange/outputDelta"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/fileChange/patchUpdated"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/mcpToolCall/progress"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/plan/delta"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/reasoning/summaryPartAdded"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/reasoning/summaryTextDelta"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/reasoning/textDelta"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/started"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/archived"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/closed"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/compacted"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/deleted"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/goal/cleared"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/goal/updated"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/name/updated"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/realtime/closed"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/realtime/error"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/realtime/itemAdded"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/realtime/outputAudio/delta"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/realtime/sdp"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/realtime/started"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/realtime/transcript/delta"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/realtime/transcript/done"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/settings/updated"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/started"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/status/changed"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/tokenUsage/updated"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "thread/unarchived"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "turn/completed"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "turn/diff/updated"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "turn/moderationMetadata"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "turn/plan/updated"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "StablePublicRoot",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "turn/started"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "AgentMessageInputContent",
+          "name": "encrypted_content"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "AgentMessageInputContent",
+          "name": "input_text"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "AskForApproval",
+          "name": "granular"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "AskForApproval",
+          "name": "never"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "AskForApproval",
+          "name": "on-request"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "AskForApproval",
+          "name": "untrusted"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "CommandAction",
+          "name": "listFiles"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "CommandAction",
+          "name": "read"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "CommandAction",
+          "name": "search"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "CommandAction",
+          "name": "unknown"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ContentItem",
+          "name": "input_image"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ContentItem",
+          "name": "input_text"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ContentItem",
+          "name": "output_text"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "DynamicToolCallOutputContentItem",
+          "name": "inputImage"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "DynamicToolCallOutputContentItem",
+          "name": "inputText"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "FunctionCallOutputContentItem",
+          "name": "encrypted_content"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "FunctionCallOutputContentItem",
+          "name": "input_image"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "FunctionCallOutputContentItem",
+          "name": "input_text"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "LocalShellAction",
+          "name": "exec"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PatchChangeKind",
+          "name": "add"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PatchChangeKind",
+          "name": "delete"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PatchChangeKind",
+          "name": "update"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ReasoningItemContent",
+          "name": "reasoning_text"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ReasoningItemContent",
+          "name": "text"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ReasoningItemReasoningSummary",
+          "name": "summary_text"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponsesApiWebSearchAction",
+          "name": "find_in_page"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponsesApiWebSearchAction",
+          "name": "open_page"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponsesApiWebSearchAction",
+          "name": "other"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "RootOwnedNestedUnion",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ResponsesApiWebSearchAction",
+          "name": "search"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "SandboxPolicy",
+          "name": "dangerFullAccess"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "SandboxPolicy",
+          "name": "externalSandbox"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "SandboxPolicy",
+          "name": "readOnly"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "SandboxPolicy",
+          "name": "workspaceWrite"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SessionSource",
+          "name": "appServer"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SessionSource",
+          "name": "cli"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SessionSource",
+          "name": "custom"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SessionSource",
+          "name": "exec"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SessionSource",
+          "name": "subAgent"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SessionSource",
+          "name": "unknown"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SessionSource",
+          "name": "vscode"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SubAgentSource",
+          "name": "compact"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SubAgentSource",
+          "name": "memory_consolidation"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SubAgentSource",
+          "name": "other"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SubAgentSource",
+          "name": "review"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "SubAgentSource",
+          "name": "thread_spawn"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadStatus",
+          "name": "active"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadStatus",
+          "name": "idle"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadStatus",
+          "name": "notLoaded"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedWithinSlice",
+        "module": "ThreadsTurnsSessions",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadStatus",
+          "name": "systemError"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "UserInput",
+          "name": "image"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "UserInput",
+          "name": "localImage"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "UserInput",
+          "name": "mention"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "UserInput",
+          "name": "skill"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "UserInput",
+          "name": "text"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "WebSearchAction",
+          "name": "findInPage"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "WebSearchAction",
+          "name": "openPage"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "WebSearchAction",
+          "name": "other"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.1",
+        "classification": "SharedCommon",
+        "module": "Common",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "WebSearchAction",
+          "name": "search"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      }
+    ],
+    "A1.2": [
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "account/login/cancel"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "account/login/start"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "account/logout"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "account/rateLimitResetCredit/consume"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "account/rateLimits/read"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "account/read"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "account/sendAddCreditsNudgeEmail"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "account/usage/read"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "account/workspaceMessages/read"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "config/batchWrite"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "config/mcpServer/reload"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "config/read"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "config/value/write"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "configRequirements/read"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "experimentalFeature/enablement/set"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "experimentalFeature/list"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "model/list"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "modelProvider/capabilities/read"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "account/login/completed"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "account/rateLimits/updated"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "account/updated"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "configWarning"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "model/rerouted"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "model/safetyBuffering/updated"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "model/verification"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "StablePublicRoot",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "account/chatgptAuthTokens/refresh"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "RootOwnedNestedUnion",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "Account",
+          "name": "amazonBedrock"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "RootOwnedNestedUnion",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "Account",
+          "name": "apiKey"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "RootOwnedNestedUnion",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "Account",
+          "name": "chatgpt"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "SharedWithinSlice",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfigLayerSource",
+          "name": "enterpriseManaged"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "SharedWithinSlice",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfigLayerSource",
+          "name": "legacyManagedConfigTomlFromFile"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "SharedWithinSlice",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfigLayerSource",
+          "name": "legacyManagedConfigTomlFromMdm"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "SharedWithinSlice",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfigLayerSource",
+          "name": "mdm"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "SharedWithinSlice",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfigLayerSource",
+          "name": "project"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "SharedWithinSlice",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfigLayerSource",
+          "name": "sessionFlags"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "SharedWithinSlice",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfigLayerSource",
+          "name": "system"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "SharedWithinSlice",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfigLayerSource",
+          "name": "user"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "RootOwnedNestedUnion",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "LoginAccountParams",
+          "name": "apiKey"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "RootOwnedNestedUnion",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "LoginAccountParams",
+          "name": "chatgpt"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "RootOwnedNestedUnion",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "LoginAccountParams",
+          "name": "chatgptAuthTokens"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "RootOwnedNestedUnion",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "LoginAccountParams",
+          "name": "chatgptDeviceCode"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "RootOwnedNestedUnion",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "LoginAccountResponse",
+          "name": "apiKey"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "RootOwnedNestedUnion",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "LoginAccountResponse",
+          "name": "chatgpt"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "RootOwnedNestedUnion",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "LoginAccountResponse",
+          "name": "chatgptAuthTokens"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.2",
+        "classification": "RootOwnedNestedUnion",
+        "module": "AccountsModelsConfiguration",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "LoginAccountResponse",
+          "name": "chatgptDeviceCode"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      }
+    ],
+    "A1.3": [
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "command/exec"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "command/exec/resize"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "command/exec/terminate"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "command/exec/write"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fs/copy"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fs/createDirectory"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fs/getMetadata"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fs/readDirectory"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fs/readFile"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fs/remove"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fs/unwatch"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fs/watch"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fs/writeFile"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fuzzyFileSearch"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "permissionProfile/list"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "review/start"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/approveGuardianDeniedAction"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "command/exec/outputDelta"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "fs/changed"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "fuzzyFileSearch/sessionCompleted"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "fuzzyFileSearch/sessionUpdated"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "guardianWarning"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/autoApprovalReview/completed"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "item/autoApprovalReview/started"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "applyPatchApproval"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "execCommandApproval"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "item/commandExecution/requestApproval"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "item/fileChange/requestApproval"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "StablePublicRoot",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "item/permissions/requestApproval"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CommandExecutionApprovalDecision",
+          "name": "accept"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CommandExecutionApprovalDecision",
+          "name": "acceptForSession"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CommandExecutionApprovalDecision",
+          "name": "acceptWithExecpolicyAmendment"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CommandExecutionApprovalDecision",
+          "name": "applyNetworkPolicyAmendment"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CommandExecutionApprovalDecision",
+          "name": "cancel"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "CommandExecutionApprovalDecision",
+          "name": "decline"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "FileChange",
+          "name": "add"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "FileChange",
+          "name": "delete"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "FileChange",
+          "name": "update"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "FileSystemPath",
+          "name": "glob_pattern"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "FileSystemPath",
+          "name": "path"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "FileSystemPath",
+          "name": "special"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "kind",
+          "domain": "FileSystemSpecialPath",
+          "name": "minimal"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "kind",
+          "domain": "FileSystemSpecialPath",
+          "name": "project_roots"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "kind",
+          "domain": "FileSystemSpecialPath",
+          "name": "root"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "kind",
+          "domain": "FileSystemSpecialPath",
+          "name": "slash_tmp"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "kind",
+          "domain": "FileSystemSpecialPath",
+          "name": "tmpdir"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "kind",
+          "domain": "FileSystemSpecialPath",
+          "name": "unknown"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "GuardianApprovalReviewAction",
+          "name": "applyPatch"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "GuardianApprovalReviewAction",
+          "name": "command"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "GuardianApprovalReviewAction",
+          "name": "execve"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "GuardianApprovalReviewAction",
+          "name": "mcpToolCall"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "GuardianApprovalReviewAction",
+          "name": "networkAccess"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "GuardianApprovalReviewAction",
+          "name": "requestPermissions"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ParsedCommand",
+          "name": "list_files"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ParsedCommand",
+          "name": "read"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ParsedCommand",
+          "name": "search"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ParsedCommand",
+          "name": "unknown"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "ReviewDecision",
+          "name": "abort"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "ReviewDecision",
+          "name": "approved"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "ReviewDecision",
+          "name": "approved_execpolicy_amendment"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "ReviewDecision",
+          "name": "approved_for_session"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "ReviewDecision",
+          "name": "denied"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "ReviewDecision",
+          "name": "network_policy_amendment"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "SharedWithinSlice",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "ReviewDecision",
+          "name": "timed_out"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ReviewTarget",
+          "name": "baseBranch"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ReviewTarget",
+          "name": "commit"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ReviewTarget",
+          "name": "custom"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.3",
+        "classification": "RootOwnedNestedUnion",
+        "module": "CommandsFilesystemReviewsApprovals",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ReviewTarget",
+          "name": "uncommittedChanges"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Complete",
+        "typed_status": "Implemented"
+      }
+    ],
+    "A1.4": [
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "app/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "externalAgentConfig/detect"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "externalAgentConfig/import"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "externalAgentConfig/import/readHistories"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "feedback/upload"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "hooks/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "marketplace/add"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "marketplace/remove"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "marketplace/upgrade"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServer/oauth/login"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServer/resource/read"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServer/tool/call"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mcpServerStatus/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/install"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/installed"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/read"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/checkout"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/delete"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/save"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/updateTargets"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/skill/read"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/uninstall"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "skills/config/write"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "skills/extraRoots/set"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "skills/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "windowsSandbox/readiness"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "windowsSandbox/setupStart"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "app/list/updated"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "deprecationNotice"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "externalAgentConfig/import/completed"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "externalAgentConfig/import/progress"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "hook/completed"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "hook/started"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "mcpServer/oauthLogin/completed"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "mcpServer/startupStatus/updated"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "process/exited"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "process/outputDelta"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "remoteControl/status/changed"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "serverRequest/resolved"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "skills/changed"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "warning"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "windows/worldWritableWarning"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_notification",
+          "discriminator_field": "method",
+          "domain": "ServerNotification",
+          "name": "windowsSandbox/setupCompleted"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "attestation/generate"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "item/tool/call"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "item/tool/requestUserInput"
+        },
+        "runtime_disposition": "Typed",
+        "stability": "stable",
+        "typed_schema_status": "Partial",
+        "typed_status": "Implemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "mcpServer/elicitation/request"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "RootOwnedNestedUnion",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "mode",
+          "domain": "McpServerElicitationRequestParams",
+          "name": "form"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "RootOwnedNestedUnion",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "mode",
+          "domain": "McpServerElicitationRequestParams",
+          "name": "openai/form"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "RootOwnedNestedUnion",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "mode",
+          "domain": "McpServerElicitationRequestParams",
+          "name": "url"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "SharedWithinSlice",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "git"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "SharedWithinSlice",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "local"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "SharedWithinSlice",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "npm"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "A1.4",
+        "classification": "SharedWithinSlice",
+        "module": "IntegrationsAndLongTail",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "PluginSource",
+          "name": "remote"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotImplemented",
+        "typed_status": "NotImplemented"
+      }
+    ],
+    "InventoryOnly": [
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "collaborationMode/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "environment/add"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "environment/info"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fuzzyFileSearch/sessionStart"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fuzzyFileSearch/sessionStop"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fuzzyFileSearch/sessionUpdate"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "memory/reset"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mock/experimentalMethod"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "process/kill"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "process/resizePty"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "process/spawn"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "process/writeStdin"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/client/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/client/revoke"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/disable"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/enable"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/pairing/start"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/pairing/status"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/status/read"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/backgroundTerminals/clean"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/backgroundTerminals/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/backgroundTerminals/terminate"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/decrement_elicitation"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/increment_elicitation"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/items/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/memoryMode/set"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/appendAudio"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/appendSpeech"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/appendText"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/listVoices"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/start"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/stop"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/search"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/settings/update"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/turns/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "currentTime/read"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "CapabilityRootLocation",
+          "name": "environment"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfiguredHookHandler",
+          "name": "agent"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfiguredHookHandler",
+          "name": "command"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfiguredHookHandler",
+          "name": "prompt"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "DynamicToolNamespaceTool",
+          "name": "function"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "DynamicToolSpec",
+          "name": "function"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "DynamicToolSpec",
+          "name": "namespace"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "MultiAgentMode",
+          "name": "custom"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "MultiAgentMode",
+          "name": "explicitRequestOnly"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "MultiAgentMode",
+          "name": "proactive"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadRealtimeStartTransport",
+          "name": "webrtc"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadRealtimeStartTransport",
+          "name": "websocket"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      }
+    ]
+  },
+  "codex_version": "codex-cli 0.144.6",
+  "counts": {
+    "final_a1_projection": {
+      "Complete": 339,
+      "NotApplicable": 48,
+      "NotImplemented": 0,
+      "Partial": 0
+    },
+    "global_start_status": {
+      "Complete": 280,
+      "NotApplicable": 48,
+      "NotImplemented": 55,
+      "Partial": 4
+    },
+    "inventory_only_classifications": {
+      "ExperimentalInventoryOnly": 36,
+      "StableUnreachableInventory": 12
+    },
+    "native_a1_4_result_kinds": {
+      "Concrete": 26,
+      "Unit": 3
+    },
+    "native_a1_4_start_status": {
+      "Complete": 0,
+      "NotApplicable": 0,
+      "NotImplemented": 55,
+      "Partial": 1
+    },
+    "native_a1_4_taxonomy": {
+      "client_request": 29,
+      "server_notification": 16,
+      "server_request": 4,
+      "tagged_union_discriminator": 7
+    },
+    "native_completion_projection": {
+      "Complete": 336,
+      "NotApplicable": 48,
+      "NotImplemented": 0,
+      "Partial": 3
+    },
+    "partition": {
+      "A1.0": 19,
+      "A1.1": 151,
+      "A1.2": 45,
+      "A1.3": 68,
+      "A1.4": 56,
+      "InventoryOnly": 48
+    },
+    "stability_accounting": {
+      "experimental_only_inventory": 36,
+      "stable_a1": 339,
+      "stable_inventory": 351,
+      "stable_unreachable_inventory": 12,
+      "total_inventory": 387
+    },
+    "total_inventory": 387
+  },
+  "format_version": 1,
+  "generated_notice": "Generated total partition guard; ProtocolSurfaceRegistryData.inc remains authoritative.",
+  "inherited_a1_0_partial_identities": [
+    {
+      "category": "client_notification",
+      "discriminator_field": "method",
+      "domain": "ClientNotification",
+      "name": "initialized"
+    },
+    {
+      "category": "client_request",
+      "discriminator_field": "method",
+      "domain": "ClientRequest",
+      "name": "initialize"
+    },
+    {
+      "category": "server_notification",
+      "discriminator_field": "method",
+      "domain": "ServerNotification",
+      "name": "error"
+    }
+  ],
+  "inventory_only": {
+    "ExperimentalInventoryOnly": [
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "collaborationMode/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "environment/add"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "environment/info"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fuzzyFileSearch/sessionStart"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fuzzyFileSearch/sessionStop"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "fuzzyFileSearch/sessionUpdate"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "memory/reset"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "mock/experimentalMethod"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "process/kill"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "process/resizePty"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "process/spawn"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "process/writeStdin"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/client/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/client/revoke"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/disable"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/enable"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/pairing/start"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/pairing/status"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "remoteControl/status/read"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/backgroundTerminals/clean"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/backgroundTerminals/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/backgroundTerminals/terminate"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/decrement_elicitation"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/increment_elicitation"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/items/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/memoryMode/set"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/appendAudio"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/appendSpeech"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/appendText"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/listVoices"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/start"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/realtime/stop"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/search"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/settings/update"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "thread/turns/list"
+        },
+        "runtime_disposition": "Deferred",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "ExperimentalInventoryOnly",
+        "module": "ExperimentalInventory",
+        "protocol_surface_key": {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "currentTime/read"
+        },
+        "runtime_disposition": "RawPreserved",
+        "stability": "experimental_only",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      }
+    ],
+    "StableUnreachableInventory": [
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "CapabilityRootLocation",
+          "name": "environment"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfiguredHookHandler",
+          "name": "agent"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfiguredHookHandler",
+          "name": "command"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ConfiguredHookHandler",
+          "name": "prompt"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "DynamicToolNamespaceTool",
+          "name": "function"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "DynamicToolSpec",
+          "name": "function"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "DynamicToolSpec",
+          "name": "namespace"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "MultiAgentMode",
+          "name": "custom"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "MultiAgentMode",
+          "name": "explicitRequestOnly"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "$variant",
+          "domain": "MultiAgentMode",
+          "name": "proactive"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadRealtimeStartTransport",
+          "name": "webrtc"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      },
+      {
+        "a1_slice": "InventoryOnly",
+        "classification": "StableUnreachableInventory",
+        "module": "StableUnreachableInventory",
+        "protocol_surface_key": {
+          "category": "tagged_union_discriminator",
+          "discriminator_field": "type",
+          "domain": "ThreadRealtimeStartTransport",
+          "name": "websocket"
+        },
+        "runtime_disposition": "OpaquePreserved",
+        "stability": "stable",
+        "typed_schema_status": "NotApplicable",
+        "typed_status": "NotImplemented"
+      }
+    ]
+  },
+  "native_a1_4_operations": [
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/AppsList",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "AppsListParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "app/list"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "AppsListResponse",
+      "result_type": "AppsListResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/ExternalAgentConfigDetect",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "ExternalAgentConfigDetectParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/detect"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "ExternalAgentConfigDetectResponse",
+      "result_type": "ExternalAgentConfigDetectResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/ExternalAgentConfigImport",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "ExternalAgentConfigImportParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/import"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "ExternalAgentConfigImportResponse",
+      "result_type": "ExternalAgentConfigImportResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/ExternalAgentConfigImportHistoriesRead",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "Unit",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/import/readHistories"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "ExternalAgentConfigImportHistoriesReadResponse",
+      "result_type": "ExternalAgentConfigImportHistoriesReadResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/FeedbackUpload",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "FeedbackUploadParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "feedback/upload"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "FeedbackUploadResponse",
+      "result_type": "FeedbackUploadResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/HooksList",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "HooksListParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "hooks/list"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "HooksListResponse",
+      "result_type": "HooksListResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/MarketplaceAdd",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "MarketplaceAddParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/add"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "MarketplaceAddResponse",
+      "result_type": "MarketplaceAddResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/MarketplaceRemove",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "MarketplaceRemoveParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/remove"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "MarketplaceRemoveResponse",
+      "result_type": "MarketplaceRemoveResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/MarketplaceUpgrade",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "MarketplaceUpgradeParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/upgrade"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "MarketplaceUpgradeResponse",
+      "result_type": "MarketplaceUpgradeResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpServerOauthLogin",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "McpServerOauthLoginParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/oauth/login"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "McpServerOauthLoginResponse",
+      "result_type": "McpServerOauthLoginResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpResourceRead",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "McpResourceReadParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/resource/read"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "McpResourceReadResponse",
+      "result_type": "McpResourceReadResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpServerToolCall",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "McpServerToolCallParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/tool/call"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "McpServerToolCallResponse",
+      "result_type": "McpServerToolCallResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/McpServerStatusList",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "ListMcpServerStatusParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServerStatus/list"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "ListMcpServerStatusResponse",
+      "result_type": "ListMcpServerStatusResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginInstall",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "PluginInstallParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/install"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "PluginInstallResponse",
+      "result_type": "PluginInstallResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginInstalled",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "PluginInstalledParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/installed"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "PluginInstalledResponse",
+      "result_type": "PluginInstalledResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginList",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "PluginListParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/list"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "PluginListResponse",
+      "result_type": "PluginListResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginRead",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "PluginReadParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/read"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "PluginReadResponse",
+      "result_type": "PluginReadResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareCheckout",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "PluginShareCheckoutParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/checkout"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "PluginShareCheckoutResponse",
+      "result_type": "PluginShareCheckoutResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareDelete",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "PluginShareDeleteParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/delete"
+      },
+      "result_kind": "Unit",
+      "result_schema_type": "PluginShareDeleteResponse",
+      "result_type": "Unit"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareList",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "PluginShareListParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/list"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "PluginShareListResponse",
+      "result_type": "PluginShareListResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareSave",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "PluginShareSaveParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/save"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "PluginShareSaveResponse",
+      "result_type": "PluginShareSaveResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginShareUpdateTargets",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "PluginShareUpdateTargetsParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/updateTargets"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "PluginShareUpdateTargetsResponse",
+      "result_type": "PluginShareUpdateTargetsResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginSkillRead",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "PluginSkillReadParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/skill/read"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "PluginSkillReadResponse",
+      "result_type": "PluginSkillReadResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/PluginUninstall",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "PluginUninstallParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/uninstall"
+      },
+      "result_kind": "Unit",
+      "result_schema_type": "PluginUninstallResponse",
+      "result_type": "Unit"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/SkillsConfigWrite",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "SkillsConfigWriteParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/config/write"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "SkillsConfigWriteResponse",
+      "result_type": "SkillsConfigWriteResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/SkillsExtraRootsSet",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "SkillsExtraRootsSetParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/extraRoots/set"
+      },
+      "result_kind": "Unit",
+      "result_schema_type": "SkillsExtraRootsSetResponse",
+      "result_type": "Unit"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/SkillsList",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "SkillsListParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/list"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "SkillsListResponse",
+      "result_type": "SkillsListResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/WindowsSandboxReadiness",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "Unit",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "windowsSandbox/readiness"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "WindowsSandboxReadinessResponse",
+      "result_type": "WindowsSandboxReadinessResponse"
+    },
+    {
+      "association_evidence_key": "codex-rs/app-server-protocol/src/protocol/common.rs#client_request_definitions!/WindowsSandboxSetupStart",
+      "association_evidence_kind": "VendoredRust",
+      "cross_check_evidence": [],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": false,
+      "parameter_type": "WindowsSandboxSetupStartParams",
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "windowsSandbox/setupStart"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "WindowsSandboxSetupStartResponse",
+      "result_type": "WindowsSandboxSetupStartResponse"
+    },
+    {
+      "association_evidence_key": "stable/ServerRequest.json#/oneOf/7+stable/AttestationGenerateResponse.json",
+      "association_evidence_kind": "VendoredSchemaPair",
+      "cross_check_evidence": [
+        {
+          "agrees": true,
+          "key": "codex-rs/app-server-protocol/src/protocol/common.rs#server_request_definitions!/AttestationGenerate",
+          "kind": "VendoredRust",
+          "parameter_type_identity": "AttestationGenerateParams",
+          "result_contract_kind": "Concrete",
+          "result_schema_type_identity": "AttestationGenerateResponse",
+          "result_type_identity": "AttestationGenerateResponse"
+        }
+      ],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": true,
+      "parameter_type": "AttestationGenerateParams",
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "attestation/generate"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "AttestationGenerateResponse",
+      "result_type": "AttestationGenerateResponse"
+    },
+    {
+      "association_evidence_key": "stable/ServerRequest.json#/oneOf/5+stable/DynamicToolCallResponse.json",
+      "association_evidence_kind": "VendoredSchemaPair",
+      "cross_check_evidence": [
+        {
+          "agrees": true,
+          "key": "codex-rs/app-server-protocol/src/protocol/common.rs#server_request_definitions!/DynamicToolCall",
+          "kind": "VendoredRust",
+          "parameter_type_identity": "DynamicToolCallParams",
+          "result_contract_kind": "Concrete",
+          "result_schema_type_identity": "DynamicToolCallResponse",
+          "result_type_identity": "DynamicToolCallResponse"
+        }
+      ],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": true,
+      "parameter_type": "DynamicToolCallParams",
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "item/tool/call"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "DynamicToolCallResponse",
+      "result_type": "DynamicToolCallResponse"
+    },
+    {
+      "association_evidence_key": "stable/ServerRequest.json#/oneOf/2+stable/ToolRequestUserInputResponse.json",
+      "association_evidence_kind": "VendoredSchemaPair",
+      "cross_check_evidence": [
+        {
+          "agrees": true,
+          "key": "codex-rs/app-server-protocol/src/protocol/common.rs#server_request_definitions!/ToolRequestUserInput",
+          "kind": "VendoredRust",
+          "parameter_type_identity": "ToolRequestUserInputParams",
+          "result_contract_kind": "Concrete",
+          "result_schema_type_identity": "ToolRequestUserInputResponse",
+          "result_type_identity": "ToolRequestUserInputResponse"
+        }
+      ],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": true,
+      "parameter_type": "ToolRequestUserInputParams",
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "item/tool/requestUserInput"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "ToolRequestUserInputResponse",
+      "result_type": "ToolRequestUserInputResponse"
+    },
+    {
+      "association_evidence_key": "stable/ServerRequest.json#/oneOf/3+stable/McpServerElicitationRequestResponse.json",
+      "association_evidence_kind": "VendoredSchemaPair",
+      "cross_check_evidence": [
+        {
+          "agrees": true,
+          "key": "codex-rs/app-server-protocol/src/protocol/common.rs#server_request_definitions!/McpServerElicitationRequest",
+          "kind": "VendoredRust",
+          "parameter_type_identity": "McpServerElicitationRequestParams",
+          "result_contract_kind": "Concrete",
+          "result_schema_type_identity": "McpServerElicitationRequestResponse",
+          "result_type_identity": "McpServerElicitationRequestResponse"
+        }
+      ],
+      "depends_on_server_request_resolved": false,
+      "direct_raw_protocol_response": true,
+      "parameter_type": "McpServerElicitationRequestParams",
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "mcpServer/elicitation/request"
+      },
+      "result_kind": "Concrete",
+      "result_schema_type": "McpServerElicitationRequestResponse",
+      "result_type": "McpServerElicitationRequestResponse"
+    }
+  ],
+  "native_partial_identity": {
+    "category": "server_request",
+    "discriminator_field": "method",
+    "domain": "ServerRequest",
+    "name": "item/tool/requestUserInput"
+  },
+  "stable_experimental_asymmetries": {
+    "experimental_process_controls": [
+      "process/kill",
+      "process/resizePty",
+      "process/spawn",
+      "process/writeStdin"
+    ],
+    "experimental_remote_control_controls": [
+      "remoteControl/client/list",
+      "remoteControl/client/revoke",
+      "remoteControl/disable",
+      "remoteControl/enable",
+      "remoteControl/pairing/start",
+      "remoteControl/pairing/status",
+      "remoteControl/status/read"
+    ],
+    "rule": "A stable status/output notification never promotes a similarly named experimental outgoing control.",
+    "stable_process_notifications": [
+      "process/exited",
+      "process/outputDelta"
+    ],
+    "stable_remote_control_notification": "remoteControl/status/changed"
+  }
+}

--- a/tools/codex/app-server-evidence/0.144.6/a1-4-type-closure.json
+++ b/tools/codex/app-server-evidence/0.144.6/a1-4-type-closure.json
@@ -1,0 +1,20945 @@
+{
+  "codex_version": "codex-cli 0.144.6",
+  "counts": {
+    "default_bearing_paths": 22,
+    "definition_namespaces": {
+      "legacy": 34,
+      "v2": 155
+    },
+    "integer_formats": {
+      "double": 3,
+      "int32": 1,
+      "int64": 8,
+      "uint": 1,
+      "uint32": 4,
+      "uint64": 6
+    },
+    "maximum_bearing_paths": 0,
+    "minimum_bearing_paths": 11,
+    "nullable_paths": 243,
+    "object_nodes": 162,
+    "opaque_json_paths": 24,
+    "optional_paths": 260,
+    "reachable_named_definitions": 189,
+    "required_paths": 288,
+    "schema_path_kinds": {
+      "array_element": 91,
+      "map_value": 7,
+      "property": 548
+    },
+    "schema_paths": 646,
+    "seed_definitions": 81,
+    "sensitive_paths": 127
+  },
+  "definitions": [
+    {
+      "definition": {
+        "name": "AttestationGenerateParams",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "aa818c50814505fce83044ee851b9b552953dc36e421706c4cc2d456a60ad619"
+    },
+    {
+      "definition": {
+        "name": "AttestationGenerateResponse",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "52716288aa370cbefb9632523b4dd0b01b916e2de4e9daa87b09e6db3ecba93d"
+    },
+    {
+      "definition": {
+        "name": "DynamicToolCallParams",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "af7d6eed112291b3974df5bcdf32d2a81ab76c9f3364fd70e54140bd461622b7"
+    },
+    {
+      "definition": {
+        "name": "DynamicToolCallResponse",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "DynamicToolCallOutputContentItem",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "21d0cccdb09c4cec8b4f71ff6702000b604ee5ad09f5fee35449b62c96d54a44"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationArrayType",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "a8224421161f51e1c363eb1598500bf8fe74dd96ae4c6e5a0e1014a0a140ceab"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationBooleanSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationBooleanType",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "6ea645bdb7886cd377e1c664e783cb3f368157cb99823324fa9016cadc6883ed"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationBooleanType",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "071bf9310ac156e2f1498ec9679f33cb2f691b0a0c27f515ecec1927c3452d45"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationConstOption",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "88e2ba392855202d6793470a9749633112d16158905c89ed9eb6c3fc6bbb4383"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationEnumSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationLegacyTitledEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationMultiSelectEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationSingleSelectEnumSchema",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "245259c95fbd17047ecedc2f1aae3da4be29f4dfaa1c0620d213161de91b7242"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationLegacyTitledEnumSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationStringType",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "dfbec9936ee4a12e3443959da0a47b5c60c667d64ff14e8cfb7349acfd500b74"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationTitledMultiSelectEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationUntitledMultiSelectEnumSchema",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "3023a2003557fc25f9442cd1ce16c49914bbfa3930efef49d03e47f4f856eca4"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationNumberSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationNumberType",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "d181a37db2573278f6998a6ff23c0933a296dc5d20215ef92b226279ff54352e"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationNumberType",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "5f78b811161b5bb62cf37f0bece8f8447002bb896561e3c9d8e47b2a7a42b426"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationObjectType",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "0c15a4822fc87fb369e8d64c3323ed39f2afc9dced28ff6fbe0cc970f2330107"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationPrimitiveSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationBooleanSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationNumberSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationStringSchema",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "d57ab20053fc844f474cfc01b858ea3f167a9c62f4c162eef9c5f042a843f2e6"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationObjectType",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationPrimitiveSchema",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "6fc36c040cc6d2a8364d018772c8d7e9f355a49ae3cbe1e7d9186bda198fafc9"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationTitledSingleSelectEnumSchema",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationUntitledSingleSelectEnumSchema",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "ac39cdc51f14f4034efb4fa03cbee16feb047e4e653cb83ca10b3d3dab644d25"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationStringFormat",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "e54df8b6f2778db47b3cae1ec8cb03ebc43138490dd6869e96959cfc3eb419d6"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationStringSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationStringFormat",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationStringType",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "2daa32a6c82f3a9430e0a30210b50df1d10a27146b13484de16e1d4338e9a063"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationStringType",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "e797617f4554bdcdae96443bb18d9ce4fef34e48584523920f8fdd87ea788263"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationTitledEnumItems",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationConstOption",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "bca4de9e4c8cf57691ee8aae22198102c3870d68da7493acde10179408ca83e5"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationTitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationArrayType",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationTitledEnumItems",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "22f60155a3c5857a1ce7fc54690f1045c9d7a1b6ccff3f3998512155351f0fb8"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationTitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationConstOption",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationStringType",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "6c08232dfca28300b161604aed55d136dba7eceef967c60278881f4c97037de1"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationUntitledEnumItems",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationStringType",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "cfe2d6a3c8cf805f542c2b6763a6fda711de42e11fa606056e844d2e9c589060"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationUntitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationArrayType",
+          "namespace": "legacy"
+        },
+        {
+          "name": "McpElicitationUntitledEnumItems",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "940bdb0d22c9915fb64982cc4a585658ce8af8a9e23ee04995bf427c6c2593db"
+    },
+    {
+      "definition": {
+        "name": "McpElicitationUntitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationStringType",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "1bab04ea5f650145fe230343e45589e7f6e3a9956f4144472761c959db669536"
+    },
+    {
+      "definition": {
+        "name": "McpServerElicitationAction",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "b6161ee717a95334d2c8cc71a4e56d6355fa23a0151f9f2afa79034d86caa973"
+    },
+    {
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpElicitationSchema",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "bcf77a3ff538637f251e86447973de10a0a55a2b95a23aa18129ecf470dd0afc"
+    },
+    {
+      "definition": {
+        "name": "McpServerElicitationRequestResponse",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpServerElicitationAction",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "57dfac54e58de0a8600e64309b5eddda4ba61e53f027370f17907cfa761c33bb"
+    },
+    {
+      "definition": {
+        "name": "ToolRequestUserInputAnswer",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "f99f938c4108dfea2370db7a3ab9a973bc59c7b56a9992ded672404374025aae"
+    },
+    {
+      "definition": {
+        "name": "ToolRequestUserInputOption",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "1e926511c66e752d915c1a5b26cf2f2188cb1799cff022c521d4d8ae5f7bc4d4"
+    },
+    {
+      "definition": {
+        "name": "ToolRequestUserInputParams",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ToolRequestUserInputQuestion",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "e7185128fdd1db09dd29156fd5359f034bb9cf40187807daf1601c47eca71744"
+    },
+    {
+      "definition": {
+        "name": "ToolRequestUserInputQuestion",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ToolRequestUserInputOption",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "996a5347da856fb27d27202ed727c70d2c59674cfe00f0e038fda1f2c9693bb9"
+    },
+    {
+      "definition": {
+        "name": "ToolRequestUserInputResponse",
+        "namespace": "legacy"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ToolRequestUserInputAnswer",
+          "namespace": "legacy"
+        }
+      ],
+      "schema_sha256": "7d302cf85e069ae6ddb28e7f28e25c126e24f0a48ee37fea92d11c78c64ca0cf"
+    },
+    {
+      "definition": {
+        "name": "AbsolutePathBuf",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "e9af5e02db115ff0eaf319e547335308143d83736099348788a6065cff75022e"
+    },
+    {
+      "definition": {
+        "name": "AppBranding",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "4046a872ea5135f1e1473e94bc9d31e608c315c06d2049d9d29736bb9906e488"
+    },
+    {
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AppBranding",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppMetadata",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "b9e14ecc8b8bce32033216810aa78a6d8f0d3d2081da7363f5f8ea8375b043dc"
+    },
+    {
+      "definition": {
+        "name": "AppListUpdatedNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AppInfo",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "7a1d57f16e3d9a01f05592ce38d919a16ec4bcdf70763db2c92cffbd85c96ec1"
+    },
+    {
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AppReview",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppScreenshot",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "080e57ffc1c8663176fcb9bbab083882870c5846f2b864716adb202e42ecd7ea"
+    },
+    {
+      "definition": {
+        "name": "AppReview",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "9a16baf78ac2b47ca47423709257463d3d315b3e35be9b5d72b9fb0b1a9910ed"
+    },
+    {
+      "definition": {
+        "name": "AppScreenshot",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "466c2fa94f8e21b369db0178609a92952af4fc9542fbff5eb993f7beaea54886"
+    },
+    {
+      "definition": {
+        "name": "AppSummary",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "f3f366b55e0f1f2fb398bddab6bad486c6e5c79f7d5fc50c8a268f8920745a2e"
+    },
+    {
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AppTemplateUnavailableReason",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "42c5f2a79b4ecc534ed60647c03165374805d59a92b0dc805afcb7a0ccfbebfa"
+    },
+    {
+      "definition": {
+        "name": "AppTemplateUnavailableReason",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "5cfb72b7a2d805bf27b74b9476f22e637226b6fecb3232482aa006e2111f5db3"
+    },
+    {
+      "definition": {
+        "name": "AppsListParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "6669bc6780ec9fbfb74fd74ec495348e4389b234f372f70064dfdee8fcfa9664"
+    },
+    {
+      "definition": {
+        "name": "AppsListResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AppInfo",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "0c3a87519f69b5deda4fc01e11505ce72f46d0fb167595b9d410199e5394799b"
+    },
+    {
+      "definition": {
+        "name": "CommandMigration",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "098974972159a1c508b6fed6baed3bba04cd70d4ee9bbe30f926fb1db0188008"
+    },
+    {
+      "definition": {
+        "name": "DeprecationNoticeNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "dd45d65ab33fca3f95fd42a0783e17770348751fd0988cf1e71a5cb152c15cfa"
+    },
+    {
+      "definition": {
+        "name": "DynamicToolCallOutputContentItem",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "6d416a929acf116831dcafeaf8cccda9887637d899b52f4cc9504b4c1a0e39f0"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigDetectParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "e7d225d9bbfd75eca4eac28b2da0a8cde4b19c55e3d99396d8a51ffd4bdbbe2e"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigDetectResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ExternalAgentConfigMigrationItem",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "c93bd7929d5539de1aa90b69d9ed07e8b1e5b0d950d1c69a062fd3cff663cb88"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigImportCompletedNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ExternalAgentConfigImportTypeResult",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "a4fc5a0b9f36027052b4c9870921eeaaa14e30a9899d792fe6f84b5d7042edcd"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigImportHistoriesReadResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ExternalAgentConfigImportHistory",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "4ffc80306533200f6f7e4110134625d65de8ecedabfc46df5513a955689e8a74"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigImportHistory",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ExternalAgentConfigImportItemTypeFailure",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigImportItemTypeSuccess",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "98ab74e89284ba01ac32b154b5c42bda30da99031c4d7063d0a8e7963614dab7"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeFailure",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ExternalAgentConfigMigrationItemType",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "6fd3978d70c5ae93ad4067875308cc993f8f93025c5f5f8109cd6342885877fa"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeSuccess",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ExternalAgentConfigMigrationItemType",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "2e2a9c463ce4f64aac556cf8dbfe31f612363eda057c9431dbef9781aededcfe"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigImportParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ExternalAgentConfigMigrationItem",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "a812ac96a2d26c9bb29523d93bc186ac1c3800fc725b85a2a9cafd4e2c0e2900"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigImportProgressNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ExternalAgentConfigImportTypeResult",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "2aad3736c747f68c1878ded4801ee07f2eda77c99b6870d6bb2b0a67605c2207"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigImportResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "ea63a6753d8ae72333443cc69c2b36400cc6c2f322ac21e8fdd0c4a9965bbbfc"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigImportTypeResult",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ExternalAgentConfigImportItemTypeFailure",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigImportItemTypeSuccess",
+          "namespace": "v2"
+        },
+        {
+          "name": "ExternalAgentConfigMigrationItemType",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "aeab90cdcb16d70fcc9d949491e094896ff73c93bb1e40cc870df30cb9428e0e"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigMigrationItem",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ExternalAgentConfigMigrationItemType",
+          "namespace": "v2"
+        },
+        {
+          "name": "MigrationDetails",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "55607a10a96fad2247ca8dac61181a779fa7554b539a25bb3bc630d9ab9ee4bb"
+    },
+    {
+      "definition": {
+        "name": "ExternalAgentConfigMigrationItemType",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "e69646a9801716a9e9111cf5276b9b3ce618b0ce844e8ccd4103732c1e8977f1"
+    },
+    {
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "305ffd92a2031bfcb240e2c42d072f34b8c56851c98e2a12ddb695e737d011bc"
+    },
+    {
+      "definition": {
+        "name": "FeedbackUploadResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "7a12bfe8b89b94a437258989b0e514361e83dbe44955e74afe16b55815f4b194"
+    },
+    {
+      "definition": {
+        "name": "HookCompletedNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "HookRunSummary",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "ab4f8976a68b21125550355c5920c072b7401a85d4de5cc7b1f212ecbd48528e"
+    },
+    {
+      "definition": {
+        "name": "HookErrorInfo",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "ab8b0e069a0116a6f9495a90880c772b464d16d192bae7ba03e36a5814bfea54"
+    },
+    {
+      "definition": {
+        "name": "HookEventName",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "f22a2dbdbfa795e3fb5ff66bef74f986bccc00bf319259faab09ea43ba6b1d28"
+    },
+    {
+      "definition": {
+        "name": "HookExecutionMode",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "fe0a367ae7e95a38b3742ece2fc50eb35110b5173ee4cb08d7c384163882116a"
+    },
+    {
+      "definition": {
+        "name": "HookHandlerType",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "cc936639ce74ad53d3c15d0910efe9ab9105f1521a64c8a8e739c99804185387"
+    },
+    {
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookEventName",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookHandlerType",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookSource",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookTrustStatus",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "cf288473c89dce66c63fd432e5efedbe8cb5b7467e29373c0904fda1e030d10e"
+    },
+    {
+      "definition": {
+        "name": "HookMigration",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "098974972159a1c508b6fed6baed3bba04cd70d4ee9bbe30f926fb1db0188008"
+    },
+    {
+      "definition": {
+        "name": "HookOutputEntry",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "HookOutputEntryKind",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "1d8d39c4ecc35cc17d9e3cd6d4e0a89072125a2a4201dc317f926a9d894be45d"
+    },
+    {
+      "definition": {
+        "name": "HookOutputEntryKind",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "df5380b388f80db9ebb4f7af738978ec2eea3fb353c30bc8876e4e8eeb674854"
+    },
+    {
+      "definition": {
+        "name": "HookRunStatus",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "8b808078d191d66f4993f2403ed62a79cdcb3feff1f7d7cccfe0077dae32bdc8"
+    },
+    {
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookEventName",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookExecutionMode",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookHandlerType",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookOutputEntry",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookRunStatus",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookScope",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookSource",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "80182e626b582e4629d395d86ef21a8f851b90de4be67779fe1519e881bfc866"
+    },
+    {
+      "definition": {
+        "name": "HookScope",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "c6c475736ebcc69befc046db43605a7dfe7280174a770cd7c1ede8f150d81cd6"
+    },
+    {
+      "definition": {
+        "name": "HookSource",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "f08ae8c11ef2ea594d275a48e047bd2bd276fb797adf658b8d299dbd2d816438"
+    },
+    {
+      "definition": {
+        "name": "HookStartedNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "HookRunSummary",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "78682811c3511cadabc751ab289fec431ec0dd347c0f83365926d32f74ff8c13"
+    },
+    {
+      "definition": {
+        "name": "HookTrustStatus",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "f8310b80e530ab5093ae74a564209187e6fe4fdbc32d82382ef1a065d6fe8e03"
+    },
+    {
+      "definition": {
+        "name": "HooksListEntry",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "HookErrorInfo",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookMetadata",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "8c29f9ba48078b1ea5d196fcaa1ede1545f5d3d69ed5a34507ae2611358a9149"
+    },
+    {
+      "definition": {
+        "name": "HooksListParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "10ca05100ec02c2b5a95ffe84d4b26605869ee4b2fd661c64e54b216cfa5ece0"
+    },
+    {
+      "definition": {
+        "name": "HooksListResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "HooksListEntry",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "b01af5100e37008e77f6f04894c79b6b811a2277d4347cdc97bfb6b936a0fcdf"
+    },
+    {
+      "definition": {
+        "name": "ListMcpServerStatusParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpServerStatusDetail",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "e0772a2a5ef9a572ddbd51d2f2930df94a7d3e755818df2f469f78db8d65e596"
+    },
+    {
+      "definition": {
+        "name": "ListMcpServerStatusResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpServerStatus",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "b0d53f8861288071f50f24752dfa9e85502dabc52cc4fbc39b7a020f678d8e0c"
+    },
+    {
+      "definition": {
+        "name": "MarketplaceAddParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "be87286d4bf6cef203d06416bbb33519d81252db429b4aeafbcd6d1e879aa3cd"
+    },
+    {
+      "definition": {
+        "name": "MarketplaceAddResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "7000b4477be9e15a463ac74bd5c254f6dd32525b186e0c96a470539e3c4f37df"
+    },
+    {
+      "definition": {
+        "name": "MarketplaceInterface",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "aeac427421c2bacfac3231b1255a4d1426c7875fbb8b9e5ac510e9622236ec7e"
+    },
+    {
+      "definition": {
+        "name": "MarketplaceLoadErrorInfo",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "a3eb3b962d7ff8d78ae3ad15ab661da96e530f1c1dad01b7b0d295efb21e4ad2"
+    },
+    {
+      "definition": {
+        "name": "MarketplaceRemoveParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "7e7feb2f9a15b16dbb7446a5432512635bda978523e596ccbd6284e0dc3f9c0b"
+    },
+    {
+      "definition": {
+        "name": "MarketplaceRemoveResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "8b201f8deb40cbfb2ffd764693cacec9fe9d8a92e872a871ec82c495863b7fe5"
+    },
+    {
+      "definition": {
+        "name": "MarketplaceUpgradeErrorInfo",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "f4d7345cc26e7d39c99780445b9fc821fc657ac6b5f5b47696f9e1f0e7deaf66"
+    },
+    {
+      "definition": {
+        "name": "MarketplaceUpgradeParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "cc5ece8ddf2764e4abfd7df6af2d97da8379fe267946ea9ade8970ab4f987bde"
+    },
+    {
+      "definition": {
+        "name": "MarketplaceUpgradeResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "MarketplaceUpgradeErrorInfo",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "8a45afe06ecf644da979054c944d0421a9fa93361d841e0b98f12676a817f258"
+    },
+    {
+      "definition": {
+        "name": "McpAuthStatus",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "457d8da321e81d258da2b0bd120045e853f0683245ee45d723db98b457f0810e"
+    },
+    {
+      "definition": {
+        "name": "McpResourceReadParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "d5bda0bd5cd45fa3e9c3957a5b16a52cce67738aaa9d78e91a540e4d44228942"
+    },
+    {
+      "definition": {
+        "name": "McpResourceReadResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ResourceContent",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "6e2d62aebac8b5c86a31f0c47ac4b6b3ebd7a67cd24b02f18b847ac6f6915dcf"
+    },
+    {
+      "definition": {
+        "name": "McpServerInfo",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "2455a4b748896babec8226b98140cd52b2262294b0f0d0c1c736b60f853acd14"
+    },
+    {
+      "definition": {
+        "name": "McpServerMigration",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "098974972159a1c508b6fed6baed3bba04cd70d4ee9bbe30f926fb1db0188008"
+    },
+    {
+      "definition": {
+        "name": "McpServerOauthLoginCompletedNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "569f04ed120618a07ddc070965905c5638df676d7482006be0f297af1a90e78b"
+    },
+    {
+      "definition": {
+        "name": "McpServerOauthLoginParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "386b6933c152957c35046e9b112a5c98da58627208557d32492d358cc87efcc1"
+    },
+    {
+      "definition": {
+        "name": "McpServerOauthLoginResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "883c2449de08a07b9032e3db701b155407c0bccee3c95f10f8664c5a3ba2462f"
+    },
+    {
+      "definition": {
+        "name": "McpServerStartupFailureReason",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "48978325633e52f4d779fbbe541d5606a8575ab7222f35344511598eeb02a8f0"
+    },
+    {
+      "definition": {
+        "name": "McpServerStartupState",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "f3035fdabf9aa8f3f14b48d505c2757806d40aa0aadddb9e01044d38ebb16a1f"
+    },
+    {
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpAuthStatus",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerInfo",
+          "namespace": "v2"
+        },
+        {
+          "name": "Resource",
+          "namespace": "v2"
+        },
+        {
+          "name": "ResourceTemplate",
+          "namespace": "v2"
+        },
+        {
+          "name": "Tool",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "054f12da8fd0a36e71cdd05d834c30a14aea2980a942b80fa039943b93af930f"
+    },
+    {
+      "definition": {
+        "name": "McpServerStatusDetail",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "905c3a1d0094bbd2b368127b35ddda7857b82ff33222bac1894f024fb744565c"
+    },
+    {
+      "definition": {
+        "name": "McpServerStatusUpdatedNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "McpServerStartupFailureReason",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerStartupState",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "720a0403c83d7ba15638f5e57703574689357e332d46b0ad47fe0b0bb103a2bc"
+    },
+    {
+      "definition": {
+        "name": "McpServerToolCallParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "497a0a80afd35b00c870866c7105a953277299e655a8ec386cbdc8d2ee1f420e"
+    },
+    {
+      "definition": {
+        "name": "McpServerToolCallResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "c7f3e71eb63378b01cac4b978a162dfe099661befc346a80e72fa33001ee184f"
+    },
+    {
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "CommandMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "HookMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "McpServerMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginsMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "SessionMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillMigration",
+          "namespace": "v2"
+        },
+        {
+          "name": "SubagentMigration",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "c5d420a62ce8dd3e2beb5025b0073f06a7ff6b5c9357b2040c74c05b1ff0cb88"
+    },
+    {
+      "definition": {
+        "name": "PluginAuthPolicy",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "00c1057ee9ef366fa67198189ab6a1167c910bd5fb0f95b2004fcb04b66a3174"
+    },
+    {
+      "definition": {
+        "name": "PluginAvailability",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "5535048c02b62f5162403f658a3f65185038400bc81002cc594c0c7db8b78ca9"
+    },
+    {
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppSummary",
+          "namespace": "v2"
+        },
+        {
+          "name": "AppTemplateSummary",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginHookSummary",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSummary",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillSummary",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "01ee9935f648dd1459c82cd4a458b2a528cfc2610d0a84e07abc34a4d161cde2"
+    },
+    {
+      "definition": {
+        "name": "PluginHookSummary",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "HookEventName",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "8eb09ff65f0f9a8c044b99a69c6eb0658a2632410e88d665aa322a0de09925d2"
+    },
+    {
+      "definition": {
+        "name": "PluginInstallParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "0dfaa8362a632645cb0d293d0431a8b5f8eaf7f97c1ca83e085ada7e438e3a8f"
+    },
+    {
+      "definition": {
+        "name": "PluginInstallPolicy",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "f44b8e8cbb45c225ca1369fb126eaf7d1ddb813dab57dbc99e1ece2d84f09ab7"
+    },
+    {
+      "definition": {
+        "name": "PluginInstallPolicySource",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "3a92ec19a402791df9bb653c9b84103b37263bcc49700919b09117fb36b0cdc3"
+    },
+    {
+      "definition": {
+        "name": "PluginInstallResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AppSummary",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginAuthPolicy",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "024ea08cadc12b0c91247da29b35561a18eaf0384637501175f97d33865af589"
+    },
+    {
+      "definition": {
+        "name": "PluginInstalledParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "904a288fb05a3ca881cdaac66aeb0f7d9c838e4eb3131b445cab3cdae6dcf509"
+    },
+    {
+      "definition": {
+        "name": "PluginInstalledResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "MarketplaceLoadErrorInfo",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginMarketplaceEntry",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "9904a624cff8a8569e6471bdd12789aadf9328d7c0820af301265c615ed6c061"
+    },
+    {
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "7943222a5cd61e7a24edefe38073babc0d0aa7edc5562748f9801e53abf7fde4"
+    },
+    {
+      "definition": {
+        "name": "PluginListMarketplaceKind",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "9d502b2154bcab4ae7a31703bf23a28fa411c0a92a5387e907da1f18c2f0767d"
+    },
+    {
+      "definition": {
+        "name": "PluginListParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginListMarketplaceKind",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "474bce87d444be2dc730939d02e76eccb7a14b4b1a3546d7099144f63f7d6b3b"
+    },
+    {
+      "definition": {
+        "name": "PluginListResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "MarketplaceLoadErrorInfo",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginMarketplaceEntry",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "135c750a89540838f7ddfcb65955ff14ef0c7ed3061d7925bca9feeef59f0d39"
+    },
+    {
+      "definition": {
+        "name": "PluginMarketplaceEntry",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "MarketplaceInterface",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSummary",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "d1b9ffcbf33e1bb98321bee46a24b6bdf4220aa4c3d3933745d4d0d40e57aadd"
+    },
+    {
+      "definition": {
+        "name": "PluginReadParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "478080fd1e24aa5496c297cd39d5a8da3614643dc26ecbf7fcfac96415dbc842"
+    },
+    {
+      "definition": {
+        "name": "PluginReadResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "PluginDetail",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "b4f1578a0ba46eb00e3cb9c350b348d05f9571409dccd4481efd30a15133bda7"
+    },
+    {
+      "definition": {
+        "name": "PluginShareCheckoutParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "6b5c708f6b212a34dc2b7e0ad6a353213d15430926e7d13afe4fbbf880986f90"
+    },
+    {
+      "definition": {
+        "name": "PluginShareCheckoutResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "d8e245d9507ec7b9d2714140242c4dd399e15699d067c63e262ca7c0468e633f"
+    },
+    {
+      "definition": {
+        "name": "PluginShareContext",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "PluginShareDiscoverability",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSharePrincipal",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "2b6adea23aa922deff96750b94dcace231795b37906f4447bef10600047d0f4b"
+    },
+    {
+      "definition": {
+        "name": "PluginShareDeleteParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "19ad3876906f26f5417c5bfa6c8c7c545611943ef35f468a56f8d52819413ef3"
+    },
+    {
+      "definition": {
+        "name": "PluginShareDeleteResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "670d7caa0f7195eca6f00fd94132ba5e4cb43fd36cb1d2f7ab04d3643fcea345"
+    },
+    {
+      "definition": {
+        "name": "PluginShareDiscoverability",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "f2d6c29d00685f223cd587c3e10eff3dabd8a0e6d0da270a8c7f6b1cc6670eeb"
+    },
+    {
+      "definition": {
+        "name": "PluginShareListItem",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSummary",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "28097adf3b606e8d5a3cfba85d23ea787c26505ffe90c29a95ea355deb7ca8d8"
+    },
+    {
+      "definition": {
+        "name": "PluginShareListParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "f93d2aca0425ed9850112fb1579fd61b8a86a5be65a02501878f04e2981b456c"
+    },
+    {
+      "definition": {
+        "name": "PluginShareListResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "PluginShareListItem",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "68d088890f4d2aa3211fb22400f9c0616e736e6e7bfc37e578bb90d84edc15a4"
+    },
+    {
+      "definition": {
+        "name": "PluginSharePrincipal",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "PluginSharePrincipalRole",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSharePrincipalType",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "fef75085cbd0f0dc87d309cad189f521887f0255e0c0f8e2a3be66316f95fb5a"
+    },
+    {
+      "definition": {
+        "name": "PluginSharePrincipalRole",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "4b7e40fabf523aafc9bf4fb241c62008c15889a0c2e114eb370c04597e90ee0d"
+    },
+    {
+      "definition": {
+        "name": "PluginSharePrincipalType",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "d95da71501f9e044069087a3daa44455d0c23a5d3fb86155ad2c8461ffe935dc"
+    },
+    {
+      "definition": {
+        "name": "PluginShareSaveParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareDiscoverability",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareTarget",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "8520dd5404c47e5e7f37cbd7b2f0b240da5d163d722532bc945899a008df43d4"
+    },
+    {
+      "definition": {
+        "name": "PluginShareSaveResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "ed686955092842c576110a16e756e993babef29fe7dc17911e1c8eb728422a35"
+    },
+    {
+      "definition": {
+        "name": "PluginShareTarget",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "PluginSharePrincipalType",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareTargetRole",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "f87d465fcdc7e9525725496dd4eab05bf183df55c4cce4dac25ae336bb8a8218"
+    },
+    {
+      "definition": {
+        "name": "PluginShareTargetRole",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "ec1d2b38904afeab49edb430d33e0dcfc54e014be42018b8127f2e52a80763bc"
+    },
+    {
+      "definition": {
+        "name": "PluginShareUpdateDiscoverability",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "d946ee903f54e8d21f1234b1cdf49f791bd375cbb50b97c911e41ae4816df8ff"
+    },
+    {
+      "definition": {
+        "name": "PluginShareUpdateTargetsParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "PluginShareTarget",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareUpdateDiscoverability",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "45bd5ebac695ef193a65e1b3494667062101a605b37eb4de36615fef61a45751"
+    },
+    {
+      "definition": {
+        "name": "PluginShareUpdateTargetsResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "PluginShareDiscoverability",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSharePrincipal",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "c4dba35c85f233b7447f39e5d16dacfda4530ac834f6bc5ff3c0bf51f5f1e08e"
+    },
+    {
+      "definition": {
+        "name": "PluginSkillReadParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "57ecfde7e70a346c4822416d53ab5477b22d418af616226c2a247ffab060e814"
+    },
+    {
+      "definition": {
+        "name": "PluginSkillReadResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "4d9a829a4bc48ffac2fff8a303223966d647ddd2538844ec3a276d8aab9e1aea"
+    },
+    {
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "4f681896f9098f060baa645cd21f4a38ba77eb8deb357615fff93a08107c58fe"
+    },
+    {
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "PluginAuthPolicy",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginAvailability",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginInstallPolicy",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginInstallPolicySource",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginInterface",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginShareContext",
+          "namespace": "v2"
+        },
+        {
+          "name": "PluginSource",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "497fc7fb6cbe7bb5774ffccdaf3e99b54dac4c436f7abb9717a6c2d5ba62fc0e"
+    },
+    {
+      "definition": {
+        "name": "PluginUninstallParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "376eab9138338f4a2b8305150e71f54da98ed720f48edfd28747472a835c32a0"
+    },
+    {
+      "definition": {
+        "name": "PluginUninstallResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "ec9c107a429159b084ac32ddc9ceeb255a2dc1b45c4fda23b3e77f90a356c871"
+    },
+    {
+      "definition": {
+        "name": "PluginsMigration",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "c3a24d65b1ea0d6a288eb695525a7d1709956b661aacf57ad6049714c8abf4e9"
+    },
+    {
+      "definition": {
+        "name": "ProcessExitedNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "9d7d3d41c0d46a9d530fa54488310bbd4e41ee9e90caa0d0b1bf1562c918e71f"
+    },
+    {
+      "definition": {
+        "name": "ProcessOutputDeltaNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "ProcessOutputStream",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "bc4400c087a5d0ad91976e45eed4f4681035ed024afb99597a4dd7e472a86264"
+    },
+    {
+      "definition": {
+        "name": "ProcessOutputStream",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "aec966d5bdba36f107b96c8cf45f3264c3c3a961aee54054f3bcbae2a790899f"
+    },
+    {
+      "definition": {
+        "name": "RemoteControlConnectionStatus",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "298d22856c858341b74c67c92d803aa5f7650c2941e9f4d5329a81fc85c2986d"
+    },
+    {
+      "definition": {
+        "name": "RemoteControlStatusChangedNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "RemoteControlConnectionStatus",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "516dae7cb4c76431f7a5c7185279d124e6625ea96406ff93706323229976ee94"
+    },
+    {
+      "definition": {
+        "name": "RequestId",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "3dc93f3205fdd9ff972a7e8031d7680d05d54749b11a61b9ae9a9479e23e116a"
+    },
+    {
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "edd1a016fee2ddec026f90a69e526ac50429a9c719d33943be2659141eb7a0fb"
+    },
+    {
+      "definition": {
+        "name": "ResourceContent",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "917705035004efdeceedf4d47df66040fc34d952d60e59c48d32a63de73bcdec"
+    },
+    {
+      "definition": {
+        "name": "ResourceTemplate",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "a1c3638d07c7e407343c9979d87247158e506eea2e7b021b7d5e031abbcdc70e"
+    },
+    {
+      "definition": {
+        "name": "ServerRequestResolvedNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "RequestId",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "079fed119c98c6f6fef37770d31d6a48a761e1a5ed6035ab27c13dcd0103b324"
+    },
+    {
+      "definition": {
+        "name": "SessionMigration",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "e82d33283944fee3615cf7ae2d3cefd140dba46b6e4a5ec430d77d9485d36eea"
+    },
+    {
+      "definition": {
+        "name": "SkillDependencies",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "SkillToolDependency",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "93bfc5525ea39bc70068319c90ac7c3f219fa64f48038e6e025b3b5cb01b957a"
+    },
+    {
+      "definition": {
+        "name": "SkillErrorInfo",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "ab8b0e069a0116a6f9495a90880c772b464d16d192bae7ba03e36a5814bfea54"
+    },
+    {
+      "definition": {
+        "name": "SkillInterface",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "0d90ac67c3e1a8fda05791e6312fabd0e50ea4fabf819e954fe7c9df350fba76"
+    },
+    {
+      "definition": {
+        "name": "SkillMetadata",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillDependencies",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillInterface",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillScope",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "a1d5eb37184c590f968dafb2d06c5c33a61ecadd45eca06a285fc23902f7a155"
+    },
+    {
+      "definition": {
+        "name": "SkillMigration",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "098974972159a1c508b6fed6baed3bba04cd70d4ee9bbe30f926fb1db0188008"
+    },
+    {
+      "definition": {
+        "name": "SkillScope",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "7b96c6271befbd330f94fcc830feb09aca9edfdc0443ff2ded6e05f81db92a3f"
+    },
+    {
+      "definition": {
+        "name": "SkillSummary",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillInterface",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "cb20e4f7a47cbf2f2c7896fe0c9c2cdae5eef448e27783cd2e4373a1388d02e8"
+    },
+    {
+      "definition": {
+        "name": "SkillToolDependency",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "aaa8b203422f33b977821def04d376722a6cd824a1922fecab12441068b1e3fd"
+    },
+    {
+      "definition": {
+        "name": "SkillsChangedNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "bf0948d41467efb01ed4c08aa948031a60cdff97addc39ae558a111ef1958e3a"
+    },
+    {
+      "definition": {
+        "name": "SkillsConfigWriteParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "5b7141f1555e2b2d1facf6491d5611db141fa4c6195da8598a26f94eda5e6bc2"
+    },
+    {
+      "definition": {
+        "name": "SkillsConfigWriteResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "c45a9194a1d04cc61e1a2253d9a940185a5b1ae6613b05438f682d1c587b813e"
+    },
+    {
+      "definition": {
+        "name": "SkillsExtraRootsSetParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "1ba739c491fa7132ea8a7bf930e11be427b4abf99dcded3ce03a363aeebdaa5a"
+    },
+    {
+      "definition": {
+        "name": "SkillsExtraRootsSetResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "1de04b5644c4d17aac8492af2cde24ebc0ecc9c11fc3e26df4b3d4ffd30c995f"
+    },
+    {
+      "definition": {
+        "name": "SkillsListEntry",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "SkillErrorInfo",
+          "namespace": "v2"
+        },
+        {
+          "name": "SkillMetadata",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "f9678ee7f61b9c8da4daeaf5abc0eb1da2896d419e84d3927ef5cd54c59c9c5c"
+    },
+    {
+      "definition": {
+        "name": "SkillsListParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "6545e3092aa7c67aab3dd2e5c602cf1a532e024530568bb3aeab96903dfb0178"
+    },
+    {
+      "definition": {
+        "name": "SkillsListResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "SkillsListEntry",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "f29e6c6bc57cd42b39a744733a6099dbd89627b44e8f18b6448f1629f5fc67cd"
+    },
+    {
+      "definition": {
+        "name": "SubagentMigration",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "098974972159a1c508b6fed6baed3bba04cd70d4ee9bbe30f926fb1db0188008"
+    },
+    {
+      "definition": {
+        "name": "Tool",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "28a239c6b4db3b3f2edcfb41ac96d98f97b6819ac70f9625742a2a5d9f44a512"
+    },
+    {
+      "definition": {
+        "name": "WarningNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "b900b5bfbd5154287849e97fdd6d82ebdda0b610399e44d4f595d8a98d575537"
+    },
+    {
+      "definition": {
+        "name": "WindowsSandboxReadiness",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "d9c15b4862f5669895f5a1bb7c1dbdd101528b01697c01d9373f5050cef199a4"
+    },
+    {
+      "definition": {
+        "name": "WindowsSandboxReadinessResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "WindowsSandboxReadiness",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "f7d13e15f5ca51a7bbe82fdb7bfd0a804f9fef0b01464184cc4e57959ed50546"
+    },
+    {
+      "definition": {
+        "name": "WindowsSandboxSetupCompletedNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "WindowsSandboxSetupMode",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "23e7ef1d56c33f75f29ec3266fcf245b5bdd3a20e7d7b27cd132502fd3d6b007"
+    },
+    {
+      "definition": {
+        "name": "WindowsSandboxSetupMode",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "4d5e368c709cad923baa16ccf62aacd7f25cfe4db4061041b6b3dde8b32acbaf"
+    },
+    {
+      "definition": {
+        "name": "WindowsSandboxSetupStartParams",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [
+        {
+          "name": "AbsolutePathBuf",
+          "namespace": "v2"
+        },
+        {
+          "name": "WindowsSandboxSetupMode",
+          "namespace": "v2"
+        }
+      ],
+      "schema_sha256": "28e3966f7f0b16c8ac5554fb1a8a3a9442454559966cdd33505a14943e6dd301"
+    },
+    {
+      "definition": {
+        "name": "WindowsSandboxSetupStartResponse",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "50efa558e8a524ea2f14e976d6b6f7052516dcb55407bd77d73c847adee15652"
+    },
+    {
+      "definition": {
+        "name": "WindowsWorldWritableWarningNotification",
+        "namespace": "v2"
+      },
+      "direct_dependencies": [],
+      "schema_sha256": "a79d7ac1c33956892f3263e2b13d8a877c312c7360a297a76dcf6ca0afbcf44c"
+    }
+  ],
+  "format_version": 1,
+  "generated_notice": "Generated A1.4 transitive stable-schema review evidence.",
+  "identity_reachable_definition_counts": [
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "app/list"
+      },
+      "reachable_definition_count": 7
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/detect"
+      },
+      "reachable_definition_count": 12
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/import"
+      },
+      "reachable_definition_count": 12
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "externalAgentConfig/import/readHistories"
+      },
+      "reachable_definition_count": 5
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "feedback/upload"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "hooks/list"
+      },
+      "reachable_definition_count": 10
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/add"
+      },
+      "reachable_definition_count": 3
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/remove"
+      },
+      "reachable_definition_count": 3
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "marketplace/upgrade"
+      },
+      "reachable_definition_count": 4
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/oauth/login"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/resource/read"
+      },
+      "reachable_definition_count": 3
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServer/tool/call"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "mcpServerStatus/list"
+      },
+      "reachable_definition_count": 9
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/install"
+      },
+      "reachable_definition_count": 5
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/installed"
+      },
+      "reachable_definition_count": 18
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/list"
+      },
+      "reachable_definition_count": 19
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/read"
+      },
+      "reachable_definition_count": 23
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/checkout"
+      },
+      "reachable_definition_count": 3
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/delete"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/list"
+      },
+      "reachable_definition_count": 16
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/save"
+      },
+      "reachable_definition_count": 7
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/share/updateTargets"
+      },
+      "reachable_definition_count": 9
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/skill/read"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "plugin/uninstall"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/config/write"
+      },
+      "reachable_definition_count": 3
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/extraRoots/set"
+      },
+      "reachable_definition_count": 3
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "skills/list"
+      },
+      "reachable_definition_count": 10
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "windowsSandbox/readiness"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "windowsSandbox/setupStart"
+      },
+      "reachable_definition_count": 4
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "app/list/updated"
+      },
+      "reachable_definition_count": 6
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "deprecationNotice"
+      },
+      "reachable_definition_count": 1
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "externalAgentConfig/import/completed"
+      },
+      "reachable_definition_count": 5
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "externalAgentConfig/import/progress"
+      },
+      "reachable_definition_count": 5
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "hook/completed"
+      },
+      "reachable_definition_count": 11
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "hook/started"
+      },
+      "reachable_definition_count": 11
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "mcpServer/oauthLogin/completed"
+      },
+      "reachable_definition_count": 1
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "mcpServer/startupStatus/updated"
+      },
+      "reachable_definition_count": 3
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "process/exited"
+      },
+      "reachable_definition_count": 1
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "process/outputDelta"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "remoteControl/status/changed"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "serverRequest/resolved"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "skills/changed"
+      },
+      "reachable_definition_count": 1
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "warning"
+      },
+      "reachable_definition_count": 1
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "windows/worldWritableWarning"
+      },
+      "reachable_definition_count": 1
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "windowsSandbox/setupCompleted"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "attestation/generate"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "item/tool/call"
+      },
+      "reachable_definition_count": 3
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "item/tool/requestUserInput"
+      },
+      "reachable_definition_count": 5
+    },
+    {
+      "protocol_surface_key": {
+        "category": "server_request",
+        "discriminator_field": "method",
+        "domain": "ServerRequest",
+        "name": "mcpServer/elicitation/request"
+      },
+      "reachable_definition_count": 25
+    },
+    {
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "name": "form"
+      },
+      "reachable_definition_count": 23
+    },
+    {
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "name": "openai/form"
+      },
+      "reachable_definition_count": 23
+    },
+    {
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "mode",
+        "domain": "McpServerElicitationRequestParams",
+        "name": "url"
+      },
+      "reachable_definition_count": 23
+    },
+    {
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "git"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "local"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "npm"
+      },
+      "reachable_definition_count": 2
+    },
+    {
+      "protocol_surface_key": {
+        "category": "tagged_union_discriminator",
+        "discriminator_field": "type",
+        "domain": "PluginSource",
+        "name": "remote"
+      },
+      "reachable_definition_count": 2
+    }
+  ],
+  "object_policies": [
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AttestationGenerateParams",
+        "namespace": "legacy"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/AttestationGenerateParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AttestationGenerateResponse",
+        "namespace": "legacy"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/AttestationGenerateResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "DynamicToolCallParams",
+        "namespace": "legacy"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/DynamicToolCallParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "DynamicToolCallResponse",
+        "namespace": "legacy"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/DynamicToolCallResponse"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationBooleanSchema",
+        "namespace": "legacy"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/McpElicitationBooleanSchema"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationConstOption",
+        "namespace": "legacy"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/McpElicitationConstOption"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationLegacyTitledEnumSchema",
+        "namespace": "legacy"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/McpElicitationLegacyTitledEnumSchema"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationNumberSchema",
+        "namespace": "legacy"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/McpElicitationNumberSchema"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationSchema",
+        "namespace": "legacy"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/McpElicitationSchema"
+    },
+    {
+      "additional_properties": "schema",
+      "definition": {
+        "name": "McpElicitationSchema",
+        "namespace": "legacy"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/McpElicitationSchema/properties/properties"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationStringSchema",
+        "namespace": "legacy"
+      },
+      "property_count": 7,
+      "schema_path": "#/definitions/McpElicitationStringSchema"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationTitledEnumItems",
+        "namespace": "legacy"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/McpElicitationTitledEnumItems"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationTitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "property_count": 7,
+      "schema_path": "#/definitions/McpElicitationTitledMultiSelectEnumSchema"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationTitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "property_count": 5,
+      "schema_path": "#/definitions/McpElicitationTitledSingleSelectEnumSchema"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationUntitledEnumItems",
+        "namespace": "legacy"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/McpElicitationUntitledEnumItems"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationUntitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "property_count": 7,
+      "schema_path": "#/definitions/McpElicitationUntitledMultiSelectEnumSchema"
+    },
+    {
+      "additional_properties": false,
+      "definition": {
+        "name": "McpElicitationUntitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "property_count": 5,
+      "schema_path": "#/definitions/McpElicitationUntitledSingleSelectEnumSchema"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/McpServerElicitationRequestParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/0"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/1"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "property_count": 5,
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/2"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerElicitationRequestResponse",
+        "namespace": "legacy"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/McpServerElicitationRequestResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ToolRequestUserInputAnswer",
+        "namespace": "legacy"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/ToolRequestUserInputAnswer"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ToolRequestUserInputOption",
+        "namespace": "legacy"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/ToolRequestUserInputOption"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ToolRequestUserInputParams",
+        "namespace": "legacy"
+      },
+      "property_count": 5,
+      "schema_path": "#/definitions/ToolRequestUserInputParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ToolRequestUserInputQuestion",
+        "namespace": "legacy"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/ToolRequestUserInputQuestion"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ToolRequestUserInputResponse",
+        "namespace": "legacy"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/ToolRequestUserInputResponse"
+    },
+    {
+      "additional_properties": "schema",
+      "definition": {
+        "name": "ToolRequestUserInputResponse",
+        "namespace": "legacy"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/ToolRequestUserInputResponse/properties/answers"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AppBranding",
+        "namespace": "v2"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/v2/AppBranding"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "property_count": 15,
+      "schema_path": "#/definitions/v2/AppInfo"
+    },
+    {
+      "additional_properties": "schema",
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/v2/AppInfo/properties/iconAssets"
+    },
+    {
+      "additional_properties": "schema",
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/v2/AppInfo/properties/iconDarkAssets"
+    },
+    {
+      "additional_properties": "schema",
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/v2/AppInfo/properties/labels"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AppListUpdatedNotification",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/AppListUpdatedNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "property_count": 12,
+      "schema_path": "#/definitions/v2/AppMetadata"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AppReview",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/AppReview"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AppScreenshot",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/AppScreenshot"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AppSummary",
+        "namespace": "v2"
+      },
+      "property_count": 5,
+      "schema_path": "#/definitions/v2/AppSummary"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "property_count": 9,
+      "schema_path": "#/definitions/v2/AppTemplateSummary"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AppsListParams",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/AppsListParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "AppsListResponse",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/AppsListResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "CommandMigration",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/CommandMigration"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "DeprecationNoticeNotification",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/DeprecationNoticeNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "DynamicToolCallOutputContentItem",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/DynamicToolCallOutputContentItem/oneOf/0"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "DynamicToolCallOutputContentItem",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/DynamicToolCallOutputContentItem/oneOf/1"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigDetectParams",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigDetectParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigDetectResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigDetectResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigImportCompletedNotification",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportCompletedNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigImportHistoriesReadResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportHistoriesReadResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigImportHistory",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportHistory"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeFailure",
+        "namespace": "v2"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeFailure"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeSuccess",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeSuccess"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigImportParams",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigImportProgressNotification",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportProgressNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigImportResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigImportTypeResult",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportTypeResult"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ExternalAgentConfigMigrationItem",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/ExternalAgentConfigMigrationItem"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/v2/FeedbackUploadParams"
+    },
+    {
+      "additional_properties": "schema",
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/v2/FeedbackUploadParams/properties/tags"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "FeedbackUploadResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/FeedbackUploadResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "HookCompletedNotification",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/HookCompletedNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "HookErrorInfo",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/HookErrorInfo"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "property_count": 15,
+      "schema_path": "#/definitions/v2/HookMetadata"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "HookMigration",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/HookMigration"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "HookOutputEntry",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/HookOutputEntry"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "property_count": 14,
+      "schema_path": "#/definitions/v2/HookRunSummary"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "HookStartedNotification",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/HookStartedNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "HooksListEntry",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/HooksListEntry"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "HooksListParams",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/HooksListParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "HooksListResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/HooksListResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ListMcpServerStatusParams",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/ListMcpServerStatusParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ListMcpServerStatusResponse",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/ListMcpServerStatusResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "MarketplaceAddParams",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/MarketplaceAddParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "MarketplaceAddResponse",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/MarketplaceAddResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "MarketplaceInterface",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/MarketplaceInterface"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "MarketplaceLoadErrorInfo",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/MarketplaceLoadErrorInfo"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "MarketplaceRemoveParams",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/MarketplaceRemoveParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "MarketplaceRemoveResponse",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/MarketplaceRemoveResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "MarketplaceUpgradeErrorInfo",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeErrorInfo"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "MarketplaceUpgradeParams",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "MarketplaceUpgradeResponse",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpResourceReadParams",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/McpResourceReadParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpResourceReadResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/McpResourceReadResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerInfo",
+        "namespace": "v2"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/v2/McpServerInfo"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerMigration",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/McpServerMigration"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerOauthLoginCompletedNotification",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/McpServerOauthLoginCompletedNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerOauthLoginParams",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/McpServerOauthLoginParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerOauthLoginResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/McpServerOauthLoginResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/v2/McpServerStatus"
+    },
+    {
+      "additional_properties": "schema",
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/v2/McpServerStatus/properties/tools"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerStatusUpdatedNotification",
+        "namespace": "v2"
+      },
+      "property_count": 5,
+      "schema_path": "#/definitions/v2/McpServerStatusUpdatedNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerToolCallParams",
+        "namespace": "v2"
+      },
+      "property_count": 5,
+      "schema_path": "#/definitions/v2/McpServerToolCallParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "McpServerToolCallResponse",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/McpServerToolCallResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "property_count": 7,
+      "schema_path": "#/definitions/v2/MigrationDetails"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "property_count": 10,
+      "schema_path": "#/definitions/v2/PluginDetail"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginHookSummary",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/PluginHookSummary"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginInstallParams",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/PluginInstallParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginInstallResponse",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/PluginInstallResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginInstalledParams",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/PluginInstalledParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginInstalledResponse",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/PluginInstalledResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "property_count": 19,
+      "schema_path": "#/definitions/v2/PluginInterface"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginListParams",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/PluginListParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginListResponse",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/PluginListResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginMarketplaceEntry",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/PluginMarketplaceEntry"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginReadParams",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/PluginReadParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginReadResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/PluginReadResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareCheckoutParams",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/PluginShareCheckoutParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareCheckoutResponse",
+        "namespace": "v2"
+      },
+      "property_count": 7,
+      "schema_path": "#/definitions/v2/PluginShareCheckoutResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareContext",
+        "namespace": "v2"
+      },
+      "property_count": 7,
+      "schema_path": "#/definitions/v2/PluginShareContext"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareDeleteParams",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/PluginShareDeleteParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareDeleteResponse",
+        "namespace": "v2"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/v2/PluginShareDeleteResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareListItem",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/PluginShareListItem"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareListParams",
+        "namespace": "v2"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/v2/PluginShareListParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareListResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/PluginShareListResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginSharePrincipal",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/PluginSharePrincipal"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareSaveParams",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/PluginShareSaveParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareSaveResponse",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/PluginShareSaveResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareTarget",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/PluginShareTarget"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareUpdateTargetsParams",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/PluginShareUpdateTargetsParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginShareUpdateTargetsResponse",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/PluginShareUpdateTargetsResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginSkillReadParams",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/PluginSkillReadParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginSkillReadResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/PluginSkillReadResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/0"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "property_count": 5,
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/1"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/2"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/3"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "property_count": 15,
+      "schema_path": "#/definitions/v2/PluginSummary"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginUninstallParams",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/PluginUninstallParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginUninstallResponse",
+        "namespace": "v2"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/v2/PluginUninstallResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "PluginsMigration",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/PluginsMigration"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ProcessExitedNotification",
+        "namespace": "v2"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/v2/ProcessExitedNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ProcessOutputDeltaNotification",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/ProcessOutputDeltaNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "RemoteControlStatusChangedNotification",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/RemoteControlStatusChangedNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "property_count": 9,
+      "schema_path": "#/definitions/v2/Resource"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ResourceContent",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/ResourceContent/anyOf/0"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ResourceContent",
+        "namespace": "v2"
+      },
+      "property_count": 4,
+      "schema_path": "#/definitions/v2/ResourceContent/anyOf/1"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ResourceTemplate",
+        "namespace": "v2"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/v2/ResourceTemplate"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "ServerRequestResolvedNotification",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/ServerRequestResolvedNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SessionMigration",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/SessionMigration"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillDependencies",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/SkillDependencies"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillErrorInfo",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/SkillErrorInfo"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillInterface",
+        "namespace": "v2"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/v2/SkillInterface"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillMetadata",
+        "namespace": "v2"
+      },
+      "property_count": 8,
+      "schema_path": "#/definitions/v2/SkillMetadata"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillMigration",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/SkillMigration"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillSummary",
+        "namespace": "v2"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/v2/SkillSummary"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillToolDependency",
+        "namespace": "v2"
+      },
+      "property_count": 6,
+      "schema_path": "#/definitions/v2/SkillToolDependency"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillsChangedNotification",
+        "namespace": "v2"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/v2/SkillsChangedNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillsConfigWriteParams",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/SkillsConfigWriteParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillsConfigWriteResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/SkillsConfigWriteResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillsExtraRootsSetParams",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/SkillsExtraRootsSetParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillsExtraRootsSetResponse",
+        "namespace": "v2"
+      },
+      "property_count": 0,
+      "schema_path": "#/definitions/v2/SkillsExtraRootsSetResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillsListEntry",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/SkillsListEntry"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillsListParams",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/SkillsListParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SkillsListResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/SkillsListResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "SubagentMigration",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/SubagentMigration"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "Tool",
+        "namespace": "v2"
+      },
+      "property_count": 8,
+      "schema_path": "#/definitions/v2/Tool"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "WarningNotification",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/WarningNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "WindowsSandboxReadinessResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/WindowsSandboxReadinessResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "WindowsSandboxSetupCompletedNotification",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/WindowsSandboxSetupCompletedNotification"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "WindowsSandboxSetupStartParams",
+        "namespace": "v2"
+      },
+      "property_count": 2,
+      "schema_path": "#/definitions/v2/WindowsSandboxSetupStartParams"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "WindowsSandboxSetupStartResponse",
+        "namespace": "v2"
+      },
+      "property_count": 1,
+      "schema_path": "#/definitions/v2/WindowsSandboxSetupStartResponse"
+    },
+    {
+      "additional_properties": "allowed_by_default",
+      "definition": {
+        "name": "WindowsWorldWritableWarningNotification",
+        "namespace": "v2"
+      },
+      "property_count": 3,
+      "schema_path": "#/definitions/v2/WindowsWorldWritableWarningNotification"
+    }
+  ],
+  "schema_paths": [
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AttestationGenerateResponse",
+        "namespace": "legacy"
+      },
+      "field": "token",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/AttestationGenerateResponse/properties/token",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallParams",
+        "namespace": "legacy"
+      },
+      "field": "arguments",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/DynamicToolCallParams/properties/arguments",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallParams",
+        "namespace": "legacy"
+      },
+      "field": "callId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/DynamicToolCallParams/properties/callId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallParams",
+        "namespace": "legacy"
+      },
+      "field": "namespace",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/DynamicToolCallParams/properties/namespace",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallParams",
+        "namespace": "legacy"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/DynamicToolCallParams/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallParams",
+        "namespace": "legacy"
+      },
+      "field": "tool",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/DynamicToolCallParams/properties/tool",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallParams",
+        "namespace": "legacy"
+      },
+      "field": "turnId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/DynamicToolCallParams/properties/turnId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallResponse",
+        "namespace": "legacy"
+      },
+      "field": "contentItems",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/DynamicToolCallResponse/properties/contentItems",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallResponse",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/DynamicToolCallResponse/properties/contentItems/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallResponse",
+        "namespace": "legacy"
+      },
+      "field": "success",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/DynamicToolCallResponse/properties/success",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationBooleanSchema",
+        "namespace": "legacy"
+      },
+      "field": "default",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationBooleanSchema/properties/default",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationBooleanSchema",
+        "namespace": "legacy"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationBooleanSchema/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationBooleanSchema",
+        "namespace": "legacy"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationBooleanSchema/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationBooleanSchema",
+        "namespace": "legacy"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationBooleanSchema/properties/type",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationConstOption",
+        "namespace": "legacy"
+      },
+      "field": "const",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationConstOption/properties/const",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationConstOption",
+        "namespace": "legacy"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationConstOption/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationLegacyTitledEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "default",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationLegacyTitledEnumSchema/properties/default",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationLegacyTitledEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationLegacyTitledEnumSchema/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationLegacyTitledEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "enum",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationLegacyTitledEnumSchema/properties/enum",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationLegacyTitledEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/McpElicitationLegacyTitledEnumSchema/properties/enum/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationLegacyTitledEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "enumNames",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationLegacyTitledEnumSchema/properties/enumNames",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationLegacyTitledEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/McpElicitationLegacyTitledEnumSchema/properties/enumNames/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationLegacyTitledEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationLegacyTitledEnumSchema/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationLegacyTitledEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationLegacyTitledEnumSchema/properties/type",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationNumberSchema",
+        "namespace": "legacy"
+      },
+      "field": "default",
+      "integer_format": "double",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationNumberSchema/properties/default",
+      "sensitive": false,
+      "value_kind": "number"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationNumberSchema",
+        "namespace": "legacy"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationNumberSchema/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationNumberSchema",
+        "namespace": "legacy"
+      },
+      "field": "maximum",
+      "integer_format": "double",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationNumberSchema/properties/maximum",
+      "sensitive": false,
+      "value_kind": "number"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationNumberSchema",
+        "namespace": "legacy"
+      },
+      "field": "minimum",
+      "integer_format": "double",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationNumberSchema/properties/minimum",
+      "sensitive": false,
+      "value_kind": "number"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationNumberSchema",
+        "namespace": "legacy"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationNumberSchema/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationNumberSchema",
+        "namespace": "legacy"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationNumberSchema/properties/type",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationSchema",
+        "namespace": "legacy"
+      },
+      "field": "$schema",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationSchema/properties/$schema",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "schema",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationSchema",
+        "namespace": "legacy"
+      },
+      "field": "properties",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "reference",
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationSchema/properties/properties",
+      "sensitive": false,
+      "value_kind": "object"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationSchema",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "reference",
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "map_value",
+      "schema_path": "#/definitions/McpElicitationSchema/properties/properties/additionalProperties",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationSchema",
+        "namespace": "legacy"
+      },
+      "field": "required",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationSchema/properties/required",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationSchema",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/McpElicitationSchema/properties/required/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationSchema",
+        "namespace": "legacy"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationSchema/properties/type",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationStringSchema",
+        "namespace": "legacy"
+      },
+      "field": "default",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationStringSchema/properties/default",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationStringSchema",
+        "namespace": "legacy"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationStringSchema/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationStringSchema",
+        "namespace": "legacy"
+      },
+      "field": "format",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationStringSchema/properties/format",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationStringSchema",
+        "namespace": "legacy"
+      },
+      "field": "maxLength",
+      "integer_format": "uint32",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": 0.0,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationStringSchema/properties/maxLength",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationStringSchema",
+        "namespace": "legacy"
+      },
+      "field": "minLength",
+      "integer_format": "uint32",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": 0.0,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationStringSchema/properties/minLength",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationStringSchema",
+        "namespace": "legacy"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationStringSchema/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationStringSchema",
+        "namespace": "legacy"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationStringSchema/properties/type",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledEnumItems",
+        "namespace": "legacy"
+      },
+      "field": "anyOf",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledEnumItems/properties/anyOf",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledEnumItems",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/McpElicitationTitledEnumItems/properties/anyOf/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "default",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledMultiSelectEnumSchema/properties/default",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/McpElicitationTitledMultiSelectEnumSchema/properties/default/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledMultiSelectEnumSchema/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "items",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledMultiSelectEnumSchema/properties/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "maxItems",
+      "integer_format": "uint64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": 0.0,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledMultiSelectEnumSchema/properties/maxItems",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "minItems",
+      "integer_format": "uint64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": 0.0,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledMultiSelectEnumSchema/properties/minItems",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledMultiSelectEnumSchema/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledMultiSelectEnumSchema/properties/type",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "default",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledSingleSelectEnumSchema/properties/default",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledSingleSelectEnumSchema/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "oneOf",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledSingleSelectEnumSchema/properties/oneOf",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/McpElicitationTitledSingleSelectEnumSchema/properties/oneOf/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledSingleSelectEnumSchema/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationTitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationTitledSingleSelectEnumSchema/properties/type",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledEnumItems",
+        "namespace": "legacy"
+      },
+      "field": "enum",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledEnumItems/properties/enum",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledEnumItems",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/McpElicitationUntitledEnumItems/properties/enum/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledEnumItems",
+        "namespace": "legacy"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledEnumItems/properties/type",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "default",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledMultiSelectEnumSchema/properties/default",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/McpElicitationUntitledMultiSelectEnumSchema/properties/default/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledMultiSelectEnumSchema/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "items",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledMultiSelectEnumSchema/properties/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "maxItems",
+      "integer_format": "uint64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": 0.0,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledMultiSelectEnumSchema/properties/maxItems",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "minItems",
+      "integer_format": "uint64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": 0.0,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledMultiSelectEnumSchema/properties/minItems",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledMultiSelectEnumSchema/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledMultiSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledMultiSelectEnumSchema/properties/type",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "default",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledSingleSelectEnumSchema/properties/default",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledSingleSelectEnumSchema/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "enum",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledSingleSelectEnumSchema/properties/enum",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/McpElicitationUntitledSingleSelectEnumSchema/properties/enum/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledSingleSelectEnumSchema/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpElicitationUntitledSingleSelectEnumSchema",
+        "namespace": "legacy"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpElicitationUntitledSingleSelectEnumSchema/properties/type",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "serverName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/properties/serverName",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "turnId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/properties/turnId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "_meta",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/0/properties/_meta",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "message",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/0/properties/message",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "mode",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/0/properties/mode",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "requestedSchema",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/0/properties/requestedSchema",
+      "sensitive": true,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "_meta",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/1/properties/_meta",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "message",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/1/properties/message",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "mode",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/1/properties/mode",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "requestedSchema",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/1/properties/requestedSchema",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "_meta",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/2/properties/_meta",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "elicitationId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/2/properties/elicitationId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "message",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/2/properties/message",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "mode",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/2/properties/mode",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "field": "url",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestParams/oneOf/2/properties/url",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestResponse",
+        "namespace": "legacy"
+      },
+      "field": "_meta",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestResponse/properties/_meta",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestResponse",
+        "namespace": "legacy"
+      },
+      "field": "action",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestResponse/properties/action",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerElicitationRequestResponse",
+        "namespace": "legacy"
+      },
+      "field": "content",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/McpServerElicitationRequestResponse/properties/content",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputAnswer",
+        "namespace": "legacy"
+      },
+      "field": "answers",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputAnswer/properties/answers",
+      "sensitive": true,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputAnswer",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/ToolRequestUserInputAnswer/properties/answers/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputOption",
+        "namespace": "legacy"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputOption/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputOption",
+        "namespace": "legacy"
+      },
+      "field": "label",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputOption/properties/label",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": true,
+      "definition": {
+        "name": "ToolRequestUserInputParams",
+        "namespace": "legacy"
+      },
+      "field": "autoResolutionMs",
+      "integer_format": "uint64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": 0.0,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputParams/properties/autoResolutionMs",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputParams",
+        "namespace": "legacy"
+      },
+      "field": "itemId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputParams/properties/itemId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputParams",
+        "namespace": "legacy"
+      },
+      "field": "questions",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputParams/properties/questions",
+      "sensitive": true,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputParams",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/ToolRequestUserInputParams/properties/questions/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputParams",
+        "namespace": "legacy"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputParams/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputParams",
+        "namespace": "legacy"
+      },
+      "field": "turnId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputParams/properties/turnId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputQuestion",
+        "namespace": "legacy"
+      },
+      "field": "header",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputQuestion/properties/header",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputQuestion",
+        "namespace": "legacy"
+      },
+      "field": "id",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputQuestion/properties/id",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": false,
+      "default_present": true,
+      "definition": {
+        "name": "ToolRequestUserInputQuestion",
+        "namespace": "legacy"
+      },
+      "field": "isOther",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputQuestion/properties/isOther",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": false,
+      "default_present": true,
+      "definition": {
+        "name": "ToolRequestUserInputQuestion",
+        "namespace": "legacy"
+      },
+      "field": "isSecret",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputQuestion/properties/isSecret",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputQuestion",
+        "namespace": "legacy"
+      },
+      "field": "options",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputQuestion/properties/options",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputQuestion",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/ToolRequestUserInputQuestion/properties/options/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputQuestion",
+        "namespace": "legacy"
+      },
+      "field": "question",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputQuestion/properties/question",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "schema",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputResponse",
+        "namespace": "legacy"
+      },
+      "field": "answers",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "reference",
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/ToolRequestUserInputResponse/properties/answers",
+      "sensitive": true,
+      "value_kind": "object"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ToolRequestUserInputResponse",
+        "namespace": "legacy"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "reference",
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "map_value",
+      "schema_path": "#/definitions/ToolRequestUserInputResponse/properties/answers/additionalProperties",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppBranding",
+        "namespace": "v2"
+      },
+      "field": "category",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppBranding/properties/category",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppBranding",
+        "namespace": "v2"
+      },
+      "field": "developer",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppBranding/properties/developer",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppBranding",
+        "namespace": "v2"
+      },
+      "field": "isDiscoverableApp",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppBranding/properties/isDiscoverableApp",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppBranding",
+        "namespace": "v2"
+      },
+      "field": "privacyPolicy",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppBranding/properties/privacyPolicy",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppBranding",
+        "namespace": "v2"
+      },
+      "field": "termsOfService",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppBranding/properties/termsOfService",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppBranding",
+        "namespace": "v2"
+      },
+      "field": "website",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppBranding/properties/website",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "appMetadata",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/appMetadata",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "branding",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/branding",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "distributionChannel",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/distributionChannel",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "schema",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "iconAssets",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "string",
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/iconAssets",
+      "sensitive": false,
+      "value_kind": "object"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "string",
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "map_value",
+      "schema_path": "#/definitions/v2/AppInfo/properties/iconAssets/additionalProperties",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "schema",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "iconDarkAssets",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "string",
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/iconDarkAssets",
+      "sensitive": false,
+      "value_kind": "object"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "string",
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "map_value",
+      "schema_path": "#/definitions/v2/AppInfo/properties/iconDarkAssets/additionalProperties",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "id",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/id",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "installUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/installUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": false,
+      "default_present": true,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "isAccessible",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/isAccessible",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": true,
+      "default_present": true,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "isEnabled",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/isEnabled",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "schema",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "labels",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "string",
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/labels",
+      "sensitive": false,
+      "value_kind": "object"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "string",
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "map_value",
+      "schema_path": "#/definitions/v2/AppInfo/properties/labels/additionalProperties",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "logoUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/logoUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "logoUrlDark",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/logoUrlDark",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": "pluginDisplayNames",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppInfo/properties/pluginDisplayNames",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppInfo",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/AppInfo/properties/pluginDisplayNames/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppListUpdatedNotification",
+        "namespace": "v2"
+      },
+      "field": "data",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppListUpdatedNotification/properties/data",
+      "sensitive": true,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppListUpdatedNotification",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/AppListUpdatedNotification/properties/data/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "categories",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/categories",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/categories/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "developer",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/developer",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "firstPartyRequiresInstall",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/firstPartyRequiresInstall",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "firstPartyType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/firstPartyType",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "review",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/review",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "screenshots",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/screenshots",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/screenshots/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "seoDescription",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/seoDescription",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "showInComposerWhenUnlinked",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/showInComposerWhenUnlinked",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "subCategories",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/subCategories",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/subCategories/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "version",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/version",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "versionId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/versionId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppMetadata",
+        "namespace": "v2"
+      },
+      "field": "versionNotes",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppMetadata/properties/versionNotes",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppReview",
+        "namespace": "v2"
+      },
+      "field": "status",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppReview/properties/status",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppScreenshot",
+        "namespace": "v2"
+      },
+      "field": "fileId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppScreenshot/properties/fileId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppScreenshot",
+        "namespace": "v2"
+      },
+      "field": "url",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppScreenshot/properties/url",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppScreenshot",
+        "namespace": "v2"
+      },
+      "field": "userPrompt",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppScreenshot/properties/userPrompt",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppSummary",
+        "namespace": "v2"
+      },
+      "field": "category",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppSummary/properties/category",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppSummary",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppSummary/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppSummary",
+        "namespace": "v2"
+      },
+      "field": "id",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppSummary/properties/id",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppSummary",
+        "namespace": "v2"
+      },
+      "field": "installUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppSummary/properties/installUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppSummary",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppSummary/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "field": "canonicalConnectorId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppTemplateSummary/properties/canonicalConnectorId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "field": "category",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppTemplateSummary/properties/category",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppTemplateSummary/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "field": "logoUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppTemplateSummary/properties/logoUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "field": "logoUrlDark",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppTemplateSummary/properties/logoUrlDark",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "field": "materializedAppIds",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppTemplateSummary/properties/materializedAppIds",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/AppTemplateSummary/properties/materializedAppIds/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppTemplateSummary/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "field": "reason",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppTemplateSummary/properties/reason",
+      "sensitive": true,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppTemplateSummary",
+        "namespace": "v2"
+      },
+      "field": "templateId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppTemplateSummary/properties/templateId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppsListParams",
+        "namespace": "v2"
+      },
+      "field": "cursor",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppsListParams/properties/cursor",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppsListParams",
+        "namespace": "v2"
+      },
+      "field": "forceRefetch",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppsListParams/properties/forceRefetch",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppsListParams",
+        "namespace": "v2"
+      },
+      "field": "limit",
+      "integer_format": "uint32",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": 0.0,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppsListParams/properties/limit",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppsListParams",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppsListParams/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppsListResponse",
+        "namespace": "v2"
+      },
+      "field": "data",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppsListResponse/properties/data",
+      "sensitive": true,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppsListResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/AppsListResponse/properties/data/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "AppsListResponse",
+        "namespace": "v2"
+      },
+      "field": "nextCursor",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/AppsListResponse/properties/nextCursor",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "CommandMigration",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/CommandMigration/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DeprecationNoticeNotification",
+        "namespace": "v2"
+      },
+      "field": "details",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/DeprecationNoticeNotification/properties/details",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DeprecationNoticeNotification",
+        "namespace": "v2"
+      },
+      "field": "summary",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/DeprecationNoticeNotification/properties/summary",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallOutputContentItem",
+        "namespace": "v2"
+      },
+      "field": "text",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/DynamicToolCallOutputContentItem/oneOf/0/properties/text",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallOutputContentItem",
+        "namespace": "v2"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/DynamicToolCallOutputContentItem/oneOf/0/properties/type",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallOutputContentItem",
+        "namespace": "v2"
+      },
+      "field": "imageUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/DynamicToolCallOutputContentItem/oneOf/1/properties/imageUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "DynamicToolCallOutputContentItem",
+        "namespace": "v2"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/DynamicToolCallOutputContentItem/oneOf/1/properties/type",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigDetectParams",
+        "namespace": "v2"
+      },
+      "field": "cwds",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigDetectParams/properties/cwds",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigDetectParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigDetectParams/properties/cwds/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigDetectParams",
+        "namespace": "v2"
+      },
+      "field": "includeHome",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigDetectParams/properties/includeHome",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigDetectResponse",
+        "namespace": "v2"
+      },
+      "field": "items",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigDetectResponse/properties/items",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigDetectResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigDetectResponse/properties/items/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "importId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportCompletedNotification/properties/importId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "itemTypeResults",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportCompletedNotification/properties/itemTypeResults",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportCompletedNotification/properties/itemTypeResults/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportHistoriesReadResponse",
+        "namespace": "v2"
+      },
+      "field": "data",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportHistoriesReadResponse/properties/data",
+      "sensitive": true,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportHistoriesReadResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportHistoriesReadResponse/properties/data/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportHistory",
+        "namespace": "v2"
+      },
+      "field": "completedAtMs",
+      "integer_format": "int64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportHistory/properties/completedAtMs",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportHistory",
+        "namespace": "v2"
+      },
+      "field": "failures",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportHistory/properties/failures",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportHistory",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportHistory/properties/failures/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportHistory",
+        "namespace": "v2"
+      },
+      "field": "importId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportHistory/properties/importId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportHistory",
+        "namespace": "v2"
+      },
+      "field": "successes",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportHistory/properties/successes",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportHistory",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportHistory/properties/successes/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeFailure",
+        "namespace": "v2"
+      },
+      "field": "cwd",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeFailure/properties/cwd",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeFailure",
+        "namespace": "v2"
+      },
+      "field": "errorType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeFailure/properties/errorType",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeFailure",
+        "namespace": "v2"
+      },
+      "field": "failureStage",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeFailure/properties/failureStage",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeFailure",
+        "namespace": "v2"
+      },
+      "field": "itemType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeFailure/properties/itemType",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeFailure",
+        "namespace": "v2"
+      },
+      "field": "message",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeFailure/properties/message",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeFailure",
+        "namespace": "v2"
+      },
+      "field": "source",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeFailure/properties/source",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeSuccess",
+        "namespace": "v2"
+      },
+      "field": "cwd",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeSuccess/properties/cwd",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeSuccess",
+        "namespace": "v2"
+      },
+      "field": "itemType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeSuccess/properties/itemType",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeSuccess",
+        "namespace": "v2"
+      },
+      "field": "source",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeSuccess/properties/source",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportItemTypeSuccess",
+        "namespace": "v2"
+      },
+      "field": "target",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportItemTypeSuccess/properties/target",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportParams",
+        "namespace": "v2"
+      },
+      "field": "migrationItems",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportParams/properties/migrationItems",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportParams/properties/migrationItems/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportParams",
+        "namespace": "v2"
+      },
+      "field": "source",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportParams/properties/source",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportProgressNotification",
+        "namespace": "v2"
+      },
+      "field": "importId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportProgressNotification/properties/importId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportProgressNotification",
+        "namespace": "v2"
+      },
+      "field": "itemTypeResults",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportProgressNotification/properties/itemTypeResults",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportProgressNotification",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportProgressNotification/properties/itemTypeResults/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportResponse",
+        "namespace": "v2"
+      },
+      "field": "importId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportResponse/properties/importId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportTypeResult",
+        "namespace": "v2"
+      },
+      "field": "failures",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportTypeResult/properties/failures",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportTypeResult",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportTypeResult/properties/failures/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportTypeResult",
+        "namespace": "v2"
+      },
+      "field": "itemType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportTypeResult/properties/itemType",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportTypeResult",
+        "namespace": "v2"
+      },
+      "field": "successes",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportTypeResult/properties/successes",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigImportTypeResult",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigImportTypeResult/properties/successes/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigMigrationItem",
+        "namespace": "v2"
+      },
+      "field": "cwd",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigMigrationItem/properties/cwd",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigMigrationItem",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigMigrationItem/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigMigrationItem",
+        "namespace": "v2"
+      },
+      "field": "details",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigMigrationItem/properties/details",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ExternalAgentConfigMigrationItem",
+        "namespace": "v2"
+      },
+      "field": "itemType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ExternalAgentConfigMigrationItem/properties/itemType",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      },
+      "field": "classification",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/FeedbackUploadParams/properties/classification",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      },
+      "field": "extraLogFiles",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/FeedbackUploadParams/properties/extraLogFiles",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/FeedbackUploadParams/properties/extraLogFiles/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      },
+      "field": "includeLogs",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/FeedbackUploadParams/properties/includeLogs",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      },
+      "field": "reason",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/FeedbackUploadParams/properties/reason",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "schema",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      },
+      "field": "tags",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "string",
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/FeedbackUploadParams/properties/tags",
+      "sensitive": false,
+      "value_kind": "object"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "string",
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "map_value",
+      "schema_path": "#/definitions/v2/FeedbackUploadParams/properties/tags/additionalProperties",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/FeedbackUploadParams/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "FeedbackUploadResponse",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/FeedbackUploadResponse/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "run",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookCompletedNotification/properties/run",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookCompletedNotification/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "turnId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookCompletedNotification/properties/turnId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookErrorInfo",
+        "namespace": "v2"
+      },
+      "field": "message",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookErrorInfo/properties/message",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookErrorInfo",
+        "namespace": "v2"
+      },
+      "field": "path",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookErrorInfo/properties/path",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "command",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/command",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "currentHash",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/currentHash",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "displayOrder",
+      "integer_format": "int64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/displayOrder",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "enabled",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/enabled",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "eventName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/eventName",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "handlerType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/handlerType",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "isManaged",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/isManaged",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "key",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/key",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "matcher",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/matcher",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "pluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/pluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "source",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/source",
+      "sensitive": true,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "sourcePath",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/sourcePath",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "statusMessage",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/statusMessage",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "timeoutSec",
+      "integer_format": "uint64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": 0.0,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/timeoutSec",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMetadata",
+        "namespace": "v2"
+      },
+      "field": "trustStatus",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMetadata/properties/trustStatus",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookMigration",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookMigration/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookOutputEntry",
+        "namespace": "v2"
+      },
+      "field": "kind",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookOutputEntry/properties/kind",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookOutputEntry",
+        "namespace": "v2"
+      },
+      "field": "text",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookOutputEntry/properties/text",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "completedAt",
+      "integer_format": "int64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/completedAt",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "displayOrder",
+      "integer_format": "int64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/displayOrder",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "durationMs",
+      "integer_format": "int64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/durationMs",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "entries",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/entries",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/entries/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "eventName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/eventName",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "executionMode",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/executionMode",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "handlerType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/handlerType",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "id",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/id",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "scope",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/scope",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": "unknown",
+      "default_present": true,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "source",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/source",
+      "sensitive": true,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "sourcePath",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/sourcePath",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "startedAt",
+      "integer_format": "int64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/startedAt",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "status",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/status",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookRunSummary",
+        "namespace": "v2"
+      },
+      "field": "statusMessage",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookRunSummary/properties/statusMessage",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookStartedNotification",
+        "namespace": "v2"
+      },
+      "field": "run",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookStartedNotification/properties/run",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookStartedNotification",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookStartedNotification/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HookStartedNotification",
+        "namespace": "v2"
+      },
+      "field": "turnId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HookStartedNotification/properties/turnId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HooksListEntry",
+        "namespace": "v2"
+      },
+      "field": "cwd",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HooksListEntry/properties/cwd",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HooksListEntry",
+        "namespace": "v2"
+      },
+      "field": "errors",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HooksListEntry/properties/errors",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HooksListEntry",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/HooksListEntry/properties/errors/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HooksListEntry",
+        "namespace": "v2"
+      },
+      "field": "hooks",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HooksListEntry/properties/hooks",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HooksListEntry",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/HooksListEntry/properties/hooks/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HooksListEntry",
+        "namespace": "v2"
+      },
+      "field": "warnings",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HooksListEntry/properties/warnings",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HooksListEntry",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/HooksListEntry/properties/warnings/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HooksListParams",
+        "namespace": "v2"
+      },
+      "field": "cwds",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HooksListParams/properties/cwds",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HooksListParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/HooksListParams/properties/cwds/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HooksListResponse",
+        "namespace": "v2"
+      },
+      "field": "data",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/HooksListResponse/properties/data",
+      "sensitive": true,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "HooksListResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/HooksListResponse/properties/data/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ListMcpServerStatusParams",
+        "namespace": "v2"
+      },
+      "field": "cursor",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ListMcpServerStatusParams/properties/cursor",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ListMcpServerStatusParams",
+        "namespace": "v2"
+      },
+      "field": "detail",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ListMcpServerStatusParams/properties/detail",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ListMcpServerStatusParams",
+        "namespace": "v2"
+      },
+      "field": "limit",
+      "integer_format": "uint32",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": 0.0,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ListMcpServerStatusParams/properties/limit",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ListMcpServerStatusParams",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ListMcpServerStatusParams/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ListMcpServerStatusResponse",
+        "namespace": "v2"
+      },
+      "field": "data",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ListMcpServerStatusResponse/properties/data",
+      "sensitive": true,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ListMcpServerStatusResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/ListMcpServerStatusResponse/properties/data/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ListMcpServerStatusResponse",
+        "namespace": "v2"
+      },
+      "field": "nextCursor",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ListMcpServerStatusResponse/properties/nextCursor",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceAddParams",
+        "namespace": "v2"
+      },
+      "field": "refName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceAddParams/properties/refName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceAddParams",
+        "namespace": "v2"
+      },
+      "field": "source",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceAddParams/properties/source",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceAddParams",
+        "namespace": "v2"
+      },
+      "field": "sparsePaths",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceAddParams/properties/sparsePaths",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceAddParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/MarketplaceAddParams/properties/sparsePaths/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceAddResponse",
+        "namespace": "v2"
+      },
+      "field": "alreadyAdded",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceAddResponse/properties/alreadyAdded",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceAddResponse",
+        "namespace": "v2"
+      },
+      "field": "installedRoot",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceAddResponse/properties/installedRoot",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceAddResponse",
+        "namespace": "v2"
+      },
+      "field": "marketplaceName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceAddResponse/properties/marketplaceName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceInterface",
+        "namespace": "v2"
+      },
+      "field": "displayName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceInterface/properties/displayName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceLoadErrorInfo",
+        "namespace": "v2"
+      },
+      "field": "marketplacePath",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceLoadErrorInfo/properties/marketplacePath",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceLoadErrorInfo",
+        "namespace": "v2"
+      },
+      "field": "message",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceLoadErrorInfo/properties/message",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceRemoveParams",
+        "namespace": "v2"
+      },
+      "field": "marketplaceName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceRemoveParams/properties/marketplaceName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceRemoveResponse",
+        "namespace": "v2"
+      },
+      "field": "installedRoot",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceRemoveResponse/properties/installedRoot",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceRemoveResponse",
+        "namespace": "v2"
+      },
+      "field": "marketplaceName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceRemoveResponse/properties/marketplaceName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceUpgradeErrorInfo",
+        "namespace": "v2"
+      },
+      "field": "marketplaceName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeErrorInfo/properties/marketplaceName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceUpgradeErrorInfo",
+        "namespace": "v2"
+      },
+      "field": "message",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeErrorInfo/properties/message",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceUpgradeParams",
+        "namespace": "v2"
+      },
+      "field": "marketplaceName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeParams/properties/marketplaceName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceUpgradeResponse",
+        "namespace": "v2"
+      },
+      "field": "errors",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeResponse/properties/errors",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceUpgradeResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeResponse/properties/errors/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceUpgradeResponse",
+        "namespace": "v2"
+      },
+      "field": "selectedMarketplaces",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeResponse/properties/selectedMarketplaces",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceUpgradeResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeResponse/properties/selectedMarketplaces/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceUpgradeResponse",
+        "namespace": "v2"
+      },
+      "field": "upgradedRoots",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeResponse/properties/upgradedRoots",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MarketplaceUpgradeResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/MarketplaceUpgradeResponse/properties/upgradedRoots/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpResourceReadParams",
+        "namespace": "v2"
+      },
+      "field": "server",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpResourceReadParams/properties/server",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpResourceReadParams",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpResourceReadParams/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpResourceReadParams",
+        "namespace": "v2"
+      },
+      "field": "uri",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpResourceReadParams/properties/uri",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpResourceReadResponse",
+        "namespace": "v2"
+      },
+      "field": "contents",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpResourceReadResponse/properties/contents",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpResourceReadResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/McpResourceReadResponse/properties/contents/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerInfo",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerInfo/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "opaque_json",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerInfo",
+        "namespace": "v2"
+      },
+      "field": "icons",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerInfo/properties/icons",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "opaque_json",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerInfo",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/McpServerInfo/properties/icons/items",
+      "sensitive": false,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerInfo",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerInfo/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerInfo",
+        "namespace": "v2"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerInfo/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerInfo",
+        "namespace": "v2"
+      },
+      "field": "version",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerInfo/properties/version",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerInfo",
+        "namespace": "v2"
+      },
+      "field": "websiteUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerInfo/properties/websiteUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerMigration",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerMigration/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerOauthLoginCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "error",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerOauthLoginCompletedNotification/properties/error",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerOauthLoginCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerOauthLoginCompletedNotification/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerOauthLoginCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "success",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerOauthLoginCompletedNotification/properties/success",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerOauthLoginCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerOauthLoginCompletedNotification/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerOauthLoginParams",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerOauthLoginParams/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerOauthLoginParams",
+        "namespace": "v2"
+      },
+      "field": "scopes",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerOauthLoginParams/properties/scopes",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerOauthLoginParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/McpServerOauthLoginParams/properties/scopes/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerOauthLoginParams",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerOauthLoginParams/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerOauthLoginParams",
+        "namespace": "v2"
+      },
+      "field": "timeoutSecs",
+      "integer_format": "int64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerOauthLoginParams/properties/timeoutSecs",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerOauthLoginResponse",
+        "namespace": "v2"
+      },
+      "field": "authorizationUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerOauthLoginResponse/properties/authorizationUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "field": "authStatus",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerStatus/properties/authStatus",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerStatus/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "field": "resourceTemplates",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerStatus/properties/resourceTemplates",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/McpServerStatus/properties/resourceTemplates/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "field": "resources",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerStatus/properties/resources",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/McpServerStatus/properties/resources/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "field": "serverInfo",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerStatus/properties/serverInfo",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "schema",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "field": "tools",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "reference",
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerStatus/properties/tools",
+      "sensitive": false,
+      "value_kind": "object"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatus",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": "reference",
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "map_value",
+      "schema_path": "#/definitions/v2/McpServerStatus/properties/tools/additionalProperties",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatusUpdatedNotification",
+        "namespace": "v2"
+      },
+      "field": "error",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerStatusUpdatedNotification/properties/error",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatusUpdatedNotification",
+        "namespace": "v2"
+      },
+      "field": "failureReason",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerStatusUpdatedNotification/properties/failureReason",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatusUpdatedNotification",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerStatusUpdatedNotification/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatusUpdatedNotification",
+        "namespace": "v2"
+      },
+      "field": "status",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerStatusUpdatedNotification/properties/status",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerStatusUpdatedNotification",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerStatusUpdatedNotification/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerToolCallParams",
+        "namespace": "v2"
+      },
+      "field": "_meta",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerToolCallParams/properties/_meta",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerToolCallParams",
+        "namespace": "v2"
+      },
+      "field": "arguments",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerToolCallParams/properties/arguments",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerToolCallParams",
+        "namespace": "v2"
+      },
+      "field": "server",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerToolCallParams/properties/server",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerToolCallParams",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerToolCallParams/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerToolCallParams",
+        "namespace": "v2"
+      },
+      "field": "tool",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerToolCallParams/properties/tool",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerToolCallResponse",
+        "namespace": "v2"
+      },
+      "field": "_meta",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerToolCallResponse/properties/_meta",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "opaque_json",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerToolCallResponse",
+        "namespace": "v2"
+      },
+      "field": "content",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerToolCallResponse/properties/content",
+      "sensitive": true,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "opaque_json",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerToolCallResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/McpServerToolCallResponse/properties/content/items",
+      "sensitive": false,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerToolCallResponse",
+        "namespace": "v2"
+      },
+      "field": "isError",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerToolCallResponse/properties/isError",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "McpServerToolCallResponse",
+        "namespace": "v2"
+      },
+      "field": "structuredContent",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/McpServerToolCallResponse/properties/structuredContent",
+      "sensitive": false,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": "commands",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/commands",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/commands/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": "hooks",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/hooks",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/hooks/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": "mcpServers",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/mcpServers",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/mcpServers/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": "plugins",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/plugins",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/plugins/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": "sessions",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/sessions",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/sessions/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": "skills",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/skills",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/skills/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": "subagents",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/subagents",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "MigrationDetails",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/MigrationDetails/properties/subagents/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": "appTemplates",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/appTemplates",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/appTemplates/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": "apps",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/apps",
+      "sensitive": true,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/apps/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": "hooks",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/hooks",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/hooks/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": "marketplaceName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/marketplaceName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": "marketplacePath",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/marketplacePath",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": "mcpServers",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/mcpServers",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/mcpServers/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": "shareUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/shareUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": "skills",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/skills",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/skills/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginDetail",
+        "namespace": "v2"
+      },
+      "field": "summary",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginDetail/properties/summary",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginHookSummary",
+        "namespace": "v2"
+      },
+      "field": "eventName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginHookSummary/properties/eventName",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginHookSummary",
+        "namespace": "v2"
+      },
+      "field": "key",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginHookSummary/properties/key",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstallParams",
+        "namespace": "v2"
+      },
+      "field": "marketplacePath",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInstallParams/properties/marketplacePath",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstallParams",
+        "namespace": "v2"
+      },
+      "field": "pluginName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInstallParams/properties/pluginName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstallParams",
+        "namespace": "v2"
+      },
+      "field": "remoteMarketplaceName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInstallParams/properties/remoteMarketplaceName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstallResponse",
+        "namespace": "v2"
+      },
+      "field": "appsNeedingAuth",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInstallResponse/properties/appsNeedingAuth",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstallResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginInstallResponse/properties/appsNeedingAuth/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstallResponse",
+        "namespace": "v2"
+      },
+      "field": "authPolicy",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInstallResponse/properties/authPolicy",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstalledParams",
+        "namespace": "v2"
+      },
+      "field": "cwds",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInstalledParams/properties/cwds",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstalledParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginInstalledParams/properties/cwds/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstalledParams",
+        "namespace": "v2"
+      },
+      "field": "installSuggestionPluginNames",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInstalledParams/properties/installSuggestionPluginNames",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstalledParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginInstalledParams/properties/installSuggestionPluginNames/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "PluginInstalledResponse",
+        "namespace": "v2"
+      },
+      "field": "marketplaceLoadErrors",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInstalledResponse/properties/marketplaceLoadErrors",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstalledResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginInstalledResponse/properties/marketplaceLoadErrors/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstalledResponse",
+        "namespace": "v2"
+      },
+      "field": "marketplaces",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInstalledResponse/properties/marketplaces",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInstalledResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginInstalledResponse/properties/marketplaces/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "brandColor",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/brandColor",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "capabilities",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/capabilities",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/capabilities/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "category",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/category",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "composerIcon",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/composerIcon",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "composerIconUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/composerIconUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "defaultPrompt",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/defaultPrompt",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/defaultPrompt/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "developerName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/developerName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "displayName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/displayName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "logo",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/logo",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "logoDark",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/logoDark",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "logoUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/logoUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "logoUrlDark",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/logoUrlDark",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "longDescription",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/longDescription",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "privacyPolicyUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/privacyPolicyUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "screenshotUrls",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/screenshotUrls",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/screenshotUrls/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "screenshots",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/screenshots",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/screenshots/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "shortDescription",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/shortDescription",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "termsOfServiceUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/termsOfServiceUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginInterface",
+        "namespace": "v2"
+      },
+      "field": "websiteUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginInterface/properties/websiteUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginListParams",
+        "namespace": "v2"
+      },
+      "field": "cwds",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginListParams/properties/cwds",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginListParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginListParams/properties/cwds/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginListParams",
+        "namespace": "v2"
+      },
+      "field": "marketplaceKinds",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginListParams/properties/marketplaceKinds",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginListParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginListParams/properties/marketplaceKinds/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "PluginListResponse",
+        "namespace": "v2"
+      },
+      "field": "featuredPluginIds",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginListResponse/properties/featuredPluginIds",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginListResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginListResponse/properties/featuredPluginIds/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "PluginListResponse",
+        "namespace": "v2"
+      },
+      "field": "marketplaceLoadErrors",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginListResponse/properties/marketplaceLoadErrors",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginListResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginListResponse/properties/marketplaceLoadErrors/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginListResponse",
+        "namespace": "v2"
+      },
+      "field": "marketplaces",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginListResponse/properties/marketplaces",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginListResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginListResponse/properties/marketplaces/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginMarketplaceEntry",
+        "namespace": "v2"
+      },
+      "field": "interface",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginMarketplaceEntry/properties/interface",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginMarketplaceEntry",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginMarketplaceEntry/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginMarketplaceEntry",
+        "namespace": "v2"
+      },
+      "field": "path",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginMarketplaceEntry/properties/path",
+      "sensitive": true,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginMarketplaceEntry",
+        "namespace": "v2"
+      },
+      "field": "plugins",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginMarketplaceEntry/properties/plugins",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginMarketplaceEntry",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginMarketplaceEntry/properties/plugins/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginReadParams",
+        "namespace": "v2"
+      },
+      "field": "marketplacePath",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginReadParams/properties/marketplacePath",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginReadParams",
+        "namespace": "v2"
+      },
+      "field": "pluginName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginReadParams/properties/pluginName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginReadParams",
+        "namespace": "v2"
+      },
+      "field": "remoteMarketplaceName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginReadParams/properties/remoteMarketplaceName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginReadResponse",
+        "namespace": "v2"
+      },
+      "field": "plugin",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginReadResponse/properties/plugin",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareCheckoutParams",
+        "namespace": "v2"
+      },
+      "field": "remotePluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareCheckoutParams/properties/remotePluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareCheckoutResponse",
+        "namespace": "v2"
+      },
+      "field": "marketplaceName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareCheckoutResponse/properties/marketplaceName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareCheckoutResponse",
+        "namespace": "v2"
+      },
+      "field": "marketplacePath",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareCheckoutResponse/properties/marketplacePath",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareCheckoutResponse",
+        "namespace": "v2"
+      },
+      "field": "pluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareCheckoutResponse/properties/pluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareCheckoutResponse",
+        "namespace": "v2"
+      },
+      "field": "pluginName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareCheckoutResponse/properties/pluginName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareCheckoutResponse",
+        "namespace": "v2"
+      },
+      "field": "pluginPath",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareCheckoutResponse/properties/pluginPath",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareCheckoutResponse",
+        "namespace": "v2"
+      },
+      "field": "remotePluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareCheckoutResponse/properties/remotePluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareCheckoutResponse",
+        "namespace": "v2"
+      },
+      "field": "remoteVersion",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareCheckoutResponse/properties/remoteVersion",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareContext",
+        "namespace": "v2"
+      },
+      "field": "creatorAccountUserId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareContext/properties/creatorAccountUserId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareContext",
+        "namespace": "v2"
+      },
+      "field": "creatorName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareContext/properties/creatorName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareContext",
+        "namespace": "v2"
+      },
+      "field": "discoverability",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareContext/properties/discoverability",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareContext",
+        "namespace": "v2"
+      },
+      "field": "remotePluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareContext/properties/remotePluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": true,
+      "definition": {
+        "name": "PluginShareContext",
+        "namespace": "v2"
+      },
+      "field": "remoteVersion",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareContext/properties/remoteVersion",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareContext",
+        "namespace": "v2"
+      },
+      "field": "sharePrincipals",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareContext/properties/sharePrincipals",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareContext",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginShareContext/properties/sharePrincipals/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareContext",
+        "namespace": "v2"
+      },
+      "field": "shareUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareContext/properties/shareUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareDeleteParams",
+        "namespace": "v2"
+      },
+      "field": "remotePluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareDeleteParams/properties/remotePluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareListItem",
+        "namespace": "v2"
+      },
+      "field": "localPluginPath",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareListItem/properties/localPluginPath",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareListItem",
+        "namespace": "v2"
+      },
+      "field": "plugin",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareListItem/properties/plugin",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareListResponse",
+        "namespace": "v2"
+      },
+      "field": "data",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareListResponse/properties/data",
+      "sensitive": true,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareListResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginShareListResponse/properties/data/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSharePrincipal",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSharePrincipal/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSharePrincipal",
+        "namespace": "v2"
+      },
+      "field": "principalId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSharePrincipal/properties/principalId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSharePrincipal",
+        "namespace": "v2"
+      },
+      "field": "principalType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSharePrincipal/properties/principalType",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSharePrincipal",
+        "namespace": "v2"
+      },
+      "field": "role",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSharePrincipal/properties/role",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareSaveParams",
+        "namespace": "v2"
+      },
+      "field": "discoverability",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareSaveParams/properties/discoverability",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareSaveParams",
+        "namespace": "v2"
+      },
+      "field": "pluginPath",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareSaveParams/properties/pluginPath",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareSaveParams",
+        "namespace": "v2"
+      },
+      "field": "remotePluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareSaveParams/properties/remotePluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareSaveParams",
+        "namespace": "v2"
+      },
+      "field": "shareTargets",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareSaveParams/properties/shareTargets",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareSaveParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginShareSaveParams/properties/shareTargets/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareSaveResponse",
+        "namespace": "v2"
+      },
+      "field": "remotePluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareSaveResponse/properties/remotePluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareSaveResponse",
+        "namespace": "v2"
+      },
+      "field": "shareUrl",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareSaveResponse/properties/shareUrl",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareTarget",
+        "namespace": "v2"
+      },
+      "field": "principalId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareTarget/properties/principalId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareTarget",
+        "namespace": "v2"
+      },
+      "field": "principalType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareTarget/properties/principalType",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareTarget",
+        "namespace": "v2"
+      },
+      "field": "role",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareTarget/properties/role",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareUpdateTargetsParams",
+        "namespace": "v2"
+      },
+      "field": "discoverability",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareUpdateTargetsParams/properties/discoverability",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareUpdateTargetsParams",
+        "namespace": "v2"
+      },
+      "field": "remotePluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareUpdateTargetsParams/properties/remotePluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareUpdateTargetsParams",
+        "namespace": "v2"
+      },
+      "field": "shareTargets",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareUpdateTargetsParams/properties/shareTargets",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareUpdateTargetsParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginShareUpdateTargetsParams/properties/shareTargets/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareUpdateTargetsResponse",
+        "namespace": "v2"
+      },
+      "field": "discoverability",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareUpdateTargetsResponse/properties/discoverability",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareUpdateTargetsResponse",
+        "namespace": "v2"
+      },
+      "field": "principals",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginShareUpdateTargetsResponse/properties/principals",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginShareUpdateTargetsResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginShareUpdateTargetsResponse/properties/principals/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSkillReadParams",
+        "namespace": "v2"
+      },
+      "field": "remoteMarketplaceName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSkillReadParams/properties/remoteMarketplaceName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSkillReadParams",
+        "namespace": "v2"
+      },
+      "field": "remotePluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSkillReadParams/properties/remotePluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSkillReadParams",
+        "namespace": "v2"
+      },
+      "field": "skillName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSkillReadParams/properties/skillName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSkillReadResponse",
+        "namespace": "v2"
+      },
+      "field": "contents",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSkillReadResponse/properties/contents",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "path",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/0/properties/path",
+      "sensitive": true,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/0/properties/type",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "path",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/1/properties/path",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "refName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/1/properties/refName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "sha",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/1/properties/sha",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/1/properties/type",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "url",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/1/properties/url",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "package",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/2/properties/package",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "registry",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/2/properties/registry",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/2/properties/type",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "version",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/2/properties/version",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSource/oneOf/3/properties/type",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "authPolicy",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/authPolicy",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": "AVAILABLE",
+      "default_present": true,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "availability",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/availability",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "enabled",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/enabled",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "id",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/id",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "installPolicy",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/installPolicy",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "installPolicySource",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/installPolicySource",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "installed",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/installed",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "interface",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/interface",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": [],
+      "default_present": true,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "keywords",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/keywords",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/keywords/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": true,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "localVersion",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/localVersion",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "remotePluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/remotePluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "shareContext",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/shareContext",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "source",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/source",
+      "sensitive": true,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": true,
+      "definition": {
+        "name": "PluginSummary",
+        "namespace": "v2"
+      },
+      "field": "version",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginSummary/properties/version",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginUninstallParams",
+        "namespace": "v2"
+      },
+      "field": "pluginId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginUninstallParams/properties/pluginId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginsMigration",
+        "namespace": "v2"
+      },
+      "field": "marketplaceName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginsMigration/properties/marketplaceName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginsMigration",
+        "namespace": "v2"
+      },
+      "field": "pluginNames",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/PluginsMigration/properties/pluginNames",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "PluginsMigration",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/PluginsMigration/properties/pluginNames/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ProcessExitedNotification",
+        "namespace": "v2"
+      },
+      "field": "exitCode",
+      "integer_format": "int32",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ProcessExitedNotification/properties/exitCode",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ProcessExitedNotification",
+        "namespace": "v2"
+      },
+      "field": "processHandle",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ProcessExitedNotification/properties/processHandle",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ProcessExitedNotification",
+        "namespace": "v2"
+      },
+      "field": "stderr",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ProcessExitedNotification/properties/stderr",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ProcessExitedNotification",
+        "namespace": "v2"
+      },
+      "field": "stderrCapReached",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ProcessExitedNotification/properties/stderrCapReached",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ProcessExitedNotification",
+        "namespace": "v2"
+      },
+      "field": "stdout",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ProcessExitedNotification/properties/stdout",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ProcessExitedNotification",
+        "namespace": "v2"
+      },
+      "field": "stdoutCapReached",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ProcessExitedNotification/properties/stdoutCapReached",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ProcessOutputDeltaNotification",
+        "namespace": "v2"
+      },
+      "field": "capReached",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ProcessOutputDeltaNotification/properties/capReached",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ProcessOutputDeltaNotification",
+        "namespace": "v2"
+      },
+      "field": "deltaBase64",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ProcessOutputDeltaNotification/properties/deltaBase64",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ProcessOutputDeltaNotification",
+        "namespace": "v2"
+      },
+      "field": "processHandle",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ProcessOutputDeltaNotification/properties/processHandle",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ProcessOutputDeltaNotification",
+        "namespace": "v2"
+      },
+      "field": "stream",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ProcessOutputDeltaNotification/properties/stream",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "RemoteControlStatusChangedNotification",
+        "namespace": "v2"
+      },
+      "field": "environmentId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/RemoteControlStatusChangedNotification/properties/environmentId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "RemoteControlStatusChangedNotification",
+        "namespace": "v2"
+      },
+      "field": "installationId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/RemoteControlStatusChangedNotification/properties/installationId",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "RemoteControlStatusChangedNotification",
+        "namespace": "v2"
+      },
+      "field": "serverName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/RemoteControlStatusChangedNotification/properties/serverName",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "RemoteControlStatusChangedNotification",
+        "namespace": "v2"
+      },
+      "field": "status",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/RemoteControlStatusChangedNotification/properties/status",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "field": "_meta",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Resource/properties/_meta",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "field": "annotations",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Resource/properties/annotations",
+      "sensitive": false,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Resource/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "opaque_json",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "field": "icons",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Resource/properties/icons",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "opaque_json",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/Resource/properties/icons/items",
+      "sensitive": false,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "field": "mimeType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Resource/properties/mimeType",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Resource/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "field": "size",
+      "integer_format": "int64",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Resource/properties/size",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Resource/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Resource",
+        "namespace": "v2"
+      },
+      "field": "uri",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Resource/properties/uri",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceContent",
+        "namespace": "v2"
+      },
+      "field": "_meta",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceContent/anyOf/0/properties/_meta",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceContent",
+        "namespace": "v2"
+      },
+      "field": "mimeType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceContent/anyOf/0/properties/mimeType",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceContent",
+        "namespace": "v2"
+      },
+      "field": "text",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceContent/anyOf/0/properties/text",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceContent",
+        "namespace": "v2"
+      },
+      "field": "uri",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceContent/anyOf/0/properties/uri",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceContent",
+        "namespace": "v2"
+      },
+      "field": "_meta",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceContent/anyOf/1/properties/_meta",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceContent",
+        "namespace": "v2"
+      },
+      "field": "blob",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceContent/anyOf/1/properties/blob",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceContent",
+        "namespace": "v2"
+      },
+      "field": "mimeType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceContent/anyOf/1/properties/mimeType",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceContent",
+        "namespace": "v2"
+      },
+      "field": "uri",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceContent/anyOf/1/properties/uri",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceTemplate",
+        "namespace": "v2"
+      },
+      "field": "annotations",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceTemplate/properties/annotations",
+      "sensitive": false,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceTemplate",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceTemplate/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceTemplate",
+        "namespace": "v2"
+      },
+      "field": "mimeType",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceTemplate/properties/mimeType",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceTemplate",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceTemplate/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceTemplate",
+        "namespace": "v2"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceTemplate/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ResourceTemplate",
+        "namespace": "v2"
+      },
+      "field": "uriTemplate",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ResourceTemplate/properties/uriTemplate",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ServerRequestResolvedNotification",
+        "namespace": "v2"
+      },
+      "field": "requestId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ServerRequestResolvedNotification/properties/requestId",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "ServerRequestResolvedNotification",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/ServerRequestResolvedNotification/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SessionMigration",
+        "namespace": "v2"
+      },
+      "field": "cwd",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SessionMigration/properties/cwd",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SessionMigration",
+        "namespace": "v2"
+      },
+      "field": "path",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SessionMigration/properties/path",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SessionMigration",
+        "namespace": "v2"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SessionMigration/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillDependencies",
+        "namespace": "v2"
+      },
+      "field": "tools",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillDependencies/properties/tools",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillDependencies",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/SkillDependencies/properties/tools/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillErrorInfo",
+        "namespace": "v2"
+      },
+      "field": "message",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillErrorInfo/properties/message",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillErrorInfo",
+        "namespace": "v2"
+      },
+      "field": "path",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillErrorInfo/properties/path",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillInterface",
+        "namespace": "v2"
+      },
+      "field": "brandColor",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillInterface/properties/brandColor",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillInterface",
+        "namespace": "v2"
+      },
+      "field": "defaultPrompt",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillInterface/properties/defaultPrompt",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillInterface",
+        "namespace": "v2"
+      },
+      "field": "displayName",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillInterface/properties/displayName",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillInterface",
+        "namespace": "v2"
+      },
+      "field": "iconLarge",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillInterface/properties/iconLarge",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillInterface",
+        "namespace": "v2"
+      },
+      "field": "iconSmall",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillInterface/properties/iconSmall",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillInterface",
+        "namespace": "v2"
+      },
+      "field": "shortDescription",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillInterface/properties/shortDescription",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillMetadata",
+        "namespace": "v2"
+      },
+      "field": "dependencies",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillMetadata/properties/dependencies",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillMetadata",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillMetadata/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillMetadata",
+        "namespace": "v2"
+      },
+      "field": "enabled",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillMetadata/properties/enabled",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillMetadata",
+        "namespace": "v2"
+      },
+      "field": "interface",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillMetadata/properties/interface",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillMetadata",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillMetadata/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillMetadata",
+        "namespace": "v2"
+      },
+      "field": "path",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillMetadata/properties/path",
+      "sensitive": true,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillMetadata",
+        "namespace": "v2"
+      },
+      "field": "scope",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillMetadata/properties/scope",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillMetadata",
+        "namespace": "v2"
+      },
+      "field": "shortDescription",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillMetadata/properties/shortDescription",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillMigration",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillMigration/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillSummary",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillSummary/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillSummary",
+        "namespace": "v2"
+      },
+      "field": "enabled",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillSummary/properties/enabled",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillSummary",
+        "namespace": "v2"
+      },
+      "field": "interface",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillSummary/properties/interface",
+      "sensitive": false,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillSummary",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillSummary/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillSummary",
+        "namespace": "v2"
+      },
+      "field": "path",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillSummary/properties/path",
+      "sensitive": true,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillSummary",
+        "namespace": "v2"
+      },
+      "field": "shortDescription",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillSummary/properties/shortDescription",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillToolDependency",
+        "namespace": "v2"
+      },
+      "field": "command",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillToolDependency/properties/command",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillToolDependency",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillToolDependency/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillToolDependency",
+        "namespace": "v2"
+      },
+      "field": "transport",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillToolDependency/properties/transport",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillToolDependency",
+        "namespace": "v2"
+      },
+      "field": "type",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillToolDependency/properties/type",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillToolDependency",
+        "namespace": "v2"
+      },
+      "field": "url",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillToolDependency/properties/url",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillToolDependency",
+        "namespace": "v2"
+      },
+      "field": "value",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillToolDependency/properties/value",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsConfigWriteParams",
+        "namespace": "v2"
+      },
+      "field": "enabled",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillsConfigWriteParams/properties/enabled",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsConfigWriteParams",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillsConfigWriteParams/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsConfigWriteParams",
+        "namespace": "v2"
+      },
+      "field": "path",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillsConfigWriteParams/properties/path",
+      "sensitive": true,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsConfigWriteResponse",
+        "namespace": "v2"
+      },
+      "field": "effectiveEnabled",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillsConfigWriteResponse/properties/effectiveEnabled",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsExtraRootsSetParams",
+        "namespace": "v2"
+      },
+      "field": "extraRoots",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillsExtraRootsSetParams/properties/extraRoots",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsExtraRootsSetParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/SkillsExtraRootsSetParams/properties/extraRoots/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsListEntry",
+        "namespace": "v2"
+      },
+      "field": "cwd",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillsListEntry/properties/cwd",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsListEntry",
+        "namespace": "v2"
+      },
+      "field": "errors",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillsListEntry/properties/errors",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsListEntry",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/SkillsListEntry/properties/errors/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsListEntry",
+        "namespace": "v2"
+      },
+      "field": "skills",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillsListEntry/properties/skills",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsListEntry",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/SkillsListEntry/properties/skills/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsListParams",
+        "namespace": "v2"
+      },
+      "field": "cwds",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillsListParams/properties/cwds",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsListParams",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/SkillsListParams/properties/cwds/items",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsListParams",
+        "namespace": "v2"
+      },
+      "field": "forceReload",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillsListParams/properties/forceReload",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsListResponse",
+        "namespace": "v2"
+      },
+      "field": "data",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SkillsListResponse/properties/data",
+      "sensitive": true,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "reference",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SkillsListResponse",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/SkillsListResponse/properties/data/items",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "SubagentMigration",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/SubagentMigration/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Tool",
+        "namespace": "v2"
+      },
+      "field": "_meta",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Tool/properties/_meta",
+      "sensitive": true,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Tool",
+        "namespace": "v2"
+      },
+      "field": "annotations",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Tool/properties/annotations",
+      "sensitive": false,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Tool",
+        "namespace": "v2"
+      },
+      "field": "description",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Tool/properties/description",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "opaque_json",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Tool",
+        "namespace": "v2"
+      },
+      "field": "icons",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Tool/properties/icons",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "opaque_json",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Tool",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/Tool/properties/icons/items",
+      "sensitive": false,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Tool",
+        "namespace": "v2"
+      },
+      "field": "inputSchema",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Tool/properties/inputSchema",
+      "sensitive": false,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Tool",
+        "namespace": "v2"
+      },
+      "field": "name",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Tool/properties/name",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Tool",
+        "namespace": "v2"
+      },
+      "field": "outputSchema",
+      "integer_format": null,
+      "intentionally_opaque_json": true,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Tool/properties/outputSchema",
+      "sensitive": false,
+      "value_kind": "opaque_json"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "Tool",
+        "namespace": "v2"
+      },
+      "field": "title",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/Tool/properties/title",
+      "sensitive": false,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WarningNotification",
+        "namespace": "v2"
+      },
+      "field": "message",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WarningNotification/properties/message",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WarningNotification",
+        "namespace": "v2"
+      },
+      "field": "threadId",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WarningNotification/properties/threadId",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WindowsSandboxReadinessResponse",
+        "namespace": "v2"
+      },
+      "field": "status",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WindowsSandboxReadinessResponse/properties/status",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WindowsSandboxSetupCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "error",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WindowsSandboxSetupCompletedNotification/properties/error",
+      "sensitive": true,
+      "value_kind": "string"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WindowsSandboxSetupCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "mode",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WindowsSandboxSetupCompletedNotification/properties/mode",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WindowsSandboxSetupCompletedNotification",
+        "namespace": "v2"
+      },
+      "field": "success",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WindowsSandboxSetupCompletedNotification/properties/success",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WindowsSandboxSetupStartParams",
+        "namespace": "v2"
+      },
+      "field": "cwd",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": true,
+      "optional": true,
+      "required": false,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WindowsSandboxSetupStartParams/properties/cwd",
+      "sensitive": true,
+      "value_kind": "union"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WindowsSandboxSetupStartParams",
+        "namespace": "v2"
+      },
+      "field": "mode",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WindowsSandboxSetupStartParams/properties/mode",
+      "sensitive": false,
+      "value_kind": "reference"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WindowsSandboxSetupStartResponse",
+        "namespace": "v2"
+      },
+      "field": "started",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WindowsSandboxSetupStartResponse/properties/started",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WindowsWorldWritableWarningNotification",
+        "namespace": "v2"
+      },
+      "field": "extraCount",
+      "integer_format": "uint",
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": 0.0,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WindowsWorldWritableWarningNotification/properties/extraCount",
+      "sensitive": false,
+      "value_kind": "integer"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": null,
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WindowsWorldWritableWarningNotification",
+        "namespace": "v2"
+      },
+      "field": "failedScan",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WindowsWorldWritableWarningNotification/properties/failedScan",
+      "sensitive": false,
+      "value_kind": "boolean"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WindowsWorldWritableWarningNotification",
+        "namespace": "v2"
+      },
+      "field": "samplePaths",
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": false,
+      "required": true,
+      "schema_node_kind": "property",
+      "schema_path": "#/definitions/v2/WindowsWorldWritableWarningNotification/properties/samplePaths",
+      "sensitive": false,
+      "value_kind": "array"
+    },
+    {
+      "additional_properties": "not_applicable",
+      "array_element_type": "string",
+      "default": null,
+      "default_present": false,
+      "definition": {
+        "name": "WindowsWorldWritableWarningNotification",
+        "namespace": "v2"
+      },
+      "field": null,
+      "integer_format": null,
+      "intentionally_opaque_json": false,
+      "map_value_type": null,
+      "maximum": null,
+      "minimum": null,
+      "nullable": false,
+      "optional": null,
+      "required": null,
+      "schema_node_kind": "array_element",
+      "schema_path": "#/definitions/v2/WindowsWorldWritableWarningNotification/properties/samplePaths/items",
+      "sensitive": false,
+      "value_kind": "string"
+    }
+  ],
+  "seed_definitions": [
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "attestation/generate"
+          }
+        }
+      ],
+      "definition": {
+        "name": "AttestationGenerateParams",
+        "namespace": "legacy"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "attestation/generate"
+          }
+        }
+      ],
+      "definition": {
+        "name": "AttestationGenerateResponse",
+        "namespace": "legacy"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "item/tool/call"
+          }
+        }
+      ],
+      "definition": {
+        "name": "DynamicToolCallParams",
+        "namespace": "legacy"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "item/tool/call"
+          }
+        }
+      ],
+      "definition": {
+        "name": "DynamicToolCallResponse",
+        "namespace": "legacy"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "registered_union_family",
+          "surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "mode",
+            "domain": "McpServerElicitationRequestParams",
+            "name": "form"
+          }
+        },
+        {
+          "role": "registered_union_family",
+          "surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "mode",
+            "domain": "McpServerElicitationRequestParams",
+            "name": "openai/form"
+          }
+        },
+        {
+          "role": "registered_union_family",
+          "surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "mode",
+            "domain": "McpServerElicitationRequestParams",
+            "name": "url"
+          }
+        },
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "mcpServer/elicitation/request"
+          }
+        }
+      ],
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "mcpServer/elicitation/request"
+          }
+        }
+      ],
+      "definition": {
+        "name": "McpServerElicitationRequestResponse",
+        "namespace": "legacy"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "item/tool/requestUserInput"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ToolRequestUserInputParams",
+        "namespace": "legacy"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "server_request",
+            "discriminator_field": "method",
+            "domain": "ServerRequest",
+            "name": "item/tool/requestUserInput"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ToolRequestUserInputResponse",
+        "namespace": "legacy"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "app/list/updated"
+          }
+        }
+      ],
+      "definition": {
+        "name": "AppListUpdatedNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "app/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "AppsListParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "app/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "AppsListResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "deprecationNotice"
+          }
+        }
+      ],
+      "definition": {
+        "name": "DeprecationNoticeNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "externalAgentConfig/detect"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ExternalAgentConfigDetectParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "externalAgentConfig/detect"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ExternalAgentConfigDetectResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "externalAgentConfig/import/completed"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ExternalAgentConfigImportCompletedNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "externalAgentConfig/import/readHistories"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ExternalAgentConfigImportHistoriesReadResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "externalAgentConfig/import"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ExternalAgentConfigImportParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "externalAgentConfig/import/progress"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ExternalAgentConfigImportProgressNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "externalAgentConfig/import"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ExternalAgentConfigImportResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "feedback/upload"
+          }
+        }
+      ],
+      "definition": {
+        "name": "FeedbackUploadParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "feedback/upload"
+          }
+        }
+      ],
+      "definition": {
+        "name": "FeedbackUploadResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "hook/completed"
+          }
+        }
+      ],
+      "definition": {
+        "name": "HookCompletedNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "hook/started"
+          }
+        }
+      ],
+      "definition": {
+        "name": "HookStartedNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "hooks/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "HooksListParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "hooks/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "HooksListResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServerStatus/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ListMcpServerStatusParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServerStatus/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ListMcpServerStatusResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "marketplace/add"
+          }
+        }
+      ],
+      "definition": {
+        "name": "MarketplaceAddParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "marketplace/add"
+          }
+        }
+      ],
+      "definition": {
+        "name": "MarketplaceAddResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "marketplace/remove"
+          }
+        }
+      ],
+      "definition": {
+        "name": "MarketplaceRemoveParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "marketplace/remove"
+          }
+        }
+      ],
+      "definition": {
+        "name": "MarketplaceRemoveResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "marketplace/upgrade"
+          }
+        }
+      ],
+      "definition": {
+        "name": "MarketplaceUpgradeParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "marketplace/upgrade"
+          }
+        }
+      ],
+      "definition": {
+        "name": "MarketplaceUpgradeResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServer/resource/read"
+          }
+        }
+      ],
+      "definition": {
+        "name": "McpResourceReadParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServer/resource/read"
+          }
+        }
+      ],
+      "definition": {
+        "name": "McpResourceReadResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "mcpServer/oauthLogin/completed"
+          }
+        }
+      ],
+      "definition": {
+        "name": "McpServerOauthLoginCompletedNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServer/oauth/login"
+          }
+        }
+      ],
+      "definition": {
+        "name": "McpServerOauthLoginParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServer/oauth/login"
+          }
+        }
+      ],
+      "definition": {
+        "name": "McpServerOauthLoginResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "mcpServer/startupStatus/updated"
+          }
+        }
+      ],
+      "definition": {
+        "name": "McpServerStatusUpdatedNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServer/tool/call"
+          }
+        }
+      ],
+      "definition": {
+        "name": "McpServerToolCallParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "mcpServer/tool/call"
+          }
+        }
+      ],
+      "definition": {
+        "name": "McpServerToolCallResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/install"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginInstallParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/install"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginInstallResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/installed"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginInstalledParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/installed"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginInstalledResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginListParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginListResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/read"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginReadParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/read"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginReadResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/checkout"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginShareCheckoutParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/checkout"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginShareCheckoutResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/delete"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginShareDeleteParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/delete"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginShareDeleteResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginShareListParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginShareListResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/save"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginShareSaveParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/save"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginShareSaveResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/updateTargets"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginShareUpdateTargetsParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/share/updateTargets"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginShareUpdateTargetsResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/skill/read"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginSkillReadParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/skill/read"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginSkillReadResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "registered_union_family",
+          "surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "type",
+            "domain": "PluginSource",
+            "name": "git"
+          }
+        },
+        {
+          "role": "registered_union_family",
+          "surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "type",
+            "domain": "PluginSource",
+            "name": "local"
+          }
+        },
+        {
+          "role": "registered_union_family",
+          "surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "type",
+            "domain": "PluginSource",
+            "name": "npm"
+          }
+        },
+        {
+          "role": "registered_union_family",
+          "surface_key": {
+            "category": "tagged_union_discriminator",
+            "discriminator_field": "type",
+            "domain": "PluginSource",
+            "name": "remote"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/uninstall"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginUninstallParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "plugin/uninstall"
+          }
+        }
+      ],
+      "definition": {
+        "name": "PluginUninstallResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "process/exited"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ProcessExitedNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "process/outputDelta"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ProcessOutputDeltaNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "remoteControl/status/changed"
+          }
+        }
+      ],
+      "definition": {
+        "name": "RemoteControlStatusChangedNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "serverRequest/resolved"
+          }
+        }
+      ],
+      "definition": {
+        "name": "ServerRequestResolvedNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "skills/changed"
+          }
+        }
+      ],
+      "definition": {
+        "name": "SkillsChangedNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "skills/config/write"
+          }
+        }
+      ],
+      "definition": {
+        "name": "SkillsConfigWriteParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "skills/config/write"
+          }
+        }
+      ],
+      "definition": {
+        "name": "SkillsConfigWriteResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "skills/extraRoots/set"
+          }
+        }
+      ],
+      "definition": {
+        "name": "SkillsExtraRootsSetParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "skills/extraRoots/set"
+          }
+        }
+      ],
+      "definition": {
+        "name": "SkillsExtraRootsSetResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "skills/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "SkillsListParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "skills/list"
+          }
+        }
+      ],
+      "definition": {
+        "name": "SkillsListResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "warning"
+          }
+        }
+      ],
+      "definition": {
+        "name": "WarningNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "windowsSandbox/readiness"
+          }
+        }
+      ],
+      "definition": {
+        "name": "WindowsSandboxReadinessResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "windowsSandbox/setupCompleted"
+          }
+        }
+      ],
+      "definition": {
+        "name": "WindowsSandboxSetupCompletedNotification",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "request_params",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "windowsSandbox/setupStart"
+          }
+        }
+      ],
+      "definition": {
+        "name": "WindowsSandboxSetupStartParams",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "successful_response",
+          "surface_key": {
+            "category": "client_request",
+            "discriminator_field": "method",
+            "domain": "ClientRequest",
+            "name": "windowsSandbox/setupStart"
+          }
+        }
+      ],
+      "definition": {
+        "name": "WindowsSandboxSetupStartResponse",
+        "namespace": "v2"
+      }
+    },
+    {
+      "associations": [
+        {
+          "role": "notification_params",
+          "surface_key": {
+            "category": "server_notification",
+            "discriminator_field": "method",
+            "domain": "ServerNotification",
+            "name": "windows/worldWritableWarning"
+          }
+        }
+      ],
+      "definition": {
+        "name": "WindowsWorldWritableWarningNotification",
+        "namespace": "v2"
+      }
+    }
+  ],
+  "union_families": [
+    {
+      "alternatives": [
+        {
+          "additional_properties": "allowed_by_default",
+          "alternative": "form",
+          "branch_index": 0,
+          "intentionally_opaque_fields": [
+            "_meta"
+          ],
+          "nullable_fields": [
+            "_meta"
+          ],
+          "optional_fields": [
+            "_meta"
+          ],
+          "property_schemas": [
+            {
+              "default_present": false,
+              "field": "_meta",
+              "nullable": true,
+              "required": false,
+              "value_kind": "opaque_json"
+            },
+            {
+              "default_present": false,
+              "field": "message",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "mode",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "requestedSchema",
+              "nullable": false,
+              "required": true,
+              "value_kind": "reference"
+            }
+          ],
+          "required_fields": [
+            "message",
+            "mode",
+            "requestedSchema"
+          ],
+          "title": null
+        },
+        {
+          "additional_properties": "allowed_by_default",
+          "alternative": "openai/form",
+          "branch_index": 1,
+          "intentionally_opaque_fields": [
+            "_meta",
+            "requestedSchema"
+          ],
+          "nullable_fields": [
+            "_meta",
+            "requestedSchema"
+          ],
+          "optional_fields": [
+            "_meta"
+          ],
+          "property_schemas": [
+            {
+              "default_present": false,
+              "field": "_meta",
+              "nullable": true,
+              "required": false,
+              "value_kind": "opaque_json"
+            },
+            {
+              "default_present": false,
+              "field": "message",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "mode",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "requestedSchema",
+              "nullable": true,
+              "required": true,
+              "value_kind": "opaque_json"
+            }
+          ],
+          "required_fields": [
+            "message",
+            "mode",
+            "requestedSchema"
+          ],
+          "title": null
+        },
+        {
+          "additional_properties": "allowed_by_default",
+          "alternative": "url",
+          "branch_index": 2,
+          "intentionally_opaque_fields": [
+            "_meta"
+          ],
+          "nullable_fields": [
+            "_meta"
+          ],
+          "optional_fields": [
+            "_meta"
+          ],
+          "property_schemas": [
+            {
+              "default_present": false,
+              "field": "_meta",
+              "nullable": true,
+              "required": false,
+              "value_kind": "opaque_json"
+            },
+            {
+              "default_present": false,
+              "field": "elicitationId",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "message",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "mode",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "url",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            }
+          ],
+          "required_fields": [
+            "elicitationId",
+            "message",
+            "mode",
+            "url"
+          ],
+          "title": null
+        }
+      ],
+      "definition": {
+        "name": "McpServerElicitationRequestParams",
+        "namespace": "legacy"
+      },
+      "discriminator": "mode",
+      "domain": "McpServerElicitationRequestParams",
+      "future_unknown_handling": "preserve raw unknown alternative and diagnostic; never coerce it to a known alternative",
+      "malformed_known_handling": "reject a known discriminator with missing or wrong-typed required fields",
+      "outer_additional_properties": "allowed_by_default",
+      "outer_nullable_fields": [
+        "turnId"
+      ],
+      "outer_optional_fields": [
+        "turnId"
+      ],
+      "outer_required_fields": [
+        "serverName",
+        "threadId"
+      ],
+      "reaching_roots": [
+        {
+          "category": "server_request",
+          "discriminator_field": "method",
+          "domain": "ServerRequest",
+          "name": "mcpServer/elicitation/request"
+        }
+      ],
+      "representation": "Draft-07 object plus oneOf branches"
+    },
+    {
+      "alternatives": [
+        {
+          "additional_properties": "allowed_by_default",
+          "alternative": "local",
+          "branch_index": 0,
+          "intentionally_opaque_fields": [],
+          "nullable_fields": [],
+          "optional_fields": [],
+          "property_schemas": [
+            {
+              "default_present": false,
+              "field": "path",
+              "nullable": false,
+              "required": true,
+              "value_kind": "reference"
+            },
+            {
+              "default_present": false,
+              "field": "type",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            }
+          ],
+          "required_fields": [
+            "path",
+            "type"
+          ],
+          "title": "LocalPluginSource"
+        },
+        {
+          "additional_properties": "allowed_by_default",
+          "alternative": "git",
+          "branch_index": 1,
+          "intentionally_opaque_fields": [],
+          "nullable_fields": [
+            "path",
+            "refName",
+            "sha"
+          ],
+          "optional_fields": [
+            "path",
+            "refName",
+            "sha"
+          ],
+          "property_schemas": [
+            {
+              "default_present": false,
+              "field": "path",
+              "nullable": true,
+              "required": false,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "refName",
+              "nullable": true,
+              "required": false,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "sha",
+              "nullable": true,
+              "required": false,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "type",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "url",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            }
+          ],
+          "required_fields": [
+            "type",
+            "url"
+          ],
+          "title": "GitPluginSource"
+        },
+        {
+          "additional_properties": "allowed_by_default",
+          "alternative": "npm",
+          "branch_index": 2,
+          "intentionally_opaque_fields": [],
+          "nullable_fields": [
+            "registry",
+            "version"
+          ],
+          "optional_fields": [
+            "registry",
+            "version"
+          ],
+          "property_schemas": [
+            {
+              "default_present": false,
+              "field": "package",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "registry",
+              "nullable": true,
+              "required": false,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "type",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            },
+            {
+              "default_present": false,
+              "field": "version",
+              "nullable": true,
+              "required": false,
+              "value_kind": "string"
+            }
+          ],
+          "required_fields": [
+            "package",
+            "type"
+          ],
+          "title": "NpmPluginSource"
+        },
+        {
+          "additional_properties": "allowed_by_default",
+          "alternative": "remote",
+          "branch_index": 3,
+          "intentionally_opaque_fields": [],
+          "nullable_fields": [],
+          "optional_fields": [],
+          "property_schemas": [
+            {
+              "default_present": false,
+              "field": "type",
+              "nullable": false,
+              "required": true,
+              "value_kind": "string"
+            }
+          ],
+          "required_fields": [
+            "type"
+          ],
+          "title": "RemotePluginSource"
+        }
+      ],
+      "definition": {
+        "name": "PluginSource",
+        "namespace": "v2"
+      },
+      "discriminator": "type",
+      "domain": "PluginSource",
+      "future_unknown_handling": "preserve raw unknown alternative and diagnostic; never coerce it to a known alternative",
+      "malformed_known_handling": "reject a known discriminator with missing or wrong-typed required fields",
+      "outer_additional_properties": "allowed_by_default",
+      "outer_nullable_fields": [],
+      "outer_optional_fields": [],
+      "outer_required_fields": [],
+      "reaching_roots": [
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/installed"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/list"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/read"
+        },
+        {
+          "category": "client_request",
+          "discriminator_field": "method",
+          "domain": "ClientRequest",
+          "name": "plugin/share/list"
+        }
+      ],
+      "representation": "Draft-07 object plus oneOf branches"
+    }
+  ]
+}

--- a/tools/codex/app-server-evidence/0.144.6/a1-final-cross-slice-ledger.json
+++ b/tools/codex/app-server-evidence/0.144.6/a1-final-cross-slice-ledger.json
@@ -1,0 +1,242 @@
+{
+  "assignment_authority": {
+    "path": "tools/codex/app-server-evidence/0.144.6/module-slice-assignment.json",
+    "sha256": "e9097d1d27acd3915da65f7c955c2e8fb25f7ee0fce9b185e4415a1ba85396cf"
+  },
+  "assignment_file_unchanged": true,
+  "codex_version": "codex-cli 0.144.6",
+  "counts": {
+    "all_current_partial": 4,
+    "inherited_a1_0_partial": 3,
+    "native_a1_4_partial": 1
+  },
+  "format_version": 1,
+  "generated_notice": "Generated cross-slice completion ledger; ownership remains defined by module-slice-assignment.json.",
+  "inherited_final_a1_obligations": [
+    {
+      "assignment_unchanged_proof": {
+        "assignment": {
+          "classification": "StablePublicRoot",
+          "module": "Common",
+          "slice": "A1.0",
+          "stability": "stable"
+        },
+        "authority": {
+          "path": "tools/codex/app-server-evidence/0.144.6/module-slice-assignment.json",
+          "sha256": "e9097d1d27acd3915da65f7c955c2e8fb25f7ee0fce9b185e4415a1ba85396cf"
+        },
+        "registry_matches_assignment": true
+      },
+      "category": "client_notification",
+      "completion_stage": "final A1 closure in A1.4",
+      "current_module": "Common",
+      "current_runtime_disposition": "Typed",
+      "current_runtime_target": "ClientNotificationTarget::Initialized",
+      "current_slice": "A1.0",
+      "current_status": "Partial",
+      "deferred_reason": "the method-only notification completes the automatic initialization lifecycle with initialize",
+      "expected_status_after_completion": "Complete",
+      "intended_completion_batch": "A1-FinalClosure",
+      "missing_codec_obligations": [
+        "exact internal method-only notification encoder",
+        "descriptor and registry direction assertion"
+      ],
+      "missing_public_type_obligations": [
+        "no new public payload type; the notification has no params"
+      ],
+      "missing_schema_completeness_facts": [
+        "direction_assertions_exercised",
+        "no_known_schema_fields_dropped",
+        "nullable_semantics_exercised",
+        "opaque_fields_declared",
+        "reachable_union_alternatives_exercised",
+        "runtime_decoder_matches_registry",
+        "schema_properties_exercised"
+      ],
+      "missing_test_obligations": [
+        "method-only positive schema case",
+        "no-payload/no-drop direction evidence"
+      ],
+      "protocol_surface_key": {
+        "category": "client_notification",
+        "discriminator_field": "method",
+        "domain": "ClientNotification",
+        "name": "initialized"
+      }
+    },
+    {
+      "assignment_unchanged_proof": {
+        "assignment": {
+          "classification": "StablePublicRoot",
+          "module": "Common",
+          "slice": "A1.0",
+          "stability": "stable"
+        },
+        "authority": {
+          "path": "tools/codex/app-server-evidence/0.144.6/module-slice-assignment.json",
+          "sha256": "e9097d1d27acd3915da65f7c955c2e8fb25f7ee0fce9b185e4415a1ba85396cf"
+        },
+        "registry_matches_assignment": true
+      },
+      "category": "client_request",
+      "completion_stage": "final A1 closure in A1.4",
+      "current_module": "Common",
+      "current_runtime_disposition": "Typed",
+      "current_runtime_target": "ClientRequestTarget::Initialize",
+      "current_slice": "A1.0",
+      "current_status": "Partial",
+      "deferred_reason": "cross-cutting automatic lifecycle compatibility belongs at the deliberate final A1 rebuild boundary",
+      "expected_status_after_completion": "Complete",
+      "intended_completion_batch": "A1-FinalClosure",
+      "missing_codec_obligations": [
+        "encode exact InitializeParams without dropping known fields",
+        "retain exact InitializeResponse decoding",
+        "do not add a generic initialize facade"
+      ],
+      "missing_public_type_obligations": [
+        "preserve automatic initialization and constructor signatures",
+        "model ClientInfo.title as omitted/null/value",
+        "append optional-null InitializeCapabilities",
+        "model experimentalApi and requestAttestation defaults",
+        "model optional mcpServerOpenaiFormElicitation",
+        "model optional-null optOutNotificationMethods"
+      ],
+      "missing_schema_completeness_facts": [
+        "direction_assertions_exercised",
+        "no_known_schema_fields_dropped",
+        "nullable_semantics_exercised",
+        "opaque_fields_declared",
+        "reachable_union_alternatives_exercised",
+        "runtime_decoder_matches_registry",
+        "schema_properties_exercised"
+      ],
+      "missing_test_obligations": [
+        "omitted/null/value ClientInfo title and capabilities",
+        "capability defaults and opt-out notification list",
+        "request/result direction and registry target assertions",
+        "automatic-handshake compatibility"
+      ],
+      "protocol_surface_key": {
+        "category": "client_request",
+        "discriminator_field": "method",
+        "domain": "ClientRequest",
+        "name": "initialize"
+      }
+    },
+    {
+      "assignment_unchanged_proof": {
+        "assignment": {
+          "classification": "StablePublicRoot",
+          "module": "Common",
+          "slice": "A1.0",
+          "stability": "stable"
+        },
+        "authority": {
+          "path": "tools/codex/app-server-evidence/0.144.6/module-slice-assignment.json",
+          "sha256": "e9097d1d27acd3915da65f7c955c2e8fb25f7ee0fce9b185e4415a1ba85396cf"
+        },
+        "registry_matches_assignment": true
+      },
+      "category": "server_notification",
+      "completion_stage": "final A1 closure in A1.4",
+      "current_module": "Common",
+      "current_runtime_disposition": "Typed",
+      "current_runtime_target": "ServerNotificationTarget::Error",
+      "current_slice": "A1.0",
+      "current_status": "Partial",
+      "deferred_reason": "error is cross-cutting Common lifecycle state and its layout change belongs at final A1 closure",
+      "expected_status_after_completion": "Complete",
+      "intended_completion_batch": "A1-FinalClosure",
+      "missing_codec_obligations": [
+        "decode every CodexErrorInfo known/future/malformed union case",
+        "preserve omitted/null/value fields and additional details",
+        "retain current BackendCore/frontend projection"
+      ],
+      "missing_public_type_obligations": [
+        "preserve Event alternative TurnErrorEvent at index 44",
+        "append schema-complete ErrorNotification canonical view",
+        "retain raw payload and diagnostics",
+        "add optional canonical view to TurnErrorEvent"
+      ],
+      "missing_schema_completeness_facts": [
+        "direction_assertions_exercised",
+        "no_known_schema_fields_dropped",
+        "nullable_semantics_exercised",
+        "opaque_fields_declared",
+        "reachable_union_alternatives_exercised",
+        "runtime_decoder_matches_registry",
+        "schema_properties_exercised"
+      ],
+      "missing_test_obligations": [
+        "all error properties and nullable states",
+        "malformed-known and future-unknown error info",
+        "Event index and backend compatibility"
+      ],
+      "protocol_surface_key": {
+        "category": "server_notification",
+        "discriminator_field": "method",
+        "domain": "ServerNotification",
+        "name": "error"
+      }
+    }
+  ],
+  "native_a1_4_obligation": {
+    "assignment_unchanged_proof": {
+      "assignment": {
+        "classification": "StablePublicRoot",
+        "module": "IntegrationsAndLongTail",
+        "slice": "A1.4",
+        "stability": "stable"
+      },
+      "authority": {
+        "path": "tools/codex/app-server-evidence/0.144.6/module-slice-assignment.json",
+        "sha256": "e9097d1d27acd3915da65f7c955c2e8fb25f7ee0fce9b185e4415a1ba85396cf"
+      },
+      "registry_matches_assignment": true
+    },
+    "category": "server_request",
+    "completion_stage": "native A1.4 implementation",
+    "current_module": "IntegrationsAndLongTail",
+    "current_runtime_disposition": "Typed",
+    "current_runtime_target": "ServerRequestTarget::ToolRequestUserInput",
+    "current_slice": "A1.4",
+    "current_status": "Partial",
+    "deferred_reason": "native A1.4 reverse-request work owns this existing compatibility projection",
+    "expected_status_after_completion": "Complete",
+    "intended_completion_batch": "A14-McpReverse",
+    "missing_codec_obligations": [
+      "exact params decoder with default and uint64 semantics",
+      "exact ToolRequestUserInputResponse encoder",
+      "post-encode schema validation and direct respondOwned path"
+    ],
+    "missing_public_type_obligations": [
+      "preserve UserInputRequest and TypedServerRequest index 2",
+      "preserve UserInputQuestion/UserInputOption/UserInputAnswer",
+      "append canonical ToolRequestUserInputParams and diagnostics",
+      "model autoResolutionMs and options as omitted/null/value",
+      "add canonical response map without removing legacy overload"
+    ],
+    "missing_schema_completeness_facts": [
+      "direction_assertions_exercised",
+      "no_known_schema_fields_dropped",
+      "nullable_semantics_exercised",
+      "opaque_fields_declared",
+      "reachable_union_alternatives_exercised",
+      "runtime_decoder_matches_registry",
+      "schema_properties_exercised"
+    ],
+    "missing_test_obligations": [
+      "all params/response fields and nullable states",
+      "known/duplicate question validation compatibility",
+      "one-shot/retry/original-ID/generation lifecycle"
+    ],
+    "protocol_surface_key": {
+      "category": "server_request",
+      "discriminator_field": "method",
+      "domain": "ServerRequest",
+      "name": "item/tool/requestUserInput"
+    }
+  },
+  "native_denominator_rule": "The three inherited rows are excluded from the native 56-identity A1.4 denominator.",
+  "ownership_rule": "A1.4 is the scheduling milestone for final Common closure, not the ownership slice of initialize, initialized, or error."
+}

--- a/tools/codex/app_server_a1_3_closure.py
+++ b/tools/codex/app_server_a1_3_closure.py
@@ -41,6 +41,22 @@ EXPECTED_GLOBAL_STATUS = {
     "NotImplemented": 55,
     "Partial": 4,
 }
+# These two records describe the historical A1.3 closure boundary. Successor
+# audit phases may extend the closure checker and source-package guard without
+# rewriting the already captured A1.3 report; their live semantics are checked
+# by successor-aware tokens below.
+FROZEN_SUCCESSOR_MUTABLE_SOURCES = {
+    "closure_generator": {
+        "path": "tools/codex/app_server_a1_3_closure.py",
+        "sha256":
+            "678e8b97267919d61ec99a0a9fa3b259d3d3c1f20eca7cb91fc068cb182f87fe",
+    },
+    "source_package_guard": {
+        "path": "tests/CodexSourcePackageTest.cmake",
+        "sha256":
+            "7a95b8cdd07dcc9702bb21bd249da09de1789efed44149f1d53401a919f08cce",
+    },
+}
 EXPECTED_CLASSIFICATIONS = {
     "RootOwnedNestedUnion": 17,
     "SharedWithinSlice": 22,
@@ -1138,12 +1154,22 @@ def validate_package_and_integrity(
         "synthetic-secret source-tree guard reported a finding",
         "ClosureSecurityGuardMismatch",
     )
+    successor_compatibility = require_tokens(
+        Path(__file__).resolve(),
+        (
+            "FROZEN_SUCCESSOR_MUTABLE_SOURCES",
+            '"A1.4 partition and implementation-plan audit"',
+        ),
+        "ClosurePackageMismatch",
+        "successor-aware A1.3 closure checker",
+    )
+    del successor_compatibility
     source_package = require_tokens(
         arguments.source_package_test,
         (
-            'assert_retained_prefix("tools/codex/app-server-evidence/0.144.6" 22)',
-            'assert_retained_prefix("docs/ai/openai/codex" 18)',
-            "top_level_codex_tool_count EQUAL 13",
+            'assert_retained_prefix("tools/codex/app-server-evidence/0.144.6" 27)',
+            'assert_retained_prefix("docs/ai/openai/codex" 19)',
+            "top_level_codex_tool_count EQUAL 14",
             '"tools/codex/app_server_a1_3.py"',
             '"tools/codex/app_server_a1_3_closure.py"',
             '"tools/codex/app-server-evidence/0.144.6/a1-3-closure-report.json"',
@@ -1153,6 +1179,14 @@ def validate_package_and_integrity(
             '"docs/ai/openai/codex/a1-3-test-integrity.md"',
             '"A1.3 implementation-plan/type-closure audit"',
             '"A1.3 final closure report"',
+            '"tools/codex/app_server_a1_4.py"',
+            '"tools/codex/app-server-evidence/0.144.6/a1-4-start-state.json"',
+            '"tools/codex/app-server-evidence/0.144.6/a1-4-total-partition.json"',
+            '"tools/codex/app-server-evidence/0.144.6/a1-4-type-closure.json"',
+            '"tools/codex/app-server-evidence/0.144.6/a1-4-implementation-plan.json"',
+            '"tools/codex/app-server-evidence/0.144.6/a1-final-cross-slice-ledger.json"',
+            '"tests/component/codex/CodexA14AuditToolTest.py"',
+            '"A1.4 partition and implementation-plan audit"',
         ),
         "ClosurePackageMismatch",
         "source-package closure guard",
@@ -1456,6 +1490,11 @@ def build_report(arguments: argparse.Namespace) -> dict[str, Any]:
         "test_integrity": arguments.test_integrity,
         "type_closure": arguments.type_closure,
     }
+    source_records = {
+        name: source_record(path, arguments.repo_root)
+        for name, path in sorted(source_paths.items())
+    }
+    source_records.update(FROZEN_SUCCESSOR_MUTABLE_SOURCES)
     return {
         "api_abi": api_abi,
         "authority": {
@@ -1499,10 +1538,7 @@ def build_report(arguments: argparse.Namespace) -> dict[str, Any]:
         "public_api": public_api,
         "response_root_obligations": response_roots,
         "server_requests": server_requests,
-        "sources": {
-            name: source_record(path, arguments.repo_root)
-            for name, path in sorted(source_paths.items())
-        },
+        "sources": source_records,
         "staged_exact_complete_ratchets": staged,
         "transport_and_lifecycle": transport,
         "union_alternatives": union_alternatives,

--- a/tools/codex/app_server_a1_4.py
+++ b/tools/codex/app_server_a1_4.py
@@ -1,0 +1,2478 @@
+#!/usr/bin/env python3
+"""Audit and freeze the Codex App Server Phase A1.4 residue.
+
+The generated JSON documents are deterministic review evidence.  They guard
+the total protocol partition, the native A1.4 start state, and the transitive
+stable schema closure.  ``ProtocolSurfaceRegistryData.inc`` remains the sole
+local production authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+sys.dont_write_bytecode = True
+
+import app_server_a1_shared as shared
+import app_server_fixtures as fixtures
+import app_server_schema_paths as schema_paths
+import app_server_surface as surface
+
+
+FORMAT_VERSION = 1
+CODEX_VERSION = "codex-cli 0.144.6"
+UPSTREAM_TAG = "rust-v0.144.6"
+UPSTREAM_SOURCE_COMMIT = "5d1fbf26c43abc65a203928b2e31561cb039e06d"
+A1_4_SLICE = "A1.4"
+A1_4_MODULE = "IntegrationsAndLongTail"
+EXPECTED_BASE_SHA = "bed5ee05184739d54cddc6518bd43b264e2b496d"
+EXPECTED_BASE_TREE = "8bf44f0eed6bd8c9d5309176db07a7d6a6240ef3"
+EXPECTED_SCHEMA_AGGREGATES = {
+    "stable": "cee1ac3bcaf95e5fcdcf07499c7e6b00fc423b90c670ea3380f1799434b72add",
+    "experimental": "4a0ef96787255364d99b15fe40fcfd6227901978d0cddc8b20340bfef98a0d1b",
+}
+EXPECTED_TYPESCRIPT_AGGREGATES = {
+    "stable": "73c95b6a19d5559939519a771e0f7285cc60bbfaa1aac8bd9c52ba308c6e6811",
+    "experimental": "d561ef0b4ef8a921fff50de4e3c662a0fdff643e82868f2b05a3e71f912aec8c",
+}
+
+EXPECTED_PARTITION = {
+    "A1.0": 19,
+    "A1.1": 151,
+    "A1.2": 45,
+    "A1.3": 68,
+    "A1.4": 56,
+    "InventoryOnly": 48,
+}
+EXPECTED_STABILITY_ACCOUNTING = {
+    "experimental_only_inventory": 36,
+    "stable_a1": 339,
+    "stable_inventory": 351,
+    "stable_unreachable_inventory": 12,
+    "total_inventory": 387,
+}
+EXPECTED_INVENTORY_CLASSIFICATIONS = {
+    "ExperimentalInventoryOnly": 36,
+    "StableUnreachableInventory": 12,
+}
+EXPECTED_TAXONOMY = {
+    "client_request": 29,
+    "server_notification": 16,
+    "server_request": 4,
+    "tagged_union_discriminator": 7,
+}
+EXPECTED_RESULT_KINDS = {"Concrete": 26, "Unit": 3}
+EXPECTED_NATIVE_START_STATUS = {
+    "Complete": 0,
+    "NotImplemented": 55,
+    "Partial": 1,
+}
+EXPECTED_GLOBAL_START_STATUS = {
+    "Complete": 280,
+    "NotApplicable": 48,
+    "NotImplemented": 55,
+    "Partial": 4,
+}
+EXPECTED_NATIVE_COMPLETION_STATUS = {
+    "Complete": 336,
+    "NotApplicable": 48,
+    "NotImplemented": 0,
+    "Partial": 3,
+}
+EXPECTED_FINAL_A1_STATUS = {
+    "Complete": 339,
+    "NotApplicable": 48,
+    "NotImplemented": 0,
+    "Partial": 0,
+}
+EXPECTED_CLOSURE_COUNTS = {
+    "default_bearing_paths": 22,
+    "definition_namespaces": {"legacy": 34, "v2": 155},
+    "integer_formats": {
+        "double": 3,
+        "int32": 1,
+        "int64": 8,
+        "uint": 1,
+        "uint32": 4,
+        "uint64": 6,
+    },
+    "maximum_bearing_paths": 0,
+    "minimum_bearing_paths": 11,
+    "nullable_paths": 243,
+    "object_nodes": 162,
+    "opaque_json_paths": 24,
+    "optional_paths": 260,
+    "reachable_named_definitions": 189,
+    "required_paths": 288,
+    "schema_path_kinds": {
+        "array_element": 91,
+        "map_value": 7,
+        "property": 548,
+    },
+    "schema_paths": 646,
+    "seed_definitions": 81,
+    "sensitive_paths": 127,
+}
+EXPECTED_OBJECT_POLICIES = {
+    "False": 12,
+    "allowed_by_default": 143,
+    "schema": 7,
+}
+
+AuditError = shared.AuditError
+AuditDiagnostic = shared.AuditDiagnostic
+Key = shared.Key
+
+
+CLIENT_REQUEST_CONTRACTS = {
+    "app/list": ("AppsListParams", "AppsListResponse", "Concrete"),
+    "externalAgentConfig/detect": (
+        "ExternalAgentConfigDetectParams",
+        "ExternalAgentConfigDetectResponse",
+        "Concrete",
+    ),
+    "externalAgentConfig/import": (
+        "ExternalAgentConfigImportParams",
+        "ExternalAgentConfigImportResponse",
+        "Concrete",
+    ),
+    "externalAgentConfig/import/readHistories": (
+        "Unit",
+        "ExternalAgentConfigImportHistoriesReadResponse",
+        "Concrete",
+    ),
+    "feedback/upload": (
+        "FeedbackUploadParams",
+        "FeedbackUploadResponse",
+        "Concrete",
+    ),
+    "hooks/list": ("HooksListParams", "HooksListResponse", "Concrete"),
+    "marketplace/add": (
+        "MarketplaceAddParams",
+        "MarketplaceAddResponse",
+        "Concrete",
+    ),
+    "marketplace/remove": (
+        "MarketplaceRemoveParams",
+        "MarketplaceRemoveResponse",
+        "Concrete",
+    ),
+    "marketplace/upgrade": (
+        "MarketplaceUpgradeParams",
+        "MarketplaceUpgradeResponse",
+        "Concrete",
+    ),
+    "mcpServer/oauth/login": (
+        "McpServerOauthLoginParams",
+        "McpServerOauthLoginResponse",
+        "Concrete",
+    ),
+    "mcpServer/resource/read": (
+        "McpResourceReadParams",
+        "McpResourceReadResponse",
+        "Concrete",
+    ),
+    "mcpServer/tool/call": (
+        "McpServerToolCallParams",
+        "McpServerToolCallResponse",
+        "Concrete",
+    ),
+    "mcpServerStatus/list": (
+        "ListMcpServerStatusParams",
+        "ListMcpServerStatusResponse",
+        "Concrete",
+    ),
+    "plugin/install": (
+        "PluginInstallParams",
+        "PluginInstallResponse",
+        "Concrete",
+    ),
+    "plugin/installed": (
+        "PluginInstalledParams",
+        "PluginInstalledResponse",
+        "Concrete",
+    ),
+    "plugin/list": ("PluginListParams", "PluginListResponse", "Concrete"),
+    "plugin/read": ("PluginReadParams", "PluginReadResponse", "Concrete"),
+    "plugin/share/checkout": (
+        "PluginShareCheckoutParams",
+        "PluginShareCheckoutResponse",
+        "Concrete",
+    ),
+    "plugin/share/delete": ("PluginShareDeleteParams", "Unit", "Unit"),
+    "plugin/share/list": (
+        "PluginShareListParams",
+        "PluginShareListResponse",
+        "Concrete",
+    ),
+    "plugin/share/save": (
+        "PluginShareSaveParams",
+        "PluginShareSaveResponse",
+        "Concrete",
+    ),
+    "plugin/share/updateTargets": (
+        "PluginShareUpdateTargetsParams",
+        "PluginShareUpdateTargetsResponse",
+        "Concrete",
+    ),
+    "plugin/skill/read": (
+        "PluginSkillReadParams",
+        "PluginSkillReadResponse",
+        "Concrete",
+    ),
+    "plugin/uninstall": ("PluginUninstallParams", "Unit", "Unit"),
+    "skills/config/write": (
+        "SkillsConfigWriteParams",
+        "SkillsConfigWriteResponse",
+        "Concrete",
+    ),
+    "skills/extraRoots/set": (
+        "SkillsExtraRootsSetParams",
+        "Unit",
+        "Unit",
+    ),
+    "skills/list": ("SkillsListParams", "SkillsListResponse", "Concrete"),
+    "windowsSandbox/readiness": (
+        "Unit",
+        "WindowsSandboxReadinessResponse",
+        "Concrete",
+    ),
+    "windowsSandbox/setupStart": (
+        "WindowsSandboxSetupStartParams",
+        "WindowsSandboxSetupStartResponse",
+        "Concrete",
+    ),
+}
+
+SERVER_NOTIFICATIONS = {
+    "app/list/updated",
+    "deprecationNotice",
+    "externalAgentConfig/import/completed",
+    "externalAgentConfig/import/progress",
+    "hook/completed",
+    "hook/started",
+    "mcpServer/oauthLogin/completed",
+    "mcpServer/startupStatus/updated",
+    "process/exited",
+    "process/outputDelta",
+    "remoteControl/status/changed",
+    "serverRequest/resolved",
+    "skills/changed",
+    "warning",
+    "windows/worldWritableWarning",
+    "windowsSandbox/setupCompleted",
+}
+
+SERVER_REQUEST_CONTRACTS = {
+    "attestation/generate": (
+        "AttestationGenerateParams",
+        "AttestationGenerateResponse",
+    ),
+    "item/tool/call": (
+        "DynamicToolCallParams",
+        "DynamicToolCallResponse",
+    ),
+    "item/tool/requestUserInput": (
+        "ToolRequestUserInputParams",
+        "ToolRequestUserInputResponse",
+    ),
+    "mcpServer/elicitation/request": (
+        "McpServerElicitationRequestParams",
+        "McpServerElicitationRequestResponse",
+    ),
+}
+
+UNION_FAMILIES = {
+    ("McpServerElicitationRequestParams", "mode"): {
+        "form",
+        "openai/form",
+        "url",
+    },
+    ("PluginSource", "type"): {"git", "local", "npm", "remote"},
+}
+
+EXPERIMENTAL_PROCESS_CONTROLS = {
+    "process/kill",
+    "process/resizePty",
+    "process/spawn",
+    "process/writeStdin",
+}
+EXPERIMENTAL_REMOTE_CONTROLS = {
+    "remoteControl/client/list",
+    "remoteControl/client/revoke",
+    "remoteControl/disable",
+    "remoteControl/enable",
+    "remoteControl/pairing/start",
+    "remoteControl/pairing/status",
+    "remoteControl/status/read",
+}
+
+NATIVE_PARTIAL = Key(
+    "server_request",
+    "ServerRequest",
+    "method",
+    "item/tool/requestUserInput",
+)
+INHERITED_PARTIALS = {
+    Key("client_request", "ClientRequest", "method", "initialize"),
+    Key(
+        "client_notification",
+        "ClientNotification",
+        "method",
+        "initialized",
+    ),
+    Key("server_notification", "ServerNotification", "method", "error"),
+}
+
+SENSITIVE_FIELD_NAMES = {
+    "_meta",
+    "answers",
+    "app",
+    "apps",
+    "arguments",
+    "attachments",
+    "authUrl",
+    "checkout",
+    "config",
+    "content",
+    "cwd",
+    "data",
+    "delta",
+    "diagnostic",
+    "environment",
+    "error",
+    "feedback",
+    "history",
+    "hook",
+    "id",
+    "input",
+    "itemId",
+    "message",
+    "name",
+    "output",
+    "path",
+    "processId",
+    "prompt",
+    "question",
+    "questions",
+    "reason",
+    "repository",
+    "requestedSchema",
+    "resource",
+    "result",
+    "serverName",
+    "source",
+    "state",
+    "stderr",
+    "stdout",
+    "target",
+    "threadId",
+    "token",
+    "tool",
+    "turnId",
+    "url",
+    "value",
+    "values",
+    "warning",
+}
+
+
+@dataclass
+class Inputs:
+    manifest: dict[str, Any]
+    assignments_document: dict[str, Any]
+    reachability_document: dict[str, Any]
+    contracts_document: dict[str, Any]
+    completeness_document: dict[str, Any]
+    fixture_document: dict[str, Any]
+    registry_rows: list[dict[str, Any]]
+    manifest_rows: dict[Key, dict[str, Any]]
+    assignments: dict[Key, dict[str, Any]]
+    reachability: dict[Key, dict[str, Any]]
+    contracts: dict[Key, dict[str, Any]]
+    completeness: dict[Key, dict[str, Any]]
+    fixture_coverage: dict[Key, dict[str, Any]]
+    registry: dict[Key, dict[str, Any]]
+
+
+def require(condition: bool, message: str, code: str) -> None:
+    shared.require(condition, message, code)
+
+
+def _counter(values: Iterable[str]) -> dict[str, int]:
+    return dict(sorted(Counter(values).items()))
+
+
+def _git(repo_root: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", *arguments],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode:
+        raise AuditError(
+            f"git {' '.join(arguments)} failed while freezing A1.4",
+            "BaseCommitMismatch",
+        )
+    return completed.stdout.strip()
+
+
+def _source(path: Path, repo_root: Path) -> dict[str, str]:
+    return {
+        "path": path.resolve().relative_to(repo_root).as_posix(),
+        "sha256": shared.sha256_file(path),
+    }
+
+
+def _keys_from_rows(
+    rows: Sequence[Mapping[str, Any]],
+    description: str,
+) -> list[Key]:
+    keys: list[Key] = []
+    seen: dict[Key, Mapping[str, Any]] = {}
+    for row in rows:
+        key = Key.from_row(row)
+        if key in seen:
+            previous_slice = seen[key].get("slice")
+            current_slice = row.get("slice")
+            code = (
+                "CrossSliceOverlap"
+                if previous_slice != current_slice
+                else "DuplicateAssignment"
+            )
+            raise AuditError(
+                f"duplicate {description} identity: {key.compact()}",
+                code,
+            )
+        seen[key] = row
+        keys.append(key)
+    return keys
+
+
+def expected_a1_4_keys() -> set[Key]:
+    result = {
+        *(
+            Key("client_request", "ClientRequest", "method", name)
+            for name in CLIENT_REQUEST_CONTRACTS
+        ),
+        *(
+            Key(
+                "server_notification",
+                "ServerNotification",
+                "method",
+                name,
+            )
+            for name in SERVER_NOTIFICATIONS
+        ),
+        *(
+            Key("server_request", "ServerRequest", "method", name)
+            for name in SERVER_REQUEST_CONTRACTS
+        ),
+    }
+    for (domain, field), alternatives in UNION_FAMILIES.items():
+        result.update(
+            Key("tagged_union_discriminator", domain, field, name)
+            for name in alternatives
+        )
+    return result
+
+
+def load_inputs(arguments: argparse.Namespace) -> Inputs:
+    manifest_document = shared.load_json(arguments.manifest)
+    assignment_document = shared.load_json(arguments.assignments)
+    registry_rows = surface.parse_registry_data(arguments.registry)
+    manifest_rows = shared.records(
+        manifest_document, ("entries",), "surface manifest"
+    )
+    assignment_rows = shared.records(
+        assignment_document,
+        ("assignments",),
+        "module/slice assignment",
+    )
+    manifest_keys = _keys_from_rows(manifest_rows, "inventory")
+    assignment_keys = _keys_from_rows(assignment_rows, "assignment")
+    registry_keys = _keys_from_rows(registry_rows, "registry")
+    require(
+        len(manifest_keys) == 387,
+        f"total inventory denominator changed: {len(manifest_keys)}",
+        "TotalDenominatorMismatch",
+    )
+    manifest_set = set(manifest_keys)
+    assignment_set = set(assignment_keys)
+    require(
+        assignment_set == manifest_set,
+        "inventory/assignment exact-key mismatch",
+        (
+            "UnassignedIdentity"
+            if manifest_set - assignment_set
+            else "ExtraAssignment"
+        ),
+    )
+    require(
+        set(registry_keys) == manifest_set,
+        "inventory/registry exact-key mismatch",
+        "RegistryIdentitySetMismatch",
+    )
+    require(
+        all(
+            row.get("slice") in EXPECTED_PARTITION
+            for row in assignment_rows
+        ),
+        "an inventory identity has no reviewed slice",
+        "UnassignedIdentity",
+    )
+    values = shared.load_surface_evidence_inputs(
+        manifest_path=arguments.manifest,
+        assignments_path=arguments.assignments,
+        reachability_path=arguments.reachability,
+        contracts_path=arguments.contracts,
+        completeness_path=arguments.schema_completeness,
+        fixture_coverage_path=arguments.fixture_coverage,
+        registry_path=arguments.registry,
+        allowed_versions=frozenset({"0.144.6", CODEX_VERSION}),
+    )
+    return Inputs(**vars(values))
+
+
+def _manifest_stability(row: Mapping[str, Any]) -> str:
+    stability = str(row.get("stability"))
+    require(
+        stability in {"stable", "experimental_only"},
+        f"unknown manifest stability: {stability}",
+        "StabilityMismatch",
+    )
+    return stability
+
+
+def validate_partition_inputs(inputs: Inputs) -> list[Key]:
+    manifest_rows = shared.records(
+        inputs.manifest, ("entries",), "surface manifest"
+    )
+    assignment_rows = shared.records(
+        inputs.assignments_document,
+        ("assignments",),
+        "module/slice assignment",
+    )
+    registry_rows = inputs.registry_rows
+    manifest_keys = _keys_from_rows(manifest_rows, "inventory")
+    assignment_keys = _keys_from_rows(assignment_rows, "assignment")
+    registry_keys = _keys_from_rows(registry_rows, "registry")
+
+    require(
+        len(manifest_keys) == EXPECTED_STABILITY_ACCOUNTING["total_inventory"],
+        f"total inventory denominator changed: {len(manifest_keys)}",
+        "TotalDenominatorMismatch",
+    )
+    manifest_set = set(manifest_keys)
+    assignment_set = set(assignment_keys)
+    registry_set = set(registry_keys)
+    require(
+        assignment_set == manifest_set,
+        "inventory/assignment exact-key mismatch",
+        (
+            "UnassignedIdentity"
+            if manifest_set - assignment_set
+            else "ExtraAssignment"
+        ),
+    )
+    require(
+        registry_set == manifest_set,
+        "inventory/registry exact-key mismatch",
+        "RegistryIdentitySetMismatch",
+    )
+
+    allowed_slices = set(EXPECTED_PARTITION)
+    for key in sorted(manifest_set):
+        manifest = inputs.manifest_rows[key]
+        assignment = inputs.assignments[key]
+        registry = inputs.registry[key]
+        assigned_slice = assignment.get("slice")
+        require(
+            assigned_slice in allowed_slices,
+            f"identity is unassigned: {key.compact()}",
+            "UnassignedIdentity",
+        )
+        stability = _manifest_stability(manifest)
+        require(
+            assignment.get("stability") == stability
+            and registry.get("stability") == stability,
+            f"stability mismatch: {key.compact()}",
+            "StabilityMismatch",
+        )
+        require(
+            registry.get("typed_module") == assignment.get("module")
+            and registry.get("a1_slice") == assigned_slice,
+            f"module/slice mismatch: {key.compact()}",
+            "ModuleMismatch",
+        )
+        require(
+            Key.from_row(manifest) == Key.from_row(assignment)
+            == Key.from_row(registry),
+            f"surface category mismatch: {key.compact()}",
+            "CategoryMismatch",
+        )
+
+    for key in sorted(manifest_set):
+        assignment = inputs.assignments[key]
+        if assignment["slice"] == A1_4_SLICE:
+            require(
+                assignment["stability"] != "experimental_only"
+                and assignment["classification"]
+                != "ExperimentalInventoryOnly",
+                f"experimental identity assigned to A1.4: {key.compact()}",
+                "ExperimentalLeakage",
+            )
+            require(
+                assignment["classification"]
+                != "StableUnreachableInventory",
+                (
+                    "stable-unreachable identity assigned to A1.4: "
+                    f"{key.compact()}"
+                ),
+                "StableUnreachableBoundaryMismatch",
+            )
+    for key in INHERITED_PARTIALS:
+        assignment = inputs.assignments[key]
+        require(
+            assignment["slice"] == "A1.0"
+            and assignment["module"] == "Common",
+            f"inherited A1.0 owner changed: {key.compact()}",
+            "CrossSliceOwnershipMismatch",
+        )
+
+    partition = _counter(
+        str(inputs.assignments[key]["slice"]) for key in manifest_set
+    )
+    require(
+        partition == EXPECTED_PARTITION,
+        f"six-bucket partition changed: {partition}",
+        "PartitionCountMismatch",
+    )
+    stability = _counter(
+        _manifest_stability(inputs.manifest_rows[key])
+        for key in manifest_set
+    )
+    require(
+        stability == {"experimental_only": 36, "stable": 351},
+        f"stable/experimental inventory changed: {stability}",
+        "HiddenStableIdentity",
+    )
+
+    inventory_keys = {
+        key
+        for key in manifest_set
+        if inputs.assignments[key]["slice"] == "InventoryOnly"
+    }
+    provisional_a1_4 = {
+        key
+        for key in manifest_set
+        if inputs.assignments[key]["slice"] == A1_4_SLICE
+    }
+    for key in sorted(provisional_a1_4):
+        assignment = inputs.assignments[key]
+        require(
+            assignment["stability"] != "experimental_only"
+            and assignment["classification"]
+            != "ExperimentalInventoryOnly",
+            f"experimental identity assigned to A1.4: {key.compact()}",
+            "ExperimentalLeakage",
+        )
+        require(
+            assignment["classification"]
+            != "StableUnreachableInventory",
+            f"stable-unreachable identity assigned to A1.4: {key.compact()}",
+            "StableUnreachableBoundaryMismatch",
+        )
+    for key in INHERITED_PARTIALS:
+        assignment = inputs.assignments[key]
+        require(
+            assignment["slice"] == "A1.0"
+            and assignment["module"] == "Common",
+            f"inherited A1.0 owner changed: {key.compact()}",
+            "CrossSliceOwnershipMismatch",
+        )
+    inventory_classifications = _counter(
+        str(inputs.assignments[key]["classification"])
+        for key in inventory_keys
+    )
+    require(
+        inventory_classifications == EXPECTED_INVENTORY_CLASSIFICATIONS,
+        (
+            "InventoryOnly must remain 36 experimental-only plus "
+            "12 stable-unreachable identities"
+        ),
+        "InventoryClassificationMismatch",
+    )
+    for key in inventory_keys:
+        assignment = inputs.assignments[key]
+        registry = inputs.registry[key]
+        classification = assignment["classification"]
+        if classification == "ExperimentalInventoryOnly":
+            require(
+                assignment["stability"] == "experimental_only",
+                f"experimental inventory stability changed: {key.compact()}",
+                "ExperimentalBoundaryMismatch",
+            )
+        else:
+            require(
+                classification == "StableUnreachableInventory"
+                and assignment["stability"] == "stable",
+                f"stable-unreachable inventory changed: {key.compact()}",
+                "StableUnreachableBoundaryMismatch",
+            )
+        require(
+            registry["typed_schema_status"] == "NotApplicable"
+            and registry["typed_status"] == "NotImplemented",
+            f"InventoryOnly status changed: {key.compact()}",
+            "InventoryStatusMismatch",
+        )
+
+    a1_4 = {
+        key
+        for key in manifest_set
+        if inputs.assignments[key]["slice"] == A1_4_SLICE
+    }
+    require(
+        a1_4 == expected_a1_4_keys(),
+        "native A1.4 identity set changed",
+        "A14IdentitySetMismatch",
+    )
+    require(
+        len(a1_4) == 56,
+        f"native A1.4 denominator changed: {len(a1_4)}",
+        "A14DenominatorMismatch",
+    )
+    for key in sorted(a1_4):
+        assignment = inputs.assignments[key]
+        require(
+            assignment["stability"] == "stable",
+            f"experimental identity assigned to A1.4: {key.compact()}",
+            "ExperimentalLeakage",
+        )
+        require(
+            assignment["module"] == A1_4_MODULE,
+            f"wrong A1.4 module: {key.compact()}",
+            "A14ModuleMismatch",
+        )
+
+    process_inventory = {
+        key.name
+        for key in inventory_keys
+        if key.name in EXPERIMENTAL_PROCESS_CONTROLS
+    }
+    require(
+        process_inventory == EXPERIMENTAL_PROCESS_CONTROLS,
+        "experimental process controls left InventoryOnly",
+        "ProcessBoundaryMismatch",
+    )
+    require(
+        {
+            "process/exited",
+            "process/outputDelta",
+        }.issubset({key.name for key in a1_4}),
+        "stable process notifications are missing from A1.4",
+        "ProcessBoundaryMismatch",
+    )
+    require(
+        "remoteControl/status/changed" in {key.name for key in a1_4},
+        "stable remote-control status notification is missing",
+        "RemoteControlBoundaryMismatch",
+    )
+    remote_inventory = {
+        key.name
+        for key in inventory_keys
+        if key.name in EXPERIMENTAL_REMOTE_CONTROLS
+    }
+    require(
+        remote_inventory == EXPERIMENTAL_REMOTE_CONTROLS,
+        "experimental remote-control methods left InventoryOnly",
+        "RemoteControlBoundaryMismatch",
+    )
+    require(
+        not (
+            EXPERIMENTAL_REMOTE_CONTROLS
+            & {
+                key.name
+                for key in a1_4
+                if key.category == "client_request"
+            }
+        ),
+        "experimental remote-control client method leaked into A1.4",
+        "RemoteControlBoundaryMismatch",
+    )
+    return sorted(a1_4)
+
+
+def _status_counter(
+    rows: Iterable[Mapping[str, Any]],
+) -> dict[str, int]:
+    values = Counter(str(row["typed_schema_status"]) for row in rows)
+    for name in (
+        "Complete",
+        "Partial",
+        "NotImplemented",
+        "NotApplicable",
+    ):
+        values.setdefault(name, 0)
+    return dict(sorted(values.items()))
+
+
+def validate_start_arithmetic(inputs: Inputs, keys: Sequence[Key]) -> None:
+    native = _status_counter(inputs.registry[key] for key in keys)
+    global_status = _status_counter(inputs.registry.values())
+    require(
+        native
+        == {
+            **EXPECTED_NATIVE_START_STATUS,
+            "NotApplicable": 0,
+        },
+        f"native A1.4 starting status changed: {native}",
+        "NativeStartStatusMismatch",
+    )
+    require(
+        global_status == EXPECTED_GLOBAL_START_STATUS,
+        f"global starting status changed: {global_status}",
+        "GlobalStartStatusMismatch",
+    )
+    native_partial = {
+        key
+        for key in keys
+        if inputs.registry[key]["typed_schema_status"] == "Partial"
+    }
+    require(
+        native_partial == {NATIVE_PARTIAL},
+        "item/tool/requestUserInput is not the sole native A1.4 Partial",
+        "NativePartialMismatch",
+    )
+    global_partial = {
+        key
+        for key, row in inputs.registry.items()
+        if row["typed_schema_status"] == "Partial"
+    }
+    require(
+        global_partial == INHERITED_PARTIALS | {NATIVE_PARTIAL},
+        "the four frozen global Partial identities changed",
+        "GlobalPartialMismatch",
+    )
+
+
+def validate_provenance(arguments: argparse.Namespace) -> dict[str, Any]:
+    schema_provenance = shared.load_json(arguments.schema_provenance)
+    protocol_provenance = shared.load_json(arguments.protocol_provenance)
+    release = schema_provenance.get("upstream", {}).get("release", {})
+    require(
+        release.get("tag") == UPSTREAM_TAG
+        and release.get("source_commit_sha") == UPSTREAM_SOURCE_COMMIT,
+        "schema provenance release changed",
+        "ProvenanceMismatch",
+    )
+    protocol_release = protocol_provenance.get("release", {})
+    require(
+        protocol_release.get("tag") == UPSTREAM_TAG
+        and protocol_release.get("source_commit_sha")
+        == UPSTREAM_SOURCE_COMMIT,
+        "protocol-source provenance release changed",
+        "ProvenanceMismatch",
+    )
+
+    schema_tree_summary: dict[str, Any] = {}
+    for stability, expected_aggregate in EXPECTED_SCHEMA_AGGREGATES.items():
+        tree = schema_provenance.get("schema_trees", {}).get(stability, {})
+        files = tree.get("files")
+        require(
+            isinstance(files, list),
+            f"{stability} schema provenance lacks files",
+            "ProvenanceMismatch",
+        )
+        records: list[str] = []
+        for row in files:
+            relative = str(row["path"])
+            path = arguments.schema_root / stability / relative
+            require(
+                path.is_file()
+                and path.stat().st_size == row["bytes"]
+                and shared.sha256_file(path) == row["sha256"],
+                f"schema provenance mismatch: {stability}/{relative}",
+                "ProvenanceHashMismatch",
+            )
+            records.append(f"{row['sha256']}  {relative}\n")
+        aggregate = hashlib.sha256(
+            "".join(records).encode("utf-8")
+        ).hexdigest()
+        require(
+            aggregate == expected_aggregate
+            and tree.get("aggregate_sha256") == expected_aggregate,
+            f"{stability} schema aggregate changed: {aggregate}",
+            "ProvenanceHashMismatch",
+        )
+        schema_tree_summary[stability] = {
+            "aggregate_sha256": aggregate,
+            "file_count": len(files),
+        }
+
+    for row in protocol_provenance.get("files", []):
+        path = arguments.protocol_source_root / str(row["path"])
+        require(
+            path.is_file()
+            and path.stat().st_size == row["bytes"]
+            and shared.sha256_file(path) == row["sha256"],
+            f"protocol-source provenance mismatch: {row['path']}",
+            "ProvenanceHashMismatch",
+        )
+
+    typescript = schema_provenance.get("typescript_cross_check", {})
+    for stability, expected in EXPECTED_TYPESCRIPT_AGGREGATES.items():
+        require(
+            typescript.get(stability, {}).get("aggregate_sha256")
+            == expected,
+            f"{stability} TypeScript aggregate changed",
+            "ProvenanceMismatch",
+        )
+    return {
+        "codex_version": CODEX_VERSION,
+        "upstream_tag": UPSTREAM_TAG,
+        "source_commit_sha": UPSTREAM_SOURCE_COMMIT,
+        "schema_trees": schema_tree_summary,
+        "typescript_aggregate_sha256": EXPECTED_TYPESCRIPT_AGGREGATES,
+        "schema_provenance_sha256": shared.sha256_file(
+            arguments.schema_provenance
+        ),
+        "protocol_source_provenance_sha256": shared.sha256_file(
+            arguments.protocol_provenance
+        ),
+        "protocol_source_files": [
+            {
+                "path": row["path"],
+                "sha256": row["sha256"],
+                "bytes": row["bytes"],
+            }
+            for row in protocol_provenance.get("files", [])
+        ],
+    }
+
+
+def start_state_document(
+    arguments: argparse.Namespace, base_sha: str
+) -> dict[str, Any]:
+    tree = _git(arguments.repo_root, "rev-parse", f"{base_sha}^{{tree}}")
+    require(
+        base_sha == EXPECTED_BASE_SHA and tree == EXPECTED_BASE_TREE,
+        f"unexpected A1.4 base {base_sha} tree {tree}",
+        "BaseCommitMismatch",
+    )
+    inputs = load_inputs(arguments)
+    keys = validate_partition_inputs(inputs)
+    validate_start_arithmetic(inputs, keys)
+    provenance = validate_provenance(arguments)
+    native_status = _status_counter(inputs.registry[key] for key in keys)
+    protected_evidence = {
+        path.resolve().relative_to(arguments.repo_root).as_posix():
+        shared.sha256_file(path)
+        for pattern in (
+            "a1-1-*.json",
+            "a1-2-*.json",
+            "a1-3-*.json",
+        )
+        for path in sorted(arguments.evidence_root.glob(pattern))
+    }
+    return {
+        "format_version": FORMAT_VERSION,
+        "generated_notice": (
+            "Frozen A1.4 audit start state; review evidence only, "
+            "never a runtime registry."
+        ),
+        "codex_version": CODEX_VERSION,
+        "upstream_tag": UPSTREAM_TAG,
+        "base_sha": base_sha,
+        "base_tree": tree,
+        "provenance": provenance,
+        "counts": {
+            "identity_count": len(keys),
+            "taxonomy": _counter(key.category for key in keys),
+            "native_schema_status": native_status,
+            "global_schema_status": _status_counter(
+                inputs.registry.values()
+            ),
+            "runtime_dispositions": _counter(
+                str(inputs.registry[key]["runtime_disposition"])
+                for key in keys
+            ),
+        },
+        "native_partial_identity": NATIVE_PARTIAL.object(),
+        "inherited_a1_0_partial_identities": [
+            key.object() for key in sorted(INHERITED_PARTIALS)
+        ],
+        "identities": [
+            {
+                "protocol_surface_key": key.object(),
+                "assignment": inputs.assignments[key],
+                "registry": inputs.registry[key],
+            }
+            for key in keys
+        ],
+        "capture_sources": {
+            "assignment": _source(
+                arguments.assignments, arguments.repo_root
+            ),
+            "contracts": _source(arguments.contracts, arguments.repo_root),
+            "fixture_coverage": _source(
+                arguments.fixture_coverage, arguments.repo_root
+            ),
+            "manifest": _source(arguments.manifest, arguments.repo_root),
+            "nested_reachability": _source(
+                arguments.reachability, arguments.repo_root
+            ),
+            "protocol_provenance": _source(
+                arguments.protocol_provenance, arguments.repo_root
+            ),
+            "registry": _source(arguments.registry, arguments.repo_root),
+            "schema_completeness": _source(
+                arguments.schema_completeness, arguments.repo_root
+            ),
+            "schema_provenance": _source(
+                arguments.schema_provenance, arguments.repo_root
+            ),
+            "soversion_authority": _source(
+                arguments.repo_root / "CMakeLists.txt",
+                arguments.repo_root,
+            ),
+        },
+        "protected_predecessor_evidence": protected_evidence,
+    }
+
+
+def validate_start_state(
+    document: Mapping[str, Any], arguments: argparse.Namespace
+) -> None:
+    require(
+        document.get("format_version") == FORMAT_VERSION
+        and document.get("codex_version") == CODEX_VERSION
+        and document.get("upstream_tag") == UPSTREAM_TAG
+        and document.get("base_sha") == EXPECTED_BASE_SHA
+        and document.get("base_tree") == EXPECTED_BASE_TREE,
+        "frozen A1.4 start-state metadata changed",
+        "StartStateMetadataMismatch",
+    )
+    counts = document.get("counts")
+    require(
+        isinstance(counts, Mapping)
+        and counts.get("identity_count") == 56
+        and counts.get("taxonomy") == EXPECTED_TAXONOMY
+        and counts.get("native_schema_status")
+        == {
+            **EXPECTED_NATIVE_START_STATUS,
+            "NotApplicable": 0,
+        }
+        and counts.get("global_schema_status")
+        == EXPECTED_GLOBAL_START_STATUS,
+        "frozen A1.4 start-state counts changed",
+        "StartStateCountMismatch",
+    )
+    sources = document.get("capture_sources")
+    require(
+        isinstance(sources, Mapping),
+        "frozen A1.4 sources are absent",
+        "StartStateSourceMismatch",
+    )
+    source_paths = {
+        "assignment": arguments.assignments,
+        "contracts": arguments.contracts,
+        "fixture_coverage": arguments.fixture_coverage,
+        "manifest": arguments.manifest,
+        "nested_reachability": arguments.reachability,
+        "protocol_provenance": arguments.protocol_provenance,
+        "registry": arguments.registry,
+        "schema_completeness": arguments.schema_completeness,
+        "schema_provenance": arguments.schema_provenance,
+        "soversion_authority": arguments.repo_root / "CMakeLists.txt",
+    }
+    for name, path in source_paths.items():
+        row = sources.get(name)
+        require(
+            isinstance(row, Mapping)
+            and row.get("sha256") == shared.sha256_file(path),
+            f"frozen A1.4 input changed: {name}",
+            "StartStateSourceMismatch",
+        )
+    protected = document.get("protected_predecessor_evidence")
+    require(
+        isinstance(protected, Mapping) and bool(protected),
+        "predecessor A1 evidence guard is absent",
+        "PredecessorEvidenceMismatch",
+    )
+    for relative, digest in protected.items():
+        path = arguments.repo_root / str(relative)
+        require(
+            path.is_file() and shared.sha256_file(path) == digest,
+            f"predecessor A1 evidence changed: {relative}",
+            "PredecessorEvidenceMismatch",
+        )
+
+
+def _operation_rows(
+    inputs: Inputs, keys: Sequence[Key]
+) -> list[dict[str, Any]]:
+    operations: list[dict[str, Any]] = []
+    client_kinds: Counter[str] = Counter()
+    for key in keys:
+        if key.category not in {"client_request", "server_request"}:
+            continue
+        contract = inputs.contracts.get(key)
+        require(
+            contract is not None,
+            f"missing operation contract: {key.compact()}",
+            "ContractMismatch",
+        )
+        registry = inputs.registry[key]
+        require(
+            registry["parameter_type_identity"]
+            == contract["parameter_type_identity"]
+            and registry["result_type_identity"]
+            == contract["result_type_identity"]
+            and registry["result_contract_kind"]
+            == contract["result_contract_kind"],
+            f"registry/contract association mismatch: {key.compact()}",
+            "ContractMismatch",
+        )
+        if key.category == "client_request":
+            expected = CLIENT_REQUEST_CONTRACTS[key.name]
+            actual = (
+                contract["parameter_type_identity"],
+                contract["result_type_identity"],
+                contract["result_contract_kind"],
+            )
+            require(
+                actual == expected,
+                f"wrong client request/result association: {key.name}",
+                "ClientResultAssociationMismatch",
+            )
+            client_kinds[str(contract["result_contract_kind"])] += 1
+        else:
+            expected_server = SERVER_REQUEST_CONTRACTS[key.name]
+            actual_server = (
+                contract["parameter_type_identity"],
+                contract["result_type_identity"],
+            )
+            require(
+                actual_server == expected_server
+                and contract["result_contract_kind"] == "Concrete",
+                f"wrong server request/response association: {key.name}",
+                "ServerResponseContractMismatch",
+            )
+        operations.append(
+            {
+                "protocol_surface_key": key.object(),
+                "parameter_type": contract["parameter_type_identity"],
+                "result_type": contract["result_type_identity"],
+                "result_schema_type": contract.get(
+                    "result_schema_type_identity"
+                ),
+                "result_kind": contract["result_contract_kind"],
+                "association_evidence_kind": contract[
+                    "association_evidence_kind"
+                ],
+                "association_evidence_key": contract[
+                    "association_evidence_key"
+                ],
+                "cross_check_evidence": contract.get(
+                    "cross_check_evidence", []
+                ),
+                "direct_raw_protocol_response": (
+                    key.category == "server_request"
+                ),
+                "depends_on_server_request_resolved": False,
+            }
+        )
+    require(
+        dict(sorted(client_kinds.items())) == EXPECTED_RESULT_KINDS,
+        f"client result-kind split changed: {dict(client_kinds)}",
+        "ResultKindMismatch",
+    )
+    return operations
+
+
+def _nullable(schema: Any) -> bool:
+    return shared.allows_null(schema)
+
+
+def _value_kind(schema: Any) -> str:
+    if schema is True or schema == {}:
+        return "opaque_json"
+    if schema is False:
+        return "never"
+    if not isinstance(schema, Mapping):
+        return "unconstrained"
+    if "$ref" in schema:
+        return "reference"
+    if "oneOf" in schema or "anyOf" in schema:
+        return "union"
+    if "allOf" in schema:
+        branches = schema.get("allOf")
+        if (
+            isinstance(branches, list)
+            and len(branches) == 1
+            and isinstance(branches[0], Mapping)
+            and "$ref" in branches[0]
+        ):
+            return "reference"
+        return "intersection"
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        values = [str(value) for value in schema_type if value != "null"]
+        return "|".join(values) or "null"
+    return str(schema_type or "opaque_json")
+
+
+def collect_schema_paths(
+    nodes: Mapping[fixtures.DefinitionId, Any],
+    closure: set[fixtures.DefinitionId],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    paths: list[dict[str, Any]] = []
+    objects: list[dict[str, Any]] = []
+
+    def transition(
+        _parent: str | None,
+        kind: str,
+        token: str | int | None,
+        _path: str,
+        _schema: Any,
+        _required: bool | None,
+    ) -> str | None:
+        return (
+            str(token)
+            if kind == schema_paths.PROPERTY
+            and isinstance(token, str)
+            else None
+        )
+
+    for definition in sorted(closure):
+        root = nodes[definition]
+        root_path = (
+            f"#/definitions/"
+            f"{'v2/' if definition.namespace == 'v2' else ''}"
+            f"{definition.name}"
+        )
+        visits = list(
+            schema_paths.walk_schema_paths(
+                root,
+                path=root_path,
+                state=None,
+                transition=transition,
+                skip_references=True,
+            )
+        )
+        object_candidates = [(root_path, root), *(
+            (visit.path, visit.schema) for visit in visits
+        )]
+        for object_path, schema in object_candidates:
+            if not isinstance(schema, Mapping):
+                continue
+            properties = schema.get("properties")
+            if (
+                schema.get("type") != "object"
+                and not isinstance(properties, Mapping)
+                and "additionalProperties" not in schema
+            ):
+                continue
+            additional = schema.get(
+                "additionalProperties", "allowed_by_default"
+            )
+            objects.append(
+                {
+                    "definition": definition.to_json(),
+                    "schema_path": object_path,
+                    "additional_properties": (
+                        "schema"
+                        if isinstance(additional, Mapping)
+                        else additional
+                    ),
+                    "property_count": (
+                        len(properties)
+                        if isinstance(properties, Mapping)
+                        else 0
+                    ),
+                }
+            )
+        for visit in visits:
+            if visit.kind not in schema_paths.VALUE_PATH_KINDS:
+                continue
+            child = visit.schema
+            child_mapping = (
+                child if isinstance(child, Mapping) else {}
+            )
+            is_property = visit.kind == schema_paths.PROPERTY
+            is_array = visit.kind == schema_paths.ARRAY_ELEMENT
+            is_map = visit.kind == schema_paths.MAP_VALUE
+            paths.append(
+                {
+                    "definition": definition.to_json(),
+                    "schema_path": visit.path,
+                    "schema_node_kind": visit.kind,
+                    "field": visit.state if is_property else None,
+                    "required": (
+                        bool(visit.required)
+                        if is_property
+                        else None
+                    ),
+                    "optional": (
+                        not bool(visit.required)
+                        if is_property
+                        else None
+                    ),
+                    "nullable": _nullable(child),
+                    "default_present": "default" in child_mapping,
+                    "default": child_mapping.get("default"),
+                    "value_kind": _value_kind(child),
+                    "integer_format": child_mapping.get("format"),
+                    "minimum": child_mapping.get("minimum"),
+                    "maximum": child_mapping.get("maximum"),
+                    "array_element_type": (
+                        _value_kind(child_mapping["items"])
+                        if "items" in child_mapping
+                        else (
+                            _value_kind(child)
+                            if is_array
+                            else None
+                        )
+                    ),
+                    "map_value_type": (
+                        _value_kind(
+                            child_mapping["additionalProperties"]
+                        )
+                        if "additionalProperties" in child_mapping
+                        else (_value_kind(child) if is_map else None)
+                    ),
+                    "additional_properties": (
+                        "schema"
+                        if isinstance(
+                            child_mapping.get("additionalProperties"),
+                            Mapping,
+                        )
+                        else child_mapping.get(
+                            "additionalProperties",
+                            (
+                                "allowed_by_default"
+                                if (
+                                    child_mapping.get("type") == "object"
+                                    or "properties" in child_mapping
+                                )
+                                else "not_applicable"
+                            ),
+                        )
+                    ),
+                    "intentionally_opaque_json": (
+                        _value_kind(child) == "opaque_json"
+                    ),
+                    "sensitive": (
+                        is_property
+                        and visit.state in SENSITIVE_FIELD_NAMES
+                    ),
+                }
+            )
+    return paths, objects
+
+
+def _definition_for_type(
+    catalog: fixtures.SchemaCatalog,
+    nodes: Mapping[fixtures.DefinitionId, Any],
+    type_identity: str,
+    key: Key,
+    role: str,
+) -> fixtures.DefinitionId:
+    definition = fixtures.locate_definition_for_type(
+        catalog, nodes, type_identity
+    )
+    require(
+        definition is not None,
+        f"schema root is absent for {key.compact()} {role}",
+        "MissingSchemaRoot",
+    )
+    return definition
+
+
+def schema_closure(
+    arguments: argparse.Namespace,
+    inputs: Inputs,
+    keys: Sequence[Key],
+) -> dict[str, Any]:
+    draft07 = fixtures.load_draft07(arguments.draft07_validator)
+    catalog = fixtures.SchemaCatalog(arguments.schema_root, draft07)
+    aggregate = catalog.load(
+        arguments.schema_root
+        / "stable/codex_app_server_protocol.schemas.json"
+    )
+    nodes, edges = fixtures.definition_graph(aggregate)
+    seeds: dict[fixtures.DefinitionId, list[dict[str, Any]]] = defaultdict(
+        list
+    )
+    identity_definitions: dict[Key, set[fixtures.DefinitionId]] = (
+        defaultdict(set)
+    )
+
+    def add(
+        definition: fixtures.DefinitionId, role: str, key: Key
+    ) -> None:
+        association = {"role": role, "surface_key": key.object()}
+        if association not in seeds[definition]:
+            seeds[definition].append(association)
+        identity_definitions[key].update(
+            fixtures.transitive_definitions((definition,), edges)
+        )
+
+    for key in keys:
+        if key.category in {"client_request", "server_request"}:
+            contract = inputs.contracts[key]
+            parameter_type = str(contract["parameter_type_identity"])
+            if parameter_type != "Unit":
+                add(
+                    _definition_for_type(
+                        catalog,
+                        nodes,
+                        parameter_type,
+                        key,
+                        "request_params",
+                    ),
+                    "request_params",
+                    key,
+                )
+            result_schema_type = str(
+                contract.get("result_schema_type_identity")
+                or contract["result_type_identity"]
+            )
+            if result_schema_type != "Unit":
+                add(
+                    _definition_for_type(
+                        catalog,
+                        nodes,
+                        result_schema_type,
+                        key,
+                        "successful_response",
+                    ),
+                    "successful_response",
+                    key,
+                )
+        elif key.category == "server_notification":
+            params = inputs.manifest_rows[key].get("params")
+            type_identity = (
+                params.get("type")
+                if isinstance(params, Mapping)
+                else None
+            )
+            require(
+                isinstance(type_identity, str) and bool(type_identity),
+                f"notification has no stable params root: {key.compact()}",
+                "ContractMismatch",
+            )
+            add(
+                _definition_for_type(
+                    catalog,
+                    nodes,
+                    type_identity,
+                    key,
+                    "notification_params",
+                ),
+                "notification_params",
+                key,
+            )
+        else:
+            candidates = [
+                definition
+                for definition in (
+                    fixtures.DefinitionId("legacy", key.domain),
+                    fixtures.DefinitionId("v2", key.domain),
+                )
+                if definition in nodes
+            ]
+            require(
+                len(candidates) == 1,
+                f"union schema namespace is ambiguous: {key.domain}",
+                "UnionSchemaMismatch",
+            )
+            add(candidates[0], "registered_union_family", key)
+
+    closure = set(fixtures.transitive_definitions(seeds.keys(), edges))
+    paths, objects = collect_schema_paths(nodes, closure)
+    union_rows: list[dict[str, Any]] = []
+    for (domain, field), expected_alternatives in sorted(
+        UNION_FAMILIES.items()
+    ):
+        alternatives = [
+            key
+            for key in keys
+            if key.category == "tagged_union_discriminator"
+            and key.domain == domain
+        ]
+        definition = next(
+            value
+            for value in (
+                fixtures.DefinitionId("legacy", domain),
+                fixtures.DefinitionId("v2", domain),
+            )
+            if value in nodes
+        )
+        schema = nodes[definition]
+        branches = schema.get("oneOf")
+        require(
+            isinstance(branches, list),
+            f"union lacks oneOf representation: {domain}",
+            "UnionSchemaMismatch",
+        )
+        branch_rows: list[dict[str, Any]] = []
+        observed: set[str] = set()
+        for index, branch in enumerate(branches):
+            properties = branch.get("properties", {})
+            discriminator = properties.get(field, {})
+            values = discriminator.get("enum", [])
+            require(
+                isinstance(values, list)
+                and len(values) == 1
+                and isinstance(values[0], str),
+                f"union discriminator is malformed: {domain}/{index}",
+                "UnionSchemaMismatch",
+            )
+            name = str(values[0])
+            observed.add(name)
+            required = set(branch.get("required", []))
+            branch_rows.append(
+                {
+                    "alternative": name,
+                    "branch_index": index,
+                    "title": branch.get("title"),
+                    "required_fields": sorted(required),
+                    "optional_fields": sorted(
+                        set(properties) - required
+                    ),
+                    "nullable_fields": sorted(
+                        name
+                        for name, child in properties.items()
+                        if _nullable(child)
+                    ),
+                    "intentionally_opaque_fields": sorted(
+                        name
+                        for name, child in properties.items()
+                        if _value_kind(child) == "opaque_json"
+                    ),
+                    "additional_properties": branch.get(
+                        "additionalProperties", "allowed_by_default"
+                    ),
+                    "property_schemas": [
+                        {
+                            "field": name,
+                            "required": name in required,
+                            "nullable": _nullable(child),
+                            "value_kind": _value_kind(child),
+                            "default_present": (
+                                isinstance(child, Mapping)
+                                and "default" in child
+                            ),
+                        }
+                        for name, child in sorted(properties.items())
+                    ],
+                }
+            )
+        require(
+            observed == expected_alternatives,
+            f"union alternatives changed: {domain} {sorted(observed)}",
+            "UnionSchemaMismatch",
+        )
+        roots = {
+            Key.from_row(root["surface_key"])
+            for key in alternatives
+            for root in inputs.reachability[key]["reaching_roots"]
+        }
+        outer_properties = schema.get("properties", {})
+        outer_required = set(schema.get("required", []))
+        union_rows.append(
+            {
+                "domain": domain,
+                "definition": definition.to_json(),
+                "representation": "Draft-07 object plus oneOf branches",
+                "discriminator": field,
+                "alternatives": branch_rows,
+                "outer_required_fields": sorted(outer_required),
+                "outer_optional_fields": sorted(
+                    set(outer_properties) - outer_required
+                ),
+                "outer_nullable_fields": sorted(
+                    name
+                    for name, child in outer_properties.items()
+                    if _nullable(child)
+                ),
+                "outer_additional_properties": schema.get(
+                    "additionalProperties", "allowed_by_default"
+                ),
+                "reaching_roots": [
+                    root.object() for root in sorted(roots)
+                ],
+                "future_unknown_handling": (
+                    "preserve raw unknown alternative and diagnostic; "
+                    "never coerce it to a known alternative"
+                ),
+                "malformed_known_handling": (
+                    "reject a known discriminator with missing or "
+                    "wrong-typed required fields"
+                ),
+            }
+        )
+
+    path_kinds = _counter(str(row["schema_node_kind"]) for row in paths)
+    return {
+        "format_version": FORMAT_VERSION,
+        "generated_notice": (
+            "Generated A1.4 transitive stable-schema review evidence."
+        ),
+        "codex_version": CODEX_VERSION,
+        "counts": {
+            "seed_definitions": len(seeds),
+            "reachable_named_definitions": len(closure),
+            "definition_namespaces": _counter(
+                definition.namespace for definition in closure
+            ),
+            "schema_paths": len(paths),
+            "schema_path_kinds": path_kinds,
+            "object_nodes": len(objects),
+            "required_paths": sum(
+                row["schema_node_kind"] == "property"
+                and bool(row["required"])
+                for row in paths
+            ),
+            "optional_paths": sum(
+                row["schema_node_kind"] == "property"
+                and bool(row["optional"])
+                for row in paths
+            ),
+            "nullable_paths": sum(bool(row["nullable"]) for row in paths),
+            "default_bearing_paths": sum(
+                bool(row["default_present"]) for row in paths
+            ),
+            "integer_formats": _counter(
+                str(row["integer_format"])
+                for row in paths
+                if row["integer_format"] is not None
+            ),
+            "minimum_bearing_paths": sum(
+                row["minimum"] is not None for row in paths
+            ),
+            "maximum_bearing_paths": sum(
+                row["maximum"] is not None for row in paths
+            ),
+            "opaque_json_paths": sum(
+                bool(row["intentionally_opaque_json"]) for row in paths
+            ),
+            "sensitive_paths": sum(
+                bool(row["sensitive"]) for row in paths
+            ),
+        },
+        "seed_definitions": [
+            {
+                "definition": definition.to_json(),
+                "associations": sorted(
+                    associations,
+                    key=lambda row: (
+                        row["role"],
+                        Key.from_row(row["surface_key"]),
+                    ),
+                ),
+            }
+            for definition, associations in sorted(seeds.items())
+        ],
+        "definitions": [
+            {
+                "definition": definition.to_json(),
+                "direct_dependencies": [
+                    dependency.to_json()
+                    for dependency in sorted(edges[definition] & closure)
+                ],
+                "schema_sha256": shared.sha256_json(nodes[definition]),
+            }
+            for definition in sorted(closure)
+        ],
+        "schema_paths": paths,
+        "object_policies": objects,
+        "union_families": union_rows,
+        "identity_reachable_definition_counts": [
+            {
+                "protocol_surface_key": key.object(),
+                "reachable_definition_count": len(
+                    identity_definitions[key]
+                ),
+            }
+            for key in keys
+        ],
+    }
+
+
+def partition_document(
+    arguments: argparse.Namespace,
+    inputs: Inputs,
+    keys: Sequence[Key],
+    operations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    all_keys = sorted(inputs.manifest_rows)
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for slice_name in EXPECTED_PARTITION:
+        slice_keys = [
+            key
+            for key in all_keys
+            if inputs.assignments[key]["slice"] == slice_name
+        ]
+        buckets[slice_name] = [
+            {
+                "protocol_surface_key": key.object(),
+                "stability": inputs.assignments[key]["stability"],
+                "classification": inputs.assignments[key][
+                    "classification"
+                ],
+                "module": inputs.assignments[key]["module"],
+                "a1_slice": inputs.assignments[key]["slice"],
+                "runtime_disposition": inputs.registry[key][
+                    "runtime_disposition"
+                ],
+                "typed_status": inputs.registry[key]["typed_status"],
+                "typed_schema_status": inputs.registry[key][
+                    "typed_schema_status"
+                ],
+            }
+            for key in slice_keys
+        ]
+    inventory = buckets["InventoryOnly"]
+    native_status = _status_counter(inputs.registry[key] for key in keys)
+    native_completion = dict(EXPECTED_GLOBAL_START_STATUS)
+    native_completion["Complete"] += 56
+    native_completion["NotImplemented"] -= 55
+    native_completion["Partial"] -= 1
+    final_a1 = dict(native_completion)
+    final_a1["Complete"] += 3
+    final_a1["Partial"] -= 3
+    require(
+        native_completion == EXPECTED_NATIVE_COMPLETION_STATUS,
+        f"native completion arithmetic changed: {native_completion}",
+        "NativeCompletionArithmeticMismatch",
+    )
+    require(
+        final_a1 == EXPECTED_FINAL_A1_STATUS,
+        f"final A1 arithmetic changed: {final_a1}",
+        "FinalA1ArithmeticMismatch",
+    )
+    changed_paths: set[str] = set()
+    if (arguments.repo_root / ".git").exists():
+        changed_paths.update(
+            line
+            for line in _git(
+                arguments.repo_root,
+                "diff",
+                "--name-only",
+                EXPECTED_BASE_SHA,
+            ).splitlines()
+            if line
+        )
+        changed_paths.update(
+            line
+            for line in _git(
+                arguments.repo_root,
+                "ls-files",
+                "--others",
+                "--exclude-standard",
+            ).splitlines()
+            if line
+        )
+    production_paths = sorted(
+        path for path in changed_paths if path.startswith("src/")
+    )
+    protected_nonproduction_paths = sorted(
+        path
+        for path in changed_paths
+        if path.startswith(
+            "tools/codex/app-server-fixtures/0.144.6/"
+        )
+        or path
+        == "docs/ai/openai/codex/frontend-protocol-v1.schema.json"
+    )
+    require(
+        not production_paths,
+        f"audit branch changes production paths: {production_paths}",
+        "ProductionScopeViolation",
+    )
+    require(
+        not protected_nonproduction_paths,
+        (
+            "audit branch changes protected fixture/frontend inputs: "
+            f"{protected_nonproduction_paths}"
+        ),
+        "ProtectedInputScopeViolation",
+    )
+    return {
+        "format_version": FORMAT_VERSION,
+        "generated_notice": (
+            "Generated total partition guard; "
+            "ProtocolSurfaceRegistryData.inc remains authoritative."
+        ),
+        "codex_version": CODEX_VERSION,
+        "counts": {
+            "total_inventory": len(all_keys),
+            "partition": {
+                name: len(rows) for name, rows in buckets.items()
+            },
+            "stability_accounting": EXPECTED_STABILITY_ACCOUNTING,
+            "inventory_only_classifications": _counter(
+                str(row["classification"]) for row in inventory
+            ),
+            "native_a1_4_taxonomy": _counter(
+                key.category for key in keys
+            ),
+            "native_a1_4_result_kinds": _counter(
+                str(row["result_kind"])
+                for row in operations
+                if row["protocol_surface_key"]["category"]
+                == "client_request"
+            ),
+            "native_a1_4_start_status": native_status,
+            "global_start_status": _status_counter(
+                inputs.registry.values()
+            ),
+            "native_completion_projection": native_completion,
+            "final_a1_projection": final_a1,
+        },
+        "buckets": buckets,
+        "inventory_only": {
+            classification: [
+                row
+                for row in inventory
+                if row["classification"] == classification
+            ]
+            for classification in EXPECTED_INVENTORY_CLASSIFICATIONS
+        },
+        "native_a1_4_operations": list(operations),
+        "native_partial_identity": NATIVE_PARTIAL.object(),
+        "inherited_a1_0_partial_identities": [
+            key.object() for key in sorted(INHERITED_PARTIALS)
+        ],
+        "stable_experimental_asymmetries": {
+            "stable_process_notifications": [
+                "process/exited",
+                "process/outputDelta",
+            ],
+            "experimental_process_controls": sorted(
+                EXPERIMENTAL_PROCESS_CONTROLS
+            ),
+            "stable_remote_control_notification": (
+                "remoteControl/status/changed"
+            ),
+            "experimental_remote_control_controls": sorted(
+                key.name
+                for key in inputs.assignments
+                if key.category == "client_request"
+                and key.name.startswith("remoteControl/")
+                and inputs.assignments[key]["classification"]
+                == "ExperimentalInventoryOnly"
+            ),
+            "rule": (
+                "A stable status/output notification never promotes a "
+                "similarly named experimental outgoing control."
+            ),
+        },
+        "bijection": {
+            "inventory_keys": len(inputs.manifest_rows),
+            "assignment_keys": len(inputs.assignments),
+            "registry_keys": len(inputs.registry),
+            "missing_assignments": [],
+            "extra_assignments": [],
+            "missing_registry_rows": [],
+            "extra_registry_rows": [],
+            "duplicate_assignments": [],
+            "cross_slice_overlaps": [],
+        },
+        "audit_boundaries": {
+            "changed_paths": sorted(changed_paths),
+            "production_paths_changed": production_paths,
+            "protected_nonproduction_paths_changed": (
+                protected_nonproduction_paths
+            ),
+            "runtime_implementation_added": False,
+            "registry_status_promoted": False,
+            "module_assignment_changed": False,
+            "soversion_changed": False,
+            "backend_state_changed": False,
+            "backend_command_changed": False,
+            "frontend_protocol_changed": False,
+        },
+    }
+
+
+def build_foundation(
+    arguments: argparse.Namespace,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    start_state = shared.load_json(arguments.start_state)
+    validate_start_state(start_state, arguments)
+    inputs = load_inputs(arguments)
+    keys = validate_partition_inputs(inputs)
+    validate_start_arithmetic(inputs, keys)
+    provenance = validate_provenance(arguments)
+    require(
+        provenance == start_state.get("provenance"),
+        "live provenance differs from frozen start state",
+        "ProvenanceMismatch",
+    )
+    taxonomy = _counter(key.category for key in keys)
+    require(
+        taxonomy == EXPECTED_TAXONOMY,
+        f"native A1.4 taxonomy changed: {taxonomy}",
+        "TaxonomyMismatch",
+    )
+    operations = _operation_rows(inputs, keys)
+    partition = partition_document(arguments, inputs, keys, operations)
+    closure = schema_closure(arguments, inputs, keys)
+    validate_foundation_reports(partition, closure)
+    return partition, closure
+
+
+def foundation_diagnostics(
+    partition: Mapping[str, Any],
+    closure: Mapping[str, Any],
+) -> list[AuditDiagnostic]:
+    diagnostics: list[AuditDiagnostic] = []
+
+    def add(code: str, location: str, message: str) -> None:
+        diagnostics.append(AuditDiagnostic(code, location, message))
+
+    counts = partition.get("counts")
+    if not isinstance(counts, Mapping):
+        add("PartitionCountMismatch", "$.counts", "counts must be an object")
+    else:
+        if counts.get("total_inventory") != 387:
+            add(
+                "TotalDenominatorMismatch",
+                "$.counts.total_inventory",
+                "total inventory must remain 387",
+            )
+        if counts.get("partition") != EXPECTED_PARTITION:
+            add(
+                "PartitionCountMismatch",
+                "$.counts.partition",
+                "six-bucket partition changed",
+            )
+        if (
+            counts.get("stability_accounting")
+            != EXPECTED_STABILITY_ACCOUNTING
+        ):
+            add(
+                "StabilityAccountingMismatch",
+                "$.counts.stability_accounting",
+                "stable/experimental accounting changed",
+            )
+        if (
+            counts.get("inventory_only_classifications")
+            != EXPECTED_INVENTORY_CLASSIFICATIONS
+        ):
+            add(
+                "InventoryClassificationMismatch",
+                "$.counts.inventory_only_classifications",
+                "InventoryOnly is not 36 experimental plus 12 stable",
+            )
+        if counts.get("native_a1_4_taxonomy") != EXPECTED_TAXONOMY:
+            add(
+                "TaxonomyMismatch",
+                "$.counts.native_a1_4_taxonomy",
+                "native A1.4 taxonomy changed",
+            )
+        if (
+            counts.get("native_a1_4_result_kinds")
+            != EXPECTED_RESULT_KINDS
+        ):
+            add(
+                "ResultKindMismatch",
+                "$.counts.native_a1_4_result_kinds",
+                "A1.4 Concrete/Unit result split changed",
+            )
+        if (
+            counts.get("native_completion_projection")
+            != EXPECTED_NATIVE_COMPLETION_STATUS
+        ):
+            add(
+                "NativeCompletionArithmeticMismatch",
+                "$.counts.native_completion_projection",
+                "native completion arithmetic changed",
+            )
+        if (
+            counts.get("final_a1_projection")
+            != EXPECTED_FINAL_A1_STATUS
+        ):
+            add(
+                "FinalA1ArithmeticMismatch",
+                "$.counts.final_a1_projection",
+                "final A1 arithmetic changed",
+            )
+
+    buckets = partition.get("buckets")
+    if not isinstance(buckets, Mapping):
+        add("PartitionSetMismatch", "$.buckets", "buckets must be an object")
+    else:
+        seen: list[Key] = []
+        for name, expected_count in EXPECTED_PARTITION.items():
+            rows = buckets.get(name)
+            if not isinstance(rows, list) or len(rows) != expected_count:
+                add(
+                    "PartitionSetMismatch",
+                    f"$.buckets.{name}",
+                    f"{name} identity set/count changed",
+                )
+                continue
+            for row in rows:
+                if isinstance(row, Mapping) and isinstance(
+                    row.get("protocol_surface_key"), Mapping
+                ):
+                    seen.append(
+                        Key.from_row(row["protocol_surface_key"])
+                    )
+        if len(seen) != len(set(seen)):
+            add(
+                "CrossSliceOverlap",
+                "$.buckets",
+                "an identity appears in more than one slice",
+            )
+        if len(set(seen)) != 387:
+            add(
+                "PartitionSetMismatch",
+                "$.buckets",
+                "partition does not cover 387 unique identities",
+            )
+        a1_4_rows = buckets.get("A1.4")
+        a1_4_keys = (
+            {
+                Key.from_row(row["protocol_surface_key"])
+                for row in a1_4_rows
+                if isinstance(row, Mapping)
+                and isinstance(row.get("protocol_surface_key"), Mapping)
+            }
+            if isinstance(a1_4_rows, list)
+            else set()
+        )
+        if a1_4_keys != expected_a1_4_keys():
+            add(
+                "A14IdentitySetMismatch",
+                "$.buckets.A1.4",
+                "native A1.4 identity set changed",
+            )
+        elif isinstance(a1_4_rows, list):
+            if any(
+                row.get("stability") != "stable"
+                for row in a1_4_rows
+                if isinstance(row, Mapping)
+            ):
+                add(
+                    "StabilityMismatch",
+                    "$.buckets.A1.4",
+                    "every native A1.4 identity must remain stable",
+                )
+            if any(
+                row.get("module") != A1_4_MODULE
+                or row.get("a1_slice") != A1_4_SLICE
+                for row in a1_4_rows
+                if isinstance(row, Mapping)
+            ):
+                add(
+                    "A14ModuleMismatch",
+                    "$.buckets.A1.4",
+                    "A1.4 module/slice projection changed",
+                )
+
+    operations = partition.get("native_a1_4_operations")
+    if not isinstance(operations, list) or len(operations) != 33:
+        add(
+            "ContractMismatch",
+            "$.native_a1_4_operations",
+            "29 client and four server request contracts are required",
+        )
+    else:
+        operation_keys = {
+            Key.from_row(row["protocol_surface_key"]): row
+            for row in operations
+            if isinstance(row, Mapping)
+            and isinstance(row.get("protocol_surface_key"), Mapping)
+        }
+        for name, expected in CLIENT_REQUEST_CONTRACTS.items():
+            key = Key(
+                "client_request", "ClientRequest", "method", name
+            )
+            row = operation_keys.get(key)
+            if (
+                row is None
+                or (
+                    row.get("parameter_type"),
+                    row.get("result_type"),
+                    row.get("result_kind"),
+                )
+                != expected
+            ):
+                add(
+                    "ClientResultAssociationMismatch",
+                    f"$.native_a1_4_operations.{name}",
+                    "client request/result association changed",
+                )
+        for name, expected in SERVER_REQUEST_CONTRACTS.items():
+            key = Key(
+                "server_request", "ServerRequest", "method", name
+            )
+            row = operation_keys.get(key)
+            if (
+                row is None
+                or (
+                    row.get("parameter_type"),
+                    row.get("result_type"),
+                )
+                != expected
+                or row.get("result_kind") != "Concrete"
+            ):
+                add(
+                    "ServerResponseContractMismatch",
+                    f"$.native_a1_4_operations.{name}",
+                    "server request/response association changed",
+                )
+            if row is not None and (
+                row.get("direct_raw_protocol_response") is not True
+                or row.get("depends_on_server_request_resolved")
+                is not False
+            ):
+                add(
+                    "ResponsePathMismatch",
+                    f"$.native_a1_4_operations.{name}",
+                    "direct response path changed",
+                )
+
+    inventory = partition.get("inventory_only")
+    if not isinstance(inventory, Mapping):
+        add(
+            "InventoryClassificationMismatch",
+            "$.inventory_only",
+            "InventoryOnly groups are absent",
+        )
+    else:
+        for classification, expected_count in (
+            EXPECTED_INVENTORY_CLASSIFICATIONS.items()
+        ):
+            rows = inventory.get(classification)
+            if not isinstance(rows, list) or len(rows) != expected_count:
+                add(
+                    "InventoryClassificationMismatch",
+                    f"$.inventory_only.{classification}",
+                    f"{classification} count changed",
+                )
+
+    native_partial = partition.get("native_partial_identity")
+    if (
+        not isinstance(native_partial, Mapping)
+        or Key.from_row(native_partial) != NATIVE_PARTIAL
+    ):
+        add(
+            "NativePartialMismatch",
+            "$.native_partial_identity",
+            "native A1.4 Partial identity changed",
+        )
+    inherited = partition.get("inherited_a1_0_partial_identities")
+    inherited_keys = (
+        {
+            Key.from_row(row)
+            for row in inherited
+            if isinstance(row, Mapping)
+        }
+        if isinstance(inherited, list)
+        else set()
+    )
+    if inherited_keys != INHERITED_PARTIALS:
+        add(
+            "CrossSliceLedgerMismatch",
+            "$.inherited_a1_0_partial_identities",
+            "all three inherited A1.0 partials must be explicit",
+        )
+
+    boundaries = partition.get("audit_boundaries")
+    if (
+        not isinstance(boundaries, Mapping)
+        or boundaries.get("production_paths_changed") != []
+        or boundaries.get("protected_nonproduction_paths_changed") != []
+        or boundaries.get("runtime_implementation_added") is not False
+    ):
+        add(
+            "ProductionScopeViolation",
+            "$.audit_boundaries",
+            "the audit must not change production paths",
+        )
+    if (
+        isinstance(boundaries, Mapping)
+        and boundaries.get("registry_status_promoted") is not False
+    ):
+        add(
+            "RegistryPromotionViolation",
+            "$.audit_boundaries.registry_status_promoted",
+            "the audit must not promote registry status",
+        )
+    if (
+        isinstance(boundaries, Mapping)
+        and (
+            boundaries.get("module_assignment_changed") is not False
+            or boundaries.get("soversion_changed") is not False
+            or boundaries.get("backend_state_changed") is not False
+            or boundaries.get("backend_command_changed") is not False
+            or boundaries.get("frontend_protocol_changed") is not False
+        )
+    ):
+        add(
+            "BoundaryMismatch",
+            "$.audit_boundaries",
+            "a frozen no-expansion boundary changed",
+        )
+
+    union_rows = closure.get("union_families")
+    actual_unions = (
+        {
+            (
+                str(row.get("domain")),
+                str(row.get("discriminator")),
+                tuple(
+                    sorted(
+                        str(branch.get("alternative"))
+                        for branch in row.get("alternatives", [])
+                        if isinstance(branch, Mapping)
+                    )
+                ),
+            )
+            for row in union_rows
+            if isinstance(row, Mapping)
+        }
+        if isinstance(union_rows, list)
+        else set()
+    )
+    expected_unions = {
+        (domain, field, tuple(sorted(alternatives)))
+        for (domain, field), alternatives in UNION_FAMILIES.items()
+    }
+    if actual_unions != expected_unions:
+        add(
+            "UnionSchemaMismatch",
+            "$.union_families",
+            "registered union alternatives changed",
+        )
+    closure_counts = closure.get("counts")
+    if not isinstance(closure_counts, Mapping):
+        add(
+            "SchemaClosureMismatch",
+            "$.counts",
+            "closure counts must be an object",
+        )
+    elif dict(closure_counts) != EXPECTED_CLOSURE_COUNTS:
+        add(
+            "SchemaClosureMismatch",
+            "$.counts",
+            "the exact transitive A1.4 schema closure changed",
+        )
+    paths = closure.get("schema_paths")
+    if (
+        not isinstance(paths, list)
+        or not paths
+        or len(paths) != EXPECTED_CLOSURE_COUNTS["schema_paths"]
+        or any(
+            not isinstance(row, Mapping)
+            or "required" not in row
+            or "nullable" not in row
+            or "value_kind" not in row
+            or "additional_properties" not in row
+            for row in paths
+        )
+    ):
+        add(
+            "SchemaPathMismatch",
+            "$.schema_paths",
+            "complete reachable field inventory is absent",
+        )
+    elif len(
+        {
+            (
+                str(row["definition"].get("namespace")),
+                str(row["definition"].get("name")),
+                str(row["schema_path"]),
+                str(row["schema_node_kind"]),
+            )
+            for row in paths
+            if isinstance(row.get("definition"), Mapping)
+        }
+    ) != EXPECTED_CLOSURE_COUNTS["schema_paths"]:
+        add(
+            "SchemaPathMismatch",
+            "$.schema_paths",
+            "schema value paths are duplicated or malformed",
+        )
+    objects = closure.get("object_policies")
+    object_counts = (
+        _counter(
+            str(row.get("additional_properties"))
+            for row in objects
+            if isinstance(row, Mapping)
+        )
+        if isinstance(objects, list)
+        else {}
+    )
+    if (
+        not isinstance(objects, list)
+        or len(objects) != EXPECTED_CLOSURE_COUNTS["object_nodes"]
+        or object_counts != EXPECTED_OBJECT_POLICIES
+    ):
+        add(
+            "AdditionalPropertiesMismatch",
+            "$.object_policies",
+            "reachable object additionalProperties policies changed",
+        )
+    return sorted(set(diagnostics))
+
+
+def validate_foundation_reports(
+    partition: Mapping[str, Any],
+    closure: Mapping[str, Any],
+) -> None:
+    shared.validate_diagnostics(
+        foundation_diagnostics(partition, closure)
+    )
+
+
+def write_or_check(
+    path: Path, document: Mapping[str, Any], check: bool
+) -> None:
+    shared.write_or_check(
+        path,
+        document,
+        check,
+        artifact_label="generated A1.4 audit",
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    repo_root = Path(__file__).resolve().parents[2]
+    evidence = repo_root / "tools/codex/app-server-evidence/0.144.6"
+    schema_root = repo_root / "tools/codex/app-server-schema/0.144.6"
+    protocol_source_root = (
+        repo_root / "tools/codex/app-server-protocol-source/0.144.6"
+    )
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument(
+        "mode", choices=("freeze-start-state", "generate", "check")
+    )
+    result.add_argument("--repo-root", type=Path, default=repo_root)
+    result.add_argument(
+        "--manifest",
+        type=Path,
+        default=repo_root
+        / "tools/codex/app-server-surface/0.144.6.json",
+    )
+    result.add_argument(
+        "--registry",
+        type=Path,
+        default=repo_root
+        / "src/ai/openai/codex/detail/ProtocolSurfaceRegistryData.inc",
+    )
+    result.add_argument(
+        "--schema-root", type=Path, default=schema_root
+    )
+    result.add_argument(
+        "--schema-provenance",
+        type=Path,
+        default=schema_root / "PROVENANCE.json",
+    )
+    result.add_argument(
+        "--protocol-source-root",
+        type=Path,
+        default=protocol_source_root,
+    )
+    result.add_argument(
+        "--protocol-provenance",
+        type=Path,
+        default=protocol_source_root / "PROVENANCE.json",
+    )
+    result.add_argument(
+        "--assignments",
+        type=Path,
+        default=evidence / "module-slice-assignment.json",
+    )
+    result.add_argument(
+        "--evidence-root", type=Path, default=evidence
+    )
+    result.add_argument(
+        "--reachability",
+        type=Path,
+        default=evidence / "nested-reachability.json",
+    )
+    result.add_argument(
+        "--contracts",
+        type=Path,
+        default=evidence / "operation-contracts.json",
+    )
+    result.add_argument(
+        "--schema-completeness",
+        type=Path,
+        default=evidence / "schema-completeness-evidence.json",
+    )
+    result.add_argument(
+        "--fixture-coverage",
+        type=Path,
+        default=evidence / "fixture-coverage.json",
+    )
+    result.add_argument(
+        "--draft07-validator",
+        type=Path,
+        default=repo_root / "tools/codex/draft07.py",
+    )
+    result.add_argument(
+        "--start-state",
+        type=Path,
+        default=evidence / "a1-4-start-state.json",
+    )
+    result.add_argument(
+        "--partition-output",
+        type=Path,
+        default=evidence / "a1-4-total-partition.json",
+    )
+    result.add_argument(
+        "--closure-output",
+        type=Path,
+        default=evidence / "a1-4-type-closure.json",
+    )
+    result.add_argument("--base-sha")
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = parser().parse_args(argv)
+    for name, value in vars(arguments).items():
+        if isinstance(value, Path):
+            setattr(arguments, name, value.resolve())
+    if arguments.mode == "freeze-start-state":
+        base_sha = arguments.base_sha or _git(
+            arguments.repo_root, "rev-parse", "HEAD"
+        )
+        document = start_state_document(arguments, base_sha)
+        write_or_check(arguments.start_state, document, False)
+        return 0
+    partition, closure = build_foundation(arguments)
+    check = arguments.mode == "check"
+    write_or_check(arguments.partition_output, partition, check)
+    write_or_check(arguments.closure_output, closure, check)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AuditError as error:
+        print(
+            f"app-server-a1-4: error: {error.code}: {error}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)

--- a/tools/codex/app_server_a1_4.py
+++ b/tools/codex/app_server_a1_4.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import subprocess
 import sys
 from collections import Counter, defaultdict
@@ -35,6 +36,11 @@ A1_4_SLICE = "A1.4"
 A1_4_MODULE = "IntegrationsAndLongTail"
 EXPECTED_BASE_SHA = "bed5ee05184739d54cddc6518bd43b264e2b496d"
 EXPECTED_BASE_TREE = "8bf44f0eed6bd8c9d5309176db07a7d6a6240ef3"
+EXPECTED_PRODUCTION_TREE = "a1833fa778e97d29b9294627842ff9bd04f22379"
+EXPECTED_FIXTURE_TREE = "be1eb65746c93a22a516af9bc1d1916ee8f2aa67"
+EXPECTED_FRONTEND_PROTOCOL_BLOB = (
+    "bb5abb687323c0a7e5ecc51bd9d5d58d0108a4da"
+)
 EXPECTED_SCHEMA_AGGREGATES = {
     "stable": "cee1ac3bcaf95e5fcdcf07499c7e6b00fc423b90c670ea3380f1799434b72add",
     "experimental": "4a0ef96787255364d99b15fe40fcfd6227901978d0cddc8b20340bfef98a0d1b",
@@ -125,6 +131,23 @@ EXPECTED_OBJECT_POLICIES = {
     "False": 12,
     "allowed_by_default": 143,
     "schema": 7,
+}
+FOUNDATION_CHANGED_PATHS = {
+    "tests/CMakeLists.txt",
+    "tests/component/codex/CodexA14AuditToolTest.py",
+    (
+        "tools/codex/app-server-evidence/0.144.6/"
+        "a1-4-start-state.json"
+    ),
+    (
+        "tools/codex/app-server-evidence/0.144.6/"
+        "a1-4-total-partition.json"
+    ),
+    (
+        "tools/codex/app-server-evidence/0.144.6/"
+        "a1-4-type-closure.json"
+    ),
+    "tools/codex/app_server_a1_4.py",
 }
 
 AuditError = shared.AuditError
@@ -332,6 +355,540 @@ INHERITED_PARTIALS = {
     Key("server_notification", "ServerNotification", "method", "error"),
 }
 
+IMPLEMENTATION_BATCHES = {
+    "A14-UserIntegrations": {
+        "branch": "codex/a1-4-user-integrations",
+        "title": "Type the Codex A1.4 user-facing integrations",
+        "subject": "Complete Codex user-facing integrations",
+        "client_requests": {
+            "app/list",
+            "externalAgentConfig/detect",
+            "externalAgentConfig/import",
+            "externalAgentConfig/import/readHistories",
+            "feedback/upload",
+            "hooks/list",
+            "marketplace/add",
+            "marketplace/remove",
+            "marketplace/upgrade",
+            "plugin/install",
+            "plugin/installed",
+            "plugin/list",
+            "plugin/read",
+            "plugin/share/checkout",
+            "plugin/share/delete",
+            "plugin/share/list",
+            "plugin/share/save",
+            "plugin/share/updateTargets",
+            "plugin/skill/read",
+            "plugin/uninstall",
+            "skills/config/write",
+            "skills/extraRoots/set",
+            "skills/list",
+        },
+        "server_notifications": {
+            "app/list/updated",
+            "externalAgentConfig/import/completed",
+            "externalAgentConfig/import/progress",
+            "hook/completed",
+            "hook/started",
+            "skills/changed",
+        },
+        "server_requests": set(),
+        "union_families": {"PluginSource"},
+        "dependencies": [],
+        "identity_count": 33,
+        "taxonomy": {
+            "client_request": 23,
+            "server_notification": 6,
+            "server_request": 0,
+            "tagged_union_discriminator": 4,
+        },
+        "client_result_kinds": {"Concrete": 20, "Unit": 3},
+        "native_start": {
+            "Complete": 0,
+            "Partial": 1,
+            "NotImplemented": 55,
+        },
+        "native_end": {
+            "Complete": 33,
+            "Partial": 1,
+            "NotImplemented": 22,
+        },
+        "global_start": EXPECTED_GLOBAL_START_STATUS,
+        "global_end": {
+            "Complete": 313,
+            "NotApplicable": 48,
+            "NotImplemented": 22,
+            "Partial": 4,
+        },
+        "headers": [
+            "ai/openai/codex/typed/Apps.h",
+            "ai/openai/codex/typed/ExternalAgents.h",
+            "ai/openai/codex/typed/Feedback.h",
+            "ai/openai/codex/typed/Hooks.h",
+            "ai/openai/codex/typed/Marketplace.h",
+            "ai/openai/codex/typed/Plugins.h",
+            "ai/openai/codex/typed/Skills.h",
+        ],
+        "facades": [
+            "Apps",
+            "ExternalAgents",
+            "Feedback",
+            "Hooks",
+            "Marketplace",
+            "Plugins",
+            "Skills",
+        ],
+        "codec_units": [
+            "detail/AppCodec.{h,cpp}",
+            "detail/ExternalAgentCodec.{h,cpp}",
+            "detail/FeedbackCodec.{h,cpp}",
+            "detail/HookCodec.{h,cpp}",
+            "detail/MarketplaceCodec.{h,cpp}",
+            "detail/PluginCodec.{h,cpp}",
+            "detail/SkillCodec.{h,cpp}",
+        ],
+        "descriptor_changes": [
+            "ClientOperationCodecDescriptors.inc",
+            "ServerNotificationCodecDescriptors.inc",
+            "IntegrationsAndLongTailUnionCodecDescriptors.inc",
+        ],
+        "primary_tests": [
+            "CodexA14UserIntegrationsCodecTest",
+            "CodexA14UserIntegrationsWireTest",
+            "CodexA14UserIntegrationsFacadeTest",
+            "CodexA14PluginSourceUnionTest",
+        ],
+        "logical_commits": [
+            "Add Codex A1.4 integration public types",
+            "Implement Codex A1.4 integration codecs and facades",
+            "Close Codex A1.4 integration registry evidence",
+        ],
+    },
+    "A14-McpReverse": {
+        "branch": "codex/a1-4-mcp-reverse-requests",
+        "title": "Type the Codex A1.4 MCP and reverse requests",
+        "subject": "Complete Codex MCP and reverse requests",
+        "client_requests": {
+            "mcpServer/oauth/login",
+            "mcpServer/resource/read",
+            "mcpServer/tool/call",
+            "mcpServerStatus/list",
+        },
+        "server_notifications": {
+            "mcpServer/oauthLogin/completed",
+            "mcpServer/startupStatus/updated",
+        },
+        "server_requests": set(SERVER_REQUEST_CONTRACTS),
+        "union_families": {"McpServerElicitationRequestParams"},
+        "dependencies": ["A14-UserIntegrations"],
+        "identity_count": 13,
+        "taxonomy": {
+            "client_request": 4,
+            "server_notification": 2,
+            "server_request": 4,
+            "tagged_union_discriminator": 3,
+        },
+        "client_result_kinds": {"Concrete": 4, "Unit": 0},
+        "native_start": {
+            "Complete": 33,
+            "Partial": 1,
+            "NotImplemented": 22,
+        },
+        "native_end": {
+            "Complete": 46,
+            "Partial": 0,
+            "NotImplemented": 10,
+        },
+        "global_start": {
+            "Complete": 313,
+            "NotApplicable": 48,
+            "NotImplemented": 22,
+            "Partial": 4,
+        },
+        "global_end": {
+            "Complete": 326,
+            "NotApplicable": 48,
+            "NotImplemented": 10,
+            "Partial": 3,
+        },
+        "headers": [
+            "ai/openai/codex/typed/Mcp.h",
+            "ai/openai/codex/typed/ServerRequests.h",
+        ],
+        "facades": ["Mcp", "Requests", "Events"],
+        "codec_units": [
+            "detail/McpCodec.{h,cpp}",
+            "detail/AttestationCodec.{h,cpp}",
+            "detail/DynamicToolCodec.{h,cpp}",
+            "detail/UserInputRequestCodec.{h,cpp}",
+            "detail/McpElicitationCodec.{h,cpp}",
+            "detail/ServerRequestDecoder.cpp",
+        ],
+        "descriptor_changes": [
+            "ClientOperationCodecDescriptors.inc",
+            "ServerNotificationCodecDescriptors.inc",
+            "ServerRequestCodecDescriptors.inc",
+            "IntegrationsAndLongTailUnionCodecDescriptors.inc",
+        ],
+        "primary_tests": [
+            "CodexA14McpCodecTest",
+            "CodexA14McpWireTest",
+            "CodexA14ReverseRequestCodecTest",
+            "CodexA14ReverseRequestWireTest",
+            "CodexA14UserInputCompatibilityTest",
+            "CodexA14McpElicitationUnionTest",
+        ],
+        "logical_commits": [
+            "Add Codex A1.4 MCP and reverse-request public types",
+            "Implement Codex A1.4 MCP and reverse-request codecs",
+            "Close Codex A1.4 MCP and reverse-request registry evidence",
+        ],
+    },
+    "A14-RuntimePlatform": {
+        "branch": "codex/a1-4-runtime-platform",
+        "title": "Type the Codex A1.4 runtime and platform long tail",
+        "subject": "Complete Codex runtime and platform long tail",
+        "client_requests": {
+            "windowsSandbox/readiness",
+            "windowsSandbox/setupStart",
+        },
+        "server_notifications": {
+            "deprecationNotice",
+            "process/exited",
+            "process/outputDelta",
+            "remoteControl/status/changed",
+            "serverRequest/resolved",
+            "warning",
+            "windows/worldWritableWarning",
+            "windowsSandbox/setupCompleted",
+        },
+        "server_requests": set(),
+        "union_families": set(),
+        "dependencies": ["A14-McpReverse"],
+        "identity_count": 10,
+        "taxonomy": {
+            "client_request": 2,
+            "server_notification": 8,
+            "server_request": 0,
+            "tagged_union_discriminator": 0,
+        },
+        "client_result_kinds": {"Concrete": 2, "Unit": 0},
+        "native_start": {
+            "Complete": 46,
+            "Partial": 0,
+            "NotImplemented": 10,
+        },
+        "native_end": {
+            "Complete": 56,
+            "Partial": 0,
+            "NotImplemented": 0,
+        },
+        "global_start": {
+            "Complete": 326,
+            "NotApplicable": 48,
+            "NotImplemented": 10,
+            "Partial": 3,
+        },
+        "global_end": EXPECTED_NATIVE_COMPLETION_STATUS,
+        "headers": [
+            "ai/openai/codex/typed/WindowsSandbox.h",
+            "ai/openai/codex/typed/Events.h",
+        ],
+        "facades": ["WindowsSandbox", "Events"],
+        "codec_units": [
+            "detail/RuntimePlatformCodec.{h,cpp}",
+            "detail/WindowsSandboxCodec.{h,cpp}",
+            "detail/EventDecoder.cpp",
+        ],
+        "descriptor_changes": [
+            "ClientOperationCodecDescriptors.inc",
+            "ServerNotificationCodecDescriptors.inc",
+        ],
+        "primary_tests": [
+            "CodexA14RuntimePlatformCodecTest",
+            "CodexA14RuntimePlatformWireTest",
+            "CodexA14ServerRequestResolvedLifecycleTest",
+            "CodexA14WindowsSandboxFacadeTest",
+        ],
+        "logical_commits": [
+            "Add Codex A1.4 runtime and platform public types",
+            "Implement Codex A1.4 runtime and platform codecs",
+            "Close the native Codex A1.4 registry slice",
+        ],
+    },
+}
+
+FACADE_METHODS = {
+    "Apps": {"list": "app/list"},
+    "ExternalAgents": {
+        "detect": "externalAgentConfig/detect",
+        "importConfig": "externalAgentConfig/import",
+        "readImportHistories": (
+            "externalAgentConfig/import/readHistories"
+        ),
+    },
+    "Feedback": {"upload": "feedback/upload"},
+    "Hooks": {"list": "hooks/list"},
+    "Marketplace": {
+        "add": "marketplace/add",
+        "remove": "marketplace/remove",
+        "upgrade": "marketplace/upgrade",
+    },
+    "Mcp": {
+        "oauthLogin": "mcpServer/oauth/login",
+        "readResource": "mcpServer/resource/read",
+        "callTool": "mcpServer/tool/call",
+        "listServerStatuses": "mcpServerStatus/list",
+    },
+    "Plugins": {
+        "install": "plugin/install",
+        "installed": "plugin/installed",
+        "list": "plugin/list",
+        "read": "plugin/read",
+        "checkoutShare": "plugin/share/checkout",
+        "deleteShare": "plugin/share/delete",
+        "listShares": "plugin/share/list",
+        "saveShare": "plugin/share/save",
+        "updateShareTargets": "plugin/share/updateTargets",
+        "readSkill": "plugin/skill/read",
+        "uninstall": "plugin/uninstall",
+    },
+    "Skills": {
+        "writeConfig": "skills/config/write",
+        "setExtraRoots": "skills/extraRoots/set",
+        "list": "skills/list",
+    },
+    "WindowsSandbox": {
+        "readiness": "windowsSandbox/readiness",
+        "setupStart": "windowsSandbox/setupStart",
+    },
+}
+
+EVENT_ADDITIONS = [
+    ("app/list/updated", 51, 53),
+    ("externalAgentConfig/import/completed", 52, 54),
+    ("externalAgentConfig/import/progress", 53, 55),
+    ("hook/completed", 54, 56),
+    ("hook/started", 55, 57),
+    ("skills/changed", 56, 58),
+    ("mcpServer/oauthLogin/completed", 57, 59),
+    ("mcpServer/startupStatus/updated", 58, 60),
+    ("deprecationNotice", 59, 61),
+    ("process/exited", 60, 62),
+    ("process/outputDelta", 61, 63),
+    ("remoteControl/status/changed", 62, 64),
+    ("serverRequest/resolved", 63, 65),
+    ("warning", 64, 66),
+    ("windows/worldWritableWarning", 65, 67),
+    ("windowsSandbox/setupCompleted", 66, 68),
+]
+
+SERVER_REQUEST_ADDITIONS = {
+    "attestation/generate": {
+        "public_type": "AttestationGenerateRequest",
+        "variant_index": 8,
+    },
+    "item/tool/call": {
+        "public_type": "DynamicToolCallRequest",
+        "variant_index": 9,
+    },
+    "item/tool/requestUserInput": {
+        "public_type": "UserInputRequest",
+        "variant_index": 2,
+        "completion_in_place": True,
+    },
+    "mcpServer/elicitation/request": {
+        "public_type": "McpServerElicitationRequest",
+        "variant_index": 10,
+    },
+}
+
+REUSABLE_PUBLIC_TYPES = {
+    "AbsolutePathBuf": "ai/openai/codex/typed/Types.h",
+    "DynamicToolCallOutputContentItem": (
+        "ai/openai/codex/typed/Conversation.h"
+    ),
+    "WindowsSandboxSetupMode": (
+        "ai/openai/codex/typed/Configuration.h"
+    ),
+}
+
+NON_REUSABLE_SIMILAR_TYPES = {
+    "CommandExecProcessId/CommandExecOutputStream": (
+        "A1.4 process handles and stream vocabulary are distinct"
+    ),
+    "ConfigWarningNotification/GuardianWarning": (
+        "generic warning and deprecation payloads have distinct schemas"
+    ),
+    "conversation UserInput": (
+        "ToolRequestUserInput is a reverse-request contract"
+    ),
+    "DynamicToolCallThreadItem": (
+        "dynamic server call params/results are distinct; only the exact "
+        "output-content union is reusable"
+    ),
+    "McpToolCallThreadItem": (
+        "MCP server operation request/response schemas are distinct"
+    ),
+    "Accounts authentication types": (
+        "MCP OAuth lifecycle is not account login lifecycle"
+    ),
+    "ConfigLayerSource/HookSource": (
+        "PluginSource has its own tagged union and ownership"
+    ),
+    "SandboxMode/SandboxPolicy": (
+        "Windows setup/readiness is a distinct platform contract"
+    ),
+}
+
+PARTIAL_OBLIGATIONS = {
+    "initialize": {
+        "public_type_obligations": [
+            "preserve automatic initialization and constructor signatures",
+            "model ClientInfo.title as omitted/null/value",
+            "append optional-null InitializeCapabilities",
+            "model experimentalApi and requestAttestation defaults",
+            "model optional mcpServerOpenaiFormElicitation",
+            "model optional-null optOutNotificationMethods",
+        ],
+        "codec_obligations": [
+            "encode exact InitializeParams without dropping known fields",
+            "retain exact InitializeResponse decoding",
+            "do not add a generic initialize facade",
+        ],
+        "test_obligations": [
+            "omitted/null/value ClientInfo title and capabilities",
+            "capability defaults and opt-out notification list",
+            "request/result direction and registry target assertions",
+            "automatic-handshake compatibility",
+        ],
+        "deferred_reason": (
+            "cross-cutting automatic lifecycle compatibility belongs at "
+            "the deliberate final A1 rebuild boundary"
+        ),
+    },
+    "initialized": {
+        "public_type_obligations": [
+            "no new public payload type; the notification has no params",
+        ],
+        "codec_obligations": [
+            "exact internal method-only notification encoder",
+            "descriptor and registry direction assertion",
+        ],
+        "test_obligations": [
+            "method-only positive schema case",
+            "no-payload/no-drop direction evidence",
+        ],
+        "deferred_reason": (
+            "the method-only notification completes the automatic "
+            "initialization lifecycle with initialize"
+        ),
+    },
+    "error": {
+        "public_type_obligations": [
+            "preserve Event alternative TurnErrorEvent at index 44",
+            "append schema-complete ErrorNotification canonical view",
+            "retain raw payload and diagnostics",
+            "add optional canonical view to TurnErrorEvent",
+        ],
+        "codec_obligations": [
+            "decode every CodexErrorInfo known/future/malformed union case",
+            "preserve omitted/null/value fields and additional details",
+            "retain current BackendCore/frontend projection",
+        ],
+        "test_obligations": [
+            "all error properties and nullable states",
+            "malformed-known and future-unknown error info",
+            "Event index and backend compatibility",
+        ],
+        "deferred_reason": (
+            "error is cross-cutting Common lifecycle state and its layout "
+            "change belongs at final A1 closure"
+        ),
+    },
+    "item/tool/requestUserInput": {
+        "public_type_obligations": [
+            "preserve UserInputRequest and TypedServerRequest index 2",
+            "preserve UserInputQuestion/UserInputOption/UserInputAnswer",
+            "append canonical ToolRequestUserInputParams and diagnostics",
+            "model autoResolutionMs and options as omitted/null/value",
+            "add canonical response map without removing legacy overload",
+        ],
+        "codec_obligations": [
+            "exact params decoder with default and uint64 semantics",
+            "exact ToolRequestUserInputResponse encoder",
+            "post-encode schema validation and direct respondOwned path",
+        ],
+        "test_obligations": [
+            "all params/response fields and nullable states",
+            "known/duplicate question validation compatibility",
+            "one-shot/retry/original-ID/generation lifecycle",
+        ],
+        "deferred_reason": (
+            "native A1.4 reverse-request work owns this existing "
+            "compatibility projection"
+        ),
+    },
+}
+
+EXPECTED_BATCH_CLOSURES = {
+    "A14-UserIntegrations": {
+        "seed_definitions": 52,
+        "reachable_named_definitions": 118,
+        "definition_namespaces": {"v2": 118},
+        "schema_paths": 411,
+        "schema_path_kinds": {
+            "array_element": 68,
+            "map_value": 4,
+            "property": 339,
+        },
+        "object_nodes": 103,
+        "required_paths": 176,
+        "optional_paths": 163,
+        "nullable_paths": 141,
+        "default_bearing_paths": 19,
+        "opaque_json_paths": 0,
+        "sensitive_paths": 66,
+    },
+    "A14-McpReverse": {
+        "seed_definitions": 18,
+        "reachable_named_definitions": 55,
+        "definition_namespaces": {"legacy": 34, "v2": 21},
+        "schema_paths": 204,
+        "schema_path_kinds": {
+            "array_element": 22,
+            "map_value": 3,
+            "property": 179,
+        },
+        "object_nodes": 48,
+        "required_paths": 87,
+        "optional_paths": 92,
+        "nullable_paths": 97,
+        "default_bearing_paths": 3,
+        "opaque_json_paths": 24,
+        "sensitive_paths": 53,
+    },
+    "A14-RuntimePlatform": {
+        "seed_definitions": 11,
+        "reachable_named_definitions": 17,
+        "definition_namespaces": {"v2": 17},
+        "schema_paths": 31,
+        "schema_path_kinds": {
+            "array_element": 1,
+            "map_value": 0,
+            "property": 30,
+        },
+        "object_nodes": 11,
+        "required_paths": 25,
+        "optional_paths": 5,
+        "nullable_paths": 5,
+        "default_bearing_paths": 0,
+        "opaque_json_paths": 0,
+        "sensitive_paths": 8,
+    },
+}
+
 SENSITIVE_FIELD_NAMES = {
     "_meta",
     "answers",
@@ -424,6 +981,21 @@ def _git(repo_root: Path, *arguments: str) -> str:
             f"git {' '.join(arguments)} failed while freezing A1.4",
             "BaseCommitMismatch",
         )
+    return completed.stdout.strip()
+
+
+def _try_git(repo_root: Path, *arguments: str) -> str | None:
+    """Return git output, or None when shallow history cannot satisfy a query."""
+
+    completed = subprocess.run(
+        ["git", *arguments],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode:
+        return None
     return completed.stdout.strip()
 
 
@@ -1766,16 +2338,56 @@ def partition_document(
     )
     changed_paths: set[str] = set()
     if (arguments.repo_root / ".git").exists():
-        changed_paths.update(
-            line
-            for line in _git(
-                arguments.repo_root,
-                "diff",
-                "--name-only",
-                EXPECTED_BASE_SHA,
-            ).splitlines()
-            if line
+        base_diff = _try_git(
+            arguments.repo_root,
+            "diff",
+            "--name-only",
+            EXPECTED_BASE_SHA,
         )
+        if base_diff is None:
+            # Pull-request CI checks out a depth-one synthetic merge commit.
+            # Its tree is complete even though the frozen base commit is not,
+            # so compare the protected tree/blob objects directly.
+            production_tree = _git(
+                arguments.repo_root,
+                "rev-parse",
+                "HEAD:src",
+            )
+            require(
+                production_tree == EXPECTED_PRODUCTION_TREE,
+                (
+                    "production tree changed in shallow checkout: "
+                    f"{production_tree}"
+                ),
+                "ProductionScopeViolation",
+            )
+            fixture_tree = _git(
+                arguments.repo_root,
+                "rev-parse",
+                "HEAD:tools/codex/app-server-fixtures/0.144.6",
+            )
+            frontend_protocol_blob = _git(
+                arguments.repo_root,
+                "rev-parse",
+                (
+                    "HEAD:docs/ai/openai/codex/"
+                    "frontend-protocol-v1.schema.json"
+                ),
+            )
+            require(
+                fixture_tree == EXPECTED_FIXTURE_TREE
+                and frontend_protocol_blob
+                == EXPECTED_FRONTEND_PROTOCOL_BLOB,
+                (
+                    "protected fixture/frontend objects changed in "
+                    "shallow checkout"
+                ),
+                "ProtectedInputScopeViolation",
+            )
+        else:
+            changed_paths.update(
+                line for line in base_diff.splitlines() if line
+            )
         changed_paths.update(
             line
             for line in _git(
@@ -1893,7 +2505,7 @@ def partition_document(
             "cross_slice_overlaps": [],
         },
         "audit_boundaries": {
-            "changed_paths": sorted(changed_paths),
+            "changed_paths": sorted(FOUNDATION_CHANGED_PATHS),
             "production_paths_changed": production_paths,
             "protected_nonproduction_paths_changed": (
                 protected_nonproduction_paths
@@ -1934,6 +2546,2084 @@ def build_foundation(
     closure = schema_closure(arguments, inputs, keys)
     validate_foundation_reports(partition, closure)
     return partition, closure
+
+
+def _batch_keys(batch_name: str) -> set[Key]:
+    batch = IMPLEMENTATION_BATCHES[batch_name]
+    keys = {
+        *(
+            Key("client_request", "ClientRequest", "method", name)
+            for name in batch["client_requests"]
+        ),
+        *(
+            Key(
+                "server_notification",
+                "ServerNotification",
+                "method",
+                name,
+            )
+            for name in batch["server_notifications"]
+        ),
+        *(
+            Key("server_request", "ServerRequest", "method", name)
+            for name in batch["server_requests"]
+        ),
+    }
+    for family in batch["union_families"]:
+        matches = [
+            (domain, field, alternatives)
+            for (domain, field), alternatives in UNION_FAMILIES.items()
+            if domain == family
+        ]
+        require(
+            len(matches) == 1,
+            f"implementation batch names unknown union: {family}",
+            "ImplementationPlanIdentityMismatch",
+        )
+        domain, field, alternatives = matches[0]
+        keys.update(
+            Key(
+                "tagged_union_discriminator",
+                domain,
+                field,
+                alternative,
+            )
+            for alternative in alternatives
+        )
+    return keys
+
+
+def _definition_key(row: Mapping[str, Any]) -> tuple[str, str]:
+    return (str(row["namespace"]), str(row["name"]))
+
+
+def _definition_object(
+    definition: tuple[str, str],
+) -> dict[str, str]:
+    return {
+        "namespace": definition[0],
+        "name": definition[1],
+    }
+
+
+def _batch_closure(
+    batch_name: str,
+    closure: Mapping[str, Any],
+) -> dict[str, Any]:
+    keys = _batch_keys(batch_name)
+    seed_rows = closure["seed_definitions"]
+    seeds = {
+        _definition_key(row["definition"])
+        for row in seed_rows
+        if any(
+            Key.from_row(association["surface_key"]) in keys
+            for association in row["associations"]
+        )
+    }
+    edges = {
+        _definition_key(row["definition"]): {
+            _definition_key(dependency)
+            for dependency in row["direct_dependencies"]
+        }
+        for row in closure["definitions"]
+    }
+    reachable = set(seeds)
+    pending = list(seeds)
+    while pending:
+        definition = pending.pop()
+        for dependency in edges[definition]:
+            if dependency not in reachable:
+                reachable.add(dependency)
+                pending.append(dependency)
+    paths = [
+        row
+        for row in closure["schema_paths"]
+        if _definition_key(row["definition"]) in reachable
+    ]
+    objects = [
+        row
+        for row in closure["object_policies"]
+        if _definition_key(row["definition"]) in reachable
+    ]
+    path_kinds = _counter(
+        str(row["schema_node_kind"]) for row in paths
+    )
+    for kind in ("array_element", "map_value", "property"):
+        path_kinds.setdefault(kind, 0)
+    counts = {
+        "seed_definitions": len(seeds),
+        "reachable_named_definitions": len(reachable),
+        "definition_namespaces": _counter(
+            definition[0] for definition in reachable
+        ),
+        "schema_paths": len(paths),
+        "schema_path_kinds": dict(sorted(path_kinds.items())),
+        "object_nodes": len(objects),
+        "required_paths": sum(
+            row["schema_node_kind"] == "property"
+            and bool(row["required"])
+            for row in paths
+        ),
+        "optional_paths": sum(
+            row["schema_node_kind"] == "property"
+            and bool(row["optional"])
+            for row in paths
+        ),
+        "nullable_paths": sum(bool(row["nullable"]) for row in paths),
+        "default_bearing_paths": sum(
+            bool(row["default_present"]) for row in paths
+        ),
+        "opaque_json_paths": sum(
+            bool(row["intentionally_opaque_json"]) for row in paths
+        ),
+        "sensitive_paths": sum(
+            bool(row["sensitive"]) for row in paths
+        ),
+    }
+    require(
+        counts == EXPECTED_BATCH_CLOSURES[batch_name],
+        f"{batch_name} transitive schema closure changed: {counts}",
+        "ImplementationDependencyMismatch",
+    )
+    return {
+        "counts": counts,
+        "seed_definitions": [
+            _definition_object(definition)
+            for definition in sorted(seeds)
+        ],
+        "reachable_definitions": [
+            _definition_object(definition)
+            for definition in sorted(reachable)
+        ],
+        "sensitive_schema_paths": [
+            {
+                "definition": row["definition"],
+                "schema_path": row["schema_path"],
+                "field": row["field"],
+                "value_kind": row["value_kind"],
+            }
+            for row in paths
+            if row["sensitive"]
+        ],
+    }
+
+
+def _parse_variant(path: Path, alias: str) -> list[str]:
+    source = path.read_text(encoding="utf-8")
+    match = re.search(
+        rf"using\s+{re.escape(alias)}\s*=\s*"
+        r"std::variant<(?P<body>.*?)>;",
+        source,
+        flags=re.DOTALL,
+    )
+    require(
+        match is not None,
+        f"unable to locate public variant {alias} in {path}",
+        "PublicVariantMismatch",
+    )
+    alternatives = [
+        alternative.strip()
+        for alternative in match.group("body").split(",")
+    ]
+    require(
+        all(
+            alternative
+            and "<" not in alternative
+            and ">" not in alternative
+            for alternative in alternatives
+        ),
+        f"{alias} is no longer a flat named-alternative variant",
+        "PublicVariantMismatch",
+    )
+    return alternatives
+
+
+def _indexed(values: Sequence[str]) -> list[dict[str, Any]]:
+    return [
+        {"index": index, "type": value}
+        for index, value in enumerate(values)
+    ]
+
+
+def public_variant_inventory(
+    arguments: argparse.Namespace,
+) -> dict[str, Any]:
+    events_path = (
+        arguments.repo_root / "src/ai/openai/codex/typed/Events.h"
+    )
+    requests_path = (
+        arguments.repo_root
+        / "src/ai/openai/codex/typed/ServerRequests.h"
+    )
+    canonical = _parse_variant(
+        events_path, "CanonicalServerNotification"
+    )
+    events = _parse_variant(events_path, "Event")
+    requests = _parse_variant(
+        requests_path, "TypedServerRequest"
+    )
+    require(
+        len(canonical) == 51
+        and len(events) == 53
+        and len(requests) == 8,
+        "current public variant denominators changed",
+        "PublicVariantMismatch",
+    )
+    require(
+        events[44] == "TurnErrorEvent"
+        and events[45] == "UnknownEvent"
+        and requests[2] == "UserInputRequest"
+        and requests[4] == "UnknownServerRequest",
+        "ABI-sensitive public variant indices changed",
+        "PublicVariantMismatch",
+    )
+    return {
+        "current": {
+            "CanonicalServerNotification": _indexed(canonical),
+            "Event": _indexed(events),
+            "TypedServerRequest": _indexed(requests),
+        },
+        "frozen_indices": {
+            "TurnErrorEvent": 44,
+            "UnknownEvent": 45,
+            "UserInputRequest": 2,
+            "UnknownServerRequest": 4,
+        },
+        "planned_notification_appends": [
+            {
+                "method": method,
+                "canonical_index": canonical_index,
+                "event_index": event_index,
+            }
+            for method, canonical_index, event_index in EVENT_ADDITIONS
+        ],
+        "planned_server_request_changes": [
+            {"method": method, **details}
+            for method, details in sorted(
+                SERVER_REQUEST_ADDITIONS.items()
+            )
+        ],
+        "final_a1_error_completion": {
+            "canonical_type": "ErrorNotification",
+            "canonical_index": 67,
+            "event_change": (
+                "TurnErrorEvent remains index 44 and gains an optional "
+                "canonical view; no Event alternative is inserted"
+            ),
+        },
+        "sources": [
+            _source(events_path, arguments.repo_root),
+            _source(requests_path, arguments.repo_root),
+        ],
+    }
+
+
+def cross_slice_ledger_document(
+    arguments: argparse.Namespace,
+    inputs: Inputs,
+) -> dict[str, Any]:
+    assignment_source = _source(
+        arguments.assignments, arguments.repo_root
+    )
+
+    def entry(
+        key: Key,
+        completion_stage: str,
+        expected_batch: str,
+    ) -> dict[str, Any]:
+        assignment = inputs.assignments[key]
+        registry = inputs.registry[key]
+        false_facts = sorted(
+            name
+            for name, value in registry[
+                "schema_completeness"
+            ].items()
+            if value is False
+        )
+        obligations = PARTIAL_OBLIGATIONS[key.name]
+        return {
+            "protocol_surface_key": key.object(),
+            "category": key.category,
+            "current_module": assignment["module"],
+            "current_slice": assignment["slice"],
+            "current_status": registry["typed_schema_status"],
+            "current_runtime_disposition": registry[
+                "runtime_disposition"
+            ],
+            "current_runtime_target": registry["runtime_target"],
+            "missing_schema_completeness_facts": false_facts,
+            "missing_public_type_obligations": obligations[
+                "public_type_obligations"
+            ],
+            "missing_codec_obligations": obligations[
+                "codec_obligations"
+            ],
+            "missing_test_obligations": obligations[
+                "test_obligations"
+            ],
+            "intended_completion_batch": expected_batch,
+            "completion_stage": completion_stage,
+            "expected_status_after_completion": "Complete",
+            "deferred_reason": obligations["deferred_reason"],
+            "assignment_unchanged_proof": {
+                "authority": assignment_source,
+                "assignment": {
+                    "stability": assignment["stability"],
+                    "classification": assignment["classification"],
+                    "module": assignment["module"],
+                    "slice": assignment["slice"],
+                },
+                "registry_matches_assignment": (
+                    registry["typed_module"] == assignment["module"]
+                    and registry["a1_slice"] == assignment["slice"]
+                ),
+            },
+        }
+
+    inherited = [
+        entry(
+            key,
+            "final A1 closure in A1.4",
+            "A1-FinalClosure",
+        )
+        for key in sorted(INHERITED_PARTIALS)
+    ]
+    native = entry(
+        NATIVE_PARTIAL,
+        "native A1.4 implementation",
+        "A14-McpReverse",
+    )
+    require(
+        {
+            row["protocol_surface_key"]["name"] for row in inherited
+        }
+        == {"initialize", "initialized", "error"}
+        and all(
+            row["current_module"] == "Common"
+            and row["current_slice"] == "A1.0"
+            and row["current_status"] == "Partial"
+            for row in inherited
+        ),
+        "inherited A1.0 completion ownership changed",
+        "CrossSliceOwnershipMismatch",
+    )
+    require(
+        native["current_module"] == A1_4_MODULE
+        and native["current_slice"] == A1_4_SLICE
+        and native["current_status"] == "Partial",
+        "native A1.4 partial ownership changed",
+        "NativePartialMismatch",
+    )
+    return {
+        "format_version": FORMAT_VERSION,
+        "generated_notice": (
+            "Generated cross-slice completion ledger; ownership remains "
+            "defined by module-slice-assignment.json."
+        ),
+        "codex_version": CODEX_VERSION,
+        "counts": {
+            "inherited_a1_0_partial": len(inherited),
+            "native_a1_4_partial": 1,
+            "all_current_partial": len(inherited) + 1,
+        },
+        "ownership_rule": (
+            "A1.4 is the scheduling milestone for final Common closure, "
+            "not the ownership slice of initialize, initialized, or error."
+        ),
+        "inherited_final_a1_obligations": inherited,
+        "native_a1_4_obligation": native,
+        "native_denominator_rule": (
+            "The three inherited rows are excluded from the native "
+            "56-identity A1.4 denominator."
+        ),
+        "assignment_file_unchanged": True,
+        "assignment_authority": assignment_source,
+    }
+
+
+def server_request_resolved_document(
+    arguments: argparse.Namespace,
+) -> dict[str, Any]:
+    schema_path = (
+        arguments.schema_root
+        / "stable/v2/ServerRequestResolvedNotification.json"
+    )
+    schema = shared.load_json(schema_path)
+    properties = schema.get("properties")
+    require(
+        schema.get("title") == "ServerRequestResolvedNotification"
+        and schema.get("type") == "object"
+        and set(schema.get("required", []))
+        == {"requestId", "threadId"}
+        and isinstance(properties, Mapping)
+        and set(properties) == {"requestId", "threadId"}
+        and "additionalProperties" not in schema,
+        "serverRequest/resolved payload schema changed",
+        "ServerRequestResolvedSemanticsMismatch",
+    )
+    request_id = schema.get("definitions", {}).get("RequestId", {})
+    request_id_types = {
+        (
+            str(branch.get("type")),
+            branch.get("format"),
+        )
+        for branch in request_id.get("anyOf", [])
+        if isinstance(branch, Mapping)
+    }
+    require(
+        request_id_types
+        == {("string", None), ("integer", "int64")}
+        and properties["threadId"] == {"type": "string"}
+        and properties["requestId"]
+        == {"$ref": "#/definitions/RequestId"},
+        "serverRequest/resolved field types changed",
+        "ServerRequestResolvedSemanticsMismatch",
+    )
+    commit_url = (
+        "https://github.com/openai/codex/blob/"
+        f"{UPSTREAM_SOURCE_COMMIT}/"
+    )
+    method_matrix = [
+        {
+            "slice": "A1.3",
+            "method": "item/commandExecution/requestApproval",
+            "emits_notification": True,
+        },
+        {
+            "slice": "A1.3",
+            "method": "item/fileChange/requestApproval",
+            "emits_notification": True,
+        },
+        {
+            "slice": "A1.3",
+            "method": "item/permissions/requestApproval",
+            "emits_notification": True,
+        },
+        {
+            "slice": "A1.3",
+            "method": "applyPatchApproval",
+            "emits_notification": False,
+        },
+        {
+            "slice": "A1.3",
+            "method": "execCommandApproval",
+            "emits_notification": False,
+        },
+        {
+            "slice": "A1.4",
+            "method": "item/tool/requestUserInput",
+            "emits_notification": True,
+        },
+        {
+            "slice": "A1.4",
+            "method": "mcpServer/elicitation/request",
+            "emits_notification": True,
+        },
+        {
+            "slice": "A1.4",
+            "method": "item/tool/call",
+            "emits_notification": False,
+        },
+        {
+            "slice": "A1.4",
+            "method": "attestation/generate",
+            "emits_notification": False,
+        },
+    ]
+    return {
+        "method": "serverRequest/resolved",
+        "payload": {
+            "type": "ServerRequestResolvedNotification",
+            "required_fields": {
+                "threadId": "string",
+                "requestId": "string | int64",
+            },
+            "optional_fields": [],
+            "nullable_fields": [],
+            "additional_properties": "allowed_by_default",
+            "absent_semantics": [
+                "method",
+                "item ID",
+                "result",
+                "error",
+                "outcome",
+                "generation",
+                "completion status",
+            ],
+            "schema_authority": _source(
+                schema_path, arguments.repo_root
+            ),
+        },
+        "identifier_semantics": {
+            "kind": "original server-generated JSON-RPC request ID",
+            "not": [
+                "item ID",
+                "call ID",
+                "SNode.C occurrence token",
+            ],
+            "preserve_string_ids": True,
+            "upstream_current_generation": (
+                "process-wide monotonically allocated integer"
+            ),
+        },
+        "generation_semantics": {
+            "payload_generation_scoped": False,
+            "recipient_rule": (
+                "scope the notification to the SNode.C transport "
+                "generation that delivered it"
+            ),
+            "restart_risk": (
+                "the upstream process counter can restart; an old "
+                "generation must never consume a new occurrence"
+            ),
+        },
+        "emission_method_matrix": method_matrix,
+        "terminal_path_matrix": [
+            {
+                "path": "successful JSON-RPC result",
+                "emitted_for_positive_methods": True,
+            },
+            {
+                "path": "domain decline/cancel encoded as valid result",
+                "emitted_for_positive_methods": True,
+            },
+            {
+                "path": "client JSON-RPC rejection/error",
+                "emitted_for_positive_methods": True,
+            },
+            {
+                "path": "malformed successful result",
+                "emitted_for_positive_methods": True,
+                "note": "emission precedes fallback result decoding",
+            },
+            {
+                "path": "turn start/complete/interrupt cleanup",
+                "emitted_for_positive_methods": True,
+            },
+            {
+                "path": "generic timeout",
+                "emitted_for_positive_methods": False,
+                "note": (
+                    "the five positive handlers have no generic timer; "
+                    "autoResolutionMs is only forwarded"
+                ),
+            },
+            {
+                "path": "disconnect alone",
+                "emitted_for_positive_methods": False,
+            },
+            {
+                "path": "server-side auto-resolution",
+                "emitted_for_positive_methods": False,
+                "note": "no such App Server timer exists at this pin",
+            },
+        ],
+        "ordering": {
+            "causal_sequence": [
+                "client enqueues direct JSON-RPC result or error",
+                "App Server removes the matching callback",
+                "the per-method waiter wakes",
+                "the handler queues ResolveServerRequest",
+                "the listener emits serverRequest/resolved",
+                "the handler resumes core processing",
+            ],
+            "direct_response_is_earlier": True,
+            "notification_is_opposite_direction": True,
+            "notification_precedes_downstream_completion": (
+                "ordinary positive-handler paths"
+            ),
+        },
+        "meaning": {
+            "classification": "informational and lifecycle-significant",
+            "communicates": (
+                "a shared pending request was resolved or cleared"
+            ),
+            "does_not_communicate": (
+                "success, decline, cancellation, rejection, or outcome"
+            ),
+            "outcome_authority": (
+                "downstream item/completed or turn/completed"
+            ),
+        },
+        "recipient_behavior": {
+            "already_consumed_possible": True,
+            "multi_subscriber_case": (
+                "the responder usually removed its occurrence while "
+                "another subscriber may still have the shared ID pending"
+            ),
+            "current_pending_match": (
+                "retire idempotently as externally resolved only when "
+                "ID, thread, and transport generation all match"
+            ),
+            "unknown_or_stale": (
+                "deliver the typed event, perform no registry mutation, "
+                "and keep the connection healthy"
+            ),
+            "duplicate": "nonfatal idempotent no-op",
+            "thread_mismatch": "nonfatal no-op",
+            "later_answer_after_external_resolution": (
+                "fail locally without wire output"
+            ),
+        },
+        "direct_response_non_regression": {
+            "frozen_path": [
+                "incoming server request",
+                "existing occurrence token and generation",
+                "typed callback",
+                "typed response validation",
+                (
+                    "direct JSON-RPC response using the original "
+                    "request ID"
+                ),
+            ],
+            "is_response_transport": False,
+            "is_response_prerequisite": False,
+            "is_acknowledgement_prerequisite": False,
+            "is_second_terminal_completion": False,
+            "can_reopen_completed_occurrence": False,
+            "changes_a1_3_response_contract": False,
+        },
+        "future_tests": [
+            "integer and string IDs; required/null/wrong-type fields",
+            "future additional properties are accepted and preserved",
+            "positive five-method and negative four-method matrices",
+            "success, decline/cancel, rejection, malformed-result paths",
+            "turn-transition cleanup behavior",
+            "response bytes and local consumption precede reentrant event",
+            "typed responses remain valid if the event never arrives",
+            "already-consumed event causes no second terminal action",
+            "external resolution retires a current matching occurrence",
+            "unknown, duplicate, thread-mismatched IDs are nonfatal",
+            "old-generation event cannot consume a restarted occurrence",
+            "multi-subscriber responder/observer behavior",
+            "resolved precedes downstream completion where promised",
+            "reuse A1.3 original-ID, one-shot, and generation tests",
+        ],
+        "pinned_upstream_evidence": [
+            {
+                "finding": "payload struct",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server-protocol/src/protocol/"
+                    "v2/notification.rs#L50-L56"
+                ),
+            },
+            {
+                "finding": "RequestId representation",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server-protocol/src/rpc.rs#L13-L29"
+                ),
+            },
+            {
+                "finding": "ID generation and callback insertion",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server/src/"
+                    "outgoing_message.rs#L282-L350"
+                ),
+            },
+            {
+                "finding": "callback removal before waiter wake-up",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server/src/"
+                    "outgoing_message.rs#L373-L410"
+                ),
+            },
+            {
+                "finding": "single notification emission site",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server/src/request_processors/"
+                    "thread_lifecycle.rs#L748-L771"
+                ),
+            },
+            {
+                "finding": "five positive response handlers",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server/src/"
+                    "bespoke_event_handling.rs#L1569-L1923"
+                ),
+            },
+            {
+                "finding": "dynamic tool negative path",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server/src/"
+                    "dynamic_tools.rs#L16-L55"
+                ),
+            },
+            {
+                "finding": "attestation negative/timeout path",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server/src/"
+                    "attestation.rs#L63-L127"
+                ),
+            },
+            {
+                "finding": "turn-transition callback cancellation",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server/src/"
+                    "outgoing_message.rs#L176-L190"
+                ),
+            },
+            {
+                "finding": "disconnect behavior",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server/src/"
+                    "message_processor.rs#L695-L721"
+                ),
+            },
+            {
+                "finding": "listener serialization",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server/src/"
+                    "thread_state.rs#L164-L193"
+                ),
+            },
+            {
+                "finding": "documented lifecycle meaning",
+                "url": (
+                    commit_url
+                    + "codex-rs/app-server/README.md#L1444-L1497"
+                ),
+            },
+        ],
+        "local_non_regression_evidence": [
+            {
+                "path": (
+                    "src/ai/openai/codex/AppServerClient.cpp"
+                ),
+                "finding": (
+                    "answerServerRequest enqueues the original ID and "
+                    "consumes the occurrence before reentrant flush"
+                ),
+            },
+            {
+                "path": (
+                    "tools/codex/app-server-evidence/0.144.6/"
+                    "a1-3-implementation-plan.json"
+                ),
+                "finding": (
+                    "all A1.3 response operations explicitly exclude "
+                    "serverRequest/resolved as a transport dependency"
+                ),
+            },
+        ],
+    }
+
+
+def _soversion_inventory(
+    arguments: argparse.Namespace,
+) -> dict[str, Any]:
+    root_cmake = arguments.repo_root / "CMakeLists.txt"
+    root_source = root_cmake.read_text(encoding="utf-8")
+    require(
+        re.search(
+            r"project\(\s*SNode\.C\b.*?\bVERSION\s+1\.0\.1\s*\)",
+            root_source,
+            flags=re.DOTALL,
+        )
+        is not None
+        and "set(SNODEC_SOVERSION ${SNode.C_VERSION_MAJOR})"
+        in root_source,
+        "root SOVERSION authority changed",
+        "SOVERSIONDecisionMissing",
+    )
+    declaration_count = 0
+    declaration_paths: list[str] = []
+    for path in arguments.repo_root.rglob("CMakeLists.txt"):
+        relative = path.relative_to(arguments.repo_root)
+        if any(
+            part == ".git"
+            or part == "_deps"
+            or part.startswith("build")
+            for part in relative.parts
+        ):
+            continue
+        count = path.read_text(encoding="utf-8").count(
+            "SOVERSION ${SNODEC_SOVERSION}"
+        )
+        if count:
+            declaration_count += count
+            declaration_paths.extend([relative.as_posix()] * count)
+    require(
+        declaration_count == 68,
+        (
+            "global SNODEC_SOVERSION declaration count changed: "
+            f"{declaration_count}"
+        ),
+        "SOVERSIONDecisionMissing",
+    )
+    codex_paths = {
+        "src/ai/openai/codex/CMakeLists.txt",
+        "src/ai/openai/codex/backend/CMakeLists.txt",
+        "src/ai/openai/codex/frontend/CMakeLists.txt",
+    }
+    require(
+        {
+            path for path in declaration_paths if path in codex_paths
+        }
+        == codex_paths
+        and sum(path in codex_paths for path in declaration_paths) == 3,
+        "the three Codex shared-library SOVERSION consumers changed",
+        "SOVERSIONDecisionMissing",
+    )
+    a1_3_abi_path = (
+        arguments.evidence_root / "a1-3-api-abi-evidence.json"
+    )
+    a1_3_abi = shared.load_json(a1_3_abi_path)
+    require(
+        a1_3_abi.get("conclusion", {}).get("binary_compatible")
+        is False
+        and a1_3_abi.get("conclusion", {}).get("soversion") == 1
+        and "TypedServerRequest=312"
+        in a1_3_abi["layout_probe"]["base"]["stdout_lines"]
+        and "TypedServerRequest=960"
+        in a1_3_abi["layout_probe"]["final"]["stdout_lines"],
+        "A1.3 ABI evidence no longer proves the A1 rebuild boundary",
+        "SOVERSIONDecisionMissing",
+    )
+    return {
+        "current_authority": {
+            "project_version": "1.0.1",
+            "SNODEC_SOVERSION": 1,
+            "definition": (
+                "SNODEC_SOVERSION = SNode.C_VERSION_MAJOR"
+            ),
+            "root_source": _source(
+                root_cmake, arguments.repo_root
+            ),
+            "declarations_using_global_authority": declaration_count,
+            "codex_declarations": sorted(codex_paths),
+            "unrelated_declarations": declaration_count - 3,
+        },
+        "existing_a1_policy": {
+            "source": (
+                "docs/ai/openai/codex/a1-typed-foundation.md"
+                "#final-closure-policy"
+            ),
+            "decision": (
+                "remain at 1 through native A1.4 implementation, then "
+                "bump once at final A1 closure"
+            ),
+        },
+        "actual_abi_evidence": {
+            "source": _source(
+                a1_3_abi_path, arguments.repo_root
+            ),
+            "binary_compatible": False,
+            "installed_consumers_must_rebuild": True,
+            "base_typed_server_request_size": 312,
+            "current_typed_server_request_size": 960,
+            "current_app_server_client_size": 16,
+            "current_typed_client_size": 8,
+            "removed_symbols_at_a1_3_boundary": 6286,
+            "added_symbols_at_a1_3_boundary": 15733,
+        },
+        "final_action": {
+            "decision": "bump Codex SOVERSION 1 -> 2",
+            "scope": sorted(
+                [
+                    "ai-openai-codex",
+                    "ai-openai-codex-backend",
+                    "ai-openai-codex-frontend",
+                ]
+            ),
+            "mechanism": (
+                "introduce a Codex-specific SOVERSION authority at "
+                "final closure; do not bump 65 unrelated targets"
+            ),
+            "sequence_point": (
+                "after the 339 Complete / 0 Partial / 0 "
+                "NotImplemented / 48 NotApplicable proof, before final "
+                "ABI and package capture"
+            ),
+            "binary_package_change": ".so.1 -> .so.2",
+            "installed_consumer_action": (
+                "rebuild and relink every installed consumer"
+            ),
+            "earlier_pr_rule": (
+                "an unchanged SONAME 1 is not a binary-compatibility "
+                "claim during native A1.4 implementation"
+            ),
+        },
+        "required_layout_probes": [
+            "AppServerClient",
+            "typed::Client",
+            "Event",
+            "CanonicalServerNotification",
+            "TypedServerRequest",
+            "UserInputRequest",
+            "TurnErrorEvent",
+            "ClientInfo",
+            "InitializeResult",
+            "every introduced public aggregate and variant",
+            "every new typed facade object",
+        ],
+        "expected_api_abi_changes": {
+            "variants_gain_alternatives": [
+                "CanonicalServerNotification",
+                "Event",
+                "TypedServerRequest",
+                "PluginSource",
+                "McpServerElicitationRequestParams",
+            ],
+            "aggregates_may_grow": [
+                "ClientInfo",
+                "TurnErrorEvent",
+                "UserInputRequest",
+                "notification and operation result aggregates",
+            ],
+            "symbols_added": [
+                "typed::Client facade accessors",
+                "typed operation methods",
+                "typed reverse-request response overloads",
+                "new aggregate and variant support symbols",
+            ],
+            "intentional_symbols_removed": [],
+        },
+    }
+
+
+def implementation_plan_document(
+    arguments: argparse.Namespace,
+    inputs: Inputs,
+    partition: Mapping[str, Any],
+    closure: Mapping[str, Any],
+    ledger: Mapping[str, Any],
+) -> dict[str, Any]:
+    batch_names = list(IMPLEMENTATION_BATCHES)
+    key_batches: dict[Key, list[str]] = defaultdict(list)
+    batch_closures: dict[str, dict[str, Any]] = {}
+    definition_batches: dict[tuple[str, str], list[str]] = defaultdict(
+        list
+    )
+    for batch_name in batch_names:
+        for key in _batch_keys(batch_name):
+            key_batches[key].append(batch_name)
+        batch_closures[batch_name] = _batch_closure(
+            batch_name, closure
+        )
+        for row in batch_closures[batch_name][
+            "reachable_definitions"
+        ]:
+            definition_batches[_definition_key(row)].append(batch_name)
+    require(
+        set(key_batches) == expected_a1_4_keys(),
+        "implementation batches do not cover the native A1.4 slice",
+        "ImplementationPlanIdentityMissing",
+    )
+    require(
+        all(len(owners) == 1 for owners in key_batches.values()),
+        "an A1.4 identity is owned by multiple implementation batches",
+        "ImplementationPlanIdentityOverlap",
+    )
+    facade_accessors = {
+        "Apps": "apps",
+        "ExternalAgents": "externalAgents",
+        "Feedback": "feedback",
+        "Hooks": "hooks",
+        "Marketplace": "marketplace",
+        "Mcp": "mcp",
+        "Plugins": "plugins",
+        "Skills": "skills",
+        "WindowsSandbox": "windowsSandbox",
+    }
+    client_api_rows = [
+        {
+            "method": method,
+            "facade": facade,
+            "client_accessor": (
+                f"typed::Client::{facade_accessors[facade]}"
+            ),
+            "operation": operation,
+            "implementation_batch": key_batches[
+                Key(
+                    "client_request",
+                    "ClientRequest",
+                    "method",
+                    method,
+                )
+            ][0],
+        }
+        for facade, operations in FACADE_METHODS.items()
+        for operation, method in operations.items()
+    ]
+    require(
+        {row["method"] for row in client_api_rows}
+        == set(CLIENT_REQUEST_CONTRACTS)
+        and len(client_api_rows) == 29,
+        "public facade plan does not own all 29 client requests once",
+        "PublicApiOwnershipMismatch",
+    )
+    notification_rows = [
+        {
+            "method": method,
+            "owner": "typed::Events",
+            "canonical_variant_index": canonical_index,
+            "event_variant_index": event_index,
+            "implementation_batch": key_batches[
+                Key(
+                    "server_notification",
+                    "ServerNotification",
+                    "method",
+                    method,
+                )
+            ][0],
+        }
+        for method, canonical_index, event_index in EVENT_ADDITIONS
+    ]
+    request_rows = [
+        {
+            "method": method,
+            "owner": "typed::Requests",
+            "occurrence_machinery": "existing occurrence token/generation",
+            "response_transport": (
+                "existing direct RawProtocol JSON-RPC response"
+            ),
+            "implementation_batch": key_batches[
+                Key(
+                    "server_request",
+                    "ServerRequest",
+                    "method",
+                    method,
+                )
+            ][0],
+            **details,
+        }
+        for method, details in sorted(
+            SERVER_REQUEST_ADDITIONS.items()
+        )
+    ]
+    operation_rows = {
+        Key.from_row(row["protocol_surface_key"]): row
+        for row in partition["native_a1_4_operations"]
+    }
+    partition_rows = {
+        Key.from_row(row["protocol_surface_key"]): row
+        for row in partition["buckets"]["A1.4"]
+    }
+    primary_definition_owner = {
+        definition: owners[0]
+        for definition, owners in definition_batches.items()
+    }
+    batch_documents: list[dict[str, Any]] = []
+    for batch_name in batch_names:
+        batch = IMPLEMENTATION_BATCHES[batch_name]
+        keys = sorted(_batch_keys(batch_name))
+        taxonomy = _counter(key.category for key in keys)
+        for category in EXPECTED_TAXONOMY:
+            taxonomy.setdefault(category, 0)
+        require(
+            len(keys) == batch["identity_count"]
+            and dict(sorted(taxonomy.items())) == batch["taxonomy"],
+            f"{batch_name} identity denominator/taxonomy changed",
+            "ImplementationPlanIdentityMismatch",
+        )
+        result_kinds = _counter(
+            CLIENT_REQUEST_CONTRACTS[key.name][2]
+            for key in keys
+            if key.category == "client_request"
+        )
+        if not result_kinds:
+            result_kinds = {}
+        require(
+            {
+                kind: result_kinds.get(kind, 0)
+                for kind in ("Concrete", "Unit")
+            }
+            == batch["client_result_kinds"],
+            f"{batch_name} client result split changed",
+            "ResultKindMismatch",
+        )
+        closure_document = batch_closures[batch_name]
+        reachable = {
+            _definition_key(row)
+            for row in closure_document["reachable_definitions"]
+        }
+        owned = sorted(
+            definition
+            for definition in reachable
+            if primary_definition_owner[definition] == batch_name
+        )
+        reused = sorted(
+            definition
+            for definition in reachable
+            if primary_definition_owner[definition] != batch_name
+        )
+        identity_rows = [
+            {
+                "protocol_surface_key": key.object(),
+                "current_runtime_disposition": partition_rows[key][
+                    "runtime_disposition"
+                ],
+                "current_status": partition_rows[key][
+                    "typed_schema_status"
+                ],
+                "operation_contract": (
+                    operation_rows[key]
+                    if key in operation_rows
+                    else None
+                ),
+                "registry_promotion_at_honest_closure": (
+                    "Complete"
+                ),
+            }
+            for key in keys
+        ]
+        batch_documents.append(
+            {
+                "batch": batch_name,
+                "branch": batch["branch"],
+                "draft_pr_title": batch["title"],
+                "identity_count": len(keys),
+                "taxonomy": batch["taxonomy"],
+                "client_result_kinds": batch[
+                    "client_result_kinds"
+                ],
+                "owned_start_status": _counter(
+                    partition_rows[key]["typed_schema_status"]
+                    for key in keys
+                ),
+                "native_metrics": {
+                    "start": batch["native_start"],
+                    "end": batch["native_end"],
+                },
+                "global_metrics": {
+                    "start": batch["global_start"],
+                    "end": batch["global_end"],
+                },
+                "identities": identity_rows,
+                "schema_closure": closure_document,
+                "primary_owned_schema_definitions": [
+                    _definition_object(definition)
+                    for definition in owned
+                ],
+                "reused_schema_dependencies": [
+                    {
+                        "definition": _definition_object(definition),
+                        "primary_owner": primary_definition_owner[
+                            definition
+                        ],
+                    }
+                    for definition in reused
+                ],
+                "owned_public_headers": batch["headers"],
+                "proposed_facades_and_channels": batch["facades"],
+                "codec_units": batch["codec_units"],
+                "descriptor_changes": batch[
+                    "descriptor_changes"
+                ],
+                "registry_promotions": [
+                    key.object() for key in keys
+                ],
+                "primary_tests": batch["primary_tests"],
+                "lifecycle_tests": (
+                    [
+                        (
+                            "all nine A1.3/A1.4 typed requests "
+                            "concurrent and out of order"
+                        ),
+                        (
+                            "original request ID, one-shot token, "
+                            "generation and reconnect isolation"
+                        ),
+                    ]
+                    if batch_name == "A14-McpReverse"
+                    else (
+                        [
+                            (
+                                "direct response versus "
+                                "serverRequest/resolved ordering"
+                            ),
+                            (
+                                "unknown/stale/duplicate/external "
+                                "resolution handling"
+                            ),
+                        ]
+                        if batch_name == "A14-RuntimePlatform"
+                        else []
+                    )
+                ),
+                "package_tests": [
+                    "public headers are self-contained",
+                    "installed consumer compiles and links",
+                    "source archive retains implementation evidence",
+                    "binary archive excludes private evidence",
+                ],
+                "security_obligations": [
+                    (
+                        "redact every listed sensitive schema path "
+                        "and every raw/opaque JSON value"
+                    ),
+                    (
+                        "diagnostics may contain only method, schema "
+                        "path, expected type, and safe counts"
+                    ),
+                    (
+                        "fixtures use synthetic IDs, /synthetic paths, "
+                        "example.invalid URLs, and fake tokens"
+                    ),
+                ],
+                "api_abi_impact": (
+                    "public headers, aggregates, facade symbols, and "
+                    "variants may grow; unchanged SONAME 1 is not a "
+                    "binary-compatibility claim"
+                ),
+                "logical_commit_subjects": batch[
+                    "logical_commits"
+                ],
+                "dependencies": batch["dependencies"],
+                "honest_closure_rule": (
+                    "promote an identity only after its complete "
+                    "transitive types, codecs, descriptors, API, and "
+                    "tests are present in this PR"
+                ),
+            }
+        )
+    overlaps = [
+        {
+            "definition": _definition_object(definition),
+            "batches": owners,
+            "primary_owner": primary_definition_owner[definition],
+        }
+        for definition, owners in sorted(definition_batches.items())
+        if len(owners) > 1
+    ]
+    require(
+        overlaps
+        == [
+            {
+                "definition": {
+                    "namespace": "v2",
+                    "name": "AbsolutePathBuf",
+                },
+                "batches": [
+                    "A14-UserIntegrations",
+                    "A14-RuntimePlatform",
+                ],
+                "primary_owner": "A14-UserIntegrations",
+            }
+        ],
+        f"cross-batch schema overlap changed: {overlaps}",
+        "ImplementationDependencyMismatch",
+    )
+    resolved = server_request_resolved_document(arguments)
+    variants = public_variant_inventory(arguments)
+    soversion = _soversion_inventory(arguments)
+    runtime_matrix_pairs = (
+        ("Deferred", "NotImplemented"),
+        ("RawPreserved", "NotImplemented"),
+        ("Typed", "Partial"),
+        ("OpaquePreserved", "NotImplemented"),
+        ("Deferred", "NotApplicable"),
+        ("RawPreserved", "NotApplicable"),
+        ("OpaquePreserved", "NotApplicable"),
+    )
+    global_runtime_matrix = [
+        {
+            "runtime_disposition": disposition,
+            "typed_schema_status": status,
+            "count": sum(
+                row["runtime_disposition"] == disposition
+                and row["typed_schema_status"] == status
+                for rows in partition["buckets"].values()
+                for row in rows
+            ),
+        }
+        for disposition, status in runtime_matrix_pairs
+    ]
+    native_runtime_matrix = [
+        {
+            "runtime_disposition": disposition,
+            "typed_schema_status": status,
+            "count": sum(
+                row["runtime_disposition"] == disposition
+                and row["typed_schema_status"] == status
+                for row in partition["buckets"]["A1.4"]
+            ),
+        }
+        for disposition, status in runtime_matrix_pairs
+        if status != "NotApplicable"
+    ]
+    return {
+        "format_version": FORMAT_VERSION,
+        "generated_notice": (
+            "Generated implementation and final-A1 closure plan. "
+            "Nothing in this report promotes production status."
+        ),
+        "authority": {
+            "base_sha": EXPECTED_BASE_SHA,
+            "base_tree": EXPECTED_BASE_TREE,
+            "codex_version": CODEX_VERSION,
+            "upstream_tag": UPSTREAM_TAG,
+            "upstream_source_commit": UPSTREAM_SOURCE_COMMIT,
+            "partition_report": _source(
+                arguments.partition_output, arguments.repo_root
+            ),
+            "type_closure_report": _source(
+                arguments.closure_output, arguments.repo_root
+            ),
+            "cross_slice_ledger": (
+                "tools/codex/app-server-evidence/0.144.6/"
+                "a1-final-cross-slice-ledger.json"
+            ),
+        },
+        "decision": {
+            "selected_native_implementation_pr_count": 3,
+            "selected_batches": batch_names,
+            "candidate_evaluation": [
+                {
+                    "candidate": "one native implementation PR",
+                    "decision": "rejected",
+                    "reason": (
+                        "mixes nine facade domains, reverse-request "
+                        "lifecycle, high-volume runtime events, platform "
+                        "behavior, and two union families"
+                    ),
+                },
+                {
+                    "candidate": "two native implementation PRs",
+                    "decision": "rejected",
+                    "reason": (
+                        "still forces either reverse-request lifecycle "
+                        "or runtime/platform behavior into the large "
+                        "user-facing integration review"
+                    ),
+                },
+                {
+                    "candidate": "three native implementation PRs",
+                    "decision": "selected",
+                    "reason": (
+                        "creates coherent schema/API/lifecycle review "
+                        "boundaries and every PR ends in an honest "
+                        "registry state"
+                    ),
+                },
+                {
+                    "candidate": "more than three native PRs",
+                    "decision": "rejected",
+                    "reason": (
+                        "fragments cohesive app/plugin/hook/skill or MCP "
+                        "schema families without another independent "
+                        "closure boundary"
+                    ),
+                },
+            ],
+            "selection_factors": [
+                "domain cohesion",
+                "transitive schema and codec sharing",
+                "public facade ownership",
+                "server-request and notification lifecycle risk",
+                "API/ABI impact",
+                "test-corpus reviewability",
+                "honest independent registry closure",
+            ],
+        },
+        "native_start": {
+            "identity_count": 56,
+            "taxonomy": EXPECTED_TAXONOMY,
+            "status": EXPECTED_NATIVE_START_STATUS,
+            "global_status": EXPECTED_GLOBAL_START_STATUS,
+            "client_result_kinds": EXPECTED_RESULT_KINDS,
+            "native_runtime_status_matrix": native_runtime_matrix,
+            "global_runtime_status_matrix": global_runtime_matrix,
+        },
+        "implementation_batches": batch_documents,
+        "identity_bijection": [
+            {
+                "protocol_surface_key": key.object(),
+                "implementation_batch": owners[0],
+            }
+            for key, owners in sorted(key_batches.items())
+        ],
+        "schema_dependency_graph": {
+            "edges": [
+                {
+                    "from": "A14-UserIntegrations",
+                    "to": "A14-McpReverse",
+                    "reason": (
+                        "review sequence and stable public facade "
+                        "foundation; schema closures are disjoint"
+                    ),
+                },
+                {
+                    "from": "A14-McpReverse",
+                    "to": "A14-RuntimePlatform",
+                    "reason": (
+                        "serverRequest/resolved lifecycle tests require "
+                        "all four A1.4 reverse-request types"
+                    ),
+                },
+                {
+                    "from": "A14-RuntimePlatform",
+                    "to": "A1-FinalClosure",
+                    "reason": (
+                        "native 56 must be complete before inherited "
+                        "Common closure and SONAME action"
+                    ),
+                },
+            ],
+            "definition_overlap": overlaps,
+            "overlap_rule": (
+                "v2::AbsolutePathBuf is an existing reusable public "
+                "type, implemented once and referenced by the platform "
+                "batch; no union family is implemented twice"
+            ),
+        },
+        "public_api_plan": {
+            "facade_operations": sorted(
+                client_api_rows,
+                key=lambda row: row["method"],
+            ),
+            "notification_ownership": notification_rows,
+            "server_request_ownership": request_rows,
+            "rules": [
+                "retain typed::Client's PIMPL",
+                "add no members to AppServerClient",
+                "add no public virtual interface",
+                "add no generic invoke-by-method API",
+                "do not move A1.1-A1.3 operations",
+                "notifications remain on Events",
+                "incoming requests remain on Requests occurrences",
+                (
+                    "stable process and remote status notifications do "
+                    "not create outgoing control facades"
+                ),
+            ],
+            "reusable_exact_public_types": REUSABLE_PUBLIC_TYPES,
+            "reusable_shared_vocabulary": [
+                "Unit and OperationResult<T>",
+                "ThreadId, TurnId, and ItemId",
+                "Json, OptionalNullable, and DecodeDiagnostic",
+                "ServerRequestId and ServerRequestToken",
+            ],
+            "similar_types_that_must_not_be_reused": (
+                NON_REUSABLE_SIMILAR_TYPES
+            ),
+            "request_user_input_compatibility": (
+                ledger["native_a1_4_obligation"]
+            ),
+            "variant_and_layout_plan": variants,
+        },
+        "server_request_resolved_semantics": resolved,
+        "final_a1_closure": {
+            "branch": "codex/a1-final-closure",
+            "draft_pr_title": (
+                "Close the Codex A1 typed surface and bump its SOVERSION"
+            ),
+            "identity_count": 3,
+            "identities": [
+                row["protocol_surface_key"]
+                for row in ledger[
+                    "inherited_final_a1_obligations"
+                ]
+            ],
+            "owner": "A1.0 / Common, unchanged",
+            "completion_stage": "final A1 closure in A1.4",
+            "global_start": EXPECTED_NATIVE_COMPLETION_STATUS,
+            "global_end": EXPECTED_FINAL_A1_STATUS,
+            "native_a1_4_status": {
+                "Complete": 56,
+                "Partial": 0,
+                "NotImplemented": 0,
+            },
+            "ordered_sequence": [
+                "implement initialize schema-complete lifecycle in place",
+                "implement initialized exact direction evidence in place",
+                "implement error canonical completeness in place",
+                "prove all 339 stable A1 identities Complete",
+                "capture final public API/ABI layout and symbol evidence",
+                "perform the scoped Codex SOVERSION 1 -> 2 action",
+                "rebuild installed consumers and source/binary packages",
+                "run the final A1 closure checker",
+            ],
+            "commit_rule": (
+                "the pure closure commit follows the three production "
+                "completion commits and contains no deferred runtime "
+                "implementation"
+            ),
+        },
+        "api_abi_and_soversion": soversion,
+        "security_and_sensitive_data": {
+            "default_policy": (
+                "treat every raw envelope, opaque JSON field, and "
+                "listed sensitive path as sensitive; redact values"
+            ),
+            "heuristic_schema_paths": {
+                "count": closure["counts"]["sensitive_paths"],
+                "coverage_note": (
+                    "the 127 mechanically flagged paths are a minimum; "
+                    "family/root policy remains default-deny"
+                ),
+            },
+            "family_inventory": {
+                "apps": [
+                    "metadata",
+                    "configuration",
+                    "branding",
+                    "screenshots",
+                    "reviews",
+                ],
+                "external_agents": [
+                    "configuration",
+                    "cwd/home detection",
+                    "import histories",
+                    "progress",
+                    "failures",
+                ],
+                "feedback": [
+                    "content",
+                    "reason",
+                    "tags",
+                    "attachments/logs",
+                    "thread IDs",
+                ],
+                "hooks": [
+                    "definitions",
+                    "handlers",
+                    "sources and paths",
+                    "input/output",
+                    "failures",
+                ],
+                "marketplace_plugins_skills": [
+                    "source URLs, paths, refs, SHAs, packages",
+                    "checkout/share principals and targets",
+                    "installation roots and skill roots",
+                    "configuration and errors",
+                ],
+                "mcp_and_reverse_requests": [
+                    "server IDs and names",
+                    "OAuth scopes, state, and URLs",
+                    "resource URIs and contents",
+                    "tool names, schemas, arguments, and results",
+                    "elicitation messages, values, schemas, and URLs",
+                    "all user questions, options, and answers",
+                    "entire attestation input and output",
+                ],
+                "runtime_and_platform": [
+                    "process handles and output",
+                    "remote identities and status",
+                    "warning/deprecation text",
+                    "request/thread IDs",
+                    "filesystem paths",
+                    "Windows sandbox diagnostics",
+                ],
+            },
+            "forbidden_real_fixture_data": [
+                "credentials and OAuth tokens",
+                "environment variables",
+                "plugin repositories",
+                "private filesystem paths",
+                "MCP server configuration",
+                "feedback content",
+                "process output",
+                "user answers",
+                "attestation material",
+            ],
+            "safe_fixture_vocabulary": [
+                "synthetic IDs",
+                "/synthetic/... paths",
+                "example.invalid URLs",
+                "fake tokens and values",
+            ],
+            "diagnostic_rule": (
+                "emit method, structural path, expected type, and safe "
+                "counts only; never payload values"
+            ),
+        },
+        "source_and_binary_package_plan": {
+            "source_counts": {
+                "evidence_files": {"before": 22, "after": 27},
+                "codex_docs": {"before": 18, "after": 19},
+                "top_level_codex_tools": {
+                    "before": 13,
+                    "after": 14,
+                },
+            },
+            "required_source_entries": [
+                "tools/codex/app_server_a1_4.py",
+                "tests/component/codex/CodexA14AuditToolTest.py",
+                (
+                    "tools/codex/app-server-evidence/0.144.6/"
+                    "a1-4-start-state.json"
+                ),
+                (
+                    "tools/codex/app-server-evidence/0.144.6/"
+                    "a1-4-total-partition.json"
+                ),
+                (
+                    "tools/codex/app-server-evidence/0.144.6/"
+                    "a1-4-type-closure.json"
+                ),
+                (
+                    "tools/codex/app-server-evidence/0.144.6/"
+                    "a1-4-implementation-plan.json"
+                ),
+                (
+                    "tools/codex/app-server-evidence/0.144.6/"
+                    "a1-final-cross-slice-ledger.json"
+                ),
+                (
+                    "docs/ai/openai/codex/"
+                    "a1-4-integrations-and-long-tail-plan.md"
+                ),
+            ],
+            "extracted_check": (
+                "python3 -B tools/codex/app_server_a1_4.py check "
+                "--repo-root <extracted-root>"
+            ),
+            "predecessor_closure_compatibility": (
+                "A1.3 retains its historical generator/package source "
+                "records while live successor-aware tokens require all "
+                "A1.4 package entries and the extracted A1.4 check"
+            ),
+            "binary_and_installed_policy": (
+                "tools, tests, docs, evidence, JSON, and Python remain "
+                "excluded; this audit adds no installed public header"
+            ),
+            "audit_public_header_count": {
+                "before": 34,
+                "after": 34,
+            },
+            "future_public_header_counts": [
+                34,
+                41,
+                42,
+                43,
+            ],
+        },
+        "no_expansion_boundaries": [
+            "no production implementation in this audit",
+            "no ProtocolSurfaceRegistryData.inc status promotion",
+            "no module-slice-assignment rewrite",
+            "no generated operation/notification/request descriptor change",
+            "no fixture or fixture-index change",
+            "no BackendState or BackendCommand expansion",
+            "no frontend protocol or application behavior change",
+            "no outgoing process or remote-control stable API",
+            "no SOVERSION change in this audit",
+        ],
+        "long_run_test_policy": {
+            "skipped": [
+                "unfiltered full-repository CTest",
+                "stress tests",
+                "soak tests",
+                "fuzzing campaigns",
+                "benchmarks",
+                "sanitizer matrices",
+                "credential-bearing live App Server integration",
+            ],
+            "reason": (
+                "audit-only changes need deterministic Python, focused "
+                "CTest, configure/registration, and package evidence; "
+                "these long targets add no A1.4-specific signal"
+            ),
+            "residual_risk": (
+                "runtime integration risk remains intentionally deferred "
+                "to the three production implementation PRs"
+            ),
+        },
+        "a2_non_goals": [
+            "all 36 experimental-only InventoryOnly identities",
+            "all 12 stable-unreachable InventoryOnly identities",
+            "process control requests",
+            "remote-control outgoing requests",
+            "fuzzy-search session controls",
+            "collaboration, environment, and memory operations",
+            "background-terminal, realtime, search, and settings controls",
+            "frontend/backend/application expansion outside typed A1",
+        ],
+    }
+
+
+def planning_diagnostics(
+    plan: Mapping[str, Any],
+    ledger: Mapping[str, Any],
+) -> list[AuditDiagnostic]:
+    diagnostics: list[AuditDiagnostic] = []
+
+    def add(code: str, location: str, message: str) -> None:
+        diagnostics.append(AuditDiagnostic(code, location, message))
+
+    native_start = plan.get("native_start")
+    if (
+        not isinstance(native_start, Mapping)
+        or native_start.get("identity_count") != 56
+        or native_start.get("taxonomy") != EXPECTED_TAXONOMY
+        or native_start.get("status") != EXPECTED_NATIVE_START_STATUS
+        or native_start.get("global_status")
+        != EXPECTED_GLOBAL_START_STATUS
+    ):
+        add(
+            "NativeDenominatorMismatch",
+            "$.native_start",
+            (
+                "native A1.4 must remain exactly 56 identities with "
+                "one native Partial"
+            ),
+        )
+
+    batches = plan.get("implementation_batches")
+    planned_keys: list[Key] = []
+    if not isinstance(batches, list) or len(batches) != 3:
+        add(
+            "ImplementationPlanIdentityMismatch",
+            "$.implementation_batches",
+            "exactly three native implementation batches are required",
+        )
+    else:
+        by_name = {
+            str(row.get("batch")): row
+            for row in batches
+            if isinstance(row, Mapping)
+        }
+        if set(by_name) != set(IMPLEMENTATION_BATCHES):
+            add(
+                "ImplementationPlanIdentityMismatch",
+                "$.implementation_batches",
+                "implementation batch names changed",
+            )
+        for name, expected in IMPLEMENTATION_BATCHES.items():
+            row = by_name.get(name)
+            if not isinstance(row, Mapping):
+                continue
+            identities = row.get("identities")
+            keys = (
+                [
+                    Key.from_row(item["protocol_surface_key"])
+                    for item in identities
+                    if isinstance(item, Mapping)
+                    and isinstance(
+                        item.get("protocol_surface_key"), Mapping
+                    )
+                ]
+                if isinstance(identities, list)
+                else []
+            )
+            planned_keys.extend(keys)
+            if set(keys) != _batch_keys(name):
+                add(
+                    "ImplementationPlanIdentityMissing",
+                    f"$.implementation_batches.{name}.identities",
+                    f"{name} identity ownership changed",
+                )
+            if (
+                row.get("identity_count")
+                != expected["identity_count"]
+                or row.get("taxonomy") != expected["taxonomy"]
+            ):
+                add(
+                    "ImplementationPlanIdentityMismatch",
+                    f"$.implementation_batches.{name}",
+                    f"{name} denominator or taxonomy changed",
+                )
+            if (
+                row.get("native_metrics")
+                != {
+                    "start": expected["native_start"],
+                    "end": expected["native_end"],
+                }
+                or row.get("global_metrics")
+                != {
+                    "start": expected["global_start"],
+                    "end": expected["global_end"],
+                }
+            ):
+                add(
+                    "NativeCompletionArithmeticMismatch",
+                    f"$.implementation_batches.{name}",
+                    f"{name} start/end arithmetic changed",
+                )
+            schema = row.get("schema_closure")
+            if (
+                not isinstance(schema, Mapping)
+                or schema.get("counts")
+                != EXPECTED_BATCH_CLOSURES[name]
+            ):
+                add(
+                    "ImplementationDependencyMismatch",
+                    (
+                        "$.implementation_batches."
+                        f"{name}.schema_closure"
+                    ),
+                    f"{name} schema dependency closure changed",
+                )
+        if len(planned_keys) != len(set(planned_keys)):
+            add(
+                "ImplementationPlanIdentityOverlap",
+                "$.implementation_batches",
+                "a native identity is owned by multiple batches",
+            )
+        if set(planned_keys) != expected_a1_4_keys():
+            add(
+                "ImplementationPlanIdentityMissing",
+                "$.implementation_batches",
+                "the 56-identity native slice is not covered exactly once",
+            )
+
+    identity_bijection = plan.get("identity_bijection")
+    bijection_keys = (
+        [
+            Key.from_row(row["protocol_surface_key"])
+            for row in identity_bijection
+            if isinstance(row, Mapping)
+            and isinstance(row.get("protocol_surface_key"), Mapping)
+        ]
+        if isinstance(identity_bijection, list)
+        else []
+    )
+    if (
+        len(bijection_keys) != 56
+        or len(set(bijection_keys)) != 56
+        or set(bijection_keys) != expected_a1_4_keys()
+    ):
+        add(
+            "ImplementationPlanIdentityMismatch",
+            "$.identity_bijection",
+            "implementation ownership bijection changed",
+        )
+
+    api = plan.get("public_api_plan")
+    if not isinstance(api, Mapping):
+        add(
+            "PublicApiOwnershipMismatch",
+            "$.public_api_plan",
+            "public API ownership plan is absent",
+        )
+    else:
+        facade_rows = api.get("facade_operations")
+        facade_methods = (
+            [
+                str(row.get("method"))
+                for row in facade_rows
+                if isinstance(row, Mapping)
+            ]
+            if isinstance(facade_rows, list)
+            else []
+        )
+        if (
+            len(facade_methods) != 29
+            or set(facade_methods) != set(CLIENT_REQUEST_CONTRACTS)
+        ):
+            add(
+                "PublicApiOwnershipMismatch",
+                "$.public_api_plan.facade_operations",
+                "all 29 client requests need one facade owner",
+            )
+        notification_rows = api.get("notification_ownership")
+        notification_methods = (
+            [
+                str(row.get("method"))
+                for row in notification_rows
+                if isinstance(row, Mapping)
+            ]
+            if isinstance(notification_rows, list)
+            else []
+        )
+        if (
+            len(notification_methods) != 16
+            or set(notification_methods) != SERVER_NOTIFICATIONS
+        ):
+            add(
+                "PublicApiOwnershipMismatch",
+                "$.public_api_plan.notification_ownership",
+                "all 16 notifications need Events ownership",
+            )
+        request_rows = api.get("server_request_ownership")
+        request_methods = (
+            [
+                str(row.get("method"))
+                for row in request_rows
+                if isinstance(row, Mapping)
+            ]
+            if isinstance(request_rows, list)
+            else []
+        )
+        if (
+            len(request_methods) != 4
+            or set(request_methods) != set(SERVER_REQUEST_CONTRACTS)
+        ):
+            add(
+                "PublicApiOwnershipMismatch",
+                "$.public_api_plan.server_request_ownership",
+                "all four incoming requests need Requests ownership",
+            )
+
+    resolved = plan.get("server_request_resolved_semantics")
+    direct = (
+        resolved.get("direct_response_non_regression")
+        if isinstance(resolved, Mapping)
+        else None
+    )
+    if (
+        not isinstance(direct, Mapping)
+        or direct.get("is_response_transport") is not False
+        or direct.get("is_response_prerequisite") is not False
+        or direct.get("is_acknowledgement_prerequisite") is not False
+        or direct.get("is_second_terminal_completion") is not False
+        or direct.get("can_reopen_completed_occurrence") is not False
+        or direct.get("changes_a1_3_response_contract") is not False
+    ):
+        add(
+            "ResponsePathMismatch",
+            "$.server_request_resolved_semantics",
+            (
+                "serverRequest/resolved must not replace, gate, repeat, "
+                "or retroactively change direct responses"
+            ),
+        )
+    method_matrix = (
+        resolved.get("emission_method_matrix")
+        if isinstance(resolved, Mapping)
+        else None
+    )
+    expected_emitting = {
+        "item/commandExecution/requestApproval",
+        "item/fileChange/requestApproval",
+        "item/permissions/requestApproval",
+        "item/tool/requestUserInput",
+        "mcpServer/elicitation/request",
+    }
+    observed_emitting = (
+        {
+            str(row.get("method"))
+            for row in method_matrix
+            if isinstance(row, Mapping)
+            and row.get("emits_notification") is True
+        }
+        if isinstance(method_matrix, list)
+        else set()
+    )
+    if observed_emitting != expected_emitting:
+        add(
+            "ServerRequestResolvedSemanticsMismatch",
+            (
+                "$.server_request_resolved_semantics."
+                "emission_method_matrix"
+            ),
+            "serverRequest/resolved production method matrix changed",
+        )
+
+    inherited = ledger.get("inherited_final_a1_obligations")
+    inherited_rows = (
+        [row for row in inherited if isinstance(row, Mapping)]
+        if isinstance(inherited, list)
+        else []
+    )
+    inherited_names = {
+        str(row.get("protocol_surface_key", {}).get("name"))
+        for row in inherited_rows
+    }
+    if inherited_names != {"initialize", "initialized", "error"}:
+        add(
+            "CrossSliceLedgerMismatch",
+            "$.inherited_final_a1_obligations",
+            "the three inherited A1.0 ledger entries are required",
+        )
+    elif any(
+        row.get("current_slice") != "A1.0"
+        or row.get("current_module") != "Common"
+        or row.get("current_status") != "Partial"
+        or row.get("expected_status_after_completion") != "Complete"
+        for row in inherited_rows
+    ):
+        add(
+            "CrossSliceOwnershipMismatch",
+            "$.inherited_final_a1_obligations",
+            "inherited entries must remain Common/A1.0-owned",
+        )
+    native = ledger.get("native_a1_4_obligation")
+    if (
+        not isinstance(native, Mapping)
+        or native.get("protocol_surface_key", {}).get("name")
+        != "item/tool/requestUserInput"
+        or native.get("current_slice") != "A1.4"
+        or native.get("current_module") != A1_4_MODULE
+    ):
+        add(
+            "NativePartialMismatch",
+            "$.native_a1_4_obligation",
+            "native partial ledger entry changed",
+        )
+
+    closure_stage = plan.get("final_a1_closure")
+    if (
+        not isinstance(closure_stage, Mapping)
+        or closure_stage.get("identity_count") != 3
+        or closure_stage.get("global_start")
+        != EXPECTED_NATIVE_COMPLETION_STATUS
+        or closure_stage.get("global_end") != EXPECTED_FINAL_A1_STATUS
+    ):
+        add(
+            "FinalA1ArithmeticMismatch",
+            "$.final_a1_closure",
+            "final inherited completion arithmetic changed",
+        )
+
+    soversion = plan.get("api_abi_and_soversion")
+    action = (
+        soversion.get("final_action")
+        if isinstance(soversion, Mapping)
+        else None
+    )
+    if (
+        not isinstance(action, Mapping)
+        or action.get("decision") != "bump Codex SOVERSION 1 -> 2"
+        or action.get("binary_package_change") != ".so.1 -> .so.2"
+        or action.get("earlier_pr_rule") is None
+    ):
+        add(
+            "SOVERSIONDecisionMissing",
+            "$.api_abi_and_soversion",
+            "the final scoped SOVERSION 1 -> 2 decision is required",
+        )
+
+    boundaries = plan.get("no_expansion_boundaries")
+    if (
+        not isinstance(boundaries, list)
+        or "no production implementation in this audit"
+        not in boundaries
+        or "no SOVERSION change in this audit" not in boundaries
+    ):
+        add(
+            "BoundaryMismatch",
+            "$.no_expansion_boundaries",
+            "audit-only no-expansion boundaries changed",
+        )
+    return sorted(set(diagnostics))
+
+
+def validate_planning_reports(
+    plan: Mapping[str, Any],
+    ledger: Mapping[str, Any],
+) -> None:
+    shared.validate_diagnostics(planning_diagnostics(plan, ledger))
+
+
+def build_reports(
+    arguments: argparse.Namespace,
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
+    partition, closure = build_foundation(arguments)
+    inputs = load_inputs(arguments)
+    ledger = cross_slice_ledger_document(arguments, inputs)
+    plan = implementation_plan_document(
+        arguments, inputs, partition, closure, ledger
+    )
+    validate_planning_reports(plan, ledger)
+    return partition, closure, plan, ledger
 
 
 def foundation_diagnostics(
@@ -2444,6 +5134,16 @@ def parser() -> argparse.ArgumentParser:
         type=Path,
         default=evidence / "a1-4-type-closure.json",
     )
+    result.add_argument(
+        "--plan-output",
+        type=Path,
+        default=evidence / "a1-4-implementation-plan.json",
+    )
+    result.add_argument(
+        "--ledger-output",
+        type=Path,
+        default=evidence / "a1-final-cross-slice-ledger.json",
+    )
     result.add_argument("--base-sha")
     return result
 
@@ -2460,10 +5160,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         document = start_state_document(arguments, base_sha)
         write_or_check(arguments.start_state, document, False)
         return 0
-    partition, closure = build_foundation(arguments)
+    partition, closure, plan, ledger = build_reports(arguments)
     check = arguments.mode == "check"
     write_or_check(arguments.partition_output, partition, check)
     write_or_check(arguments.closure_output, closure, check)
+    write_or_check(arguments.plan_output, plan, check)
+    write_or_check(arguments.ledger_output, ledger, check)
     return 0
 
 


### PR DESCRIPTION
## Summary

Audit and freeze the final native A1 residue and its inherited Common closure obligations. This PR adds deterministic audit tooling, five generated evidence documents, focused mutation guards, the reviewed implementation decomposition, lifecycle/API/ABI/security planning, and source-package retention.

This is audit-only. It does not implement an A1.4 protocol operation or change production behavior.

## Authority and history

- Base SHA: `bed5ee05184739d54cddc6518bd43b264e2b496d`
- Base tree: `8bf44f0eed6bd8c9d5309176db07a7d6a6240ef3`
- Final head: `46edab0cc800a2e8a2d799a644962861b6d2cd78`
- Codex pin: `codex-cli 0.144.6`, tag `rust-v0.144.6`, source `5d1fbf26c43abc65a203928b2e31561cb039e06d`
- Commit 1: `a2af0ccf6e5ab6402fd48a5177eddc679c50376b` — `Audit the Codex A1.4 residue and total partition`
- Commit 2: `46edab0cc800a2e8a2d799a644962861b6d2cd78` — `Freeze the Codex A1.4 implementation and A1 closure plan`
- History rewrite mapping: `6a073400f607e538e3c07ed65439872765e1858f -> 46edab0cc800a2e8a2d799a644962861b6d2cd78`; the former head and its CI evidence are superseded

## Frozen partition and arithmetic

Exact total partition:

```text
A1.0          19
A1.1         151
A1.2          45
A1.3          68
A1.4          56
InventoryOnly 48
Total         387
```

Exact stability accounting:

```text
stable A1                         339
stable-unreachable InventoryOnly  12
experimental-only InventoryOnly   36
total stable inventory            351
total inventory                   387
```

InventoryOnly is explicitly 36 experimental-only plus 12 stable-unreachable; the 48 rows are not described as uniformly experimental.

Native A1.4 taxonomy is exactly 29 client requests / 16 server notifications / 4 server requests / 7 tagged-union alternatives. All 56 are stable, `IntegrationsAndLongTail`, and A1.4-owned. Client results are 26 Concrete / 3 Unit; the Unit results are only `plugin/share/delete`, `plugin/uninstall`, and `skills/extraRoots/set`.

Current global metrics:

```text
Complete        280
Partial           4
NotImplemented   55
NotApplicable    48
```

Native A1.4 starts `0 Complete / 1 Partial / 55 NotImplemented`. Native completion projects global metrics to `336 / 3 / 0 / 48`. Final inherited A1.0 completion projects them to `339 / 0 / 0 / 48`.

The one native Partial is `item/tool/requestUserInput`. The inherited Partials are `initialize`, `initialized`, and `error`.

## Exact native implementation split

### PR A — user-facing integrations

- Proposed branch: `codex/a1-4-user-integrations`
- Proposed title: `Type the Codex A1.4 user-facing integrations`
- 33 identities: 23 client requests / 6 notifications / 0 server requests / 4 unions
- Results: 20 Concrete / 3 Unit
- Native: `0/1/55 -> 33/1/22`
- Global: `280/4/55/48 -> 313/4/22/48`
- Closure: 52 seeds, 118 v2 definitions, 411 paths

```text
client requests
  app/list
  externalAgentConfig/detect
  externalAgentConfig/import
  externalAgentConfig/import/readHistories
  feedback/upload
  hooks/list
  marketplace/add
  marketplace/remove
  marketplace/upgrade
  plugin/install
  plugin/installed
  plugin/list
  plugin/read
  plugin/share/checkout
  plugin/share/delete
  plugin/share/list
  plugin/share/save
  plugin/share/updateTargets
  plugin/skill/read
  plugin/uninstall
  skills/config/write
  skills/extraRoots/set
  skills/list

notifications
  app/list/updated
  externalAgentConfig/import/completed
  externalAgentConfig/import/progress
  hook/completed
  hook/started
  skills/changed

PluginSource:type alternatives
  git
  local
  npm
  remote
```

### PR B — MCP and reverse requests

- Proposed branch: `codex/a1-4-mcp-reverse-requests`
- Proposed title: `Type the Codex A1.4 MCP and reverse requests`
- 13 identities: 4 client requests / 2 notifications / 4 server requests / 3 unions
- Native: `33/1/22 -> 46/0/10`
- Global: `313/4/22/48 -> 326/3/10/48`
- Closure: 18 seeds, 55 definitions (34 legacy, 21 v2), 204 paths

```text
client requests
  mcpServer/oauth/login
  mcpServer/resource/read
  mcpServer/tool/call
  mcpServerStatus/list

notifications
  mcpServer/oauthLogin/completed
  mcpServer/startupStatus/updated

server requests
  attestation/generate
  item/tool/call
  item/tool/requestUserInput
  mcpServer/elicitation/request

McpServerElicitationRequestParams:mode alternatives
  form
  openai/form
  url
```

All four response contracts are concrete and retain the existing occurrence-token/generation/direct-`RawProtocol` response path.

### PR C — runtime and platform long tail

- Proposed branch: `codex/a1-4-runtime-platform`
- Proposed title: `Type the Codex A1.4 runtime and platform long tail`
- 10 identities: 2 client requests / 8 notifications
- Native: `46/0/10 -> 56/0/0`
- Global: `326/3/10/48 -> 336/3/0/48`
- Closure: 11 seeds, 17 v2 definitions, 31 paths

```text
client requests
  windowsSandbox/readiness
  windowsSandbox/setupStart

notifications
  deprecationNotice
  process/exited
  process/outputDelta
  remoteControl/status/changed
  serverRequest/resolved
  warning
  windows/worldWritableWarning
  windowsSandbox/setupCompleted
```

The three batches cover all 56 identities exactly once. The only cross-batch schema dependency is the existing reusable `v2::AbsolutePathBuf`; neither union family is implemented twice.

Stable `process/exited`, `process/outputDelta`, and `remoteControl/status/changed` stay in A1.4. Experimental process controls and all outgoing remote-control methods remain InventoryOnly and receive no stable facade.

## Cross-slice ledger

```text
identity                     owner                         completion stage
initialize                   Common / A1.0                 final A1 closure in A1.4
initialized                  Common / A1.0                 final A1 closure in A1.4
error                        Common / A1.0                 final A1 closure in A1.4
item/tool/requestUserInput    IntegrationsAndLongTail/A1.4 native A1.4 implementation
```

The assignment file is unchanged. The inherited three never enter the native 56 denominator. A distinct proposed `codex/a1-final-closure` PR completes them in place, proves `339/0/0/48`, captures final ABI/package evidence, performs the scoped SONAME action, and then runs a pure closure commit containing no deferred implementation.

## `serverRequest/resolved`

The exact stable payload is `{threadId: string, requestId: string|int64}` with both fields required and future properties allowed. `requestId` is the original server-generated JSON-RPC request ID, not an item ID or SNode.C occurrence token. The payload has no outcome or generation.

Pinned production emission matrix:

- Yes: A1.3 command-execution, file-change, and permissions approvals.
- No: legacy A1.3 apply-patch and exec-command approvals.
- Yes: A1.4 user-input and MCP elicitation requests.
- No: A1.4 dynamic-tool call and attestation requests.

For the positive methods, valid result/decline/cancel, JSON-RPC error, malformed success, and turn-transition cleanup can emit it. There is no generic timeout or App Server-owned auto-resolution timer, and disconnect alone does not emit it.

The direct JSON-RPC response is causally earlier: upstream removes the callback before the handler emits this later opposite-direction lifecycle event. It is informational and lifecycle-significant for shared pending UI, not a response transport or outcome. Already-consumed, unknown, duplicate, stale-generation, and thread-mismatched IDs are nonfatal, idempotent registry no-ops. A matching current occurrence may be retired as externally resolved; the notification never reopens a request or causes wire output.

Frozen non-regression: it is not a response prerequisite, acknowledgement prerequisite, replacement transport, second terminal completion, or retroactive A1.3 contract change.

## Public API, ABI, SOVERSION, and security

Proposed typed facades group operations as Apps, ExternalAgents, Feedback, Hooks, Marketplace, MCP, Plugins, Skills, and WindowsSandbox. Notifications remain on Events; incoming requests remain on Requests occurrences. `typed::Client` retains its PIMPL; `AppServerClient` gains no member; there is no public virtual or generic invoke API.

Existing variant indices remain fixed. A1.4 appends notification alternatives; `UserInputRequest` stays request index 2, while Attestation, DynamicTool, and MCP Elicitation append at 8–10. Final `ErrorNotification` appends canonically while `TurnErrorEvent` remains Event index 44.

Current root authority is SOVERSION 1. Existing A1 policy and actual A1.3 ABI evidence require a final scoped Codex `1 -> 2` bump. It occurs only after the `339/0/0/48` proof and before final ABI/package capture, affecting the three Codex shared libraries rather than 65 unrelated targets. Installed consumers rebuild/relink; no preceding implementation PR may claim binary compatibility from an unchanged SONAME.

Security defaults every raw envelope, opaque JSON field, and mechanically flagged sensitive path to redacted. The plan covers app/external-agent/feedback/hook/plugin/skill data, MCP/OAuth/resources/tools/elicitation, all user questions and answers, attestation, process output, remote status, warnings, IDs, paths, and Windows diagnostics. Evidence uses synthetic IDs, `/synthetic/...`, `example.invalid`, and fake tokens; diagnostics never dump payload values.

## Validation on final head

Environment: 28 CPUs, 62 GiB RAM, 28 GiB available at final validation. No production build was needed; focused test concurrency was capped at 2.

Passed:

```text
python3 -B tools/codex/app_server_a1_3.py check
python3 -B tools/codex/app_server_a1_3_closure.py check
python3 -B tools/codex/app_server_a1_4.py check
python3 -B tests/component/codex/CodexA14AuditToolTest.py
  20 tests, OK

cmake -S . -B build -DBUILD_TESTING=ON

ctest --test-dir build -R '^(CodexA13AuditToolTest|CodexA13ClosureEvidenceTest|CodexA14AuditToolTest|StagedInstalledConsumerTest|CodexSyntheticSecretLeakGuardTest)$' --output-on-failure --parallel 2
  5/5 passed

ctest --test-dir build -R '^CodexSourcePackageTest$' --output-on-failure
  passed in 96.35 seconds, including extracted A1.4 check

git diff --check
Python compile/import checks for all changed Python files
exact deterministic regeneration in a fresh clone and SHA-256 comparison of all five reports
real depth-1 clone check exercising the shallow-history fallback
no changed path under src/
registry, assignment, A1.0-A1.3 closure evidence, and root SOVERSION unchanged
```

Deterministic evidence hashes:

```text
a1-4-start-state.json             a9dfea82e640e62ed3126d66f16e4e1aea7c27455f0e99aadb46c04c99f50c62
a1-4-total-partition.json         81e0ed3e4b1a9d089a2d39291bafe66d14ea44f4346ab8614b98605117f502ac
a1-4-type-closure.json            f2967c958d405a9658a9940f0bdc6b0570c956a0f0849f9764b4b8bbc3574631
a1-4-implementation-plan.json     13168314150b94764f83dc34e67849340bc8d1304e18b5ce7a69362d77cae147
a1-final-cross-slice-ledger.json  5d21f18013a534ab95b4a973da462db78270df9ff579d627136f5cfd0a988bc8
```

`CodexBinaryPackageTest` was attempted both alongside installed staging and in isolation; both runs reached its fixed 120.10-second timeout without a package-specific failure. It was not extended into an unbounded build. The static forbidden-path guard is unchanged, this PR changes no production/install rule or public header, installed staging passed, and source packaging passed. Residual risk: a fresh final-head binary archive was not completed and inspected within the focused timeout.

Intentionally not run: unfiltered repository CTest, stress, soak, fuzzing, benchmarks, sanitizer matrices, exhaustive unrelated regressions, and credential-bearing live App Server integration. They add no A1.4-audit-specific evidence; runtime risk remains explicitly deferred to the three implementation PRs.

## Final-head CI

Run `30220990290` (CI #349) targets exactly `46edab0cc800a2e8a2d799a644962861b6d2cd78` and completed successfully. Job `89843310188` (`gcc-debug`) completed successfully after checking out synthetic merge `fddc91b19e97f806b7e4c7cd64722c78efaf6071` of the final head into the verified base. Build and all 300 registered tests passed; CTest reported 0 failures in 513.93 seconds. `CodexA14AuditToolTest` passed in 5.09 seconds, and the source/binary package checks passed. The only skips were credential-bearing `CodexAppServerIntegrationTest` and `CodexTypedAppServerIntegrationTest`. The superseded-head run remains invalidated and is not cited as final evidence.

## Audit-only guarantees

- No runtime implementation was added.
- No registry status was promoted.
- No module/slice assignment changed.
- No existing A1.0–A1.3 closure evidence changed.
- No SOVERSION change was made.
- No production path under `src/` changed.
- The PR is draft, open, unmerged, and must not be merged as part of this audit.