### PR TITLE
Export immutable AISuite extraction snapshot

### DIFF
--- a/.github/workflows/aisuite-extraction-snapshot.yml
+++ b/.github/workflows/aisuite-extraction-snapshot.yml
@@ -1,0 +1,52 @@
+name: AISuite extraction snapshot
+
+on:
+  push:
+    branches:
+      - extraction/aisuite-source-snapshot
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out complete history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify immutable extraction source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD^)" = "d18b231a1d2ec2235fd6f204786b0a761cc24ff5"
+          printf 'source_commit=%s\n' "$(git rev-parse HEAD^)" | tee extraction-source.txt
+          printf 'source_tree=%s\n' "$(git rev-parse HEAD^^{tree})" | tee -a extraction-source.txt
+          printf 'snapshot_commit=%s\n' "$(git rev-parse HEAD)" | tee -a extraction-source.txt
+
+      - name: Create history bundle and source archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          git bundle create snodec-history.bundle --all
+          git archive \
+            --format=tar.gz \
+            --prefix=snode.c-d18b231/ \
+            --output=snodec-source.tar.gz \
+            d18b231a1d2ec2235fd6f204786b0a761cc24ff5
+          sha256sum snodec-history.bundle snodec-source.tar.gz extraction-source.txt \
+            | tee SHA256SUMS
+
+      - name: Upload extraction snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: aisuite-extraction-snapshot
+          path: |
+            snodec-history.bundle
+            snodec-source.tar.gz
+            extraction-source.txt
+            SHA256SUMS
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/aisuite-extraction-snapshot.yml
+++ b/.github/workflows/aisuite-extraction-snapshot.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - extraction/aisuite-source-snapshot
+  pull_request:
+    branches:
+      - master
 
 permissions:
   contents: read
@@ -21,9 +24,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD^)" = "d18b231a1d2ec2235fd6f204786b0a761cc24ff5"
-          printf 'source_commit=%s\n' "$(git rev-parse HEAD^)" | tee extraction-source.txt
-          printf 'source_tree=%s\n' "$(git rev-parse HEAD^^{tree})" | tee -a extraction-source.txt
+          source_commit=d18b231a1d2ec2235fd6f204786b0a761cc24ff5
+          git merge-base --is-ancestor "${source_commit}" HEAD
+          printf 'source_commit=%s\n' "${source_commit}" | tee extraction-source.txt
+          printf 'source_tree=%s\n' "$(git rev-parse "${source_commit}^{tree}")" | tee -a extraction-source.txt
           printf 'snapshot_commit=%s\n' "$(git rev-parse HEAD)" | tee -a extraction-source.txt
 
       - name: Create history bundle and source archive

--- a/.github/workflows/aisuite-extraction-snapshot.yml
+++ b/.github/workflows/aisuite-extraction-snapshot.yml
@@ -54,3 +54,53 @@ jobs:
             SHA256SUMS
           if-no-files-found: error
           retention-days: 7
+
+  staged-dependency:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out immutable source
+        uses: actions/checkout@v4
+        with:
+          ref: d18b231a1d2ec2235fd6f204786b0a761cc24ff5
+          fetch-depth: 1
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ pkg-config libssl-dev nlohmann-json3-dev
+
+      - name: Configure and install SNode.C
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_INSTALL_PREFIX="${PWD}/stage" \
+            -DSNODEC_BUILD_TESTS=OFF \
+            -DSNODEC_BUILD_APPS=OFF
+          cmake --build build --parallel 2
+          cmake --install build
+
+      - name: Archive staged dependency and JSON headers
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -C stage -czf snodec-stage.tar.gz .
+          mkdir -p external/include external/pkgconfig
+          cp -a /usr/include/nlohmann external/include/
+          pc_file="$(pkg-config --variable=pcfiledir nlohmann_json)/nlohmann_json.pc"
+          cp "${pc_file}" external/pkgconfig/
+          tar -C external -czf nlohmann-json-stage.tar.gz .
+          sha256sum snodec-stage.tar.gz nlohmann-json-stage.tar.gz \
+            | tee STAGE-SHA256SUMS
+
+      - name: Upload staged dependency
+        uses: actions/upload-artifact@v4
+        with:
+          name: aisuite-snodec-stage
+          path: |
+            snodec-stage.tar.gz
+            nlohmann-json-stage.tar.gz
+            STAGE-SHA256SUMS
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
Temporary extraction helper only. The immutable history/source bundle and staged SNode.C dependency were exported successfully from source commit `d18b231a1d2ec2235fd6f204786b0a761cc24ff5`.

This PR was intentionally closed without merge. It changed no SNode.C source and must never be merged. SNode.C master remains the complete working fallback throughout AISuite extraction.